### PR TITLE
chore: backport busybox removal (#5717, #5754) to release-v2.9 [CVE-2025-60876]

### DIFF
--- a/.chloggen/backport-5717-to-release-v2.9.yaml
+++ b/.chloggen/backport-5717-to-release-v2.9.yaml
@@ -1,0 +1,6 @@
+change_type: change
+component: tempo
+note: Remove busybox from Tempo image to make it more minimal and prevent future vulnerabilities.
+issues: [5717]
+subtext:
+user: carles-grafana

--- a/cmd/tempo-vulture/Dockerfile
+++ b/cmd/tempo-vulture/Dockerfile
@@ -1,16 +1,18 @@
 FROM alpine:latest AS ca-certificates
 RUN apk add --update --no-cache ca-certificates
 
-FROM gcr.io/distroless/static-debian12:debug
-
-SHELL ["/busybox/sh", "-c"]
+FROM gcr.io/distroless/static-debian12:debug AS tempo-setup
 
 RUN ["/busybox/addgroup", "-g", "10001", "-S", "tempo"]
 RUN ["/busybox/adduser", "-u", "10001", "-S", "tempo", "-G", "tempo"]
 
+FROM gcr.io/distroless/static-debian12
+
 ARG TARGETARCH
 COPY bin/linux/tempo-vulture-${TARGETARCH} /tempo-vulture
 COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=tempo-setup /etc/passwd /etc/passwd
+COPY --from=tempo-setup /etc/group /etc/group
 
 USER 10001:10001
 

--- a/cmd/tempo/Dockerfile
+++ b/cmd/tempo/Dockerfile
@@ -15,7 +15,7 @@ COPY bin/linux/tempo-${TARGETARCH} /tempo
 COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=tempo-setup /etc/passwd /etc/passwd
 COPY --from=tempo-setup /etc/group /etc/group
-COPY --from=tempo-setup --chown=10001:10001 /var/tempo /var/tempo
+COPY --from=tempo-setup --chown=10001:10001 --chmod=0700 /var/tempo /var/tempo
 
 USER 10001:10001
 

--- a/cmd/tempo/Dockerfile
+++ b/cmd/tempo/Dockerfile
@@ -1,19 +1,21 @@
 FROM alpine:latest AS ca-certificates
 RUN apk add --update --no-cache ca-certificates
 
-FROM gcr.io/distroless/static-debian12:debug
-
-# we need this because some docker-compose files call chown assuming there's a shell
-SHELL ["/busybox/sh", "-c"]
+# Use the same image with busybox for the setup to ensure the /etc files are compatible.
+FROM gcr.io/distroless/static-debian12:debug AS tempo-setup
 
 RUN ["/busybox/addgroup", "-g", "10001", "-S", "tempo"]
 RUN ["/busybox/adduser", "-u", "10001", "-S", "tempo", "-G", "tempo"]
-RUN ["/busybox/mkdir", "-p", "/var/tempo", "-m", "0700"]
-RUN ["/busybox/chown", "-R", "tempo:tempo", "/var/tempo"]
+RUN ["/busybox/mkdir", "-p", "/var/tempo"]
+
+FROM gcr.io/distroless/static-debian12
 
 ARG TARGETARCH
 COPY bin/linux/tempo-${TARGETARCH} /tempo
 COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=tempo-setup /etc/passwd /etc/passwd
+COPY --from=tempo-setup /etc/group /etc/group
+COPY --from=tempo-setup --chown=10001:10001 /var/tempo /var/tempo
 
 USER 10001:10001
 

--- a/example/docker-compose/alloy/docker-compose.yaml
+++ b/example/docker-compose/alloy/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: *tempoImage
+    image: grafana/tempo:2.9.2
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/debug/docker-compose.yaml
+++ b/example/docker-compose/debug/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo-debug:latest
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: *tempoImage
+    image: grafana/tempo-debug:latest
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -12,7 +12,7 @@ services:
       - ./tempo-data:/var/tempo
 
   distributor:
-    image: *tempoImage
+    image: &tempoImage grafana/tempo:2.9.2
     depends_on:
       - kafka
     command: "-target=distributor -config.file=/etc/tempo.yaml"

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -21,7 +21,7 @@ services:
       - MEMCACHED_THREADS=4 # Number of threads to use
 
   tempo:
-    image: *tempoImage
+    image: grafana/tempo:2.9.2
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: *tempoImage
+    image: grafana/tempo:2.9.2
     command: [ "-config.file=/etc/tempo.yaml" ]
     environment:
       - GRPC_TRACE=api

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: *tempoImage
+    image: grafana/tempo:2.9.2
     command: [ "-multitenancy.enabled=true", "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: *tempoImage
+    image: grafana/tempo:2.9.2
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/vulture/docker-compose.yaml
+++ b/example/docker-compose/vulture/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   # Tempo runs as user 10001, and docker compose creates the volume as root.
   # As such, we need to chown the volume in order for Tempo to start correctly.
   init:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: busybox:latest
     user: root
     entrypoint:
       - "chown"
@@ -12,7 +12,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: *tempoImage
+    image: grafana/tempo:2.9.2
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml


### PR DESCRIPTION
**What this PR does**:

Backports #5717 and #5754 to `release-v2.9` to remove busybox from the Tempo image, fixing CVE-2025-60876 (BusyBox `wget` request-line/header injection) reported against `grafana/tempo:2.9.2`.

`:debug` is now used only in a throwaway `tempo-setup` builder stage; the final image ships from plain `gcr.io/distroless/static-debian12` with no busybox. Example docker-compose `init` helpers switch to `busybox:latest`; Tempo images stay pinned to `2.9.2`.

The fix landed on `main`/`release-v2.10`/`release-v3.0` after the 2.9 branch was cut, so it was never backported.

**Which issue(s) this PR fixes**:
Backport of #5717, #5754

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
