### PR TITLE
MCP server: Update TraceQL docs for tempo MCP server

### DIFF
--- a/.chloggen/7375-update-traceql-doc-mcp.yaml
+++ b/.chloggen/7375-update-traceql-doc-mcp.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Update the TraceQL and metrics documentation served by the MCP server to match current capabilities.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7375]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: knylander-grafana

--- a/modules/frontend/docs/basic.md
+++ b/modules/frontend/docs/basic.md
@@ -28,7 +28,7 @@ Intrinsic fields use colon notation `<scope>:`:
 - `span:kind` - Kind: server, client, producer, consumer, internal, unspecified
 - `span:id` - Span ID using hex string
 - `span:parentID` - Parent span ID using hex string
-- `span:childCount` - Number of direct children of the span
+- `span:childCount` - Number of direct children of the span (requires vParquet5 or later)
 - `trace:duration` - Max(end) - min(start) time of spans in trace
 - `trace:rootName` - Name of the root span (if it exists)
 - `trace:rootService` - Service name of the root span (if it exists)
@@ -47,6 +47,24 @@ Attributes use dot notation `<scope>.`:
 - `event.` - Event attributes
 - `link.` - Link attributes
 - `instrumentation.` - Instrumentation scope attributes
+
+## Value Types and Literals
+TraceQL supports several literal types for expressing values in queries.
+
+- Integers: positive or negative whole numbers, for example `200` or `-1`. The constants `minInt` and `maxInt` represent the minimum and maximum 64-bit integer values.
+- Floats: decimal notation, for example `1.5`.
+- Durations: a number with a unit. Supported units are `ns`, `us`, `ms`, `s`, `m`, and `h`, for example `100ms` or `5s`. Durations can be signed.
+- Strings: enclosed in double quotes, for example `"GET"`.
+- Nil: use `nil` to check for missing or null attributes, and `!= nil` to require an attribute to be present.
+
+Examples:
+```
+{ span.http.status_code = 200 }
+{ span:duration > 100ms }
+{ span.value > 1.5 }
+{ span.optional_field = nil }
+{ span.required_field != nil }
+```
 
 ## Comparison Operators
 - `=` - Equality
@@ -131,6 +149,26 @@ Spanset operators allow conditions to be asserted on different spans within a tr
 ```
 { span."attribute name with space" = "value" }
 { span.attribute."attribute name with space" = "value" }
+```
+
+## Selecting Fields
+Use the `select()` pipeline operator to return specific attributes from matching spans. Selected fields aren't retrieved until all other criteria are met, which makes this performant.
+```
+{ span.http.status_code = 200 } | select(resource.service.name)
+{ span:status = error } | select(span.http.status_code, span.http.url)
+```
+
+## Arithmetic in Expressions
+TraceQL supports arithmetic within field expressions, which can make queries more readable.
+```
+{ span.http.request_content_length > 10 * 1024 * 1024 }
+```
+
+## Retrieve Most Recent Results
+By default, Tempo returns the first `N` matching traces, which might not be the newest. Use the `most_recent=true` query hint with any selection query to force Tempo to return the most recent results ordered by time.
+```
+{} with (most_recent=true)
+{ span.foo = "bar" } >> { span:status = error } with (most_recent=true)
 ```
 
 ## Performance Tips

--- a/modules/frontend/docs/basic.md
+++ b/modules/frontend/docs/basic.md
@@ -54,7 +54,7 @@ TraceQL supports several literal types for expressing values in queries.
 - Integers: positive or negative whole numbers, for example `200` or `-1`. The constants `minInt` and `maxInt` represent the minimum and maximum 64-bit integer values.
 - Floats: decimal notation, for example `1.5`.
 - Durations: a number with a unit. Supported units are `ns`, `us`, `ms`, `s`, `m`, and `h`, for example `100ms` or `5s`. Durations can be signed.
-- Strings: enclosed in double quotes, for example `"GET"`.
+- Strings: enclosed in double quotes or backticks, for example `"GET"` or `` `GET` ``.
 - Nil: use `nil` to check for missing or null attributes, and `!= nil` to require an attribute to be present.
 
 Examples:
@@ -86,7 +86,7 @@ Examples:
 - `||` - OR (either condition can be true)
 
 ## Spanset Operators
-Spanset operators allow conditions to be asserted on different spans within a trace. Also see strutural operators.
+Spanset operators allow conditions to be asserted on different spans within a trace. Also see structural operators.
 
 - `{condA} && {condB}` - Both conditions found matches
 - `{condA} || {condB}` - Either condition found matches

--- a/modules/frontend/docs/metrics.md
+++ b/modules/frontend/docs/metrics.md
@@ -25,7 +25,7 @@ Counts matching spans per time interval (controlled by `step` parameter).
 
 Examples:
 ```
-{ name = "GET /api/users" } | count_over_time()
+{ span:name = "GET /api/users" } | count_over_time()
 { span.http.status_code >= 500 } | count_over_time() by (resource.service.name)
 ```
 
@@ -98,16 +98,66 @@ Limit results to top or bottom N series:
 { } | rate() by (span.http.route) | bottomk(5)
 ```
 
+## Comparison Operators on Results
+Apply comparison operators to a metrics result to keep only the data points that meet a threshold. Supported operators are `>`, `>=`, `<`, `<=`, `=`, and `!=`. You can compare against integers, floats, and durations (for example `1s` or `500ms`).
+```
+{ } | rate() by (resource.service.name) > 10
+{ span:name = "GET /:endpoint" } | avg_over_time(span:duration) > 1s
+{ } | count_over_time() by (span:name) != 0
+```
+
+Data points that don't match are removed. If all data points in a series are removed, the entire series is dropped.
+
+Comparison operators can be chained with `topk` and `bottomk` in any order, applied left to right:
+```
+{ } | rate() by (span.http.url) | topk(5) > 10
+{ } | rate() by (span.http.url) > 0 | topk(5)
+```
+
+## Data Sampling
+TraceQL metrics queries support sampling hints to optimize performance. Sampling hints only work with metrics queries (functions like `rate()`, `count_over_time()`, and so on).
+
+- Dynamic sampling: `with(sample=true)` automatically determines the sampling strategy and amount based on the query.
+- Fixed sampling: `with(sample=0.xx)`.
+- Fixed span sampling: `with(span_sample=0.xx)` selects the given percentage of spans.
+- Fixed trace sampling: `with(trace_sample=0.xx)` selects complete traces.
+
+Examples:
+```
+{ resource.service.name = "frontend" } | rate() with(sample=true)
+{ } | count_over_time() by (resource.service.name) with(sample=0.1)
+{ span:status = error } | count_over_time() with(span_sample=0.1)
+{ } | count_over_time() by (resource.service.name) with(trace_sample=0.05)
+```
+
 ## Compare Function
-Split spans into selection and baseline groups to highlight differences:
+Split spans into a selection group and a baseline group to highlight the differences between them. The function returns time-series for all attributes found on the spans.
 ```
 { <base_condition> } | compare({<selection_condition>}, <topN>, <start_timestamp>, <end_timestamp>)
 ```
+
+Parameters:
+- Required. A spanset filter that chooses the subset of spans. Matching spans are the selection; the rest are the baseline. Common filters are `{span:status = error}` (what is different about errors?) or `{span:duration > 1s}` (what is different about slow spans?).
+- Optional. The top `N` values to return per attribute. Defaults to `10`.
+- Optional. Start and end timestamps in Unix nanoseconds to constrain the selection window by time. Both must be given, or neither.
 
 Example:
 ```
 { resource.service.name = "api" && span.http.path = "/users" } | compare({span:status = error})
 ```
+
+The output is flat time-series for each attribute/value found in the spans. Each series carries a `__meta_type` label set to either `selection` or `baseline`:
+```
+{ __meta_type="baseline", resource.cluster="prod" } 123
+{ __meta_type="selection", resource.cluster="prod" } 456
+```
+
+When an attribute exceeds the top `N` limit, an error indicator series is included:
+```
+{ __meta_error="__too_many_values__", resource.cluster=<nil> }
+```
+
+`compare()` can't be combined with `topk`, `bottomk`, or comparison operators. It's generally run as an instant query.
 
 ## Practical Examples
 

--- a/modules/frontend/docs/metrics.md
+++ b/modules/frontend/docs/metrics.md
@@ -146,18 +146,22 @@ Example:
 { resource.service.name = "api" && span.http.path = "/users" } | compare({span:status = error})
 ```
 
-The output is flat time-series for each attribute/value found in the spans. Each series carries a `__meta_type` label set to either `selection` or `baseline`:
+The output is flat time-series for each attribute/value found in the spans. Each series carries a `__meta_type` label indicating the group. Possible values are `baseline`, `selection`, `baseline_total`, and `selection_total`:
 ```
 { __meta_type="baseline", resource.cluster="prod" } 123
 { __meta_type="selection", resource.cluster="prod" } 456
+{ __meta_type="baseline_total", resource.cluster="prod" } 1000
+{ __meta_type="selection_total", resource.cluster="prod" } 800
 ```
+
+The `baseline_total` and `selection_total` series report the overall count across all values for each attribute, which helps calculate relative proportions.
 
 When an attribute exceeds the top `N` limit, an error indicator series is included:
 ```
 { __meta_error="__too_many_values__", resource.cluster=<nil> }
 ```
 
-`compare()` can't be combined with `topk`, `bottomk`, or comparison operators. It's generally run as an instant query.
+`compare()` can't be combined with second-stage functions such as `topk`, `bottomk`, comparison operators, or arithmetic expressions. It's generally run as an instant query.
 
 ## Practical Examples
 


### PR DESCRIPTION
**What this PR does**:

Updates the TraceQL docs in the tempo MCP server for 3.0 TraceQL capabilities. 

**Which issue(s) this PR fixes**:
Fixes #7375 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)