### PR TITLE
jsonnet: use AverageValue for the live-store autoscaler trigger

### DIFF
--- a/.chloggen/fix_live_store_keda_average_value.yaml
+++ b/.chloggen/fix_live_store_keda_average_value.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: operations
+
+note: Use `AverageValue` (not `Value`) for the live-store KEDA autoscaler trigger; the `Value` metricType mis-scales the byte-valued ingest metric and runs the autoscaler away to maxReplicas regardless of load.
+
+issues: [7376]
+
+subtext:
+
+user: zalegrala

--- a/operations/jsonnet/microservices/autoscaling.libsonnet
+++ b/operations/jsonnet/microservices/autoscaling.libsonnet
@@ -337,15 +337,20 @@
       $.scaledObjectForController($.tempo_live_store_replica_template, 'live_store')
       + scaledObject.spec.withTriggersMixin(
         [
-          // metricType: Value → desiredReplicas = ceil(queryResult / threshold).
-          // The query returns total expected bytes across all pods, so we must use
-          // Value rather than the default AverageValue (which would multiply by
-          // currentReplicas and cause runaway scaling).
+          // metricType: AverageValue → desiredReplicas = ceil(queryResult / threshold), where the
+          // query returns total expected bytes across all pods and threshold is the per-replica
+          // target (bytes_per_replica). This yields total / per-replica = the desired replica count.
+          //
+          // Do NOT use metricType 'Value' here. KEDA serves the metric to the HPA as a
+          // milli-quantity; for a large byte-valued metric the 'Value' path mis-scales it (the HPA
+          // divides the milli-integer by the plain threshold) and the scaler runs away to
+          // maxReplicas regardless of actual load (observed in dev). 'AverageValue' computes the
+          // same intended replica count and is unit-safe.
           $.prometheusTrigger(
             query=query,
             metricName='tempo_live_store_expected_bytes',
             threshold='%d' % config.bytes_per_replica,
-          ) + { metricType: 'Value' },
+          ) + { metricType: 'AverageValue' },
         ] + config.additional_triggers
       )
     else {},

--- a/operations/jsonnet/microservices/test/test1.jsonnet
+++ b/operations/jsonnet/microservices/test/test1.jsonnet
@@ -102,6 +102,13 @@ test.new(std.thisFile)
   )
 )
 + test.case.new(
+  'live_store KEDA Prometheus trigger uses AverageValue metricType',
+  test.expect.eq(
+    withLiveStoreKeda('http://prometheus:9090').tempo_live_store_scaled_object.spec.triggers[0].metricType,
+    'AverageValue'
+  )
+)
++ test.case.new(
   'live_store KEDA Prometheus trigger includes X-Scope-OrgID header when tenant is set',
   test.expect.eq(
     withLiveStoreKeda('http://prometheus:9090', 'my-tenant').tempo_live_store_scaled_object.spec.triggers[0].metadata.customHeaders,


### PR DESCRIPTION
**What this PR does**:

Use `metricType: AverageValue` (not `Value`) for the live-store KEDA autoscaler trigger.

The trigger intended `desiredReplicas = ceil(total_bytes / bytes_per_replica)`, but KEDA serves the metric to the HPA as a milli-quantity and the `Value` path mis-scales this large byte-valued metric, so the autoscaler runs away to `maxReplicas` regardless of load (observed on a dev cell: flat ingest, live-store replicas climbing to the cap). `AverageValue` computes the same intended replica count (total / per-replica) and is unit-safe.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
