### PR TITLE
chore(ci): annotate PR coverage via shared annotate-coverage action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,7 @@ jobs:
   coverage-annotations:
     name: Coverage Annotations
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     needs: [unit-tests]
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,12 +296,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0  # Fetch full history for proper diff computation
 
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: 'go.mod'
-
       - name: Download all coverage artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -309,9 +303,10 @@ jobs:
           path: .coverage/
           merge-multiple: true
 
-      - name: Generate coverage annotations with canopy
-        run: |
-          go run github.com/oleg-kozlyuk-grafana/go-canopy/cmd/canopy@e147d900bcd82da500bf3b8ce55dfddceb73f310 \
-            --base ${{ github.event.pull_request.base.sha }} \
-            --commit ${{ github.event.pull_request.head.sha }} \
-            --format GitHubAnnotations
+      - name: Annotate uncovered lines in PR diff
+        uses: grafana/shared-workflows/actions/annotate-coverage@ccd82960521026200c6b51f6c61100732a1a62f3 # annotate-coverage/v0.2.0
+        with:
+          coverage-path: .coverage
+          format: GitHubAnnotations
+          base-ref: ${{ github.event.pull_request.base.sha }}
+          commit-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Migrates the `coverage-annotations` CI job to the [`annotate-coverage`](https://github.com/grafana/shared-workflows/tree/main/actions/annotate-coverage) composite action, now that it's merged and released in `grafana/shared-workflows`.

## What changed

- Replaces the inline `go run .../go-canopy` step with `grafana/shared-workflows/actions/annotate-coverage`, SHA-pinned to `annotate-coverage/v0.2.0` (matching how Tempo pins every other shared-workflows action).
- Removes the job's separate `Set up Go` step — the composite action sets up Go and builds its own binary.

The action reads the merged coverage profiles from `.coverage/`, intersects them with the PR diff (`base-ref`..`commit-sha`), and emits `::notice` workflow commands that GitHub renders as annotations on uncovered changed lines. Behaviour is unchanged from the `canopy`-based step it replaces.

No changelog entry: this is a CI-only change with no operator- or user-facing impact (hence the `chore(ci):` title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
