### PR TITLE
chore(chloggen): backport changelog tooling to release-v2.9

### DIFF
--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -1,0 +1,51 @@
+# Changelog entries
+
+Tempo manages `CHANGELOG.md` with [chloggen](../tools/chloggen) (the in-tree tool
+at `tools/chloggen`). Instead of editing `CHANGELOG.md` directly, every PR adds a
+small YAML file to this directory; the files are collated into the changelog at
+release time. This avoids merge conflicts on a shared file.
+
+## Add an entry
+
+```bash
+make chlog-new        # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+```
+
+Edit the generated file:
+
+```yaml
+change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
+component: metrics-generator   # must be in the components allowlist in config.yaml
+note: A brief description of the change.
+issues: [1234]                 # PR or issue number(s)
+subtext:                       # optional extra detail
+user: your-github-handle       # rendered as "(@your-github-handle)"
+```
+
+`change_type` keywords render under these sections:
+
+| keyword       | section               |
+| ------------- | --------------------- |
+| `breaking`    | 🛑 Breaking changes 🛑 |
+| `change`      | 🔧 Changes 🔧          |
+| `feature`     | 🚀 Features 🚀         |
+| `enhancement` | 💡 Enhancements 💡     |
+| `bug_fix`     | 🧰 Bug fixes 🧰        |
+| `security`    | 🔒 Security 🔒         |
+
+`component` must be one of the values in the `components` allowlist in
+[`config.yaml`](./config.yaml); `chlog-validate` rejects anything else. Adding a
+new component? Add it to that list in the same PR.
+
+## Validate / preview
+
+```bash
+make chlog-validate   # validate all entry files
+make chlog-preview    # render the pending entries to stdout
+```
+
+## Release (maintainers)
+
+```bash
+make chlog-update VERSION=v2.11.0   # collate entries into CHANGELOG.md and delete them
+```

--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -8,19 +8,32 @@ release time. This avoids merge conflicts on a shared file.
 ## Add an entry
 
 ```bash
-make chlog-new        # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+make chlog-new                     # creates .chloggen/<your-branch>.yaml from TEMPLATE.yaml
+make chlog-new FILENAME=my-change  # optional: name the file explicitly
 ```
 
-Edit the generated file:
+The filename defaults to the current branch name; pass `FILENAME=` to override
+it (required on `main`/`master` or a detached HEAD). Edit the generated file:
 
 ```yaml
 change_type: enhancement       # breaking | change | feature | enhancement | bug_fix | security
 component: metrics-generator   # must be in the components allowlist in config.yaml
 note: A brief description of the change.
-issues: [1234]                 # PR or issue number(s)
+issues: []                     # (optional) PR number(s); blank = auto-filled at release
 subtext:                       # optional extra detail
 user: your-github-handle       # rendered as "(@your-github-handle)"
 ```
+
+`issues` is optional. If you leave it blank, `chlog-update` fills it at release
+time with the PR number parsed from the commit that added this file (Tempo
+squash-merges PRs as `... (#1234)`). On a release branch the file is added by the
+backport PR, so the backport PR number is used; to pin a specific number instead,
+set `issues` explicitly.
+
+If the PR cannot be determined (for example the entry was committed directly to
+`main`, or its PR is not yet merged), both `chlog-update` and `chlog-preview`
+fail and list the entries needing an explicit `issues` — they never render an
+entry without a PR link.
 
 `change_type` keywords render under these sections:
 

--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -10,7 +10,8 @@ component:
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
 note:
 
-# One or more PR or issue numbers, e.g. [1234].
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
 issues: []
 
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.

--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -1,0 +1,20 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type:
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component:
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note:
+
+# One or more PR or issue numbers, e.g. [1234].
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user:

--- a/.chloggen/_migrated_00_7338.yaml
+++ b/.chloggen/_migrated_00_7338.yaml
@@ -1,0 +1,6 @@
+change_type: change
+component: deps
+note: Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others).
+issues: [7338]
+subtext:
+user: zhxiaogg

--- a/.chloggen/_migrated_01_7323.yaml
+++ b/.chloggen/_migrated_01_7323.yaml
@@ -1,0 +1,6 @@
+change_type: breaking
+component: distributor
+note: Dropped support for the OpenCensus receiver.
+issues: [7323]
+subtext:
+user: zhxiaogg

--- a/.chloggen/_migrated_02_7338.yaml
+++ b/.chloggen/_migrated_02_7338.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: metrics-generator
+note: Fix panic when `write_relabel_configs` is configured on remote write endpoints.
+issues: [7338]
+subtext:
+user: carles-grafana

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -1,0 +1,64 @@
+# Configuration for chloggen (the in-tree tool at tools/chloggen).
+# See .chloggen/README.md for usage.
+
+# Directory holding individual, unreleased changelog entries (one YAML per change).
+entries_dir: .chloggen
+
+# Template copied by `chloggen new` / `make chlog-new`.
+template_yaml: .chloggen/TEMPLATE.yaml
+
+# Custom render template producing Tempo's CHANGELOG.md format.
+summary_template: .chloggen/summary.tmpl
+
+# Target changelog file(s). Tempo uses a single changelog.
+change_logs:
+  default: CHANGELOG.md
+
+# Changelog used when an entry does not set `change_logs`.
+default_change_logs: [default]
+
+# Change types, in render order, with their section headings. Derived from Tempo's
+# historical CHANGELOG categories ([CHANGE], [FEATURE], [ENHANCEMENT], [BUGFIX],
+# [SECURITY]) plus breaking changes (historically the `**BREAKING CHANGE**` marker).
+change_types:
+  - key: security
+    heading: 🔒 Security 🔒
+  - key: breaking
+    heading: 🛑 Breaking changes 🛑
+  - key: feature
+    heading: 🚀 Features 🚀
+  - key: enhancement
+    heading: 💡 Enhancements 💡
+  - key: bug_fix
+    heading: 🧰 Bug fixes 🧰
+  - key: change
+    heading: 🔧 Changes 🔧
+
+# Allowlist of valid `component` values. Entries with a component outside this
+# list fail `chlog-validate`. Add a new component here when introducing one.
+components:
+  # services / modules
+  - distributor
+  - querier
+  - query-frontend
+  - compactor
+  - metrics-generator
+  - block-builder
+  - live-store
+  - backend-scheduler
+  - backend-worker
+  - overrides
+  - cache
+  # storage / core
+  - storage
+  - traceql
+  - api
+  # binaries
+  - tempo
+  - tempo-cli
+  - tempo-query
+  - tempo-vulture
+  # operations / tooling / meta
+  - operations
+  - docs
+  - deps

--- a/.chloggen/summary.tmpl
+++ b/.chloggen/summary.tmpl
@@ -1,0 +1,24 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+[#{{ $issue }}](https://github.com/grafana/tempo/issues/{{ $issue }})
+{{- end -}}
+)
+{{- if .User }} (@{{ .User }}){{- end }}
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+# {{ .Version }}
+{{- range .Groups }}
+{{- if .Entries }}
+
+## {{ .Heading }}
+{{- range $i, $change := .Entries }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Fixes #<issue number>
 **Checklist**
 - [ ] Tests updated
 - [ ] Documentation added
-- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
+- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`; see `.chloggen/README.md`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,4 +12,4 @@ Fixes #<issue number>
 **Checklist**
 - [ ] Tests updated
 - [ ] Documentation added
-- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`; see `.chloggen/README.md`)
+- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,63 @@
+# Requires every PR targeting main to add a .chloggen entry.
+# Skip by adding the "Skip Changelog" label or using a "chore:" / "chore(scope):" / "[chore]" PR title.
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request'
+      && !contains(github.event.pull_request.labels.*.name, 'dependencies')
+      && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
+      && !contains(github.event.pull_request.title, '[chore]')
+      && !startsWith(github.event.pull_request.title, 'chore:')
+      && !startsWith(github.event.pull_request.title, 'chore(')
+    env:
+      PR_HEAD: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Ensure CHANGELOG.md was not edited directly
+        run: |
+          base=$(git merge-base origin/main "$PR_HEAD")
+          if [[ -n "$(git diff --name-only "$base" "$PR_HEAD" ./CHANGELOG.md)" ]]; then
+            echo "CHANGELOG.md should not be edited directly."
+            echo "Add a .yaml file under ./.chloggen/ instead (run 'make chlog-new')."
+            echo "See .chloggen/README.md, or use a 'chore:' title / 'Skip Changelog' label to skip."
+            exit 1
+          fi
+          echo "CHANGELOG.md was not modified."
+
+      - name: Ensure a .chloggen entry was added
+        run: |
+          base=$(git merge-base origin/main "$PR_HEAD")
+          added=$(git diff --diff-filter=A --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
+          if [[ "$added" -lt 1 ]]; then
+            echo "No changelog entry was added under ./.chloggen/."
+            echo "Run 'make chlog-new' to create one. See .chloggen/README.md."
+            echo "Use a 'chore:' title / 'Skip Changelog' label to skip."
+            exit 1
+          fi
+          echo "A .chloggen entry was added."
+
+      - name: Validate .chloggen entries
+        run: make chlog-validate

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Ensure a .chloggen entry was added
         run: |
           base=$(git merge-base origin/main "$PR_HEAD")
-          added=$(git diff --diff-filter=A --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
+          added=$(git diff --diff-filter=AM --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
           if [[ "$added" -lt 1 ]]; then
             echo "No changelog entry was added under ./.chloggen/."
             echo "Run 'make chlog-new' to create one. See .chloggen/README.md."

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-# Requires every PR targeting main to add a .chloggen entry.
+# Requires every PR targeting release-v2.9 to add a .chloggen entry.
 # Skip by adding the "Skip Changelog", "dependencies", or "type/docs" label, or using a "chore:" / "chore(scope):" / "[chore]" PR title.
 name: changelog
 
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
     branches:
-      - main
+      - release-v2.9
 
 permissions:
   contents: read
@@ -39,7 +39,7 @@ jobs:
 
       - name: Ensure CHANGELOG.md was not edited directly
         run: |
-          base=$(git merge-base origin/main "$PR_HEAD")
+          base=$(git merge-base origin/release-v2.9 "$PR_HEAD")
           if [[ -n "$(git diff --name-only "$base" "$PR_HEAD" ./CHANGELOG.md)" ]]; then
             echo "CHANGELOG.md should not be edited directly."
             echo "Add a .yaml file under ./.chloggen/ instead (run 'make chlog-new')."
@@ -50,7 +50,7 @@ jobs:
 
       - name: Ensure a .chloggen entry was added
         run: |
-          base=$(git merge-base origin/main "$PR_HEAD")
+          base=$(git merge-base origin/release-v2.9 "$PR_HEAD")
           added=$(git diff --diff-filter=AM --name-only "$base" "$PR_HEAD" ./.chloggen | grep -cE '\.ya?ml$' || true)
           if [[ "$added" -lt 1 ]]; then
             echo "No changelog entry was added under ./.chloggen/."

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,5 @@
 # Requires every PR targeting main to add a .chloggen entry.
-# Skip by adding the "Skip Changelog" label or using a "chore:" / "chore(scope):" / "[chore]" PR title.
+# Skip by adding the "Skip Changelog", "dependencies", or "type/docs" label, or using a "chore:" / "chore(scope):" / "[chore]" PR title.
 name: changelog
 
 on:
@@ -18,6 +18,7 @@ jobs:
       github.event_name == 'pull_request'
       && !contains(github.event.pull_request.labels.*.name, 'dependencies')
       && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog')
+      && !contains(github.event.pull_request.labels.*.name, 'type/docs')
       && !contains(github.event.pull_request.title, '[chore]')
       && !startsWith(github.event.pull_request.title, 'chore:')
       && !startsWith(github.event.pull_request.title, 'chore(')

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,0 +1,30 @@
+# Runs the unit tests for the separate `tools` Go module (tools/go.mod), which
+# the main CI unit-tests job does not cover. Runs on every PR (no path filter)
+# so it can be a required status check without blocking PRs that don't touch
+# the tools module.
+name: Tools Unit Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tools-tests:
+    name: Run tools unit tests
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'tools/go.mod'
+
+      - name: Run tools unit tests
+        working-directory: tools
+        run: go test ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
-## main / unreleased
-
-* [CHANGE] Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others). [#7338](https://github.com/grafana/tempo/pull/7338) (@zhxiaogg)
-* [CHANGE] **BREAKING CHANGE** Dropped support for the OpenCensus receiver. [#7323](https://github.com/grafana/tempo/pull/7323) (@zhxiaogg)
-* [BUGFIX] generator: fix panic when `write_relabel_configs` is configured on remote write endpoints [#7338](https://github.com/grafana/tempo/pull/7338) (@carles-grafana)
+<!-- next version -->
 
 # v2.9.2
 

--- a/Makefile
+++ b/Makefile
@@ -403,18 +403,26 @@ generate-manifest:
 
 # chloggen is built from the tools module and run from the repo root so it can
 # find .chloggen/ and CHANGELOG.md. A .chloggen/config.yaml is used only if it
-# exists. Pass FILENAME=... to chlog-new and VERSION=vX.Y.Z to chlog-update.
+# exists. chlog-new defaults the entry filename to the current branch; override
+# with FILENAME=... . Pass VERSION=vX.Y.Z to chlog-update.
 CHLOGGEN ?= $(CURDIR)/bin/chloggen
 CHLOGGEN_CONFIG := .chloggen/config.yaml
 CHLOGGEN_CONFIG_ARG := $(if $(wildcard $(CHLOGGEN_CONFIG)),--config $(CHLOGGEN_CONFIG),)
+CHLOG_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+CHLOG_FILENAME := $(if $(FILENAME),$(FILENAME),$(CHLOG_BRANCH))
 
 .PHONY: $(CHLOGGEN)
 $(CHLOGGEN):
 	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
 
 .PHONY: chlog-new
-chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (FILENAME=... optional)
-	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) $(if $(FILENAME),--filename $(FILENAME))
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (defaults to branch name; override with FILENAME=...)
+	@if [ -z "$(CHLOG_FILENAME)" ] || [ "$(CHLOG_FILENAME)" = "HEAD" ] || \
+	    [ "$(CHLOG_FILENAME)" = "main" ] || [ "$(CHLOG_FILENAME)" = "master" ]; then \
+	  echo "Cannot default the changelog filename from branch '$(CHLOG_BRANCH)'; pass FILENAME=<name>."; \
+	  exit 1; \
+	fi
+	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) --filename "$(CHLOG_FILENAME)"
 
 .PHONY: chlog-validate
 chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries

--- a/Makefile
+++ b/Makefile
@@ -401,30 +401,32 @@ generate-manifest:
 
 ##@ Changelog
 
-# chloggen is vendored under tools/chloggen and built from the tools module.
-# It must run from the repo root so it can find .chloggen/ and CHANGELOG.md.
+# chloggen is built from the tools module and run from the repo root so it can
+# find .chloggen/ and CHANGELOG.md. A .chloggen/config.yaml is used only if it
+# exists. Pass FILENAME=... to chlog-new and VERSION=vX.Y.Z to chlog-update.
 CHLOGGEN ?= $(CURDIR)/bin/chloggen
 CHLOGGEN_CONFIG := .chloggen/config.yaml
+CHLOGGEN_CONFIG_ARG := $(if $(wildcard $(CHLOGGEN_CONFIG)),--config $(CHLOGGEN_CONFIG),)
 
 .PHONY: $(CHLOGGEN)
 $(CHLOGGEN):
 	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
 
 .PHONY: chlog-new
-chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/
-	$(CHLOGGEN) new --config $(CHLOGGEN_CONFIG)
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/ (FILENAME=... optional)
+	$(CHLOGGEN) new $(CHLOGGEN_CONFIG_ARG) $(if $(FILENAME),--filename $(FILENAME))
 
 .PHONY: chlog-validate
 chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries
-	$(CHLOGGEN) validate --config $(CHLOGGEN_CONFIG)
+	$(CHLOGGEN) validate $(CHLOGGEN_CONFIG_ARG)
 
 .PHONY: chlog-preview
 chlog-preview: $(CHLOGGEN) ## Render the pending changelog entries to stdout
-	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry
+	$(CHLOGGEN) update $(CHLOGGEN_CONFIG_ARG) --dry
 
 .PHONY: chlog-update
 chlog-update: $(CHLOGGEN) ## Collate pending entries into CHANGELOG.md (VERSION=vX.Y.Z)
-	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --version "$(VERSION)"
+	$(CHLOGGEN) update $(CHLOGGEN_CONFIG_ARG) --version "$(VERSION)"
 
 # Import fragments
 include build/tools.mk

--- a/Makefile
+++ b/Makefile
@@ -399,5 +399,32 @@ tempo-mixin-check: tools-image
 generate-manifest:
 	GO111MODULE=on CGO_ENABLED=0 go run -v pkg/docsgen/generate_manifest.go
 
+##@ Changelog
+
+# chloggen is vendored under tools/chloggen and built from the tools module.
+# It must run from the repo root so it can find .chloggen/ and CHANGELOG.md.
+CHLOGGEN ?= $(CURDIR)/bin/chloggen
+CHLOGGEN_CONFIG := .chloggen/config.yaml
+
+.PHONY: $(CHLOGGEN)
+$(CHLOGGEN):
+	cd $(CURDIR)/tools/chloggen && go build -o $(CHLOGGEN) .
+
+.PHONY: chlog-new
+chlog-new: $(CHLOGGEN) ## Create a new changelog entry under .chloggen/
+	$(CHLOGGEN) new --config $(CHLOGGEN_CONFIG)
+
+.PHONY: chlog-validate
+chlog-validate: $(CHLOGGEN) ## Validate the pending changelog entries
+	$(CHLOGGEN) validate --config $(CHLOGGEN_CONFIG)
+
+.PHONY: chlog-preview
+chlog-preview: $(CHLOGGEN) ## Render the pending changelog entries to stdout
+	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --dry
+
+.PHONY: chlog-update
+chlog-update: $(CHLOGGEN) ## Collate pending entries into CHANGELOG.md (VERSION=vX.Y.Z)
+	$(CHLOGGEN) update --config $(CHLOGGEN_CONFIG) --version "$(VERSION)"
+
 # Import fragments
 include build/tools.mk

--- a/RELEASES.MD
+++ b/RELEASES.MD
@@ -1,7 +1,9 @@
 # Release Candidates
 
-- Create a branch named `changelog-<version>-<rc.#>`. Clean up the changelog, add the version heading
-  and merge to main. 
+- Create a branch named `changelog-<version>-<rc.#>`. Generate the changelog section from the
+  `.chloggen/` entries by running `make chlog-update VERSION=v<version>-<rc.#>` (this collates the
+  entries into `CHANGELOG.md` under the version heading and deletes the consumed files). Review the
+  result, then merge to main.
 - Push a semver tag to main on the merge commit above.  Something like:
   - `git tag -a v1.2.0-rc.0`
   - `git push origin v1.2.0-rc.0`
@@ -25,10 +27,10 @@ This document details release procedures for Tempo.
     - `git tag -a v1.2.0`
     - `git push origin v1.2.0`
   - Make sure that the "This is a pre-release" is unchecked when publishing the release.
-- Submit a PR cleaning up the changelog and moving everything under "main/unreleased" to be under
-  the newly minted version.
-  - Given that the changelog was already cleaned up for the RC above. This will likely be simply
-    renaming the release candidate to the full version.
+- Submit a PR updating the changelog for the full version. Because the RC above already ran
+  `make chlog-update` (consuming the `.chloggen/` entries), this is usually just renaming the
+  `# v<version>-<rc.#>` heading in `CHANGELOG.md` to the final `# v<version>`. If new entries landed
+  since the RC, run `make chlog-update VERSION=v<version>` instead to collate them.
 - In [github releases](https://github.com/grafana/tempo/releases) there should be a "Draft" release.
   Pretty up the changelog, add it to the release notes and hit "Publish release". Make sure that
   "Set as the latest release" is checked.
@@ -46,14 +48,17 @@ Patches release should be cut for serious bug fixes or security issues.
 - Commits should already have been backported to this branch using backport automation, but if 
   you need to add more you can cherry-pick them:
    `git cherry-pick <commit hash>`
+- Generate the patch version's changelog section on the release branch by running
+  `make chlog-update VERSION=v1.0.1` (this collates the backported `.chloggen/*.yaml` entries into
+  `CHANGELOG.md` under the new version heading and deletes the consumed files), then commit it.
 - Push the commit  
   `git push`
 - Create and push a tag to initiate the release. This will be pushed to the release branch.
   `git tag -a v1.0.1`  
   `git push origin v1.0.1`  
   This triggers the build.
-- Submit a PR to main cleaning up the changelog and moving those entries in the patch release under "main/unreleased" 
-  to be under the newly minted version.
+- Submit a PR to main adding the new patch version's section to `CHANGELOG.md` so the released notes
+  are reflected there too.
 - In [github releases](https://github.com/grafana/tempo/releases) there should be a "Draft" release.
   Pretty up the changelog, add it to the release notes and hit "Publish release". Make sure that
   "Set as the latest release" is checked.

--- a/tools/chloggen/FORK.md
+++ b/tools/chloggen/FORK.md
@@ -1,0 +1,13 @@
+# chloggen — attribution
+
+Tempo's in-tree tool for managing `CHANGELOG.md` from per-PR entry files. It is
+part of the `tools` module and is maintained directly in this repository.
+
+The code originates from the OpenTelemetry `chloggen` tool
+(https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/chloggen)
+and is **not** synced with upstream.
+
+- License: Apache-2.0 (see `LICENSE`). The OpenTelemetry copyright headers on
+  each `.go` file are retained as required by the license.
+- Modified for Tempo (import paths, formatting, and ongoing changes); details
+  are tracked in Tempo's git history.

--- a/tools/chloggen/LICENSE
+++ b/tools/chloggen/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tools/chloggen/README.md
+++ b/tools/chloggen/README.md
@@ -1,0 +1,17 @@
+# Changelog generator
+
+Tool that can be used to generate a CHANGELOG file from individual change
+files written in YAML.
+
+Usage:
+
+```sh
+    # generates a new change YAML file from a template
+    chloggen new -filename <filename>
+    # validates all change YAML files
+    chloggen validate
+    # provide a preview of the generated changelog file
+    chloggen update -dry
+    # updates the changelog file
+    chloggen update -version <version>
+```

--- a/tools/chloggen/cmd/cmd_test.go
+++ b/tools/chloggen/cmd/cmd_test.go
@@ -47,6 +47,7 @@ func enhancementEntry() *chlog.Entry {
 		Component:  "receiver/foo",
 		Note:       "Add some bar",
 		Issues:     []int{12345},
+		User:       "octocat",
 	}
 }
 
@@ -56,6 +57,7 @@ func bugFixEntry() *chlog.Entry {
 		Component:  "testbed",
 		Note:       "Fix blah",
 		Issues:     []int{12346, 12347},
+		User:       "octocat",
 	}
 }
 
@@ -65,6 +67,7 @@ func deprecationEntry() *chlog.Entry {
 		Component:  "exporter/old",
 		Note:       "Deprecate old",
 		Issues:     []int{12348},
+		User:       "octocat",
 	}
 }
 
@@ -74,6 +77,7 @@ func newComponentEntry() *chlog.Entry {
 		Component:  "exporter/new",
 		Note:       "Add new exporter ...",
 		Issues:     []int{12349},
+		User:       "octocat",
 	}
 }
 
@@ -83,6 +87,7 @@ func breakingEntry() *chlog.Entry {
 		Component:  "processor/oops",
 		Note:       "Change behavior when ...",
 		Issues:     []int{12350},
+		User:       "octocat",
 	}
 }
 
@@ -95,6 +100,7 @@ func entryWithSubtext() *chlog.Entry {
 		Note:       "Change behavior when ...",
 		Issues:     []int{12350},
 		SubText:    strings.Join(lines, "\n"),
+		User:       "octocat",
 	}
 }
 
@@ -109,6 +115,7 @@ func entryForChangelogs(changeType string, issue int, keys ...string) *chlog.Ent
 		Component:  "receiver/foo",
 		Note:       fmt.Sprintf("Some change relevant to [%s]", keyStr),
 		Issues:     []int{issue},
+		User:       "octocat",
 	}
 }
 

--- a/tools/chloggen/cmd/cmd_test.go
+++ b/tools/chloggen/cmd/cmd_test.go
@@ -1,0 +1,167 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+func getSampleEntries() []*chlog.Entry {
+	return []*chlog.Entry{
+		enhancementEntry(),
+		bugFixEntry(),
+		deprecationEntry(),
+		newComponentEntry(),
+		breakingEntry(),
+		entryWithSubtext(),
+	}
+}
+
+func enhancementEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.Enhancement,
+		Component:  "receiver/foo",
+		Note:       "Add some bar",
+		Issues:     []int{12345},
+	}
+}
+
+func bugFixEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "testbed",
+		Note:       "Fix blah",
+		Issues:     []int{12346, 12347},
+	}
+}
+
+func deprecationEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.Deprecation,
+		Component:  "exporter/old",
+		Note:       "Deprecate old",
+		Issues:     []int{12348},
+	}
+}
+
+func newComponentEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.NewComponent,
+		Component:  "exporter/new",
+		Note:       "Add new exporter ...",
+		Issues:     []int{12349},
+	}
+}
+
+func breakingEntry() *chlog.Entry {
+	return &chlog.Entry{
+		ChangeType: chlog.Breaking,
+		Component:  "processor/oops",
+		Note:       "Change behavior when ...",
+		Issues:     []int{12350},
+	}
+}
+
+func entryWithSubtext() *chlog.Entry {
+	lines := []string{"- foo\n  - bar\n- blah\n  - 1234567"}
+
+	return &chlog.Entry{
+		ChangeType: chlog.Breaking,
+		Component:  "processor/oops",
+		Note:       "Change behavior when ...",
+		Issues:     []int{12350},
+		SubText:    strings.Join(lines, "\n"),
+	}
+}
+
+func entryForChangelogs(changeType string, issue int, keys ...string) *chlog.Entry {
+	keyStr := "default"
+	if len(keys) > 0 {
+		keyStr = strings.Join(keys, ",")
+	}
+	return &chlog.Entry{
+		ChangeLogs: keys,
+		ChangeType: changeType,
+		Component:  "receiver/foo",
+		Note:       fmt.Sprintf("Some change relevant to [%s]", keyStr),
+		Issues:     []int{issue},
+	}
+}
+
+func setupTestDir(t *testing.T, entries []*chlog.Entry) {
+	require.NotNil(t, globalCfg, "test should instantiate globalCfg before calling setupTestDir")
+
+	// Create dummy changelogs which may be updated by the test
+	changelogBytes, err := readBytes(filepath.Join("testdata", config.DefaultChangeLogFilename))
+	require.NoError(t, err)
+	for _, filename := range globalCfg.ChangeLogs {
+		require.NoError(t, os.MkdirAll(filepath.Dir(filename), os.FileMode(0o755)))
+		require.NoError(t, os.WriteFile(filename, changelogBytes, os.FileMode(0o755)))
+	}
+
+	// Create the entries directory
+	require.NoError(t, os.MkdirAll(globalCfg.EntriesDir, os.FileMode(0o755)))
+
+	// Copy the entry template, for tests that ensure it is not deleted
+	templateInRootDir := config.New("testdata").TemplateYAML
+	templateBytes, err := readBytes(filepath.Clean(templateInRootDir))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(globalCfg.TemplateYAML, templateBytes, os.FileMode(0o755)))
+
+	// Write the entries to the entries directory
+	for i, entry := range entries {
+		entryBytes, err := yaml.Marshal(entry)
+		require.NoError(t, err)
+		path := filepath.Join(globalCfg.EntriesDir, fmt.Sprintf("%d.yaml", i))
+		require.NoError(t, os.WriteFile(path, entryBytes, os.FileMode(0o755)))
+	}
+}
+
+func runCobra(t *testing.T, args ...string) (string, error) {
+	cmd := rootCmd()
+
+	outBytes := bytes.NewBufferString("")
+	cmd.SetOut(outBytes)
+
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+
+	out, ioErr := io.ReadAll(outBytes)
+	require.NoError(t, ioErr, "read stdout")
+
+	return string(out), err
+}
+
+func readBytes(path string) ([]byte, error) {
+	file, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return io.ReadAll(file)
+}

--- a/tools/chloggen/cmd/new.go
+++ b/tools/chloggen/cmd/new.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var filename string
+
+func newCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "new",
+		Short: "Creates new change file",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			sanitizedName := filepath.Base(cleanFileName(filename))
+			if sanitizedName == "." || sanitizedName == ".." || sanitizedName == "" {
+				return fmt.Errorf("invalid filename %q", filename)
+			}
+
+			path := filepath.Join(globalCfg.EntriesDir, sanitizedName)
+			var pathWithExt string
+			switch ext := filepath.Ext(path); ext {
+			case ".yaml":
+				pathWithExt = path
+			case ".yml":
+				pathWithExt = strings.TrimSuffix(path, ".yml") + ".yaml"
+			default:
+				pathWithExt = path + ".yaml"
+			}
+
+			templateFile, err := os.Open(filepath.Clean(globalCfg.TemplateYAML))
+			if err != nil {
+				return err
+			}
+			defer templateFile.Close()
+
+			templateBytes, err := io.ReadAll(templateFile)
+			if err != nil {
+				return err
+			}
+			err = os.WriteFile(filepath.Clean(pathWithExt), templateBytes, os.FileMode(0o644))
+			if err != nil {
+				return err
+			}
+			cmd.Printf("Changelog entry template copied to: %s\n", pathWithExt)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&filename, "filename", "f", "", "name of the file to add")
+	if err := cmd.MarkFlagRequired("filename"); err != nil {
+		cmd.PrintErrf("could not mark filename flag as required: %v", err)
+		os.Exit(1)
+	}
+	return cmd
+}
+
+func cleanFileName(filename string) string {
+	replace := strings.NewReplacer("/", "_", "\\", "_")
+	return replace.Replace(filename)
+}

--- a/tools/chloggen/cmd/new_test.go
+++ b/tools/chloggen/cmd/new_test.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const newUsage = `Usage:
+  chloggen new [flags]
+
+Flags:
+  -f, --filename string   name of the file to add
+  -h, --help              help for new
+
+Global Flags:
+      --config string   (optional) chloggen config file`
+
+func TestNewErr(t *testing.T) {
+	var out string
+	var err error
+
+	out, err = runCobra(t, "new", "--help")
+	assert.Contains(t, out, newUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new")
+	assert.Contains(t, out, newUsage)
+	assert.ErrorContains(t, err, `required flag(s) "filename" not set`)
+
+	out, err = runCobra(t, "new", "--filename", "my-change")
+	assert.Contains(t, out, newUsage)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestNew(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+	setupTestDir(t, []*chlog.Entry{})
+
+	var out string
+	var err error
+
+	out, err = runCobra(t, "new", "--filename", "my-change")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "my-change.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "some-change.yaml")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "some-change.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "some-change.yml")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "some-change.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "replace/forward/slash")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "replace_forward_slash.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "not.an.extension")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "not.an.extension.yaml")))
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "new", "--filename", "my-change.txt")
+	assert.Contains(t, out, fmt.Sprintf("Changelog entry template copied to: %s", filepath.Join(globalCfg.EntriesDir, "my-change.txt.yaml")))
+	assert.Empty(t, err)
+}
+
+func TestCleanFilename(t *testing.T) {
+	assert.Equal(t, "fix_some_bug", cleanFileName("fix/some_bug"))
+	assert.Equal(t, "fix_some_bug", cleanFileName("fix\\some_bug"))
+}

--- a/tools/chloggen/cmd/root.go
+++ b/tools/chloggen/cmd/root.go
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd provides the command line interface for the chloggen tool.
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+var (
+	configFile string
+	globalCfg  *config.Config
+)
+
+func rootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "chloggen",
+		Short: "Updates CHANGELOG.MD to include all new changes",
+		Long:  `chloggen is a tool used to automate the generation of CHANGELOG files using individual yaml files as the source.`,
+	}
+	cmd.SetOut(os.Stdout)
+	cmd.PersistentFlags().StringVar(&configFile, "config", "", "(optional) chloggen config file")
+	cmd.AddCommand(newCmd())
+	cmd.AddCommand(updateCmd())
+	cmd.AddCommand(validateCmd())
+	return cmd
+}
+
+// Execute executes the root command.
+func Execute() {
+	cobra.CheckErr(rootCmd().Execute())
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+}
+
+func initConfig() {
+	// Don't override if already set in tests
+	if globalCfg != nil {
+		return
+	}
+
+	if configFile == "" {
+		globalCfg = config.New(repoRoot())
+	} else {
+		var err error
+		globalCfg, err = config.NewFromFile(repoRoot(), configFile)
+		if err != nil {
+			fmt.Printf("FAIL: Could not load config file: %s\n", err.Error())
+			os.Exit(1)
+		}
+	}
+}
+
+func repoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		// This is not expected, but just in case
+		fmt.Println("FAIL: Could not determine current working directory")
+	}
+	return dir
+}

--- a/tools/chloggen/cmd/root_test.go
+++ b/tools/chloggen/cmd/root_test.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const rootUsage = `chloggen is a tool used to automate the generation of CHANGELOG files using individual yaml files as the source.
+
+Usage:
+  chloggen [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  new         Creates new change file
+  update      Updates CHANGELOG.MD to include all new changes
+  validate    Validates the files in the changelog directory
+
+Flags:
+      --config string   (optional) chloggen config file
+  -h, --help            help for chloggen
+
+Use "chloggen [command] --help" for more information about a command.`
+
+func TestRoot(t *testing.T) {
+	var out string
+	var err error
+
+	out, err = runCobra(t)
+	assert.Contains(t, out, rootUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "--help")
+	assert.Contains(t, out, rootUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "--config", "foo.yaml")
+	assert.Contains(t, out, rootUsage)
+	assert.Empty(t, err)
+}
+
+func TestRepoRoot(t *testing.T) {
+	assert.DirExists(t, repoRoot())
+}

--- a/tools/chloggen/cmd/testdata/.chloggen/TEMPLATE.yaml
+++ b/tools/chloggen/cmd/testdata/.chloggen/TEMPLATE.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/tools/chloggen/cmd/testdata/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
@@ -15,19 +15,19 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 💡 Enhancements 💡
+
+- `receiver/a`: Some change (#1)
+- `receiver/aa`: Some other change for aa (#2)
+- `receiver/b`: Some other change (#3)
+- `receiver/bb`: One more bb change (#4)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_alphabetical/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/a`: Some change (#1)
-- `receiver/aa`: Some other change for aa (#2)
-- `receiver/b`: Some other change (#3)
-- `receiver/bb`: One more bb change (#4)
+- `receiver/a`: Some change (#1) (@octocat)
+- `receiver/aa`: Some other change for aa (#2) (@octocat)
+- `receiver/b`: Some other change (#3) (@octocat)
+- `receiver/bb`: One more bb change (#4) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348)
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345)
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/all_change_types_multiple/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
     - 1234567
-- `processor/oops`: Change behavior when ... (#12350)
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah
@@ -21,23 +21,23 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/breaking_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🧰 Bug fixes 🧰
+
+- `testbed`: Fix blah (#12346, #12347)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/bug_fix_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🧰 Bug fixes 🧰
 
-- `testbed`: Fix blah (#12346, #12347)
+- `testbed`: Fix blah (#12346, #12347) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🚩 Deprecations 🚩
+
+- `exporter/old`: Deprecate old (#12348)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/deprecation_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🚩 Deprecations 🚩
 
-- `exporter/old`: Deprecate old (#12348)
+- `exporter/old`: Deprecate old (#12348) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/dry_run/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/dry_run/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Add some bar (#12345)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/enhancement_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Add some bar (#12345)
+- `receiver/foo`: Add some bar (#12345) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change (#1)
+- `receiver/foo`: One more foo change (#4)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/filter_component/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change (#1)
-- `receiver/foo`: One more foo change (#4)
+- `receiver/foo`: Some change (#1) (@octocat)
+- `receiver/foo`: One more foo change (#4) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/filter_component_no_match/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/filter_component_no_match/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
@@ -1,0 +1,40 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [api] (#125)
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [api] (#223)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [api] (#555)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [api] (#111)
+- `receiver/foo`: Some change relevant to [api] (#777)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG-API.md
@@ -6,23 +6,23 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [user] (#123)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [user] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [user] (#32)
+- `receiver/foo`: Some change relevant to [user] (#222)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [user] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [user] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [user] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [user] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [user] (#32)
-- `receiver/foo`: Some change relevant to [user] (#222)
+- `receiver/foo`: Some change relevant to [user] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [user] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
@@ -1,0 +1,44 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [api] (#125)
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [default] (#123)
+- `receiver/foo`: Some change relevant to [api] (#223)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [default] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [api] (#555)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [default] (#32)
+- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [api] (#111)
+- `receiver/foo`: Some change relevant to [api] (#777)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG-API.md
@@ -6,27 +6,27 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [default] (#123)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [default] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [default] (#32)
+- `receiver/foo`: Some change relevant to [default] (#222)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_multiple_defaults/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
@@ -1,0 +1,40 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [api] (#125)
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [api] (#223)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [api] (#555)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [api] (#111)
+- `receiver/foo`: Some change relevant to [api] (#777)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG-API.md
@@ -6,23 +6,23 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [api] (#125)
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [api] (#125) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [api] (#223)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [api] (#223) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [api,user] (#333)
-- `receiver/foo`: Some change relevant to [api] (#555)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#555) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [api] (#111)
-- `receiver/foo`: Some change relevant to [api] (#777)
+- `receiver/foo`: Some change relevant to [api] (#111) (@octocat)
+- `receiver/foo`: Some change relevant to [api] (#777) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `receiver/foo`: Some change relevant to [user,api] (#11)
+
+### 🚩 Deprecations 🚩
+
+- `receiver/foo`: Some change relevant to [default] (#123)
+- `receiver/foo`: Some change relevant to [user,api] (#234)
+
+### 💡 Enhancements 💡
+
+- `receiver/foo`: Some change relevant to [default] (#21)
+- `receiver/foo`: Some change relevant to [api,user] (#333)
+
+### 🧰 Bug fixes 🧰
+
+- `receiver/foo`: Some change relevant to [default] (#32)
+- `receiver/foo`: Some change relevant to [default] (#222)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/multiple_changelogs_single_default/CHANGELOG.md
@@ -6,22 +6,22 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `receiver/foo`: Some change relevant to [user,api] (#11)
+- `receiver/foo`: Some change relevant to [user,api] (#11) (@octocat)
 
 ### 🚩 Deprecations 🚩
 
-- `receiver/foo`: Some change relevant to [default] (#123)
-- `receiver/foo`: Some change relevant to [user,api] (#234)
+- `receiver/foo`: Some change relevant to [default] (#123) (@octocat)
+- `receiver/foo`: Some change relevant to [user,api] (#234) (@octocat)
 
 ### 💡 Enhancements 💡
 
-- `receiver/foo`: Some change relevant to [default] (#21)
-- `receiver/foo`: Some change relevant to [api,user] (#333)
+- `receiver/foo`: Some change relevant to [default] (#21) (@octocat)
+- `receiver/foo`: Some change relevant to [api,user] (#333) (@octocat)
 
 ### 🧰 Bug fixes 🧰
 
-- `receiver/foo`: Some change relevant to [default] (#32)
-- `receiver/foo`: Some change relevant to [default] (#222)
+- `receiver/foo`: Some change relevant to [default] (#32) (@octocat)
+- `receiver/foo`: Some change relevant to [default] (#222) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🚀 New components 🚀
+
+- `exporter/new`: Add new exporter ... (#12349)
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/new_component_only/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🚀 New components 🚀
 
-- `exporter/new`: Add new exporter ... (#12349)
+- `exporter/new`: Add new exporter ... (#12349) (@octocat)
 
 ## v0.44.0
 

--- a/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+<!-- next version -->
+
+## v0.45.0
+
+### 🛑 Breaking changes 🛑
+
+- `processor/oops`: Change behavior when ... (#12350)
+  - foo
+    - bar
+  - blah
+    - 1234567
+
+## v0.44.0
+
+### 🛑 Breaking changes 🛑
+
+- `prometheusexporter`: Automatically rename metrics with units to follow Prometheus naming convention (#8950)
+
+### 💡 Enhancements 💡
+
+- `filterprocessor`: Ability to filter `Spans` (#6341)
+- `flinkmetricsreceiver`: add attribute values to metadata #11520
+
+### 🧰 Bug fixes 🧰
+
+- `redactionprocessor`: respect allow_all_keys configuration (#11542)

--- a/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
+++ b/tools/chloggen/cmd/testdata/subtext/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🛑 Breaking changes 🛑
 
-- `processor/oops`: Change behavior when ... (#12350)
+- `processor/oops`: Change behavior when ... (#12350) (@octocat)
   - foo
     - bar
   - blah

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -47,6 +47,13 @@ func updateCmd() *cobra.Command {
 				return err
 			}
 
+			// Validate before rendering/deleting so an invalid entry is never
+			// silently dropped from the summary and then lost when its source
+			// file is deleted.
+			if err = chlog.ValidateEntries(globalCfg, entriesByChangelog); err != nil {
+				return err
+			}
+
 			for changeLogKey, entries := range entriesByChangelog {
 
 				slices.SortFunc(entries, func(a, b *chlog.Entry) int {
@@ -68,7 +75,7 @@ func updateCmd() *cobra.Command {
 				}
 
 				if dry {
-					cmd.Printf("Generated changelog updates for %s:", changeLogKey)
+					cmd.Printf("Generated changelog updates for %s:\n", changeLogKey)
 					cmd.Println(chlogUpdate)
 					continue
 				}
@@ -92,7 +99,7 @@ func updateCmd() *cobra.Command {
 				chlogBuilder.WriteString(chlogHistory)
 
 				tmpMD := filename + ".tmp"
-				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o600); err != nil {
+				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o644); err != nil {
 					return err
 				}
 
@@ -101,7 +108,12 @@ func updateCmd() *cobra.Command {
 				}
 
 				cmd.Printf("Finished updating %s\n", filename)
+			}
 
+			// Delete the consumed entry files only once, after every changelog has
+			// been written successfully, and never in dry-run mode. This avoids
+			// losing the source YAMLs if a later changelog write fails.
+			if !dry {
 				if err = chlog.DeleteEntries(globalCfg); err != nil {
 					return err
 				}

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -1,0 +1,116 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+)
+
+const (
+	insertPoint = "<!-- next version -->\n"
+)
+
+var (
+	version         string
+	dry             bool
+	componentFilter string
+)
+
+func updateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Updates CHANGELOG.MD to include all new changes",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			entriesByChangelog, err := chlog.ReadEntries(globalCfg)
+			if err != nil {
+				return err
+			}
+
+			for changeLogKey, entries := range entriesByChangelog {
+
+				slices.SortFunc(entries, func(a, b *chlog.Entry) int {
+					return strings.Compare(a.Component, b.Component)
+				})
+
+				if componentFilter != "" {
+					filteredEntries := make([]*chlog.Entry, 0, len(entries))
+					for _, e := range entries {
+						if e.Component == componentFilter {
+							filteredEntries = append(filteredEntries, e)
+						}
+					}
+					entries = filteredEntries
+				}
+				chlogUpdate, err := chlog.GenerateSummary(version, entries, globalCfg)
+				if err != nil {
+					return err
+				}
+
+				if dry {
+					cmd.Printf("Generated changelog updates for %s:", changeLogKey)
+					cmd.Println(chlogUpdate)
+					continue
+				}
+
+				filename := globalCfg.ChangeLogs[changeLogKey]
+				oldChlogBytes, err := os.ReadFile(filepath.Clean(filename))
+				if err != nil {
+					return err
+				}
+				chlogParts := bytes.Split(oldChlogBytes, []byte(insertPoint))
+				if len(chlogParts) != 2 {
+					return fmt.Errorf("expected one instance of %s", insertPoint)
+				}
+
+				chlogHeader, chlogHistory := string(chlogParts[0]), string(chlogParts[1])
+
+				var chlogBuilder strings.Builder
+				chlogBuilder.WriteString(chlogHeader)
+				chlogBuilder.WriteString(insertPoint)
+				chlogBuilder.WriteString(chlogUpdate)
+				chlogBuilder.WriteString(chlogHistory)
+
+				tmpMD := filename + ".tmp"
+				if err = os.WriteFile(filepath.Clean(tmpMD), []byte(chlogBuilder.String()), 0o600); err != nil {
+					return err
+				}
+
+				if err = os.Rename(tmpMD, filename); err != nil {
+					return err
+				}
+
+				cmd.Printf("Finished updating %s\n", filename)
+
+				if err = chlog.DeleteEntries(globalCfg); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&version, "version", "v", "vTODO", "will be rendered directly into the update text")
+	cmd.Flags().BoolVarP(&dry, "dry", "d", false, "will generate the update text and print to stdout")
+	cmd.Flags().StringVarP(&componentFilter, "component", "c", "", "only select entries with this exact component")
+	return cmd
+}

--- a/tools/chloggen/cmd/update.go
+++ b/tools/chloggen/cmd/update.go
@@ -54,6 +54,31 @@ func updateCmd() *cobra.Command {
 				return err
 			}
 
+			// Backfill empty 'issues' from git here, not in validate, so the PR-CI
+			// validation of an unmerged entry doesn't depend on git history. Dedupe
+			// by pointer: one entry can appear under several changelogs, and a
+			// failed backfill would otherwise re-spawn git for it each time.
+			backfilled := make(map[*chlog.Entry]bool)
+			for _, entries := range entriesByChangelog {
+				for _, e := range entries {
+					if backfilled[e] {
+						continue
+					}
+					backfilled[e] = true
+					e.BackfillIssues()
+				}
+			}
+
+			// Never render an entry without a PR link: fail, listing all of them.
+			if missing := chlog.MissingIssues(entriesByChangelog); len(missing) > 0 {
+				noun := "entry"
+				if len(missing) > 1 {
+					noun = "entries"
+				}
+				return fmt.Errorf("could not determine a PR number for %d changelog %s; set 'issues' explicitly in:\n  %s",
+					len(missing), noun, strings.Join(missing, "\n  "))
+			}
+
 			for changeLogKey, entries := range entriesByChangelog {
 
 				slices.SortFunc(entries, func(a, b *chlog.Entry) int {

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -1,0 +1,346 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const updateUsage = `Usage:
+  chloggen update [flags]
+
+Flags:
+  -c, --component string   only select entries with this exact component
+  -d, --dry                will generate the update text and print to stdout
+  -h, --help               help for update
+  -v, --version string     will be rendered directly into the update text (default "vTODO")
+
+Global Flags:
+      --config string   (optional) chloggen config file`
+
+func TestUpdateErr(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+	setupTestDir(t, []*chlog.Entry{})
+
+	var out string
+	var err error
+
+	out, err = runCobra(t, "update", "--help")
+	assert.Contains(t, out, updateUsage)
+	assert.NoError(t, err)
+
+	badEntry, ioErr := os.CreateTemp(globalCfg.EntriesDir, "*.yaml")
+	require.NoError(t, ioErr)
+	defer badEntry.Close()
+
+	_, ioErr = badEntry.Write([]byte("bad yaml"))
+	require.NoError(t, ioErr)
+	out, err = runCobra(t, "update")
+	assert.Contains(t, out, updateUsage)
+	assert.ErrorContains(t, err, "yaml: unmarshal errors")
+}
+
+func TestUpdate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows line breaks cause comparison failures w/ golden files.")
+	}
+
+	tests := []struct {
+		name              string
+		entries           []*chlog.Entry
+		changeLogs        map[string]string
+		defaultChangeLogs []string
+		version           string
+		dry               bool
+		componentFilter   string
+	}{
+		{
+			name:    "all_change_types",
+			entries: getSampleEntries(),
+			version: "v0.45.0",
+		},
+		{
+			name:    "all_change_types_multiple",
+			entries: append(getSampleEntries(), getSampleEntries()...),
+			version: "v0.45.0",
+		},
+		{
+			name:    "dry_run",
+			entries: getSampleEntries(),
+			version: "v0.45.0",
+			dry:     true,
+		},
+		{
+			name:    "deprecation_only",
+			entries: []*chlog.Entry{deprecationEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "new_component_only",
+			entries: []*chlog.Entry{newComponentEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "bug_fix_only",
+			entries: []*chlog.Entry{bugFixEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "enhancement_only",
+			entries: []*chlog.Entry{enhancementEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "breaking_only",
+			entries: []*chlog.Entry{breakingEntry()},
+			version: "v0.45.0",
+		},
+		{
+			name:    "subtext",
+			entries: []*chlog.Entry{entryWithSubtext()},
+			version: "v0.45.0",
+		},
+		{
+			name: "multiple_changelogs",
+			entries: []*chlog.Entry{
+				entryForChangelogs(chlog.Deprecation, 123, "user"),
+				entryForChangelogs(chlog.Breaking, 125, "api"),
+				entryForChangelogs(chlog.Enhancement, 333, "api", "user"),
+				entryForChangelogs(chlog.BugFix, 222, "user"),
+				entryForChangelogs(chlog.Deprecation, 223, "api"),
+				entryForChangelogs(chlog.BugFix, 111, "api"),
+				entryForChangelogs(chlog.Breaking, 11, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 555, "api"),
+				entryForChangelogs(chlog.BugFix, 777, "api"),
+				entryForChangelogs(chlog.Deprecation, 234, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 21, "user"),
+				entryForChangelogs(chlog.BugFix, 32, "user"),
+			},
+			changeLogs: map[string]string{
+				"user": "CHANGELOG.md",
+				"api":  "CHANGELOG-API.md",
+			},
+			version: "v0.45.0",
+		},
+		{
+			name: "multiple_changelogs_single_default",
+			entries: []*chlog.Entry{
+				entryForChangelogs(chlog.Deprecation, 123),
+				entryForChangelogs(chlog.Breaking, 125, "api"),
+				entryForChangelogs(chlog.Enhancement, 333, "api", "user"),
+				entryForChangelogs(chlog.BugFix, 222),
+				entryForChangelogs(chlog.Deprecation, 223, "api"),
+				entryForChangelogs(chlog.BugFix, 111, "api"),
+				entryForChangelogs(chlog.Breaking, 11, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 555, "api"),
+				entryForChangelogs(chlog.BugFix, 777, "api"),
+				entryForChangelogs(chlog.Deprecation, 234, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 21),
+				entryForChangelogs(chlog.BugFix, 32),
+			},
+			changeLogs: map[string]string{
+				"user": "CHANGELOG.md",
+				"api":  "CHANGELOG-API.md",
+			},
+			defaultChangeLogs: []string{"user"},
+			version:           "v0.45.0",
+		},
+		{
+			name: "multiple_changelogs_multiple_defaults",
+			entries: []*chlog.Entry{
+				entryForChangelogs(chlog.Deprecation, 123),
+				entryForChangelogs(chlog.Breaking, 125, "api"),
+				entryForChangelogs(chlog.Enhancement, 333, "api", "user"),
+				entryForChangelogs(chlog.BugFix, 222),
+				entryForChangelogs(chlog.Deprecation, 223, "api"),
+				entryForChangelogs(chlog.BugFix, 111, "api"),
+				entryForChangelogs(chlog.Breaking, 11, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 555, "api"),
+				entryForChangelogs(chlog.BugFix, 777, "api"),
+				entryForChangelogs(chlog.Deprecation, 234, "user", "api"),
+				entryForChangelogs(chlog.Enhancement, 21),
+				entryForChangelogs(chlog.BugFix, 32),
+			},
+			changeLogs: map[string]string{
+				"user": "CHANGELOG.md",
+				"api":  "CHANGELOG-API.md",
+			},
+			defaultChangeLogs: []string{"user", "api"},
+			version:           "v0.45.0",
+		},
+		{
+			name:    "filter_component",
+			version: "v0.45.0",
+			entries: []*chlog.Entry{
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "Some change",
+					Issues:     []int{1},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/bar",
+					Note:       "Some other change",
+					Issues:     []int{2},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foobar",
+					Note:       "Some other change for foobar",
+					Issues:     []int{3},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "One more foo change",
+					Issues:     []int{4},
+				},
+			},
+			componentFilter: "receiver/foo",
+		},
+		{
+			name:    "filter_component_no_match",
+			version: "v0.45.0",
+			entries: []*chlog.Entry{
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "Some change",
+					Issues:     []int{1},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/bar",
+					Note:       "Some other change",
+					Issues:     []int{2},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foobar",
+					Note:       "Some other change for foobar",
+					Issues:     []int{3},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/foo",
+					Note:       "One more foo change",
+					Issues:     []int{4},
+				},
+			},
+			componentFilter: "receiver/foob",
+		},
+		{
+			name: "all_change_types_alphabetical",
+			entries: []*chlog.Entry{
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/a",
+					Note:       "Some change",
+					Issues:     []int{1},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/bb",
+					Note:       "One more bb change",
+					Issues:     []int{4},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/b",
+					Note:       "Some other change",
+					Issues:     []int{3},
+				},
+				{
+					ChangeType: "enhancement",
+					Component:  "receiver/aa",
+					Note:       "Some other change for aa",
+					Issues:     []int{2},
+				},
+			},
+			version: "v0.45.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			globalCfg = config.New(tempDir)
+			if len(tc.changeLogs) > 0 {
+				globalCfg.ChangeLogs = make(map[string]string)
+				for key, filename := range tc.changeLogs {
+					globalCfg.ChangeLogs[key] = filepath.Join(tempDir, filename)
+				}
+			}
+			if len(tc.defaultChangeLogs) > 0 {
+				globalCfg.DefaultChangeLogs = tc.defaultChangeLogs
+			}
+
+			setupTestDir(t, tc.entries)
+
+			args := []string{"update", "--version", tc.version}
+			if tc.dry {
+				args = append(args, "--dry")
+			}
+			if tc.componentFilter != "" {
+				args = append(args, "--component", tc.componentFilter)
+			}
+
+			var out string
+			var err error
+
+			out, err = runCobra(t, args...)
+
+			assert.Empty(t, err)
+			if tc.dry {
+				assert.Contains(t, out, "Generated changelog updates for")
+			} else {
+				for _, filename := range globalCfg.ChangeLogs {
+					assert.Contains(t, out, fmt.Sprintf("Finished updating %s", filename))
+				}
+			}
+
+			for _, filename := range globalCfg.ChangeLogs {
+				actualBytes, ioErr := os.ReadFile(filename) // nolint:gosec
+				require.NoError(t, ioErr)
+
+				expectedChangelogMD := filepath.Join("testdata", tc.name, filepath.Base(filename))
+				expectedBytes, ioErr := os.ReadFile(filepath.Clean(expectedChangelogMD))
+				require.NoError(t, ioErr)
+
+				require.Equal(t, string(expectedBytes), string(actualBytes))
+
+				remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+				require.NoError(t, ioErr)
+				if tc.dry {
+					require.Equal(t, 1+len(tc.entries), len(remainingYAMLs))
+				} else {
+					require.Equal(t, 1, len(remainingYAMLs))
+					require.Equal(t, globalCfg.TemplateYAML, remainingYAMLs[0])
+				}
+			}
+		})
+	}
+}

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -379,3 +379,63 @@ func TestUpdateValidatesBeforeWriting(t *testing.T) {
 	require.NoError(t, ioErr)
 	require.Equal(t, 2, len(remainingYAMLs))
 }
+
+func TestUpdateFailsWhenPRUnresolved(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// A valid entry that left 'issues' empty. The temp dir is not a git repo, so
+	// the PR can't be backfilled.
+	entry := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Fix something",
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{entry})
+
+	// Both --dry and a real update fail rather than emit an entry with no link.
+	_, err := runCobra(t, "update", "--dry")
+	require.ErrorContains(t, err, "could not determine a PR number")
+
+	_, err = runCobra(t, "update")
+	require.ErrorContains(t, err, "could not determine a PR number")
+
+	// The source entry file must not be deleted when the update fails.
+	remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+	require.NoError(t, ioErr)
+	require.Equal(t, 2, len(remainingYAMLs))
+}
+
+func TestUpdateListsAllUnresolvedPRs(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// Two unresolvable entries plus one with an explicit issue: both unresolved
+	// files must appear in a single error, not just the first.
+	resolvable := &chlog.Entry{
+		ChangeType: chlog.Enhancement,
+		Component:  "receiver/foo",
+		Note:       "Has a PR",
+		Issues:     []int{42},
+		User:       "octocat",
+	}
+	missingA := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Missing A",
+		User:       "octocat",
+	}
+	missingB := &chlog.Entry{
+		ChangeType: chlog.BugFix,
+		Component:  "receiver/foo",
+		Note:       "Missing B",
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{resolvable, missingA, missingB})
+
+	_, err := runCobra(t, "update")
+	require.ErrorContains(t, err, "could not determine a PR number for 2 changelog")
+	// setupTestDir writes entries as 0.yaml (resolvable), 1.yaml, 2.yaml.
+	assert.ErrorContains(t, err, "1.yaml")
+	assert.ErrorContains(t, err, "2.yaml")
+	assert.NotContains(t, err.Error(), "0.yaml")
+}

--- a/tools/chloggen/cmd/update_test.go
+++ b/tools/chloggen/cmd/update_test.go
@@ -199,24 +199,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/foo",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bar",
 					Note:       "Some other change",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foobar",
 					Note:       "Some other change for foobar",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foo",
 					Note:       "One more foo change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 			},
 			componentFilter: "receiver/foo",
@@ -230,24 +234,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/foo",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bar",
 					Note:       "Some other change",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foobar",
 					Note:       "Some other change for foobar",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/foo",
 					Note:       "One more foo change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 			},
 			componentFilter: "receiver/foob",
@@ -260,24 +268,28 @@ func TestUpdate(t *testing.T) {
 					Component:  "receiver/a",
 					Note:       "Some change",
 					Issues:     []int{1},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/bb",
 					Note:       "One more bb change",
 					Issues:     []int{4},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/b",
 					Note:       "Some other change",
 					Issues:     []int{3},
+					User:       "octocat",
 				},
 				{
 					ChangeType: "enhancement",
 					Component:  "receiver/aa",
 					Note:       "Some other change for aa",
 					Issues:     []int{2},
+					User:       "octocat",
 				},
 			},
 			version: "v0.45.0",
@@ -343,4 +355,27 @@ func TestUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateValidatesBeforeWriting(t *testing.T) {
+	globalCfg = config.New(t.TempDir())
+
+	// An entry with an invalid change_type must abort update before rendering
+	// or deleting, so the source entry file is not lost.
+	bad := &chlog.Entry{
+		ChangeType: "not_a_real_type",
+		Component:  "receiver/foo",
+		Note:       "Some change",
+		Issues:     []int{1},
+		User:       "octocat",
+	}
+	setupTestDir(t, []*chlog.Entry{bad})
+
+	_, err := runCobra(t, "update", "--version", "v1.0.0")
+	require.ErrorContains(t, err, "not_a_real_type")
+
+	// The source entry file (plus TEMPLATE.yaml) must still be present.
+	remainingYAMLs, ioErr := filepath.Glob(filepath.Join(globalCfg.EntriesDir, "*.yaml"))
+	require.NoError(t, ioErr)
+	require.Equal(t, 2, len(remainingYAMLs))
 }

--- a/tools/chloggen/cmd/validate.go
+++ b/tools/chloggen/cmd/validate.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -36,21 +35,8 @@ func validateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var errs error
-			for _, entries := range entriesByChangelog {
-				for _, entry := range entries {
-					changelogRequired := len(globalCfg.DefaultChangeLogs) == 0
-					validChangeLogs := []string{}
-					for changeLogKey := range globalCfg.ChangeLogs {
-						validChangeLogs = append(validChangeLogs, changeLogKey)
-					}
-					if err = entry.Validate(changelogRequired, globalCfg.Components, validChangeLogs...); err != nil {
-						errs = errors.Join(errs, err)
-					}
-				}
-			}
-			if errs != nil {
-				return errs
+			if err = chlog.ValidateEntries(globalCfg, entriesByChangelog); err != nil {
+				return err
 			}
 			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.EntriesDir)
 			return nil

--- a/tools/chloggen/cmd/validate.go
+++ b/tools/chloggen/cmd/validate.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+)
+
+func validateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validates the files in the changelog directory",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := os.Stat(globalCfg.EntriesDir); err != nil {
+				return err
+			}
+
+			entriesByChangelog, err := chlog.ReadEntries(globalCfg)
+			if err != nil {
+				return err
+			}
+			var errs error
+			for _, entries := range entriesByChangelog {
+				for _, entry := range entries {
+					changelogRequired := len(globalCfg.DefaultChangeLogs) == 0
+					validChangeLogs := []string{}
+					for changeLogKey := range globalCfg.ChangeLogs {
+						validChangeLogs = append(validChangeLogs, changeLogKey)
+					}
+					if err = entry.Validate(changelogRequired, globalCfg.Components, validChangeLogs...); err != nil {
+						errs = errors.Join(errs, err)
+					}
+				}
+			}
+			if errs != nil {
+				return errs
+			}
+			cmd.Printf("PASS: all files in %s/ are valid\n", globalCfg.EntriesDir)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/tools/chloggen/cmd/validate_test.go
+++ b/tools/chloggen/cmd/validate_test.go
@@ -1,0 +1,205 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/chlog"
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const validateUsage = `Usage:
+  chloggen validate [flags]
+
+Flags:
+  -h, --help   help for validate
+
+Global Flags:
+      --config string   (optional) chloggen config file`
+
+func TestValidateErr(t *testing.T) {
+	var out string
+	var err error
+
+	out, err = runCobra(t, "validate", "--help")
+	assert.Contains(t, out, validateUsage)
+	assert.Empty(t, err)
+
+	out, err = runCobra(t, "validate")
+	assert.Contains(t, out, validateUsage)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfgFn   func(*config.Config)
+		entries []*chlog.Entry
+		wantErr string
+	}{
+		{
+			name:    "all_valid",
+			entries: getSampleEntries(),
+		},
+		{
+			name: "invalid_change_type",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: "fake",
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "'fake' is not a valid 'change_type'",
+		},
+		{
+			name: "missing_component",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'component'",
+		},
+		{
+			name: "empty_component",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  " ",
+					Note:       "Add some bar",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'component'",
+		},
+		{
+			name: "missing_note",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "receiver/foo",
+					Note:       "",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'note'",
+		},
+		{
+			name: "empty_note",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "receiver/foo",
+					Note:       " ",
+					Issues:     []int{12345},
+				})
+			}(),
+			wantErr: "specify a 'note'",
+		},
+		{
+			name: "missing_issue",
+			entries: func() []*chlog.Entry {
+				return append(getSampleEntries(), &chlog.Entry{
+					ChangeType: chlog.BugFix,
+					Component:  "receiver/foo",
+					Note:       "Add some bar",
+					Issues:     []int{},
+				})
+			}(),
+			wantErr: "specify one or more issues #'s",
+		},
+		{
+			name: "all_invalid",
+			entries: func() []*chlog.Entry {
+				sampleEntries := getSampleEntries()
+				for _, e := range sampleEntries {
+					e.ChangeType = "fake"
+				}
+				return sampleEntries
+			}(),
+			wantErr: "'fake' is not a valid 'change_type'",
+		},
+		{
+			name: "gomodule_validation",
+			cfgFn: func(cfg *config.Config) {
+				cfg.Components = []string{"github.com/foo/bar/receiver", "github.com/foo/bar/exporter"}
+			},
+			entries: func() []*chlog.Entry {
+				sampleEntries := getSampleEntries()
+				for _, e := range sampleEntries {
+					e.Component = "foo"
+				}
+				return sampleEntries
+			}(),
+			wantErr: "foo is not a valid 'component'. It must be one of [github.com/foo/bar/receiver github.com/foo/bar/exporter]",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.New(t.TempDir())
+			if tc.cfgFn != nil {
+				tc.cfgFn(cfg)
+			}
+			globalCfg = cfg
+			setupTestDir(t, tc.entries)
+
+			out, err := runCobra(t, "validate")
+
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+			} else {
+				assert.Empty(t, err)
+				assert.Contains(t, out, fmt.Sprintf("PASS: all files in %s/ are valid", globalCfg.EntriesDir))
+			}
+		})
+	}
+}
+
+func TestValidateAccumulatesErrors(t *testing.T) {
+	entries := []*chlog.Entry{
+		{
+			ChangeType: "fake_type",
+			Component:  "component",
+			Note:       "note",
+			Issues:     []int{123},
+		},
+		{
+			ChangeType: "bug_fix",
+			Component:  "",
+			Note:       "note",
+			Issues:     []int{456},
+		},
+	}
+
+	cfg := config.New(t.TempDir())
+	globalCfg = cfg
+	setupTestDir(t, entries)
+
+	_, err := runCobra(t, "validate")
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "'fake_type' is not a valid 'change_type'")
+	assert.ErrorContains(t, err, "specify a 'component'")
+}

--- a/tools/chloggen/cmd/validate_test.go
+++ b/tools/chloggen/cmd/validate_test.go
@@ -119,16 +119,18 @@ func TestValidate(t *testing.T) {
 			wantErr: "specify a 'note'",
 		},
 		{
-			name: "missing_issue",
+			// 'issues' is optional; update backfills it from git history, so an
+			// entry without issues must pass validation.
+			name: "no_issues_is_valid",
 			entries: func() []*chlog.Entry {
 				return append(getSampleEntries(), &chlog.Entry{
 					ChangeType: chlog.BugFix,
 					Component:  "receiver/foo",
 					Note:       "Add some bar",
 					Issues:     []int{},
+					User:       "octocat",
 				})
 			}(),
-			wantErr: "specify one or more issues #'s",
 		},
 		{
 			name: "all_invalid",

--- a/tools/chloggen/internal/chlog/TEMPLATE.yaml
+++ b/tools/chloggen/internal/chlog/TEMPLATE.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. crosslink)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/tools/chloggen/internal/chlog/TEMPLATE.yaml
+++ b/tools/chloggen/internal/chlog/TEMPLATE.yaml
@@ -23,3 +23,7 @@ issues: []
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext:
+
+# The GitHub handle (without the leading @) of the change's author.
+# Rendered as a "(@handle)" suffix on the changelog entry.
+user:

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -17,11 +17,15 @@
 package chlog
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -51,6 +55,10 @@ type Entry struct {
 	Issues     []int    `yaml:"issues"`
 	SubText    string   `yaml:"subtext"`
 	User       string   `yaml:"user"`
+
+	// path is the source file (not part of the on-disk format); BackfillIssues
+	// uses it to recover the PR number from git.
+	path string
 }
 
 // DefaultChangeTypes lists the built-in change types in render order, along with
@@ -114,15 +122,61 @@ func (e Entry) Validate(requireChangelog bool, components []string, changeTypes 
 		errs = errors.Join(errs, fmt.Errorf("specify a 'note'"))
 	}
 
-	if len(e.Issues) == 0 {
-		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
-	}
+	// 'issues' is optional; 'update' backfills it from git (see BackfillIssues).
 
 	if strings.TrimSpace(e.User) == "" {
 		errs = errors.Join(errs, fmt.Errorf("specify a 'user'"))
 	}
 
 	return errs
+}
+
+// prSuffix captures the PR number from a squash-merge subject like "title (#1234)".
+var prSuffix = regexp.MustCompile(`\(#(\d+)\)\s*$`)
+
+// BackfillIssues fills Issues from the PR number in the commit that added the
+// entry file, when the author left 'issues' empty. Best-effort: on any failure
+// Issues stays empty and 'update' then fails via MissingIssues.
+func (e *Entry) BackfillIssues() {
+	if len(e.Issues) > 0 || e.path == "" {
+		return
+	}
+	if pr, ok := prFromGitHistory(e.path); ok {
+		e.Issues = []int{pr}
+	}
+}
+
+// MissingIssues returns the de-duplicated source paths of entries that still
+// have no 'issues' after backfill.
+func MissingIssues(entriesByChangelog map[string][]*Entry) []string {
+	seen := make(map[string]bool)
+	var paths []string
+	for _, entries := range entriesByChangelog {
+		for _, e := range entries {
+			if len(e.Issues) == 0 && !seen[e.path] {
+				seen[e.path] = true
+				paths = append(paths, e.path)
+			}
+		}
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+func prFromGitHistory(path string) (int, bool) {
+	// -C <dir> so resolution doesn't depend on the process working directory.
+	dir, base := filepath.Dir(path), filepath.Base(path)
+	// Only the commit that added the file; a later edit could carry a different PR.
+	out, err := exec.Command("git", "-C", dir, "log", "-1", "--diff-filter=A", "--format=%s", "--", base).Output()
+	if err != nil {
+		return 0, false
+	}
+	if m := prSuffix.FindSubmatch(bytes.TrimSpace(out)); m != nil {
+		if n, err := strconv.Atoi(string(m[1])); err == nil {
+			return n, true
+		}
+	}
+	return 0, false
 }
 
 // ValidateEntries validates every entry against the configuration, accumulating
@@ -173,6 +227,7 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 		if err = yaml.Unmarshal(fileBytes, entry); err != nil {
 			return nil, err
 		}
+		entry.path = file
 		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
 		// 'user' is documented as a handle without the leading '@'; normalize it
 		// away so a value like "@octocat" doesn't render as "(@@octocat)".

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -1,0 +1,180 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chlog provides internal functionality for the generation of
+// changelogs for OpenTelemetry Go projects.
+package chlog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+const (
+	// Breaking is a breaking change.
+	Breaking = "breaking"
+	// Deprecation is a deprecation change.
+	Deprecation = "deprecation"
+	// NewComponent is a new component change.
+	NewComponent = "new_component"
+	// Enhancement is an enhancement change.
+	Enhancement = "enhancement"
+	// BugFix is a bug fix change.
+	BugFix = "bug_fix"
+)
+
+// Entry represents a changelog entry.
+type Entry struct {
+	ChangeLogs []string `yaml:"change_logs"`
+	ChangeType string   `yaml:"change_type"`
+	Component  string   `yaml:"component"`
+	Note       string   `yaml:"note"`
+	Issues     []int    `yaml:"issues"`
+	SubText    string   `yaml:"subtext"`
+}
+
+var changeTypes = []string{
+	Breaking,
+	Deprecation,
+	NewComponent,
+	Enhancement,
+	BugFix,
+}
+
+// Validate validates the changelog entry.
+func (e Entry) Validate(requireChangelog bool, components []string, validChangeLogs ...string) error {
+	var errs error
+	if requireChangelog && len(e.ChangeLogs) == 0 {
+		errs = errors.Join(errs, fmt.Errorf("specify one or more 'change_logs'"))
+	}
+	for _, cl := range e.ChangeLogs {
+		var valid bool
+		for _, vcl := range validChangeLogs {
+			if cl == vcl {
+				valid = true
+			}
+		}
+		if !valid {
+			errs = errors.Join(errs, fmt.Errorf("'%s' is not a valid value in 'change_logs'. Specify one of %v", cl, validChangeLogs))
+		}
+	}
+
+	if !slices.Contains(changeTypes, e.ChangeType) {
+		errs = errors.Join(errs, fmt.Errorf("'%s' is not a valid 'change_type'. Specify one of %v", e.ChangeType, changeTypes))
+	}
+
+	if strings.TrimSpace(e.Component) == "" {
+		errs = errors.Join(errs, fmt.Errorf("specify a 'component'"))
+	}
+
+	found := slices.Contains(components, e.Component)
+	// only apply component validation if one or more values are present.
+	if len(components) > 0 && !found {
+		errs = errors.Join(errs, fmt.Errorf("%s is not a valid 'component'. It must be one of %v", e.Component, components))
+	}
+
+	if strings.TrimSpace(e.Note) == "" {
+		errs = errors.Join(errs, fmt.Errorf("specify a 'note'"))
+	}
+
+	if len(e.Issues) == 0 {
+		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
+	}
+
+	return errs
+}
+
+// ReadEntries reads changelog entries from YAML files based on the provided configuration.
+func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
+	yamlFiles, err := findYamlFiles(cfg.EntriesDir)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make(map[string][]*Entry)
+	for key := range cfg.ChangeLogs {
+		entries[key] = make([]*Entry, 0)
+	}
+
+	for _, file := range yamlFiles {
+		if file == cfg.TemplateYAML || file == cfg.ConfigYAML {
+			continue
+		}
+
+		fileBytes, err := os.ReadFile(filepath.Clean(file))
+		if err != nil {
+			return nil, err
+		}
+
+		entry := &Entry{}
+		if err = yaml.Unmarshal(fileBytes, entry); err != nil {
+			return nil, err
+		}
+		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
+
+		if len(entry.ChangeLogs) == 0 {
+			for _, cl := range cfg.DefaultChangeLogs {
+				entries[cl] = append(entries[cl], entry)
+			}
+		} else {
+			for _, cl := range entry.ChangeLogs {
+				entries[cl] = append(entries[cl], entry)
+			}
+		}
+	}
+	return entries, nil
+}
+
+// DeleteEntries deletes changelog entries from YAML files based on the provided configuration.
+func DeleteEntries(cfg *config.Config) error {
+	yamlFiles, err := findYamlFiles(cfg.EntriesDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range yamlFiles {
+		if file == cfg.TemplateYAML || file == cfg.ConfigYAML {
+			continue
+		}
+
+		if err := os.Remove(file); err != nil {
+			fmt.Printf("Failed to delete: %s\n", file)
+		}
+	}
+	return nil
+}
+
+// findYamlFiles finds all YAML files in the specified directory.
+// It includes files with both .yaml and .yml extensions.
+func findYamlFiles(dir string) ([]string, error) {
+	yamlFiles, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find YAML files in %s: %w", dir, err)
+	}
+
+	ymlFiles, err := filepath.Glob(filepath.Join(dir, "*.yml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find YML files in %s: %w", dir, err)
+	}
+
+	return slices.Concat(yamlFiles, ymlFiles), nil
+}

--- a/tools/chloggen/internal/chlog/entry.go
+++ b/tools/chloggen/internal/chlog/entry.go
@@ -50,18 +50,36 @@ type Entry struct {
 	Note       string   `yaml:"note"`
 	Issues     []int    `yaml:"issues"`
 	SubText    string   `yaml:"subtext"`
+	User       string   `yaml:"user"`
 }
 
-var changeTypes = []string{
-	Breaking,
-	Deprecation,
-	NewComponent,
-	Enhancement,
-	BugFix,
+// DefaultChangeTypes lists the built-in change types in render order, along with
+// the headings used to group them in the generated changelog. It is the value
+// used when a configuration does not specify its own 'change_types'.
+var DefaultChangeTypes = []config.ChangeType{
+	{Key: Breaking, Heading: "🛑 Breaking changes 🛑"},
+	{Key: Deprecation, Heading: "🚩 Deprecations 🚩"},
+	{Key: NewComponent, Heading: "🚀 New components 🚀"},
+	{Key: Enhancement, Heading: "💡 Enhancements 💡"},
+	{Key: BugFix, Heading: "🧰 Bug fixes 🧰"},
 }
 
-// Validate validates the changelog entry.
-func (e Entry) Validate(requireChangelog bool, components []string, validChangeLogs ...string) error {
+// changeTypeKeys returns the change type keys from the provided change types,
+// preserving order.
+func changeTypeKeys(changeTypes []config.ChangeType) []string {
+	keys := make([]string, 0, len(changeTypes))
+	for _, ct := range changeTypes {
+		keys = append(keys, ct.Key)
+	}
+	return keys
+}
+
+// Validate validates the changelog entry. The set of valid change types is
+// given by changeTypes; when empty, the built-in DefaultChangeTypes are used.
+func (e Entry) Validate(requireChangelog bool, components []string, changeTypes []string, validChangeLogs ...string) error {
+	if len(changeTypes) == 0 {
+		changeTypes = changeTypeKeys(DefaultChangeTypes)
+	}
 	var errs error
 	if requireChangelog && len(e.ChangeLogs) == 0 {
 		errs = errors.Join(errs, fmt.Errorf("specify one or more 'change_logs'"))
@@ -100,6 +118,32 @@ func (e Entry) Validate(requireChangelog bool, components []string, validChangeL
 		errs = errors.Join(errs, fmt.Errorf("specify one or more issues #'s"))
 	}
 
+	if strings.TrimSpace(e.User) == "" {
+		errs = errors.Join(errs, fmt.Errorf("specify a 'user'"))
+	}
+
+	return errs
+}
+
+// ValidateEntries validates every entry against the configuration, accumulating
+// all errors. Both the 'validate' and 'update' commands use this so they
+// enforce identical rules (and 'update' never drops or deletes invalid entries).
+func ValidateEntries(cfg *config.Config, entriesByChangelog map[string][]*Entry) error {
+	changelogRequired := len(cfg.DefaultChangeLogs) == 0
+	validChangeLogs := make([]string, 0, len(cfg.ChangeLogs))
+	for changeLogKey := range cfg.ChangeLogs {
+		validChangeLogs = append(validChangeLogs, changeLogKey)
+	}
+	validChangeTypes := changeTypeKeys(cfg.ChangeTypes)
+
+	var errs error
+	for _, entries := range entriesByChangelog {
+		for _, entry := range entries {
+			if err := entry.Validate(changelogRequired, cfg.Components, validChangeTypes, validChangeLogs...); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
 	return errs
 }
 
@@ -130,6 +174,9 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 			return nil, err
 		}
 		entry.SubText = strings.ReplaceAll(entry.SubText, "\r\n", "\n")
+		// 'user' is documented as a handle without the leading '@'; normalize it
+		// away so a value like "@octocat" doesn't render as "(@@octocat)".
+		entry.User = strings.TrimPrefix(strings.TrimSpace(entry.User), "@")
 
 		if len(entry.ChangeLogs) == 0 {
 			for _, cl := range cfg.DefaultChangeLogs {
@@ -137,6 +184,9 @@ func ReadEntries(cfg *config.Config) (map[string][]*Entry, error) {
 			}
 		} else {
 			for _, cl := range entry.ChangeLogs {
+				if _, ok := entries[cl]; !ok {
+					return nil, fmt.Errorf("%s: '%s' is not a valid value in 'change_logs'", file, cl)
+				}
 				entries[cl] = append(entries[cl], entry)
 			}
 		}
@@ -151,16 +201,17 @@ func DeleteEntries(cfg *config.Config) error {
 		return err
 	}
 
+	var errs error
 	for _, file := range yamlFiles {
 		if file == cfg.TemplateYAML || file == cfg.ConfigYAML {
 			continue
 		}
 
 		if err := os.Remove(file); err != nil {
-			fmt.Printf("Failed to delete: %s\n", file)
+			errs = errors.Join(errs, fmt.Errorf("failed to delete %s: %w", file, err))
 		}
 	}
-	return nil
+	return errs
 }
 
 // findYamlFiles finds all YAML files in the specified directory.

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -42,13 +42,14 @@ func TestEntry(t *testing.T) {
 		requireChangeLog bool
 		validChangeLogs  []string
 		components       []string
+		changeTypes      []string
 		expectErr        string
 		toString         string
 	}{
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s\nspecify a 'user'",
 		},
 		{
 			name: "missing_component",
@@ -57,6 +58,7 @@ func TestEntry(t *testing.T) {
 				Note:       "enhance!",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify a 'component'",
 		},
@@ -67,6 +69,7 @@ func TestEntry(t *testing.T) {
 				Component:  "bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify a 'note'",
 		},
@@ -77,6 +80,7 @@ func TestEntry(t *testing.T) {
 				Component:  "bar",
 				Note:       "fix bar",
 				SubText:    "",
+				User:       "octocat",
 			},
 			expectErr: "specify one or more issues #'s",
 		},
@@ -88,6 +92,7 @@ func TestEntry(t *testing.T) {
 				Note:       "fix bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			requireChangeLog: true,
 			validChangeLogs:  []string{"foo"},
@@ -102,6 +107,7 @@ func TestEntry(t *testing.T) {
 				Note:       "fix bar",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo"},
 			expectErr:       "'bar' is not a valid value in 'change_logs'. Specify one of [foo]",
@@ -114,8 +120,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)",
+			toString: "- `foo`: broke foo (#123) (@octocat)",
 		},
 		{
 			name: "multiple_issues",
@@ -125,8 +132,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123, 345},
 				SubText:    "",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123, #345)",
+			toString: "- `foo`: broke foo (#123, #345) (@octocat)",
 		},
 		{
 			name: "subtext",
@@ -136,8 +144,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)\n  more details",
+			toString: "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "multiline subtext",
@@ -147,8 +156,9 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details\nsecond line",
+				User:       "octocat",
 			},
-			toString: "- `foo`: broke foo (#123)\n  more details\n  second line",
+			toString: "- `foo`: broke foo (#123) (@octocat)\n  more details\n  second line",
 		},
 		{
 			name: "required_changelog",
@@ -159,10 +169,11 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			requireChangeLog: true,
 			validChangeLogs:  []string{"foo"},
-			toString:         "- `foo`: broke foo (#123)\n  more details",
+			toString:         "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "default_changelog",
@@ -173,10 +184,11 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			requireChangeLog: false,
 			validChangeLogs:  []string{"foo"},
-			toString:         "- `foo`: broke foo (#123)\n  more details",
+			toString:         "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "subset_of_changelogs",
@@ -187,9 +199,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar", "baz"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "all_changelogs",
@@ -200,9 +213,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "all_changelogs",
@@ -213,9 +227,10 @@ func TestEntry(t *testing.T) {
 				Note:       "broke foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: broke foo (#123)\n  more details",
+			toString:        "- `foo`: broke foo (#123) (@octocat)\n  more details",
 		},
 		{
 			name: "with_components",
@@ -226,17 +241,63 @@ func TestEntry(t *testing.T) {
 				Note:       "changed foo",
 				Issues:     []int{123},
 				SubText:    "more details",
+				User:       "octocat",
 			},
 			components:      []string{"bar"},
 			validChangeLogs: []string{"foo", "bar"},
-			toString:        "- `foo`: changed foo (#123)\n  more details",
+			toString:        "- `foo`: changed foo (#123) (@octocat)\n  more details",
 			expectErr:       "foo is not a valid 'component'. It must be one of [bar]",
+		},
+		{
+			name: "custom_change_type_valid",
+			entry: Entry{
+				ChangeType: "security",
+				Component:  "foo",
+				Note:       "fix vuln",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			changeTypes: []string{"security"},
+			toString:    "- `foo`: fix vuln (#123) (@octocat)",
+		},
+		{
+			name: "custom_change_types_reject_builtin",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			changeTypes: []string{"security"},
+			expectErr:   "'breaking' is not a valid 'change_type'. Specify one of [security]",
+		},
+		{
+			name: "user_rendered_as_handle",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				User:       "octocat",
+			},
+			toString: "- `foo`: broke foo (#123) (@octocat)",
+		},
+		{
+			name: "missing_user",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				Issues:     []int{123},
+			},
+			expectErr: "specify a 'user'",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.validChangeLogs...)
+			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.changeTypes, tc.validChangeLogs...)
 			if tc.expectErr != "" {
 				assert.Error(t, err)
 				assert.Equal(t, tc.expectErr, err.Error())
@@ -335,6 +396,59 @@ func TestReadDeleteEntries(t *testing.T) {
 	// Ensure these weren't deleted
 	assert.FileExists(t, cfg.ConfigYAML)
 	assert.FileExists(t, cfg.TemplateYAML)
+}
+
+func TestReadEntriesNormalizesUserHandle(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	// A user written with a leading '@' must be normalized so it doesn't render
+	// as "(@@handle)".
+	entry := Entry{
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+		User:       "@octocat",
+	}
+	writeEntry(t, entriesDir, &entry, "yaml")
+
+	cfg := &config.Config{
+		ChangeLogs:        map[string]string{"default": filepath.Join(entriesDir, "CHANGELOG.md")},
+		DefaultChangeLogs: []string{"default"},
+		EntriesDir:        entriesDir,
+	}
+
+	entries, err := ReadEntries(cfg)
+	require.NoError(t, err)
+	require.Len(t, entries["default"], 1)
+	assert.Equal(t, "octocat", entries["default"][0].User)
+}
+
+func TestReadEntriesRejectsUnknownChangelog(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	entry := Entry{
+		ChangeLogs: []string{"nonexistent"},
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+		User:       "octocat",
+	}
+	writeEntry(t, entriesDir, &entry, "yaml")
+
+	cfg := &config.Config{
+		ChangeLogs:        map[string]string{"foo": filepath.Join(entriesDir, "CHANGELOG.foo.md")},
+		DefaultChangeLogs: []string{"foo"},
+		EntriesDir:        entriesDir,
+	}
+
+	_, err := ReadEntries(cfg)
+	require.ErrorContains(t, err, "'nonexistent' is not a valid value in 'change_logs'")
 }
 
 func TestFindYamlFilesEmptyDir(t *testing.T) {

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -1,0 +1,403 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chlog
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+func TestEntry(t *testing.T) {
+	tmpl := template.Must(
+		template.
+			New("summary.tmpl").
+			Funcs(TemplateFuncMap()).
+			Option("missingkey=error").
+			Parse(string(defaultTmpl)))
+
+	testCases := []struct {
+		name             string
+		entry            Entry
+		requireChangeLog bool
+		validChangeLogs  []string
+		components       []string
+		expectErr        string
+		toString         string
+	}{
+		{
+			name:      "empty",
+			entry:     Entry{},
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s",
+		},
+		{
+			name: "missing_component",
+			entry: Entry{
+				ChangeType: "enhancement",
+				Note:       "enhance!",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			expectErr: "specify a 'component'",
+		},
+		{
+			name: "missing_note",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			expectErr: "specify a 'note'",
+		},
+		{
+			name: "missing_issue",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				SubText:    "",
+			},
+			expectErr: "specify one or more issues #'s",
+		},
+		{
+			name: "missing_required_changelog",
+			entry: Entry{
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			requireChangeLog: true,
+			validChangeLogs:  []string{"foo"},
+			expectErr:        "specify one or more 'change_logs'",
+		},
+		{
+			name: "invalid_changelog",
+			entry: Entry{
+				ChangeLogs: []string{"bar"},
+				ChangeType: "bug_fix",
+				Component:  "bar",
+				Note:       "fix bar",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			validChangeLogs: []string{"foo"},
+			expectErr:       "'bar' is not a valid value in 'change_logs'. Specify one of [foo]",
+		},
+		{
+			name: "valid",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "",
+			},
+			toString: "- `foo`: broke foo (#123)",
+		},
+		{
+			name: "multiple_issues",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123, 345},
+				SubText:    "",
+			},
+			toString: "- `foo`: broke foo (#123, #345)",
+		},
+		{
+			name: "subtext",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			toString: "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "multiline subtext",
+			entry: Entry{
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details\nsecond line",
+			},
+			toString: "- `foo`: broke foo (#123)\n  more details\n  second line",
+		},
+		{
+			name: "required_changelog",
+			entry: Entry{
+				ChangeLogs: []string{"foo"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			requireChangeLog: true,
+			validChangeLogs:  []string{"foo"},
+			toString:         "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "default_changelog",
+			entry: Entry{
+				ChangeLogs: []string{"foo"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			requireChangeLog: false,
+			validChangeLogs:  []string{"foo"},
+			toString:         "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "subset_of_changelogs",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			validChangeLogs: []string{"foo", "bar", "baz"},
+			toString:        "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "all_changelogs",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			validChangeLogs: []string{"foo", "bar"},
+			toString:        "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "all_changelogs",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "breaking",
+				Component:  "foo",
+				Note:       "broke foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			validChangeLogs: []string{"foo", "bar"},
+			toString:        "- `foo`: broke foo (#123)\n  more details",
+		},
+		{
+			name: "with_components",
+			entry: Entry{
+				ChangeLogs: []string{"foo", "bar"},
+				ChangeType: "enhancement",
+				Component:  "foo",
+				Note:       "changed foo",
+				Issues:     []int{123},
+				SubText:    "more details",
+			},
+			components:      []string{"bar"},
+			validChangeLogs: []string{"foo", "bar"},
+			toString:        "- `foo`: changed foo (#123)\n  more details",
+			expectErr:       "foo is not a valid 'component'. It must be one of [bar]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.entry.Validate(tc.requireChangeLog, tc.components, tc.validChangeLogs...)
+			if tc.expectErr != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectErr, err.Error())
+				return
+			}
+			assert.NoError(t, err)
+
+			buf := bytes.Buffer{}
+			err = tmpl.ExecuteTemplate(&buf, "entry", tc.entry)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.toString, buf.String())
+		})
+	}
+}
+
+func TestReadDeleteEntries(t *testing.T) {
+	tempDir := t.TempDir()
+	entriesDir := filepath.Join(tempDir, config.DefaultEntriesDir)
+	require.NoError(t, os.Mkdir(entriesDir, 0o750))
+
+	entryA := Entry{
+		ChangeLogs: []string{"foo"},
+		ChangeType: "breaking",
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+	}
+	writeEntry(t, entriesDir, &entryA, "yaml")
+
+	entryB := Entry{
+		ChangeLogs: []string{"bar"},
+		ChangeType: "bug_fix",
+		Component:  "bar",
+		Note:       "fix bar",
+		Issues:     []int{345, 678},
+		SubText:    "more details",
+	}
+	writeEntry(t, entriesDir, &entryB, "yml")
+
+	entryC := Entry{
+		ChangeLogs: []string{},
+		ChangeType: "enhancement",
+		Component:  "other",
+		Note:       "enhance!",
+		Issues:     []int{555},
+	}
+	writeEntry(t, entriesDir, &entryC, "yaml")
+
+	entryD := Entry{
+		ChangeLogs: []string{"foo", "bar"},
+		ChangeType: "deprecation",
+		Component:  "foobar",
+		Note:       "deprecate something",
+		Issues:     []int{999},
+	}
+	writeEntry(t, entriesDir, &entryD, "yml")
+
+	// Put config and template files in entries_dir to ensure they are ignored when reading/deleting entries
+	configYAML, err := os.Create(filepath.Join(entriesDir, "config.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer configYAML.Close()
+
+	templateYAML, err := os.Create(filepath.Join(entriesDir, "TEMPLATE.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer templateYAML.Close()
+
+	cfg := &config.Config{
+		ConfigYAML:   configYAML.Name(),
+		TemplateYAML: templateYAML.Name(),
+		ChangeLogs: map[string]string{
+			"foo": filepath.Join(entriesDir, "CHANGELOG.foo.md"),
+			"bar": filepath.Join(entriesDir, "CHANGELOG.bar.md"),
+		},
+		DefaultChangeLogs: []string{"foo"},
+		EntriesDir:        entriesDir,
+	}
+
+	changeLogEntries, err := ReadEntries(cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(changeLogEntries))
+
+	assert.Contains(t, changeLogEntries, "foo")
+	assert.Contains(t, changeLogEntries, "bar")
+
+	assert.ElementsMatch(t, []*Entry{&entryA, &entryC, &entryD}, changeLogEntries["foo"])
+	assert.ElementsMatch(t, []*Entry{&entryB, &entryD}, changeLogEntries["bar"])
+
+	assert.NoError(t, DeleteEntries(cfg))
+	changeLogEntries, err = ReadEntries(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(changeLogEntries))
+	assert.Empty(t, changeLogEntries["foo"])
+	assert.Empty(t, changeLogEntries["bar"])
+
+	// Ensure these weren't deleted
+	assert.FileExists(t, cfg.ConfigYAML)
+	assert.FileExists(t, cfg.TemplateYAML)
+}
+
+func TestFindYamlFilesEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	files, err := findYamlFiles(dir)
+	require.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestFindYamlFilesBothExtensions(t *testing.T) {
+	dir := t.TempDir()
+
+	yamlFile, err := os.Create(filepath.Join(dir, "one.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer yamlFile.Close()
+
+	ymlFile, err := os.Create(filepath.Join(dir, "two.yml")) //nolint:gosec
+	require.NoError(t, err)
+	defer ymlFile.Close()
+
+	// Non-YAML file should be ignored
+	txtFile, err := os.Create(filepath.Join(dir, "ignore.txt")) //nolint:gosec
+	require.NoError(t, err)
+	defer txtFile.Close()
+
+	files, err := findYamlFiles(dir)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{yamlFile.Name(), ymlFile.Name()}, files)
+}
+
+func TestFindYamlFilesNonRecursive(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a YAML file in the root dir
+	rootYAML, err := os.Create(filepath.Join(dir, "root.yaml")) //nolint:gosec
+	require.NoError(t, err)
+	defer rootYAML.Close()
+
+	// Create a subdirectory with a YAML file inside it
+	subdir := filepath.Join(dir, "nested")
+	require.NoError(t, os.Mkdir(subdir, 0o750))
+
+	nestedYML, err := os.Create(filepath.Join(subdir, "nested.yml")) //nolint:gosec
+	require.NoError(t, err)
+	defer nestedYML.Close()
+
+	files, err := findYamlFiles(dir)
+	require.NoError(t, err)
+	// Should only include files directly under dir, not nested ones
+	assert.ElementsMatch(t, []string{rootYAML.Name()}, files)
+}
+
+func writeEntry(t *testing.T, dir string, entry *Entry, ext string) {
+	require.Contains(t, []string{"yaml", "yml"}, ext, "ext must be 'yaml' or 'yml'")
+
+	entryBytes, err := yaml.Marshal(entry)
+	require.NoError(t, err)
+
+	entryFile, err := os.CreateTemp(dir, "*."+ext)
+	require.NoError(t, err)
+	defer entryFile.Close()
+
+	_, err = entryFile.Write(entryBytes)
+	require.NoError(t, err)
+}

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -17,6 +17,7 @@ package chlog
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -49,7 +50,7 @@ func TestEntry(t *testing.T) {
 		{
 			name:      "empty",
 			entry:     Entry{},
-			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify one or more issues #'s\nspecify a 'user'",
+			expectErr: "'' is not a valid 'change_type'. Specify one of [breaking deprecation new_component enhancement bug_fix]\nspecify a 'component'\nspecify a 'note'\nspecify a 'user'",
 		},
 		{
 			name: "missing_component",
@@ -74,7 +75,10 @@ func TestEntry(t *testing.T) {
 			expectErr: "specify a 'note'",
 		},
 		{
-			name: "missing_issue",
+			// 'issues' is optional and validates when empty; update fails before
+			// rendering such an entry, so the bare "()" here is never reached in
+			// practice.
+			name: "no_issues",
 			entry: Entry{
 				ChangeType: "bug_fix",
 				Component:  "bar",
@@ -82,7 +86,7 @@ func TestEntry(t *testing.T) {
 				SubText:    "",
 				User:       "octocat",
 			},
-			expectErr: "specify one or more issues #'s",
+			toString: "- `bar`: fix bar () (@octocat)",
 		},
 		{
 			name: "missing_required_changelog",
@@ -451,6 +455,71 @@ func TestReadEntriesRejectsUnknownChangelog(t *testing.T) {
 	require.ErrorContains(t, err, "'nonexistent' is not a valid value in 'change_logs'")
 }
 
+func TestBackfillIssues(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+	runGit("init")
+	runGit("config", "user.email", "test@example.com")
+	runGit("config", "user.name", "Test")
+
+	// Simulate Tempo's squash-merge: the commit that adds the entry file carries
+	// the PR number in its subject.
+	path := filepath.Join(dir, "my-change.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("note: x\n"), 0o600))
+	runGit("add", "my-change.yaml")
+	runGit("commit", "-m", "Add a thing (#4242)")
+
+	t.Run("backfills PR from git when empty", func(t *testing.T) {
+		e := &Entry{path: path}
+		e.BackfillIssues()
+		assert.Equal(t, []int{4242}, e.Issues)
+	})
+
+	t.Run("keeps issues set by the author", func(t *testing.T) {
+		e := &Entry{path: path, Issues: []int{1}}
+		e.BackfillIssues()
+		assert.Equal(t, []int{1}, e.Issues)
+	})
+
+	t.Run("no-op when the file has no git history", func(t *testing.T) {
+		e := &Entry{path: filepath.Join(t.TempDir(), "untracked.yaml")}
+		e.BackfillIssues()
+		assert.Empty(t, e.Issues)
+	})
+
+	t.Run("uses the adding commit, not a later edit", func(t *testing.T) {
+		p := filepath.Join(dir, "edited.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("note: a\n"), 0o600))
+		runGit("add", "edited.yaml")
+		runGit("commit", "-m", "Add edited (#100)")
+		require.NoError(t, os.WriteFile(p, []byte("note: b\n"), 0o600))
+		runGit("commit", "-am", "Tweak edited (#200)")
+
+		e := &Entry{path: p}
+		e.BackfillIssues()
+		assert.Equal(t, []int{100}, e.Issues)
+	})
+
+	t.Run("not found when the adding commit has no PR", func(t *testing.T) {
+		p := filepath.Join(dir, "nopr.yaml")
+		require.NoError(t, os.WriteFile(p, []byte("note: c\n"), 0o600))
+		runGit("add", "nopr.yaml")
+		runGit("commit", "-m", "local wip, no pr number")
+
+		e := &Entry{path: p}
+		e.BackfillIssues()
+		assert.Empty(t, e.Issues)
+	})
+}
+
 func TestFindYamlFilesEmptyDir(t *testing.T) {
 	dir := t.TempDir()
 
@@ -514,4 +583,8 @@ func writeEntry(t *testing.T, dir string, entry *Entry, ext string) {
 
 	_, err = entryFile.Write(entryBytes)
 	require.NoError(t, err)
+
+	// Record the source path so it matches what ReadEntries sets on the entries
+	// it returns (used by struct-equality assertions and BackfillIssues).
+	entry.path = entryFile.Name()
 }

--- a/tools/chloggen/internal/chlog/summary.go
+++ b/tools/chloggen/internal/chlog/summary.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chlog
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+//go:embed summary.tmpl
+var defaultTmpl []byte
+
+type summary struct {
+	Version         string
+	BreakingChanges []*Entry
+	Deprecations    []*Entry
+	NewComponents   []*Entry
+	Enhancements    []*Entry
+	BugFixes        []*Entry
+}
+
+// GenerateSummary generates a changelog entry summary.
+func GenerateSummary(version string, entries []*Entry, cfg *config.Config) (string, error) {
+	s := summary{
+		Version: version,
+	}
+
+	for _, entry := range entries {
+		switch entry.ChangeType {
+		case Breaking:
+			s.BreakingChanges = append(s.BreakingChanges, entry)
+		case Deprecation:
+			s.Deprecations = append(s.Deprecations, entry)
+		case NewComponent:
+			s.NewComponents = append(s.NewComponents, entry)
+		case Enhancement:
+			s.Enhancements = append(s.Enhancements, entry)
+		case BugFix:
+			s.BugFixes = append(s.BugFixes, entry)
+		}
+	}
+
+	return s.String(cfg.SummaryTemplate)
+}
+
+// TemplateFuncMap returns a map of functions to be used in the template.
+func TemplateFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"indent": func(n int, s string) string {
+			indent := strings.Repeat(" ", n)
+			return indent + strings.ReplaceAll(s, "\n", "\n"+indent)
+		},
+	}
+}
+
+// String renders the summary using the provided template.
+func (s summary) String(summaryTemplate string) (string, error) {
+	var tmpl *template.Template
+	var err error
+
+	if summaryTemplate != "" {
+		tmpl, err = template.
+			New(filepath.Base(summaryTemplate)).
+			Funcs(TemplateFuncMap()).
+			Option("missingkey=error").
+			ParseFiles(summaryTemplate)
+	} else {
+		tmpl, err = template.
+			New("summary.tmpl").
+			Funcs(TemplateFuncMap()).
+			Option("missingkey=error").
+			Parse(string(defaultTmpl))
+	}
+	if err != nil {
+		return "", err
+	}
+
+	buf := bytes.Buffer{}
+	if err := tmpl.Execute(&buf, s); err != nil {
+		return "", fmt.Errorf("failed executing template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/tools/chloggen/internal/chlog/summary.go
+++ b/tools/chloggen/internal/chlog/summary.go
@@ -28,8 +28,23 @@ import (
 //go:embed summary.tmpl
 var defaultTmpl []byte
 
+// group is one rendered section of the changelog: a heading and the entries
+// that belong to a single change type.
+type group struct {
+	Heading string
+	Entries []*Entry
+}
+
 type summary struct {
-	Version         string
+	Version string
+
+	// Groups holds every configured change type in configured order. This is
+	// the data model the bundled template ranges over and the only path that
+	// surfaces custom change types.
+	Groups []group
+
+	// The following fields mirror the built-in change types and are retained so
+	// that custom summary templates referencing them by name keep working.
 	BreakingChanges []*Entry
 	Deprecations    []*Entry
 	NewComponents   []*Entry
@@ -37,24 +52,40 @@ type summary struct {
 	BugFixes        []*Entry
 }
 
-// GenerateSummary generates a changelog entry summary.
+// GenerateSummary generates a changelog entry summary. Entries are grouped and
+// ordered according to cfg.ChangeTypes; when none are configured, the built-in
+// DefaultChangeTypes are used.
 func GenerateSummary(version string, entries []*Entry, cfg *config.Config) (string, error) {
 	s := summary{
 		Version: version,
 	}
 
-	for _, entry := range entries {
-		switch entry.ChangeType {
+	changeTypes := cfg.ChangeTypes
+	if len(changeTypes) == 0 {
+		changeTypes = DefaultChangeTypes
+	}
+
+	for _, ct := range changeTypes {
+		var grouped []*Entry
+		for _, entry := range entries {
+			if entry.ChangeType == ct.Key {
+				grouped = append(grouped, entry)
+			}
+		}
+		s.Groups = append(s.Groups, group{Heading: ct.Heading, Entries: grouped})
+
+		// Mirror built-in change types onto the named fields for backward compatibility.
+		switch ct.Key {
 		case Breaking:
-			s.BreakingChanges = append(s.BreakingChanges, entry)
+			s.BreakingChanges = grouped
 		case Deprecation:
-			s.Deprecations = append(s.Deprecations, entry)
+			s.Deprecations = grouped
 		case NewComponent:
-			s.NewComponents = append(s.NewComponents, entry)
+			s.NewComponents = grouped
 		case Enhancement:
-			s.Enhancements = append(s.Enhancements, entry)
+			s.Enhancements = grouped
 		case BugFix:
-			s.BugFixes = append(s.BugFixes, entry)
+			s.BugFixes = grouped
 		}
 	}
 

--- a/tools/chloggen/internal/chlog/summary.tmpl
+++ b/tools/chloggen/internal/chlog/summary.tmpl
@@ -1,0 +1,68 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+#{{ $issue }}
+{{- end -}}
+)
+
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### 🛑 Breaking changes 🛑
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### 🚩 Deprecations 🚩
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### 🚀 New components 🚀
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### 💡 Enhancements 💡
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### 🧰 Bug fixes 🧰
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}

--- a/tools/chloggen/internal/chlog/summary.tmpl
+++ b/tools/chloggen/internal/chlog/summary.tmpl
@@ -5,64 +5,21 @@
 #{{ $issue }}
 {{- end -}}
 )
-
+{{- if .User }} (@{{ .User }}){{- end }}
 {{- if .SubText }}
 {{ .SubText | indent 2 }}
 {{- end }}
 {{- end }}
 ## {{ .Version }}
+{{- range .Groups }}
+{{- if .Entries }}
 
-{{- if .BreakingChanges }}
+### {{ .Heading }}
 
-### 🛑 Breaking changes 🛑
-
-{{- range $i, $change := .BreakingChanges }}
+{{- range $i, $change := .Entries }}
 {{- if eq $i 0}}
 {{end}}
 {{ template "entry" $change }}
 {{- end }}
-{{- end }}
-
-{{- if .Deprecations }}
-
-### 🚩 Deprecations 🚩
-
-{{- range $i, $change := .Deprecations }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .NewComponents }}
-
-### 🚀 New components 🚀
-
-{{- range $i, $change := .NewComponents }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .Enhancements }}
-
-### 💡 Enhancements 💡
-
-{{- range $i, $change := .Enhancements }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
-{{- end }}
-{{- end }}
-
-{{- if .BugFixes }}
-
-### 🧰 Bug fixes 🧰
-
-{{- range $i, $change := .BugFixes }}
-{{- if eq $i 0}}
-{{end}}
-{{ template "entry" $change }}
 {{- end }}
 {{- end }}

--- a/tools/chloggen/internal/chlog/summary_test.go
+++ b/tools/chloggen/internal/chlog/summary_test.go
@@ -17,6 +17,7 @@ package chlog
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,6 +101,41 @@ func TestSummary(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, string(expected), actual)
+}
+
+func TestConfiguredChangeTypes(t *testing.T) {
+	sec := Entry{
+		ChangeType: "security",
+		Component:  "foo",
+		Note:       "fix vuln",
+		Issues:     []int{1},
+	}
+	enh := Entry{
+		ChangeType: Enhancement,
+		Component:  "bar",
+		Note:       "improve bar",
+		Issues:     []int{2},
+	}
+
+	cfg := &config.Config{
+		ChangeTypes: []config.ChangeType{
+			{Key: "security", Heading: "Security"},
+			{Key: Enhancement, Heading: "Enhancements"},
+		},
+	}
+
+	// enh is passed before sec, but the configured order must drive the output.
+	actual, err := GenerateSummary("1.0", []*Entry{&enh, &sec}, cfg)
+	require.NoError(t, err)
+
+	// The custom 'security' change type renders (the default template would drop it).
+	assert.Contains(t, actual, "### Security")
+	assert.Contains(t, actual, "- `foo`: fix vuln (#1)")
+	assert.Contains(t, actual, "### Enhancements")
+	assert.Contains(t, actual, "- `bar`: improve bar (#2)")
+
+	// Sections appear in the configured order, not entry order or built-in order.
+	assert.Less(t, strings.Index(actual, "### Security"), strings.Index(actual, "### Enhancements"))
 }
 
 func TestCustomSummary(t *testing.T) {

--- a/tools/chloggen/internal/chlog/summary_test.go
+++ b/tools/chloggen/internal/chlog/summary_test.go
@@ -1,0 +1,128 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chlog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/tools/chloggen/internal/config"
+)
+
+func TestSummary(t *testing.T) {
+	brk1 := Entry{
+		ChangeType: Breaking,
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+	}
+	brk2 := Entry{
+		ChangeType: Breaking,
+		Component:  "bar",
+		Note:       "broke bar",
+		Issues:     []int{345, 678},
+		SubText:    "more details",
+	}
+	dep1 := Entry{
+		ChangeType: Deprecation,
+		Component:  "foo",
+		Note:       "deprecate foo",
+		Issues:     []int{1234},
+	}
+	dep2 := Entry{
+		ChangeType: Deprecation,
+		Component:  "bar",
+		Note:       "deprecate bar",
+		Issues:     []int{3456, 6789},
+		SubText:    "more details",
+	}
+	enh1 := Entry{
+		ChangeType: Enhancement,
+		Component:  "foo",
+		Note:       "enhance foo",
+		Issues:     []int{12},
+	}
+	enh2 := Entry{
+		ChangeType: Enhancement,
+		Component:  "bar",
+		Note:       "enhance bar",
+		Issues:     []int{34, 67},
+		SubText:    "more details",
+	}
+	bug1 := Entry{
+		ChangeType: BugFix,
+		Component:  "foo",
+		Note:       "bug foo",
+		Issues:     []int{1},
+	}
+	bug2 := Entry{
+		ChangeType: BugFix,
+		Component:  "bar",
+		Note:       "bug bar",
+		Issues:     []int{3, 6},
+		SubText:    "more details",
+	}
+	new1 := Entry{
+		ChangeType: NewComponent,
+		Component:  "foo",
+		Note:       "new foo",
+		Issues:     []int{2},
+	}
+	new2 := Entry{
+		ChangeType: NewComponent,
+		Component:  "bar",
+		Note:       "new bar",
+		Issues:     []int{4, 7},
+		SubText:    "more details",
+	}
+
+	actual, err := GenerateSummary("1.0", []*Entry{&brk1, &brk2, &dep1, &dep2, &enh1, &enh2, &bug1, &bug2, &new1, &new2}, &config.Config{})
+	assert.NoError(t, err)
+
+	// This file is not meant to be the entire changelog so will not pass markdownlint if named with .md extension.
+	expected, err := os.ReadFile(filepath.Join("testdata", "CHANGELOG"))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), actual)
+}
+
+func TestCustomSummary(t *testing.T) {
+	brk1 := Entry{
+		ChangeType: Breaking,
+		Component:  "foo",
+		Note:       "broke foo",
+		Issues:     []int{123},
+	}
+	brk2 := Entry{
+		ChangeType: Breaking,
+		Component:  "bar",
+		Note:       "broke bar",
+		Issues:     []int{345, 678},
+		SubText:    "more details",
+	}
+
+	actual, err := GenerateSummary("1.0", []*Entry{&brk1, &brk2}, &config.Config{SummaryTemplate: filepath.Join("testdata", "custom.tmpl")})
+	require.NoError(t, err)
+
+	// This file is not meant to be the entire changelog so will not pass markdownlint if named with .md extension.
+	expected, err := os.ReadFile(filepath.Join("testdata", "CHANGELOG_custom"))
+	require.NoError(t, err)
+
+	assert.Equal(t, string(expected), actual)
+}

--- a/tools/chloggen/internal/chlog/testdata/CHANGELOG
+++ b/tools/chloggen/internal/chlog/testdata/CHANGELOG
@@ -1,0 +1,32 @@
+
+## 1.0
+
+### 🛑 Breaking changes 🛑
+
+- `foo`: broke foo (#123)
+- `bar`: broke bar (#345, #678)
+  more details
+
+### 🚩 Deprecations 🚩
+
+- `foo`: deprecate foo (#1234)
+- `bar`: deprecate bar (#3456, #6789)
+  more details
+
+### 🚀 New components 🚀
+
+- `foo`: new foo (#2)
+- `bar`: new bar (#4, #7)
+  more details
+
+### 💡 Enhancements 💡
+
+- `foo`: enhance foo (#12)
+- `bar`: enhance bar (#34, #67)
+  more details
+
+### 🧰 Bug fixes 🧰
+
+- `foo`: bug foo (#1)
+- `bar`: bug bar (#3, #6)
+  more details

--- a/tools/chloggen/internal/chlog/testdata/CHANGELOG_custom
+++ b/tools/chloggen/internal/chlog/testdata/CHANGELOG_custom
@@ -1,0 +1,8 @@
+
+## 1.0
+
+### 🛑 Breaking changes 🛑
+
+- `foo`: broke foo ([#123](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/123))
+- `bar`: broke bar ([#345](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/345), [#678](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/678))
+  more details

--- a/tools/chloggen/internal/chlog/testdata/custom.tmpl
+++ b/tools/chloggen/internal/chlog/testdata/custom.tmpl
@@ -1,0 +1,68 @@
+{{- define "entry" -}}
+- `{{ .Component }}`: {{ .Note }} (
+{{- range $i, $issue := .Issues }}
+{{- if $i }}, {{ end -}}
+[#{{ $issue }}](https://github.com/open-telemetry/opentelemetry-go-build-tools/issues/{{ $issue }})
+{{- end -}}
+)
+
+{{- if .SubText }}
+{{ .SubText | indent 2 }}
+{{- end }}
+{{- end }}
+## {{ .Version }}
+
+{{- if .BreakingChanges }}
+
+### 🛑 Breaking changes 🛑
+
+{{- range $i, $change := .BreakingChanges }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Deprecations }}
+
+### 🚩 Deprecations 🚩
+
+{{- range $i, $change := .Deprecations }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .NewComponents }}
+
+### 🚀 New components 🚀
+
+{{- range $i, $change := .NewComponents }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .Enhancements }}
+
+### 💡 Enhancements 💡
+
+{{- range $i, $change := .Enhancements }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}
+
+{{- if .BugFixes }}
+
+### 🧰 Bug fixes 🧰
+
+{{- range $i, $change := .BugFixes }}
+{{- if eq $i 0}}
+{{end}}
+{{ template "entry" $change }}
+{{- end }}
+{{- end }}

--- a/tools/chloggen/internal/config/config.go
+++ b/tools/chloggen/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -35,6 +36,15 @@ const (
 	DefaultChangeLogFilename = "CHANGELOG.md"
 )
 
+// ChangeType defines a valid change_type and how entries of that type are
+// grouped when rendering the changelog summary.
+type ChangeType struct {
+	// Key is the value an entry's 'change_type' must match.
+	Key string `yaml:"key"`
+	// Heading is the section heading used for this change type in the summary.
+	Heading string `yaml:"heading"`
+}
+
 // Config represents the configuration for changelogs.
 type Config struct {
 	ChangeLogs        map[string]string `yaml:"change_logs"`
@@ -43,6 +53,7 @@ type Config struct {
 	TemplateYAML      string            `yaml:"template_yaml"`
 	SummaryTemplate   string            `yaml:"summary_template"`
 	Components        []string          `yaml:"components"`
+	ChangeTypes       []ChangeType      `yaml:"change_types"`
 	ConfigYAML        string
 }
 
@@ -67,7 +78,7 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 		return nil, err
 	}
 	cfg := &Config{}
-	if err = yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+	if err = yaml.Unmarshal(cfgBytes, cfg); err != nil {
 		return nil, err
 	}
 
@@ -75,12 +86,20 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 	cfg.EntriesDir = makeAbs(rootDir, cfg.EntriesDir, DefaultEntriesDir)
 	cfg.TemplateYAML = makeAbs(rootDir, cfg.TemplateYAML, filepath.Join(DefaultEntriesDir, DefaultTemplateYAML))
 
+	if err = validateChangeTypes(cfg.ChangeTypes); err != nil {
+		return nil, err
+	}
+
 	if len(cfg.ChangeLogs) == 0 && len(cfg.DefaultChangeLogs) > 0 {
-		return nil, errors.New("cannot specify 'default_changelogs' without 'changelogs'")
+		return nil, errors.New("cannot specify 'default_change_logs' without 'change_logs'")
 	}
 
 	if len(cfg.ChangeLogs) == 0 {
-		cfg.ChangeLogs[DefaultChangeLogKey] = filepath.Join(rootDir, DefaultChangeLogFilename)
+		// 'change_logs' was omitted; initialize the map before writing the default
+		// (yaml.Unmarshal leaves it nil when the key is absent).
+		cfg.ChangeLogs = map[string]string{
+			DefaultChangeLogKey: filepath.Join(rootDir, DefaultChangeLogFilename),
+		}
 		cfg.DefaultChangeLogs = []string{DefaultChangeLogKey}
 		return cfg, nil
 	}
@@ -96,11 +115,31 @@ func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
 
 	for _, key := range cfg.DefaultChangeLogs {
 		if _, ok := cfg.ChangeLogs[key]; !ok {
-			return nil, fmt.Errorf("'default_changelogs' contains key %q which is not defined in 'changelogs'", key)
+			return nil, fmt.Errorf("'default_change_logs' contains key %q which is not defined in 'change_logs'", key)
 		}
 	}
 
 	return cfg, nil
+}
+
+// validateChangeTypes fails fast on a malformed 'change_types' configuration:
+// empty keys or headings, or duplicate keys. An empty list is valid (the
+// built-in defaults are used).
+func validateChangeTypes(changeTypes []ChangeType) error {
+	seen := make(map[string]struct{}, len(changeTypes))
+	for _, ct := range changeTypes {
+		if strings.TrimSpace(ct.Key) == "" {
+			return errors.New("'change_types' entries must each have a non-empty 'key'")
+		}
+		if strings.TrimSpace(ct.Heading) == "" {
+			return fmt.Errorf("'change_types' entry %q must have a non-empty 'heading'", ct.Key)
+		}
+		if _, dup := seen[ct.Key]; dup {
+			return fmt.Errorf("'change_types' contains duplicate key %q", ct.Key)
+		}
+		seen[ct.Key] = struct{}{}
+	}
+	return nil
 }
 
 func makeAbs(rootDir, path, defaultPath string) string {

--- a/tools/chloggen/internal/config/config.go
+++ b/tools/chloggen/internal/config/config.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config provides changelog configuration.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DefaultEntriesDir is the default directory for changelog entries.
+	DefaultEntriesDir = ".chloggen"
+	// DefaultTemplateYAML is the default template file for changelog entries.
+	DefaultTemplateYAML = "TEMPLATE.yaml"
+	// DefaultChangeLogKey is the default key for the changelog.
+	DefaultChangeLogKey = "default"
+	// DefaultChangeLogFilename is the default filename for the changelog.
+	DefaultChangeLogFilename = "CHANGELOG.md"
+)
+
+// Config represents the configuration for changelogs.
+type Config struct {
+	ChangeLogs        map[string]string `yaml:"change_logs"`
+	DefaultChangeLogs []string          `yaml:"default_change_logs"`
+	EntriesDir        string            `yaml:"entries_dir"`
+	TemplateYAML      string            `yaml:"template_yaml"`
+	SummaryTemplate   string            `yaml:"summary_template"`
+	Components        []string          `yaml:"components"`
+	ConfigYAML        string
+}
+
+// New returns a new Config with default values.
+func New(rootDir string) *Config {
+	return &Config{
+		ChangeLogs:        map[string]string{DefaultChangeLogKey: filepath.Join(rootDir, DefaultChangeLogFilename)},
+		DefaultChangeLogs: []string{DefaultChangeLogKey},
+		EntriesDir:        filepath.Join(rootDir, DefaultEntriesDir),
+		TemplateYAML:      filepath.Join(rootDir, DefaultEntriesDir, DefaultTemplateYAML),
+	}
+}
+
+// NewFromFile returns a new Config from the specified YAML file.
+func NewFromFile(rootDir string, cfgFilename string) (*Config, error) {
+	if !filepath.IsAbs(cfgFilename) {
+		cfgFilename = filepath.Join(rootDir, cfgFilename)
+	}
+	cfgYAML := filepath.Clean(cfgFilename)
+	cfgBytes, err := os.ReadFile(cfgYAML) // nolint:gosec // false positive
+	if err != nil {
+		return nil, err
+	}
+	cfg := &Config{}
+	if err = yaml.Unmarshal(cfgBytes, &cfg); err != nil {
+		return nil, err
+	}
+
+	cfg.ConfigYAML = cfgYAML
+	cfg.EntriesDir = makeAbs(rootDir, cfg.EntriesDir, DefaultEntriesDir)
+	cfg.TemplateYAML = makeAbs(rootDir, cfg.TemplateYAML, filepath.Join(DefaultEntriesDir, DefaultTemplateYAML))
+
+	if len(cfg.ChangeLogs) == 0 && len(cfg.DefaultChangeLogs) > 0 {
+		return nil, errors.New("cannot specify 'default_changelogs' without 'changelogs'")
+	}
+
+	if len(cfg.ChangeLogs) == 0 {
+		cfg.ChangeLogs[DefaultChangeLogKey] = filepath.Join(rootDir, DefaultChangeLogFilename)
+		cfg.DefaultChangeLogs = []string{DefaultChangeLogKey}
+		return cfg, nil
+	}
+
+	// The user specified at least one changelog. Interpret filename as a relative path from rootDir
+	// (unless they specified an absolute path including rootDir)
+	for key, filename := range cfg.ChangeLogs {
+		if !filepath.IsAbs(filename) {
+			cfg.ChangeLogs[key] = filepath.Join(rootDir, filename)
+		}
+		cfg.ChangeLogs[key] = filepath.Clean(cfg.ChangeLogs[key])
+	}
+
+	for _, key := range cfg.DefaultChangeLogs {
+		if _, ok := cfg.ChangeLogs[key]; !ok {
+			return nil, fmt.Errorf("'default_changelogs' contains key %q which is not defined in 'changelogs'", key)
+		}
+	}
+
+	return cfg, nil
+}
+
+func makeAbs(rootDir, path, defaultPath string) string {
+	if path == "" {
+		return filepath.Clean(filepath.Join(rootDir, defaultPath))
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(rootDir, path))
+}

--- a/tools/chloggen/internal/config/config.yaml
+++ b/tools/chloggen/internal/config/config.yaml
@@ -1,0 +1,26 @@
+# The directory that stores individual changelog entries.
+# Each entry is stored in a dedicated yaml file.
+# - 'chloggen new' will copy the 'template_yaml' to this directory as a new entry file.
+# - 'chloggen validate' will validate that all entry files are valid.
+# - 'chloggen update' will read and delete all entry files in this directory, and update 'changelog_md'.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen
+# entries_dir:
+
+# This file is used as the input for individual changelog entries.
+# Specify as relative path from root of repo.
+# (Optional) Default: .chloggen/TEMPLATE.yaml
+# template_yaml:
+
+# The CHANGELOG file or files to which 'chloggen update' will write new entries
+# (Optional) Default filename: CHANGELOG.md
+# change_logs:
+#   default: CHANGELOG.md
+
+# The default change_log or change_logs to which an entry should be added.
+# If 'change_logs' is specified in this file, and no value is specified for 'default_change_logs',
+# then 'change_logs' MUST be specified in every entry file.
+# default_change_logs: []
+
+# The component values accepted. If empty, any component value is accepted.
+# components: []

--- a/tools/chloggen/internal/config/config_test.go
+++ b/tools/chloggen/internal/config/config_test.go
@@ -78,7 +78,7 @@ func TestNewFromFile(t *testing.T) {
 				TemplateYAML:      "TEMPLATE-custom.yaml",
 				DefaultChangeLogs: []string{"foo"},
 			},
-			expectErr: "cannot specify 'default_changelogs' without 'changelogs",
+			expectErr: "cannot specify 'default_change_logs' without 'change_logs'",
 		},
 		{
 			name: "default-changelog-not-in-changelogs",
@@ -91,7 +91,7 @@ func TestNewFromFile(t *testing.T) {
 				},
 				DefaultChangeLogs: []string{"foo", "bar", "fake"},
 			},
-			expectErr: `contains key "fake" which is not defined in 'changelogs'`,
+			expectErr: `contains key "fake" which is not defined in 'change_logs'`,
 		},
 		{
 			name: "absolute-entries-dir",
@@ -207,4 +207,60 @@ func TestNewFromFileErr(t *testing.T) {
 
 	_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
 	assert.Error(t, err)
+}
+
+func TestNewFromFileOmittedChangeLogs(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+	require.NoError(t, err)
+	defer cfgFile.Close()
+
+	// A config file that omits 'change_logs' entirely must not panic; the
+	// default changelog should be applied.
+	_, err = cfgFile.WriteString("components: [foo]\n")
+	require.NoError(t, err)
+
+	cfg, err := NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(cfg.ChangeLogs))
+	assert.Equal(t, filepath.Join(tempDir, DefaultChangeLogFilename), cfg.ChangeLogs[DefaultChangeLogKey])
+	assert.Equal(t, []string{DefaultChangeLogKey}, cfg.DefaultChangeLogs)
+}
+
+func TestNewFromFileMalformedChangeTypes(t *testing.T) {
+	testCases := []struct {
+		name      string
+		yaml      string
+		expectErr string
+	}{
+		{
+			name:      "empty_key",
+			yaml:      "change_types:\n  - key: \"\"\n    heading: Stuff\n",
+			expectErr: "must each have a non-empty 'key'",
+		},
+		{
+			name:      "empty_heading",
+			yaml:      "change_types:\n  - key: stuff\n    heading: \"\"\n",
+			expectErr: `entry "stuff" must have a non-empty 'heading'`,
+		},
+		{
+			name:      "duplicate_key",
+			yaml:      "change_types:\n  - key: stuff\n    heading: Stuff\n  - key: stuff\n    heading: More stuff\n",
+			expectErr: `duplicate key "stuff"`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+			require.NoError(t, err)
+			defer cfgFile.Close()
+			_, err = cfgFile.WriteString(tc.yaml)
+			require.NoError(t, err)
+
+			_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+			require.ErrorContains(t, err, tc.expectErr)
+		})
+	}
 }

--- a/tools/chloggen/internal/config/config_test.go
+++ b/tools/chloggen/internal/config/config_test.go
@@ -1,0 +1,210 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNew(t *testing.T) {
+	root := "/tmp"
+	cfg := New(root)
+	assert.Equal(t, filepath.Join(root, DefaultEntriesDir), cfg.EntriesDir)
+	assert.Equal(t, filepath.Join(root, DefaultEntriesDir, DefaultTemplateYAML), cfg.TemplateYAML)
+
+	assert.Equal(t, 1, len(cfg.ChangeLogs))
+	assert.NotNil(t, cfg.ChangeLogs[DefaultChangeLogKey])
+	assert.Equal(t, filepath.Join(root, DefaultChangeLogFilename), cfg.ChangeLogs[DefaultChangeLogKey])
+
+	assert.Equal(t, 1, len(cfg.DefaultChangeLogs))
+	assert.Equal(t, DefaultChangeLogKey, cfg.DefaultChangeLogs[0])
+}
+
+func TestNewFromFile(t *testing.T) {
+	testCases := []struct {
+		name      string
+		cfg       *Config
+		expectErr string
+	}{
+		{
+			name: "empty",
+			cfg:  &Config{},
+		},
+		{
+			name: "multi-changelog-no-default",
+			cfg: &Config{
+				EntriesDir:   ".test",
+				TemplateYAML: "TEMPLATE-custom.yaml",
+				ChangeLogs: map[string]string{
+					"foo": "CHANGELOG-1.md",
+					"bar": "CHANGELOG-2.md",
+				},
+			},
+		},
+		{
+			name: "multi-changelog-with-default",
+			cfg: &Config{
+				EntriesDir:   ".test",
+				TemplateYAML: "TEMPLATE-custom.yaml",
+				ChangeLogs: map[string]string{
+					"foo": "CHANGELOG-1.md",
+					"bar": "CHANGELOG-2.md",
+				},
+				DefaultChangeLogs: []string{"foo"},
+			},
+		},
+		{
+			name: "default-changelogs-without-changelogs",
+			cfg: &Config{
+				EntriesDir:        ".test",
+				TemplateYAML:      "TEMPLATE-custom.yaml",
+				DefaultChangeLogs: []string{"foo"},
+			},
+			expectErr: "cannot specify 'default_changelogs' without 'changelogs",
+		},
+		{
+			name: "default-changelog-not-in-changelogs",
+			cfg: &Config{
+				EntriesDir:   ".test",
+				TemplateYAML: "TEMPLATE-custom.yaml",
+				ChangeLogs: map[string]string{
+					"foo": "CHANGELOG-1.md",
+					"bar": "CHANGELOG-2.md",
+				},
+				DefaultChangeLogs: []string{"foo", "bar", "fake"},
+			},
+			expectErr: `contains key "fake" which is not defined in 'changelogs'`,
+		},
+		{
+			name: "absolute-entries-dir",
+			cfg: &Config{
+				EntriesDir: "/tmp/abs_entries",
+			},
+		},
+		{
+			name: "absolute-template-yaml",
+			cfg: &Config{
+				TemplateYAML: "/tmp/abs_template.yaml",
+			},
+		},
+		{
+			name: "absolute-changelog",
+			cfg: &Config{
+				ChangeLogs: map[string]string{
+					"default": "/tmp/abs_changelog.md",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			cfgBytes, err := yaml.Marshal(tc.cfg)
+			require.NoError(t, err)
+
+			cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+			require.NoError(t, err)
+			defer cfgFile.Close()
+
+			_, err = cfgFile.Write(cfgBytes)
+			require.NoError(t, err)
+
+			actualCfg, err := NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			assert.NoError(t, err)
+
+			// This would be the default config is no values were specified in the config file.
+			// Instantiate it here to compare against the actual config as appropriate.
+			defaultCfg := New(tempDir)
+
+			expectedEntriesDir := defaultCfg.EntriesDir
+			if tc.cfg.EntriesDir != "" {
+				if filepath.IsAbs(tc.cfg.EntriesDir) {
+					expectedEntriesDir = filepath.Clean(tc.cfg.EntriesDir)
+				} else {
+					expectedEntriesDir = filepath.Join(tempDir, tc.cfg.EntriesDir)
+				}
+			}
+			assert.Equal(t, expectedEntriesDir, actualCfg.EntriesDir)
+
+			expectedTemplateYAML := defaultCfg.TemplateYAML
+			if tc.cfg.TemplateYAML != "" {
+				if filepath.IsAbs(tc.cfg.TemplateYAML) {
+					expectedTemplateYAML = filepath.Clean(tc.cfg.TemplateYAML)
+				} else {
+					expectedTemplateYAML = filepath.Join(tempDir, tc.cfg.TemplateYAML)
+				}
+			}
+			assert.Equal(t, expectedTemplateYAML, actualCfg.TemplateYAML)
+
+			if len(tc.cfg.ChangeLogs) == 0 {
+				assert.Equal(t, 1, len(actualCfg.ChangeLogs))
+				assert.NotNil(t, actualCfg.ChangeLogs[DefaultChangeLogKey])
+				assert.Equal(t, filepath.Join(tempDir, DefaultChangeLogFilename), actualCfg.ChangeLogs[DefaultChangeLogKey])
+
+				// When no changelogs are specified, the default changelog must be the only default changelog.
+				assert.Equal(t, 1, len(actualCfg.DefaultChangeLogs))
+				assert.Equal(t, DefaultChangeLogKey, actualCfg.DefaultChangeLogs[0])
+			} else {
+				assert.Equal(t, len(tc.cfg.ChangeLogs), len(actualCfg.ChangeLogs))
+				for key, filename := range tc.cfg.ChangeLogs {
+					assert.NotNil(t, actualCfg.ChangeLogs[key])
+					expectedFilename := filename
+					if !filepath.IsAbs(filename) {
+						expectedFilename = filepath.Join(tempDir, filename)
+					}
+					assert.Equal(t, filepath.Clean(expectedFilename), actualCfg.ChangeLogs[key])
+				}
+
+				// When changelogs are specified, the default changelogs must be a subset of the changelogs.
+				// It is acceptable to have no default changelog.
+				assert.Equal(t, len(tc.cfg.DefaultChangeLogs), len(actualCfg.DefaultChangeLogs))
+			}
+
+			for _, key := range actualCfg.DefaultChangeLogs {
+				assert.NotNil(t, actualCfg.ChangeLogs[key])
+			}
+		})
+	}
+}
+
+func TestNewFromFileErr(t *testing.T) {
+	tempDir := t.TempDir()
+
+	_, err := NewFromFile(tempDir, "nonexistent.yaml")
+	assert.Error(t, err)
+
+	// Write a file with invalid YAML and then read it back to get expected error
+	cfgFile, err := os.CreateTemp(tempDir, "*.yaml")
+	require.NoError(t, err)
+	defer cfgFile.Close()
+
+	_, err = cfgFile.WriteString("!@#$%^&*())")
+	require.NoError(t, err)
+
+	_, err = NewFromFile(tempDir, filepath.Base(cfgFile.Name()))
+	assert.Error(t, err)
+}

--- a/tools/chloggen/main.go
+++ b/tools/chloggen/main.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Chloggen generates changelog entries.
+package main
+
+import (
+	"github.com/grafana/tempo/tools/chloggen/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -8,7 +8,10 @@ require (
 	github.com/grafana/tanka v0.32.0
 	github.com/jsonnet-bundler/jsonnet-bundler v0.6.0
 	github.com/psampaz/go-mod-outdated v0.9.0
+	github.com/spf13/cobra v1.9.1
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/tools v0.44.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/gotestsum v1.12.1
 	mvdan.cc/gofumpt v0.8.0
 )
@@ -189,14 +192,12 @@ require (
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
 	github.com/tetafro/godot v1.5.0 // indirect
@@ -236,7 +237,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.6.1 // indirect
 	k8s.io/apimachinery v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/tools/vendor/github.com/stretchr/testify/require/doc.go
+++ b/tools/vendor/github.com/stretchr/testify/require/doc.go
@@ -1,0 +1,29 @@
+// Package require implements the same assertions as the `assert` package but
+// stops test execution when a test fails.
+//
+// # Example Usage
+//
+// The following is a complete example using require in a standard test function:
+//
+//	import (
+//	  "testing"
+//	  "github.com/stretchr/testify/require"
+//	)
+//
+//	func TestSomething(t *testing.T) {
+//
+//	  var a string = "Hello"
+//	  var b string = "Hello"
+//
+//	  require.Equal(t, a, b, "The two words should be the same.")
+//
+//	}
+//
+// # Assertions
+//
+// The `require` package have same global functions as in the `assert` package,
+// but instead of returning a boolean result they call `t.FailNow()`.
+//
+// Every assertion function also takes an optional string message as the final argument,
+// allowing custom error messages to be appended to the message the assertion method outputs.
+package require

--- a/tools/vendor/github.com/stretchr/testify/require/forward_requirements.go
+++ b/tools/vendor/github.com/stretchr/testify/require/forward_requirements.go
@@ -1,0 +1,16 @@
+package require
+
+// Assertions provides assertion methods around the
+// TestingT interface.
+type Assertions struct {
+	t TestingT
+}
+
+// New makes a new Assertions object for the specified TestingT.
+func New(t TestingT) *Assertions {
+	return &Assertions{
+		t: t,
+	}
+}
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require_forward.go.tmpl -include-format-funcs"

--- a/tools/vendor/github.com/stretchr/testify/require/require.go
+++ b/tools/vendor/github.com/stretchr/testify/require/require.go
@@ -1,0 +1,2124 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func Condition(t TestingT, comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Condition(t, comp, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func Conditionf(t TestingT, comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Conditionf(t, comp, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	require.Contains(t, "Hello World", "World")
+//	require.Contains(t, ["Hello", "World"], "World")
+//	require.Contains(t, {"Hello": "World"}, "Hello")
+func Contains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Contains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	require.Containsf(t, "Hello World", "World", "error message %s", "formatted")
+//	require.Containsf(t, ["Hello", "World"], "World", "error message %s", "formatted")
+//	require.Containsf(t, {"Hello": "World"}, "Hello", "error message %s", "formatted")
+func Containsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Containsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func DirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.DirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// require.ElementsMatch(t, [1, 3, 2, 3], [1, 3, 3, 2])
+func ElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// require.ElementsMatchf(t, [1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func ElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	require.Empty(t, obj)
+func Empty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Empty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	require.Emptyf(t, obj, "error message %s", "formatted")
+func Emptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Emptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equal asserts that two objects are equal.
+//
+//	require.Equal(t, 123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equal(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equal(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	require.EqualError(t, err,  expectedErrorString)
+func EqualError(t TestingT, theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualError(t, theError, errString, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	require.EqualErrorf(t, err,  expectedErrorString, "error message %s", "formatted")
+func EqualErrorf(t TestingT, theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualErrorf(t, theError, errString, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValues(t, S{1, 2}, S{1, 3}) => true
+//	 require.EqualExportedValues(t, S{1, 2}, S{2, 3}) => false
+func EqualExportedValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 require.EqualExportedValuesf(t, S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func EqualExportedValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualExportedValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	require.EqualValues(t, uint32(123), int32(123))
+func EqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	require.EqualValuesf(t, uint32(123), int32(123), "error message %s", "formatted")
+func EqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	require.Equalf(t, 123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func Equalf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Equalf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.Error(t, err) {
+//		   require.Equal(t, expectedError, err)
+//	  }
+func Error(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Error(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	require.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContains(t, theError, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	require.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContainsf(t, theError, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.Errorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedErrorf, err)
+//	  }
+func Errorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Errorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	require.Eventually(t, func() bool { return true; }, time.Second, 10*time.Millisecond)
+func Eventually(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventually(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithT(t, func(c *require.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithT(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithT(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	require.EventuallyWithTf(t, func(c *require.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		require.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func EventuallyWithTf(t TestingT, condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.EventuallyWithTf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	require.Eventuallyf(t, func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Eventuallyf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Eventuallyf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	require.Exactly(t, int32(123), int64(123))
+func Exactly(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactly(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	require.Exactlyf(t, int32(123), int64(123), "error message %s", "formatted")
+func Exactlyf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Exactlyf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Fail reports a failure through
+func Fail(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Fail(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNow fails test
+func FailNow(t TestingT, failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNow(t, failureMessage, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FailNowf fails test
+func FailNowf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FailNowf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Failf reports a failure through
+func Failf(t TestingT, failureMessage string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Failf(t, failureMessage, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// False asserts that the specified value is false.
+//
+//	require.False(t, myBool)
+func False(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.False(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	require.Falsef(t, myBool, "error message %s", "formatted")
+func Falsef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Falsef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func FileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.FileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	require.Greater(t, 2, 1)
+//	require.Greater(t, float64(2), float64(1))
+//	require.Greater(t, "b", "a")
+func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greater(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	require.GreaterOrEqual(t, 2, 1)
+//	require.GreaterOrEqual(t, 2, 2)
+//	require.GreaterOrEqual(t, "b", "a")
+//	require.GreaterOrEqual(t, "b", "b")
+func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	require.GreaterOrEqualf(t, 2, 1, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "a", "error message %s", "formatted")
+//	require.GreaterOrEqualf(t, "b", "b", "error message %s", "formatted")
+func GreaterOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.GreaterOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	require.Greaterf(t, 2, 1, "error message %s", "formatted")
+//	require.Greaterf(t, float64(2), float64(1), "error message %s", "formatted")
+//	require.Greaterf(t, "b", "a", "error message %s", "formatted")
+func Greaterf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Greaterf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	require.HTTPBodyContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	require.HTTPBodyContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	require.HTTPBodyNotContains(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContains(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContains(t, handler, method, url, values, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	require.HTTPBodyNotContainsf(t, myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPBodyNotContainsf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPBodyNotContainsf(t, handler, method, url, values, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	require.HTTPError(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPError(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPError(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	require.HTTPErrorf(t, myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPErrorf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPErrorf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	require.HTTPRedirect(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirect(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirect(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	require.HTTPRedirectf(t, myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPRedirectf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPRedirectf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	require.HTTPStatusCode(t, myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCode(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCode(t, handler, method, url, values, statuscode, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	require.HTTPStatusCodef(t, myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPStatusCodef(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPStatusCodef(t, handler, method, url, values, statuscode, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	require.HTTPSuccess(t, myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccess(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccess(t, handler, method, url, values, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	require.HTTPSuccessf(t, myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func HTTPSuccessf(t TestingT, handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.HTTPSuccessf(t, handler, method, url, values, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	require.Implements(t, (*MyInterface)(nil), new(MyObject))
+func Implements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	require.Implementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func Implementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Implementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	require.InDelta(t, math.Pi, 22/7.0, 0.01)
+func InDelta(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDelta(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValues(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValues(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func InDeltaMapValuesf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaMapValuesf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func InDeltaSlice(t TestingT, expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlice(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func InDeltaSlicef(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaSlicef(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	require.InDeltaf(t, math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func InDeltaf(t TestingT, expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InDeltaf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func InEpsilon(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilon(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlice(t TestingT, expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlice(t, expected, actual, epsilon, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func InEpsilonSlicef(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonSlicef(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func InEpsilonf(t TestingT, expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.InEpsilonf(t, expected, actual, epsilon, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	require.IsDecreasing(t, []int{2, 1, 0})
+//	require.IsDecreasing(t, []float{2, 1})
+//	require.IsDecreasing(t, []string{"b", "a"})
+func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	require.IsDecreasingf(t, []int{2, 1, 0}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsDecreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	require.IsIncreasing(t, []int{1, 2, 3})
+//	require.IsIncreasing(t, []float{1, 2})
+//	require.IsIncreasing(t, []string{"a", "b"})
+func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	require.IsIncreasingf(t, []int{1, 2, 3}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsIncreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	require.IsNonDecreasing(t, []int{1, 1, 2})
+//	require.IsNonDecreasing(t, []float{1, 2})
+//	require.IsNonDecreasing(t, []string{"a", "b"})
+func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	require.IsNonDecreasingf(t, []int{1, 1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []float{1, 2}, "error message %s", "formatted")
+//	require.IsNonDecreasingf(t, []string{"a", "b"}, "error message %s", "formatted")
+func IsNonDecreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonDecreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	require.IsNonIncreasing(t, []int{2, 1, 1})
+//	require.IsNonIncreasing(t, []float{2, 1})
+//	require.IsNonIncreasing(t, []string{"b", "a"})
+func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasing(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	require.IsNonIncreasingf(t, []int{2, 1, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []float{2, 1}, "error message %s", "formatted")
+//	require.IsNonIncreasingf(t, []string{"b", "a"}, "error message %s", "formatted")
+func IsNonIncreasingf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsNonIncreasingf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsType asserts that the specified objects are of the same type.
+func IsType(t TestingT, expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsType(t, expectedType, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func IsTypef(t TestingT, expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.IsTypef(t, expectedType, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	require.JSONEq(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func JSONEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	require.JSONEqf(t, `{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func JSONEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.JSONEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	require.Len(t, mySlice, 3)
+func Len(t TestingT, object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Len(t, object, length, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	require.Lenf(t, mySlice, 3, "error message %s", "formatted")
+func Lenf(t TestingT, object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lenf(t, object, length, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Less asserts that the first element is less than the second
+//
+//	require.Less(t, 1, 2)
+//	require.Less(t, float64(1), float64(2))
+//	require.Less(t, "a", "b")
+func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Less(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	require.LessOrEqual(t, 1, 2)
+//	require.LessOrEqual(t, 2, 2)
+//	require.LessOrEqual(t, "a", "b")
+//	require.LessOrEqual(t, "b", "b")
+func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqual(t, e1, e2, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	require.LessOrEqualf(t, 1, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, 2, 2, "error message %s", "formatted")
+//	require.LessOrEqualf(t, "a", "b", "error message %s", "formatted")
+//	require.LessOrEqualf(t, "b", "b", "error message %s", "formatted")
+func LessOrEqualf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.LessOrEqualf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	require.Lessf(t, 1, 2, "error message %s", "formatted")
+//	require.Lessf(t, float64(1), float64(2), "error message %s", "formatted")
+//	require.Lessf(t, "a", "b", "error message %s", "formatted")
+func Lessf(t TestingT, e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Lessf(t, e1, e2, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negative asserts that the specified element is negative
+//
+//	require.Negative(t, -1)
+//	require.Negative(t, -1.23)
+func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negative(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	require.Negativef(t, -1, "error message %s", "formatted")
+//	require.Negativef(t, -1.23, "error message %s", "formatted")
+func Negativef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Negativef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	require.Never(t, func() bool { return false; }, time.Second, 10*time.Millisecond)
+func Never(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Never(t, condition, waitFor, tick, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	require.Neverf(t, func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func Neverf(t TestingT, condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Neverf(t, condition, waitFor, tick, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	require.Nil(t, err)
+func Nil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	require.Nilf(t, err, "error message %s", "formatted")
+func Nilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Nilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func NoDirExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoDirExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.NoError(t, err) {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
+func NoError(t TestingT, err error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoError(t, err, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if require.NoErrorf(t, err, "error message %s", "formatted") {
+//		   require.Equal(t, expectedObj, actualObj)
+//	  }
+func NoErrorf(t TestingT, err error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoErrorf(t, err, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExists(t TestingT, path string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExists(t, path, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func NoFileExistsf(t TestingT, path string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NoFileExistsf(t, path, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	require.NotContains(t, "Hello World", "Earth")
+//	require.NotContains(t, ["Hello", "World"], "Earth")
+//	require.NotContains(t, {"Hello": "World"}, "Earth")
+func NotContains(t TestingT, s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContains(t, s, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	require.NotContainsf(t, "Hello World", "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, ["Hello", "World"], "Earth", "error message %s", "formatted")
+//	require.NotContainsf(t, {"Hello": "World"}, "Earth", "error message %s", "formatted")
+func NotContainsf(t TestingT, s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotContainsf(t, s, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// require.NotElementsMatch(t, [1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// require.NotElementsMatch(t, [1, 2, 3], [1, 2, 4]) -> true
+func NotElementsMatch(t TestingT, listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatch(t, listA, listB, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// require.NotElementsMatchf(t, [1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// require.NotElementsMatchf(t, [1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func NotElementsMatchf(t TestingT, listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotElementsMatchf(t, listA, listB, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if require.NotEmpty(t, obj) {
+//	  require.Equal(t, "two", obj[1])
+//	}
+func NotEmpty(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmpty(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if require.NotEmptyf(t, obj, "error message %s", "formatted") {
+//	  require.Equal(t, "two", obj[1])
+//	}
+func NotEmptyf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEmptyf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	require.NotEqual(t, obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqual(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqual(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	require.NotEqualValues(t, obj1, obj2)
+func NotEqualValues(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValues(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	require.NotEqualValuesf(t, obj1, obj2, "error message %s", "formatted")
+func NotEqualValuesf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualValuesf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	require.NotEqualf(t, obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func NotEqualf(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotEqualf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAs(t TestingT, err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func NotErrorAsf(t TestingT, err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorAsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIs(t, err, target, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func NotErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotErrorIsf(t, err, target, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	require.NotImplements(t, (*MyInterface)(nil), new(MyObject))
+func NotImplements(t TestingT, interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplements(t, interfaceObject, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	require.NotImplementsf(t, (*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func NotImplementsf(t TestingT, interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotImplementsf(t, interfaceObject, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	require.NotNil(t, err)
+func NotNil(t TestingT, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNil(t, object, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	require.NotNilf(t, err, "error message %s", "formatted")
+func NotNilf(t TestingT, object interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotNilf(t, object, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	require.NotPanics(t, func(){ RemainCalm() })
+func NotPanics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	require.NotPanicsf(t, func(){ RemainCalm() }, "error message %s", "formatted")
+func NotPanicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotPanicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	require.NotRegexp(t, regexp.MustCompile("starts"), "it's starting")
+//	require.NotRegexp(t, "^start", "it's not starting")
+func NotRegexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	require.NotRegexpf(t, regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	require.NotRegexpf(t, "^start", "it's not starting", "error message %s", "formatted")
+func NotRegexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotRegexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	require.NotSame(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSame(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSame(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	require.NotSamef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func NotSamef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSamef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubset asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	require.NotSubset(t, [1, 3, 4], [1, 2])
+//	require.NotSubset(t, {"x": 1, "y": 2}, {"z": 3})
+func NotSubset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	require.NotSubsetf(t, [1, 3, 4], [1, 2], "error message %s", "formatted")
+//	require.NotSubsetf(t, {"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+func NotSubsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotSubsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func NotZero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func NotZerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.NotZerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	require.Panics(t, func(){ GoCrazy() })
+func Panics(t TestingT, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panics(t, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	require.PanicsWithError(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithError(t TestingT, errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithError(t, errString, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	require.PanicsWithErrorf(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithErrorf(t TestingT, errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithErrorf(t, errString, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	require.PanicsWithValue(t, "crazy error", func(){ GoCrazy() })
+func PanicsWithValue(t TestingT, expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValue(t, expected, f, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	require.PanicsWithValuef(t, "crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func PanicsWithValuef(t TestingT, expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.PanicsWithValuef(t, expected, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	require.Panicsf(t, func(){ GoCrazy() }, "error message %s", "formatted")
+func Panicsf(t TestingT, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Panicsf(t, f, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positive asserts that the specified element is positive
+//
+//	require.Positive(t, 1)
+//	require.Positive(t, 1.23)
+func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positive(t, e, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	require.Positivef(t, 1, "error message %s", "formatted")
+//	require.Positivef(t, 1.23, "error message %s", "formatted")
+func Positivef(t TestingT, e interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Positivef(t, e, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	require.Regexp(t, regexp.MustCompile("start"), "it's starting")
+//	require.Regexp(t, "start...$", "it's not starting")
+func Regexp(t TestingT, rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexp(t, rx, str, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	require.Regexpf(t, regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	require.Regexpf(t, "start...$", "it's not starting", "error message %s", "formatted")
+func Regexpf(t TestingT, rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Regexpf(t, rx, str, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	require.Same(t, ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Same(t TestingT, expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Same(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	require.Samef(t, ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func Samef(t TestingT, expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Samef(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subset asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	require.Subset(t, [1, 2, 3], [1, 2])
+//	require.Subset(t, {"x": 1, "y": 2}, {"x": 1})
+func Subset(t TestingT, list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subset(t, list, subset, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Subsetf asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	require.Subsetf(t, [1, 2, 3], [1, 2], "error message %s", "formatted")
+//	require.Subsetf(t, {"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+func Subsetf(t TestingT, list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Subsetf(t, list, subset, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// True asserts that the specified value is true.
+//
+//	require.True(t, myBool)
+func True(t TestingT, value bool, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.True(t, value, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Truef asserts that the specified value is true.
+//
+//	require.Truef(t, myBool, "error message %s", "formatted")
+func Truef(t TestingT, value bool, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Truef(t, value, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	require.WithinDuration(t, time.Now(), time.Now(), 10*time.Second)
+func WithinDuration(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDuration(t, expected, actual, delta, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	require.WithinDurationf(t, time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	require.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRange(t, actual, start, end, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	require.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRangef(t, actual, start, end, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func YAMLEq(t TestingT, expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEq(t, expected, actual, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func YAMLEqf(t TestingT, expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.YAMLEqf(t, expected, actual, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zero asserts that i is the zero value for its type.
+func Zero(t TestingT, i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zero(t, i, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// Zerof asserts that i is the zero value for its type.
+func Zerof(t TestingT, i interface{}, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.Zerof(t, i, msg, args...) {
+		return
+	}
+	t.FailNow()
+}

--- a/tools/vendor/github.com/stretchr/testify/require/require.go.tmpl
+++ b/tools/vendor/github.com/stretchr/testify/require/require.go.tmpl
@@ -1,0 +1,6 @@
+{{ replace .Comment "assert." "require."}}
+func {{.DocInfo.Name}}(t TestingT, {{.Params}}) {
+	if h, ok := t.(tHelper); ok { h.Helper() }
+	if assert.{{.DocInfo.Name}}(t, {{.ForwardedParams}}) { return }
+	t.FailNow()
+}

--- a/tools/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/tools/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -1,0 +1,1674 @@
+// Code generated with github.com/stretchr/testify/_codegen; DO NOT EDIT.
+
+package require
+
+import (
+	assert "github.com/stretchr/testify/assert"
+	http "net/http"
+	url "net/url"
+	time "time"
+)
+
+// Condition uses a Comparison to assert a complex condition.
+func (a *Assertions) Condition(comp assert.Comparison, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Condition(a.t, comp, msgAndArgs...)
+}
+
+// Conditionf uses a Comparison to assert a complex condition.
+func (a *Assertions) Conditionf(comp assert.Comparison, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Conditionf(a.t, comp, msg, args...)
+}
+
+// Contains asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Contains("Hello World", "World")
+//	a.Contains(["Hello", "World"], "World")
+//	a.Contains({"Hello": "World"}, "Hello")
+func (a *Assertions) Contains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Contains(a.t, s, contains, msgAndArgs...)
+}
+
+// Containsf asserts that the specified string, list(array, slice...) or map contains the
+// specified substring or element.
+//
+//	a.Containsf("Hello World", "World", "error message %s", "formatted")
+//	a.Containsf(["Hello", "World"], "World", "error message %s", "formatted")
+//	a.Containsf({"Hello": "World"}, "Hello", "error message %s", "formatted")
+func (a *Assertions) Containsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Containsf(a.t, s, contains, msg, args...)
+}
+
+// DirExists checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExists(a.t, path, msgAndArgs...)
+}
+
+// DirExistsf checks whether a directory exists in the given path. It also fails
+// if the path is a file rather a directory or there is an error checking whether it exists.
+func (a *Assertions) DirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	DirExistsf(a.t, path, msg, args...)
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatch([1, 3, 2, 3], [1, 3, 3, 2])
+func (a *Assertions) ElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// ElementsMatchf asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match.
+//
+// a.ElementsMatchf([1, 3, 2, 3], [1, 3, 3, 2], "error message %s", "formatted")
+func (a *Assertions) ElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// Empty asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	a.Empty(obj)
+func (a *Assertions) Empty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Empty(a.t, object, msgAndArgs...)
+}
+
+// Emptyf asserts that the specified object is empty.  I.e. nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	a.Emptyf(obj, "error message %s", "formatted")
+func (a *Assertions) Emptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Emptyf(a.t, object, msg, args...)
+}
+
+// Equal asserts that two objects are equal.
+//
+//	a.Equal(123, 123)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equal(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equal(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualError asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualError(err,  expectedErrorString)
+func (a *Assertions) EqualError(theError error, errString string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualError(a.t, theError, errString, msgAndArgs...)
+}
+
+// EqualErrorf asserts that a function returned an error (i.e. not `nil`)
+// and that it is equal to the provided error.
+//
+//	actualObj, err := SomeFunction()
+//	a.EqualErrorf(err,  expectedErrorString, "error message %s", "formatted")
+func (a *Assertions) EqualErrorf(theError error, errString string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualErrorf(a.t, theError, errString, msg, args...)
+}
+
+// EqualExportedValues asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValues(S{1, 2}, S{1, 3}) => true
+//	 a.EqualExportedValues(S{1, 2}, S{2, 3}) => false
+func (a *Assertions) EqualExportedValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualExportedValuesf asserts that the types of two objects are equal and their public
+// fields are also equal. This is useful for comparing structs that have private fields
+// that could potentially differ.
+//
+//	 type S struct {
+//		Exported     	int
+//		notExported   	int
+//	 }
+//	 a.EqualExportedValuesf(S{1, 2}, S{1, 3}, "error message %s", "formatted") => true
+//	 a.EqualExportedValuesf(S{1, 2}, S{2, 3}, "error message %s", "formatted") => false
+func (a *Assertions) EqualExportedValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualExportedValuesf(a.t, expected, actual, msg, args...)
+}
+
+// EqualValues asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValues(uint32(123), int32(123))
+func (a *Assertions) EqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// EqualValuesf asserts that two objects are equal or convertible to the larger
+// type and equal.
+//
+//	a.EqualValuesf(uint32(123), int32(123), "error message %s", "formatted")
+func (a *Assertions) EqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// Equalf asserts that two objects are equal.
+//
+//	a.Equalf(123, 123, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses). Function equality
+// cannot be determined and will always fail.
+func (a *Assertions) Equalf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Equalf(a.t, expected, actual, msg, args...)
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.Error(err) {
+//		   assert.Equal(t, expectedError, err)
+//	  }
+func (a *Assertions) Error(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Error(a.t, err, msgAndArgs...)
+}
+
+// ErrorAs asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorAsf asserts that at least one of the errors in err's chain matches target, and if so, sets target to that error value.
+// This is a wrapper for errors.As.
+func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorAsf(a.t, err, target, msg, args...)
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//	actualObj, err := SomeFunction()
+//	a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
+// ErrorIs asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// ErrorIsf asserts that at least one of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) ErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorIsf(a.t, err, target, msg, args...)
+}
+
+// Errorf asserts that a function returned an error (i.e. not `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.Errorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedErrorf, err)
+//	  }
+func (a *Assertions) Errorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Errorf(a.t, err, msg, args...)
+}
+
+// Eventually asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventually(func() bool { return true; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Eventually(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventually(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithT asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithT(func(c *assert.CollectT) {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithT(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithT(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// EventuallyWithTf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick. In contrast to Eventually,
+// it supplies a CollectT to the condition function, so that the condition
+// function can use the CollectT to call other assertions.
+// The condition is considered "met" if no errors are raised in a tick.
+// The supplied CollectT collects all errors from one tick (if there are any).
+// If the condition is not met before waitFor, the collected errors of
+// the last tick are copied to t.
+//
+//	externalValue := false
+//	go func() {
+//		time.Sleep(8*time.Second)
+//		externalValue = true
+//	}()
+//	a.EventuallyWithTf(func(c *assert.CollectT, "error message %s", "formatted") {
+//		// add assertions as needed; any assertion failure will fail the current tick
+//		assert.True(c, externalValue, "expected 'externalValue' to be true")
+//	}, 10*time.Second, 1*time.Second, "external state has not changed to 'true'; still false")
+func (a *Assertions) EventuallyWithTf(condition func(collect *assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	EventuallyWithTf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Eventuallyf asserts that given condition will be met in waitFor time,
+// periodically checking target function each tick.
+//
+//	a.Eventuallyf(func() bool { return true; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Eventuallyf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Eventuallyf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Exactly asserts that two objects are equal in value and type.
+//
+//	a.Exactly(int32(123), int64(123))
+func (a *Assertions) Exactly(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactly(a.t, expected, actual, msgAndArgs...)
+}
+
+// Exactlyf asserts that two objects are equal in value and type.
+//
+//	a.Exactlyf(int32(123), int64(123), "error message %s", "formatted")
+func (a *Assertions) Exactlyf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Exactlyf(a.t, expected, actual, msg, args...)
+}
+
+// Fail reports a failure through
+func (a *Assertions) Fail(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Fail(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNow fails test
+func (a *Assertions) FailNow(failureMessage string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNow(a.t, failureMessage, msgAndArgs...)
+}
+
+// FailNowf fails test
+func (a *Assertions) FailNowf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FailNowf(a.t, failureMessage, msg, args...)
+}
+
+// Failf reports a failure through
+func (a *Assertions) Failf(failureMessage string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Failf(a.t, failureMessage, msg, args...)
+}
+
+// False asserts that the specified value is false.
+//
+//	a.False(myBool)
+func (a *Assertions) False(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	False(a.t, value, msgAndArgs...)
+}
+
+// Falsef asserts that the specified value is false.
+//
+//	a.Falsef(myBool, "error message %s", "formatted")
+func (a *Assertions) Falsef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Falsef(a.t, value, msg, args...)
+}
+
+// FileExists checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExists(a.t, path, msgAndArgs...)
+}
+
+// FileExistsf checks whether a file exists in the given path. It also fails if
+// the path points to a directory or there is an error when trying to check the file.
+func (a *Assertions) FileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	FileExistsf(a.t, path, msg, args...)
+}
+
+// Greater asserts that the first element is greater than the second
+//
+//	a.Greater(2, 1)
+//	a.Greater(float64(2), float64(1))
+//	a.Greater("b", "a")
+func (a *Assertions) Greater(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greater(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqual asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqual(2, 1)
+//	a.GreaterOrEqual(2, 2)
+//	a.GreaterOrEqual("b", "a")
+//	a.GreaterOrEqual("b", "b")
+func (a *Assertions) GreaterOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// GreaterOrEqualf asserts that the first element is greater than or equal to the second
+//
+//	a.GreaterOrEqualf(2, 1, "error message %s", "formatted")
+//	a.GreaterOrEqualf(2, 2, "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "a", "error message %s", "formatted")
+//	a.GreaterOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) GreaterOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	GreaterOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Greaterf asserts that the first element is greater than the second
+//
+//	a.Greaterf(2, 1, "error message %s", "formatted")
+//	a.Greaterf(float64(2), float64(1), "error message %s", "formatted")
+//	a.Greaterf("b", "a", "error message %s", "formatted")
+func (a *Assertions) Greaterf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Greaterf(a.t, e1, e2, msg, args...)
+}
+
+// HTTPBodyContains asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyContainsf asserts that a specified handler returns a
+// body that contains a string.
+//
+//	a.HTTPBodyContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPBodyNotContains asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContains(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContains(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContains(a.t, handler, method, url, values, str, msgAndArgs...)
+}
+
+// HTTPBodyNotContainsf asserts that a specified handler returns a
+// body that does not contain a string.
+//
+//	a.HTTPBodyNotContainsf(myHandler, "GET", "www.google.com", nil, "I'm Feeling Lucky", "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPBodyNotContainsf(handler http.HandlerFunc, method string, url string, values url.Values, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPBodyNotContainsf(a.t, handler, method, url, values, str, msg, args...)
+}
+
+// HTTPError asserts that a specified handler returns an error status code.
+//
+//	a.HTTPError(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPError(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPError(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPErrorf asserts that a specified handler returns an error status code.
+//
+//	a.HTTPErrorf(myHandler, "POST", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPErrorf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPErrorf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPRedirect asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirect(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirect(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirect(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPRedirectf asserts that a specified handler returns a redirect status code.
+//
+//	a.HTTPRedirectf(myHandler, "GET", "/a/b/c", url.Values{"a": []string{"b", "c"}}
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPRedirectf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPRedirectf(a.t, handler, method, url, values, msg, args...)
+}
+
+// HTTPStatusCode asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCode(myHandler, "GET", "/notImplemented", nil, 501)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCode(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCode(a.t, handler, method, url, values, statuscode, msgAndArgs...)
+}
+
+// HTTPStatusCodef asserts that a specified handler returns a specified status code.
+//
+//	a.HTTPStatusCodef(myHandler, "GET", "/notImplemented", nil, 501, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPStatusCodef(handler http.HandlerFunc, method string, url string, values url.Values, statuscode int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPStatusCodef(a.t, handler, method, url, values, statuscode, msg, args...)
+}
+
+// HTTPSuccess asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccess(myHandler, "POST", "http://www.google.com", nil)
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccess(handler http.HandlerFunc, method string, url string, values url.Values, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccess(a.t, handler, method, url, values, msgAndArgs...)
+}
+
+// HTTPSuccessf asserts that a specified handler returns a success status code.
+//
+//	a.HTTPSuccessf(myHandler, "POST", "http://www.google.com", nil, "error message %s", "formatted")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func (a *Assertions) HTTPSuccessf(handler http.HandlerFunc, method string, url string, values url.Values, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	HTTPSuccessf(a.t, handler, method, url, values, msg, args...)
+}
+
+// Implements asserts that an object is implemented by the specified interface.
+//
+//	a.Implements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) Implements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// Implementsf asserts that an object is implemented by the specified interface.
+//
+//	a.Implementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) Implementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Implementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// InDelta asserts that the two numerals are within delta of each other.
+//
+//	a.InDelta(math.Pi, 22/7.0, 0.01)
+func (a *Assertions) InDelta(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDelta(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValues is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValues(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValues(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaMapValuesf is the same as InDelta, but it compares all values between two maps. Both maps must have exactly the same keys.
+func (a *Assertions) InDeltaMapValuesf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaMapValuesf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaSlice is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlice(expected interface{}, actual interface{}, delta float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlice(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// InDeltaSlicef is the same as InDelta, except it compares two slices.
+func (a *Assertions) InDeltaSlicef(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaSlicef(a.t, expected, actual, delta, msg, args...)
+}
+
+// InDeltaf asserts that the two numerals are within delta of each other.
+//
+//	a.InDeltaf(math.Pi, 22/7.0, 0.01, "error message %s", "formatted")
+func (a *Assertions) InDeltaf(expected interface{}, actual interface{}, delta float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InDeltaf(a.t, expected, actual, delta, msg, args...)
+}
+
+// InEpsilon asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilon(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilon(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlice is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlice(expected interface{}, actual interface{}, epsilon float64, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlice(a.t, expected, actual, epsilon, msgAndArgs...)
+}
+
+// InEpsilonSlicef is the same as InEpsilon, except it compares each value from two slices.
+func (a *Assertions) InEpsilonSlicef(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonSlicef(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// InEpsilonf asserts that expected and actual have a relative error less than epsilon
+func (a *Assertions) InEpsilonf(expected interface{}, actual interface{}, epsilon float64, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	InEpsilonf(a.t, expected, actual, epsilon, msg, args...)
+}
+
+// IsDecreasing asserts that the collection is decreasing
+//
+//	a.IsDecreasing([]int{2, 1, 0})
+//	a.IsDecreasing([]float{2, 1})
+//	a.IsDecreasing([]string{"b", "a"})
+func (a *Assertions) IsDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsDecreasingf asserts that the collection is decreasing
+//
+//	a.IsDecreasingf([]int{2, 1, 0}, "error message %s", "formatted")
+//	a.IsDecreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsDecreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsDecreasingf(a.t, object, msg, args...)
+}
+
+// IsIncreasing asserts that the collection is increasing
+//
+//	a.IsIncreasing([]int{1, 2, 3})
+//	a.IsIncreasing([]float{1, 2})
+//	a.IsIncreasing([]string{"a", "b"})
+func (a *Assertions) IsIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsIncreasingf asserts that the collection is increasing
+//
+//	a.IsIncreasingf([]int{1, 2, 3}, "error message %s", "formatted")
+//	a.IsIncreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsIncreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsIncreasingf(a.t, object, msg, args...)
+}
+
+// IsNonDecreasing asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasing([]int{1, 1, 2})
+//	a.IsNonDecreasing([]float{1, 2})
+//	a.IsNonDecreasing([]string{"a", "b"})
+func (a *Assertions) IsNonDecreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonDecreasingf asserts that the collection is not decreasing
+//
+//	a.IsNonDecreasingf([]int{1, 1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]float{1, 2}, "error message %s", "formatted")
+//	a.IsNonDecreasingf([]string{"a", "b"}, "error message %s", "formatted")
+func (a *Assertions) IsNonDecreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonDecreasingf(a.t, object, msg, args...)
+}
+
+// IsNonIncreasing asserts that the collection is not increasing
+//
+//	a.IsNonIncreasing([]int{2, 1, 1})
+//	a.IsNonIncreasing([]float{2, 1})
+//	a.IsNonIncreasing([]string{"b", "a"})
+func (a *Assertions) IsNonIncreasing(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasing(a.t, object, msgAndArgs...)
+}
+
+// IsNonIncreasingf asserts that the collection is not increasing
+//
+//	a.IsNonIncreasingf([]int{2, 1, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]float{2, 1}, "error message %s", "formatted")
+//	a.IsNonIncreasingf([]string{"b", "a"}, "error message %s", "formatted")
+func (a *Assertions) IsNonIncreasingf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsNonIncreasingf(a.t, object, msg, args...)
+}
+
+// IsType asserts that the specified objects are of the same type.
+func (a *Assertions) IsType(expectedType interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsType(a.t, expectedType, object, msgAndArgs...)
+}
+
+// IsTypef asserts that the specified objects are of the same type.
+func (a *Assertions) IsTypef(expectedType interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	IsTypef(a.t, expectedType, object, msg, args...)
+}
+
+// JSONEq asserts that two JSON strings are equivalent.
+//
+//	a.JSONEq(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`)
+func (a *Assertions) JSONEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// JSONEqf asserts that two JSON strings are equivalent.
+//
+//	a.JSONEqf(`{"hello": "world", "foo": "bar"}`, `{"foo": "bar", "hello": "world"}`, "error message %s", "formatted")
+func (a *Assertions) JSONEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	JSONEqf(a.t, expected, actual, msg, args...)
+}
+
+// Len asserts that the specified object has specific length.
+// Len also fails if the object has a type that len() not accept.
+//
+//	a.Len(mySlice, 3)
+func (a *Assertions) Len(object interface{}, length int, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Len(a.t, object, length, msgAndArgs...)
+}
+
+// Lenf asserts that the specified object has specific length.
+// Lenf also fails if the object has a type that len() not accept.
+//
+//	a.Lenf(mySlice, 3, "error message %s", "formatted")
+func (a *Assertions) Lenf(object interface{}, length int, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lenf(a.t, object, length, msg, args...)
+}
+
+// Less asserts that the first element is less than the second
+//
+//	a.Less(1, 2)
+//	a.Less(float64(1), float64(2))
+//	a.Less("a", "b")
+func (a *Assertions) Less(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Less(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqual asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqual(1, 2)
+//	a.LessOrEqual(2, 2)
+//	a.LessOrEqual("a", "b")
+//	a.LessOrEqual("b", "b")
+func (a *Assertions) LessOrEqual(e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqual(a.t, e1, e2, msgAndArgs...)
+}
+
+// LessOrEqualf asserts that the first element is less than or equal to the second
+//
+//	a.LessOrEqualf(1, 2, "error message %s", "formatted")
+//	a.LessOrEqualf(2, 2, "error message %s", "formatted")
+//	a.LessOrEqualf("a", "b", "error message %s", "formatted")
+//	a.LessOrEqualf("b", "b", "error message %s", "formatted")
+func (a *Assertions) LessOrEqualf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	LessOrEqualf(a.t, e1, e2, msg, args...)
+}
+
+// Lessf asserts that the first element is less than the second
+//
+//	a.Lessf(1, 2, "error message %s", "formatted")
+//	a.Lessf(float64(1), float64(2), "error message %s", "formatted")
+//	a.Lessf("a", "b", "error message %s", "formatted")
+func (a *Assertions) Lessf(e1 interface{}, e2 interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Lessf(a.t, e1, e2, msg, args...)
+}
+
+// Negative asserts that the specified element is negative
+//
+//	a.Negative(-1)
+//	a.Negative(-1.23)
+func (a *Assertions) Negative(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negative(a.t, e, msgAndArgs...)
+}
+
+// Negativef asserts that the specified element is negative
+//
+//	a.Negativef(-1, "error message %s", "formatted")
+//	a.Negativef(-1.23, "error message %s", "formatted")
+func (a *Assertions) Negativef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Negativef(a.t, e, msg, args...)
+}
+
+// Never asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Never(func() bool { return false; }, time.Second, 10*time.Millisecond)
+func (a *Assertions) Never(condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Never(a.t, condition, waitFor, tick, msgAndArgs...)
+}
+
+// Neverf asserts that the given condition doesn't satisfy in waitFor time,
+// periodically checking the target function each tick.
+//
+//	a.Neverf(func() bool { return false; }, time.Second, 10*time.Millisecond, "error message %s", "formatted")
+func (a *Assertions) Neverf(condition func() bool, waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Neverf(a.t, condition, waitFor, tick, msg, args...)
+}
+
+// Nil asserts that the specified object is nil.
+//
+//	a.Nil(err)
+func (a *Assertions) Nil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nil(a.t, object, msgAndArgs...)
+}
+
+// Nilf asserts that the specified object is nil.
+//
+//	a.Nilf(err, "error message %s", "formatted")
+func (a *Assertions) Nilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Nilf(a.t, object, msg, args...)
+}
+
+// NoDirExists checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExists(a.t, path, msgAndArgs...)
+}
+
+// NoDirExistsf checks whether a directory does not exist in the given path.
+// It fails if the path points to an existing _directory_ only.
+func (a *Assertions) NoDirExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoDirExistsf(a.t, path, msg, args...)
+}
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoError(err) {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoError(err error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoError(a.t, err, msgAndArgs...)
+}
+
+// NoErrorf asserts that a function returned no error (i.e. `nil`).
+//
+//	  actualObj, err := SomeFunction()
+//	  if a.NoErrorf(err, "error message %s", "formatted") {
+//		   assert.Equal(t, expectedObj, actualObj)
+//	  }
+func (a *Assertions) NoErrorf(err error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoErrorf(a.t, err, msg, args...)
+}
+
+// NoFileExists checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExists(path string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExists(a.t, path, msgAndArgs...)
+}
+
+// NoFileExistsf checks whether a file does not exist in a given path. It fails
+// if the path points to an existing _file_ only.
+func (a *Assertions) NoFileExistsf(path string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NoFileExistsf(a.t, path, msg, args...)
+}
+
+// NotContains asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContains("Hello World", "Earth")
+//	a.NotContains(["Hello", "World"], "Earth")
+//	a.NotContains({"Hello": "World"}, "Earth")
+func (a *Assertions) NotContains(s interface{}, contains interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContains(a.t, s, contains, msgAndArgs...)
+}
+
+// NotContainsf asserts that the specified string, list(array, slice...) or map does NOT contain the
+// specified substring or element.
+//
+//	a.NotContainsf("Hello World", "Earth", "error message %s", "formatted")
+//	a.NotContainsf(["Hello", "World"], "Earth", "error message %s", "formatted")
+//	a.NotContainsf({"Hello": "World"}, "Earth", "error message %s", "formatted")
+func (a *Assertions) NotContainsf(s interface{}, contains interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotContainsf(a.t, s, contains, msg, args...)
+}
+
+// NotElementsMatch asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 1, 2, 3]) -> false
+//
+// a.NotElementsMatch([1, 1, 2, 3], [1, 2, 3]) -> true
+//
+// a.NotElementsMatch([1, 2, 3], [1, 2, 4]) -> true
+func (a *Assertions) NotElementsMatch(listA interface{}, listB interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatch(a.t, listA, listB, msgAndArgs...)
+}
+
+// NotElementsMatchf asserts that the specified listA(array, slice...) is NOT equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should not match.
+// This is an inverse of ElementsMatch.
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 1, 2, 3], "error message %s", "formatted") -> false
+//
+// a.NotElementsMatchf([1, 1, 2, 3], [1, 2, 3], "error message %s", "formatted") -> true
+//
+// a.NotElementsMatchf([1, 2, 3], [1, 2, 4], "error message %s", "formatted") -> true
+func (a *Assertions) NotElementsMatchf(listA interface{}, listB interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotElementsMatchf(a.t, listA, listB, msg, args...)
+}
+
+// NotEmpty asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if a.NotEmpty(obj) {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmpty(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmpty(a.t, object, msgAndArgs...)
+}
+
+// NotEmptyf asserts that the specified object is NOT empty.  I.e. not nil, "", false, 0 or either
+// a slice or a channel with len == 0.
+//
+//	if a.NotEmptyf(obj, "error message %s", "formatted") {
+//	  assert.Equal(t, "two", obj[1])
+//	}
+func (a *Assertions) NotEmptyf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEmptyf(a.t, object, msg, args...)
+}
+
+// NotEqual asserts that the specified values are NOT equal.
+//
+//	a.NotEqual(obj1, obj2)
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqual(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqual(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValues asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValues(obj1, obj2)
+func (a *Assertions) NotEqualValues(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValues(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotEqualValuesf asserts that two objects are not equal even when converted to the same type
+//
+//	a.NotEqualValuesf(obj1, obj2, "error message %s", "formatted")
+func (a *Assertions) NotEqualValuesf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualValuesf(a.t, expected, actual, msg, args...)
+}
+
+// NotEqualf asserts that the specified values are NOT equal.
+//
+//	a.NotEqualf(obj1, obj2, "error message %s", "formatted")
+//
+// Pointer variable equality is determined based on the equality of the
+// referenced values (as opposed to the memory addresses).
+func (a *Assertions) NotEqualf(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotEqualf(a.t, expected, actual, msg, args...)
+}
+
+// NotErrorAs asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAs(err error, target interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorAsf asserts that none of the errors in err's chain matches target,
+// but if so, sets target to that error value.
+func (a *Assertions) NotErrorAsf(err error, target interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorAsf(a.t, err, target, msg, args...)
+}
+
+// NotErrorIs asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIs(err error, target error, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIs(a.t, err, target, msgAndArgs...)
+}
+
+// NotErrorIsf asserts that none of the errors in err's chain matches target.
+// This is a wrapper for errors.Is.
+func (a *Assertions) NotErrorIsf(err error, target error, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotErrorIsf(a.t, err, target, msg, args...)
+}
+
+// NotImplements asserts that an object does not implement the specified interface.
+//
+//	a.NotImplements((*MyInterface)(nil), new(MyObject))
+func (a *Assertions) NotImplements(interfaceObject interface{}, object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplements(a.t, interfaceObject, object, msgAndArgs...)
+}
+
+// NotImplementsf asserts that an object does not implement the specified interface.
+//
+//	a.NotImplementsf((*MyInterface)(nil), new(MyObject), "error message %s", "formatted")
+func (a *Assertions) NotImplementsf(interfaceObject interface{}, object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotImplementsf(a.t, interfaceObject, object, msg, args...)
+}
+
+// NotNil asserts that the specified object is not nil.
+//
+//	a.NotNil(err)
+func (a *Assertions) NotNil(object interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNil(a.t, object, msgAndArgs...)
+}
+
+// NotNilf asserts that the specified object is not nil.
+//
+//	a.NotNilf(err, "error message %s", "formatted")
+func (a *Assertions) NotNilf(object interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotNilf(a.t, object, msg, args...)
+}
+
+// NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanics(func(){ RemainCalm() })
+func (a *Assertions) NotPanics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanics(a.t, f, msgAndArgs...)
+}
+
+// NotPanicsf asserts that the code inside the specified PanicTestFunc does NOT panic.
+//
+//	a.NotPanicsf(func(){ RemainCalm() }, "error message %s", "formatted")
+func (a *Assertions) NotPanicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotPanicsf(a.t, f, msg, args...)
+}
+
+// NotRegexp asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexp(regexp.MustCompile("starts"), "it's starting")
+//	a.NotRegexp("^start", "it's not starting")
+func (a *Assertions) NotRegexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexp(a.t, rx, str, msgAndArgs...)
+}
+
+// NotRegexpf asserts that a specified regexp does not match a string.
+//
+//	a.NotRegexpf(regexp.MustCompile("starts"), "it's starting", "error message %s", "formatted")
+//	a.NotRegexpf("^start", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) NotRegexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotRegexpf(a.t, rx, str, msg, args...)
+}
+
+// NotSame asserts that two pointers do not reference the same object.
+//
+//	a.NotSame(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSame(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSame(a.t, expected, actual, msgAndArgs...)
+}
+
+// NotSamef asserts that two pointers do not reference the same object.
+//
+//	a.NotSamef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) NotSamef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSamef(a.t, expected, actual, msg, args...)
+}
+
+// NotSubset asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	a.NotSubset([1, 3, 4], [1, 2])
+//	a.NotSubset({"x": 1, "y": 2}, {"z": 3})
+func (a *Assertions) NotSubset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubset(a.t, list, subset, msgAndArgs...)
+}
+
+// NotSubsetf asserts that the specified list(array, slice...) or map does NOT
+// contain all elements given in the specified subset list(array, slice...) or
+// map.
+//
+//	a.NotSubsetf([1, 3, 4], [1, 2], "error message %s", "formatted")
+//	a.NotSubsetf({"x": 1, "y": 2}, {"z": 3}, "error message %s", "formatted")
+func (a *Assertions) NotSubsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotSubsetf(a.t, list, subset, msg, args...)
+}
+
+// NotZero asserts that i is not the zero value for its type.
+func (a *Assertions) NotZero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZero(a.t, i, msgAndArgs...)
+}
+
+// NotZerof asserts that i is not the zero value for its type.
+func (a *Assertions) NotZerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	NotZerof(a.t, i, msg, args...)
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panics(func(){ GoCrazy() })
+func (a *Assertions) Panics(f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panics(a.t, f, msgAndArgs...)
+}
+
+// PanicsWithError asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithError("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithError(errString string, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithError(a.t, errString, f, msgAndArgs...)
+}
+
+// PanicsWithErrorf asserts that the code inside the specified PanicTestFunc
+// panics, and that the recovered panic value is an error that satisfies the
+// EqualError comparison.
+//
+//	a.PanicsWithErrorf("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithErrorf(errString string, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithErrorf(a.t, errString, f, msg, args...)
+}
+
+// PanicsWithValue asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValue("crazy error", func(){ GoCrazy() })
+func (a *Assertions) PanicsWithValue(expected interface{}, f assert.PanicTestFunc, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValue(a.t, expected, f, msgAndArgs...)
+}
+
+// PanicsWithValuef asserts that the code inside the specified PanicTestFunc panics, and that
+// the recovered panic value equals the expected panic value.
+//
+//	a.PanicsWithValuef("crazy error", func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) PanicsWithValuef(expected interface{}, f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	PanicsWithValuef(a.t, expected, f, msg, args...)
+}
+
+// Panicsf asserts that the code inside the specified PanicTestFunc panics.
+//
+//	a.Panicsf(func(){ GoCrazy() }, "error message %s", "formatted")
+func (a *Assertions) Panicsf(f assert.PanicTestFunc, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Panicsf(a.t, f, msg, args...)
+}
+
+// Positive asserts that the specified element is positive
+//
+//	a.Positive(1)
+//	a.Positive(1.23)
+func (a *Assertions) Positive(e interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positive(a.t, e, msgAndArgs...)
+}
+
+// Positivef asserts that the specified element is positive
+//
+//	a.Positivef(1, "error message %s", "formatted")
+//	a.Positivef(1.23, "error message %s", "formatted")
+func (a *Assertions) Positivef(e interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Positivef(a.t, e, msg, args...)
+}
+
+// Regexp asserts that a specified regexp matches a string.
+//
+//	a.Regexp(regexp.MustCompile("start"), "it's starting")
+//	a.Regexp("start...$", "it's not starting")
+func (a *Assertions) Regexp(rx interface{}, str interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexp(a.t, rx, str, msgAndArgs...)
+}
+
+// Regexpf asserts that a specified regexp matches a string.
+//
+//	a.Regexpf(regexp.MustCompile("start"), "it's starting", "error message %s", "formatted")
+//	a.Regexpf("start...$", "it's not starting", "error message %s", "formatted")
+func (a *Assertions) Regexpf(rx interface{}, str interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Regexpf(a.t, rx, str, msg, args...)
+}
+
+// Same asserts that two pointers reference the same object.
+//
+//	a.Same(ptr1, ptr2)
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Same(expected interface{}, actual interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Same(a.t, expected, actual, msgAndArgs...)
+}
+
+// Samef asserts that two pointers reference the same object.
+//
+//	a.Samef(ptr1, ptr2, "error message %s", "formatted")
+//
+// Both arguments must be pointer variables. Pointer variable sameness is
+// determined based on the equality of both type and value.
+func (a *Assertions) Samef(expected interface{}, actual interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Samef(a.t, expected, actual, msg, args...)
+}
+
+// Subset asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	a.Subset([1, 2, 3], [1, 2])
+//	a.Subset({"x": 1, "y": 2}, {"x": 1})
+func (a *Assertions) Subset(list interface{}, subset interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subset(a.t, list, subset, msgAndArgs...)
+}
+
+// Subsetf asserts that the specified list(array, slice...) or map contains all
+// elements given in the specified subset list(array, slice...) or map.
+//
+//	a.Subsetf([1, 2, 3], [1, 2], "error message %s", "formatted")
+//	a.Subsetf({"x": 1, "y": 2}, {"x": 1}, "error message %s", "formatted")
+func (a *Assertions) Subsetf(list interface{}, subset interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Subsetf(a.t, list, subset, msg, args...)
+}
+
+// True asserts that the specified value is true.
+//
+//	a.True(myBool)
+func (a *Assertions) True(value bool, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	True(a.t, value, msgAndArgs...)
+}
+
+// Truef asserts that the specified value is true.
+//
+//	a.Truef(myBool, "error message %s", "formatted")
+func (a *Assertions) Truef(value bool, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Truef(a.t, value, msg, args...)
+}
+
+// WithinDuration asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDuration(time.Now(), time.Now(), 10*time.Second)
+func (a *Assertions) WithinDuration(expected time.Time, actual time.Time, delta time.Duration, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDuration(a.t, expected, actual, delta, msgAndArgs...)
+}
+
+// WithinDurationf asserts that the two times are within duration delta of each other.
+//
+//	a.WithinDurationf(time.Now(), time.Now(), 10*time.Second, "error message %s", "formatted")
+func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta time.Duration, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRange(a.t, actual, start, end, msgAndArgs...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//	a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRangef(a.t, actual, start, end, msg, args...)
+}
+
+// YAMLEq asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEq(expected string, actual string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEq(a.t, expected, actual, msgAndArgs...)
+}
+
+// YAMLEqf asserts that two YAML strings are equivalent.
+func (a *Assertions) YAMLEqf(expected string, actual string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	YAMLEqf(a.t, expected, actual, msg, args...)
+}
+
+// Zero asserts that i is the zero value for its type.
+func (a *Assertions) Zero(i interface{}, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zero(a.t, i, msgAndArgs...)
+}
+
+// Zerof asserts that i is the zero value for its type.
+func (a *Assertions) Zerof(i interface{}, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	Zerof(a.t, i, msg, args...)
+}

--- a/tools/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
+++ b/tools/vendor/github.com/stretchr/testify/require/require_forward.go.tmpl
@@ -1,0 +1,5 @@
+{{.CommentWithoutT "a"}}
+func (a *Assertions) {{.DocInfo.Name}}({{.Params}}) {
+	if h, ok := a.t.(tHelper); ok { h.Helper() }
+	{{.DocInfo.Name}}(a.t, {{.ForwardedParams}})
+}

--- a/tools/vendor/github.com/stretchr/testify/require/requirements.go
+++ b/tools/vendor/github.com/stretchr/testify/require/requirements.go
@@ -1,0 +1,29 @@
+package require
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+type tHelper = interface {
+	Helper()
+}
+
+// ComparisonAssertionFunc is a common function prototype when comparing two values.  Can be useful
+// for table driven tests.
+type ComparisonAssertionFunc func(TestingT, interface{}, interface{}, ...interface{})
+
+// ValueAssertionFunc is a common function prototype when validating a single value.  Can be useful
+// for table driven tests.
+type ValueAssertionFunc func(TestingT, interface{}, ...interface{})
+
+// BoolAssertionFunc is a common function prototype when validating a bool value.  Can be useful
+// for table driven tests.
+type BoolAssertionFunc func(TestingT, bool, ...interface{})
+
+// ErrorAssertionFunc is a common function prototype when validating an error value.  Can be useful
+// for table driven tests.
+type ErrorAssertionFunc func(TestingT, error, ...interface{})
+
+//go:generate sh -c "cd ../_codegen && go build && cd - && ../_codegen/_codegen -output-package=require -template=require.go.tmpl -include-format-funcs"

--- a/tools/vendor/modules.txt
+++ b/tools/vendor/modules.txt
@@ -939,6 +939,7 @@ github.com/stretchr/objx
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/assert/yaml
 github.com/stretchr/testify/mock
+github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.4.1
 ## explicit; go 1.18
 github.com/subosito/gotenv


### PR DESCRIPTION
Backports the changelog-tooling (chloggen) work to `release-v2.9`.

### Cherry-picked PRs (in order)

1. #7346 — chore(tools): add chloggen for changelog management (the in-tree fork)
2. #7351 — chore(tools): configurable chloggen change types and required entry author
3. #7339 — chore: adopt chloggen for changelog management
4. #7366 — chore: update changelog check to include modified files
5. #7368 — chore(chloggen): branch-name default, optional auto-filled PR, type/docs skip

### Backport adaptations

`main`-specific content in #7339/#7368 did not belong on a release branch, so it was adapted:

- **Dropped** the 28 `.chloggen/_migrated_*.yaml` files (they captured *main's* unreleased entries, not this branch's).
- **Migrated this branch's own** `## main / unreleased` CHANGELOG entries into `.chloggen/*.yaml` and replaced the section with the `<!-- next version -->` marker.
- **CONTRIBUTING.md**: kept this branch's existing structure (it has no chloggen changelog section to edit upstream of these PRs).
- **RELEASES.MD**: applied only the chloggen-relevant edits (use `make chlog-update`), preserving this branch's existing release-process structure.
- **tools/go.mod**: kept this branch's module graph and re-tidied to add chloggen's deps.
- **changelog workflow** (`.github/workflows/changelog.yml`): retargeted from `main` to `release-v2.9` (PR trigger branch + `git merge-base` base) so the check runs on backport PRs to this branch. Added as a separate adaptation commit.

### Verification

- `make chlog-validate` passes; `make chlog-preview` renders the migrated entries correctly.
- `go test ./...` in `tools/chloggen` is green.
