### PR TITLE
chore: prepare v3.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 <!-- next version -->
 
+# v3.0.1
+
+## 🔒 Security 🔒
+
+- `deps`: Build Tempo with Go 1.26.3, which includes upstream security and bug fixes. ([#7423](https://github.com/grafana/tempo/issues/7423)) (@ie-pham)
+
 # v3.0.0
 
 * [CHANGE] **BREAKING CHANGE** Recent data queries guarantee complete results by failing when an instance is lagging. Defaults `query_frontend.query_end_cutoff` to `30s` and `live_store.fail_on_high_lag` to `true`. [#7210](https://github.com/grafana/tempo/pull/7210) (@mapno)

--- a/Makefile
+++ b/Makefile
@@ -395,6 +395,8 @@ generate-manifest:  ## Generate manifest.md file
 ##@ Release
 
 TEMPO_IMAGE_TAG ?=
+# The migrate-to-3 example intentionally pins distinct v2 and v3 tempo image
+# tags to demonstrate a 2.x -> 3.0 migration, so it is excluded from the bump.
 .PHONY: bump-tempo-image-tag
 bump-tempo-image-tag: ## Bump grafana/tempo image tag in docker-compose and jsonnet files. Usage: make bump-tempo-image-tag TEMPO_IMAGE_TAG=2.10.2
 	@test -n "$(TEMPO_IMAGE_TAG)" || (echo "ERROR: TEMPO_IMAGE_TAG is required. Usage: make bump-tempo-image-tag TEMPO_IMAGE_TAG=<tag>"; exit 1)
@@ -405,6 +407,7 @@ bump-tempo-image-tag: ## Bump grafana/tempo image tag in docker-compose and json
 		-not -path './.git/*' \
 		-not -path './vendor/*' \
 		-not -path './.worktrees/*' \
+		-not -path './example/docker-compose/migrate-to-3/*' \
 		\( -name "*.yaml" -o -name "*.libsonnet" -o -name "*.jsonnet" -o -name "*.md" \) \
 		-print0 \
 		| xargs -0 grep -l "grafana/tempo:" \

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -227,7 +227,7 @@ Install the `k.libsonnet`, Jsonnet, and Memcached libraries.
 
    tempo {
     _images+:: {
-          tempo: 'grafana/tempo:3.0.0',
+          tempo: 'grafana/tempo:3.0.1',
       },
 
        tempo_distributor_container+:: container.withPorts([

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   # tempo, backend and kafka
   distributor:
-    image: &tempoImage grafana/tempo:3.0.0
+    image: &tempoImage grafana/tempo:3.0.1
     depends_on:
       - redpanda
     command: "-target=distributor -config.file=/etc/tempo.yaml"

--- a/example/docker-compose/multitenant/docker-compose.yaml
+++ b/example/docker-compose/multitenant/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   tempo:
-    image: grafana/tempo:3.0.0
+    image: grafana/tempo:3.0.1
     command: [ "-config.file=/etc/tempo.yaml", "-target=all"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/readme.md
+++ b/example/docker-compose/readme.md
@@ -33,9 +33,9 @@ See below for a list of all examples and the features they demonstrate
 ### Build images (optional)
 
 This step is not necessary, but it can be nice for local testing. The examples use the released
-`grafana/tempo:3.0.0` image by default. To test local code, run the following from the project root
-folder and either update the compose files to use `grafana/tempo:latest` or tag the locally built image
-as `grafana/tempo:3.0.0`:
+`grafana/tempo:3.0.1` image by default. To test local code, run the following from the project root
+folder and either update the compose files to use `grafana/tempo:3.0.1` or tag the locally built image
+as `grafana/tempo:3.0.1`:
 
 ```console
 make docker-images

--- a/example/docker-compose/single-binary/docker-compose.yaml
+++ b/example/docker-compose/single-binary/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   tempo:
-    image: grafana/tempo:3.0.0
+    image: grafana/tempo:3.0.1
     command: "-target=all -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/example/tk/readme.md
+++ b/example/tk/readme.md
@@ -22,7 +22,7 @@ k3d cluster create tempo --api-port 6443 --port "3000:80@loadbalancer"
 If you wish to use a local image, you can import these into k3d
 
 ```console
-k3d image import grafana/tempo:latest --cluster tempo
+k3d image import grafana/tempo:3.0.1 --cluster tempo
 ```
 
 Next either deploy the microservices or the single binary. You can also use tanka [inline environments](https://tanka.dev/inline-environments) to deploy Tempo with either of the two.

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-distributor.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=distributor
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-metrics-generator.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-querier.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=querier
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: querier
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/Deployment-query-frontend.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=query-frontend
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-scheduler.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-scheduler
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: backend-scheduler
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-backend-worker.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-worker
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: backend-worker
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-block-builder.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=block-builder
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: block-builder
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-a.yaml
@@ -67,7 +67,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-a
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-live-store-zone-b.yaml
@@ -68,7 +68,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-b
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices-with-extras/gen/StatefulSet-metrics-generator.yaml
@@ -32,7 +32,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices-with-extras/main.jsonnet
+++ b/operations/jsonnet-compiled/microservices-with-extras/main.jsonnet
@@ -6,7 +6,7 @@ tempo
 + tempo.util.withInet6()
   {
   _images+:: {
-    tempo: 'grafana/tempo:3.0.0',
+    tempo: 'grafana/tempo:3.0.1',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     tempo_query: 'grafana/tempo-query:latest',
   },

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=distributor
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=querier
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: querier
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=query-frontend
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-scheduler
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: backend-scheduler
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
@@ -23,7 +23,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=backend-worker
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: backend-worker
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
@@ -27,7 +27,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=block-builder
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: block-builder
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
@@ -67,7 +67,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-a
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
@@ -68,7 +68,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -target=live-store
         - -live-store.instance-availability-zone=zone-b
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
@@ -32,7 +32,7 @@ spec:
       - args:
         - -config.file=/conf/tempo.yaml
         - -target=metrics-generator
-        image: grafana/tempo:3.0.0
+        image: grafana/tempo:3.0.1
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices/main.jsonnet
+++ b/operations/jsonnet-compiled/microservices/main.jsonnet
@@ -4,7 +4,7 @@ local tempo = import 'microservices/tempo.libsonnet';
 
 tempo {
   _images+:: {
-    tempo: 'grafana/tempo:3.0.0',
+    tempo: 'grafana/tempo:3.0.1',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     tempo_query: 'grafana/tempo-query:latest',
   },

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:3.0.0',
+    tempo: 'grafana/tempo:3.0.1',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     memcached: 'memcached:1.6.40-alpine',

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:3.0.0',
+    tempo: 'grafana/tempo:3.0.1',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
   },


### PR DESCRIPTION
**What this PR does**:

Prepares the v3.0.1 patch release:
- Adds the `# v3.0.1` section to `CHANGELOG.md`.
- Bumps the `grafana/tempo` image tag to 3.0.1 in example configs, docs, and compiled jsonnet (`make bump-tempo-image-tag` + `make jsonnet`).
- Excludes the `migrate-to-3` docker-compose example from `bump-tempo-image-tag`, since it intentionally pins distinct v2/v3 image tags to demonstrate a 2.x → 3.0 migration.

**Which issue(s) this PR fixes**:

N/A — release preparation.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`