### PR TITLE
ci: re-enable darwin release builds again

### DIFF
--- a/.chloggen/7404-reenable-darwin-builds.yaml
+++ b/.chloggen/7404-reenable-darwin-builds.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: tempo
+note: re-enable darwin release builds again
+issues: [7404]
+subtext:
+user: electron0zero

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+      - darwin
       - linux
       - windows
     goarch:
@@ -36,7 +36,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+      - darwin
       - linux
       - windows
     goarch:
@@ -61,7 +61,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos:
-#      - darwin  re-enable when https://github.com/golang/go/issues/73617 is fixed
+      - darwin
       - linux
       - windows
     goarch:


### PR DESCRIPTION
**What this PR does**:

re-enabeld the darwin builds that were disabled due to https://github.com/golang/go/issues/73617

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/7404

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)