### PR TITLE
chore: prepare v2.10.6 release

### DIFF
--- a/.chloggen/_migrated_00_7298.yaml
+++ b/.chloggen/_migrated_00_7298.yaml
@@ -1,6 +1,0 @@
-change_type: change
-component: deps
-note: Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others).
-issues: [7298]
-subtext:
-user: zhxiaogg

--- a/.chloggen/_migrated_01_7322.yaml
+++ b/.chloggen/_migrated_01_7322.yaml
@@ -1,6 +1,0 @@
-change_type: breaking
-component: distributor
-note: Dropped support for the OpenCensus receiver.
-issues: [7322]
-subtext:
-user: zhxiaogg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 <!-- next version -->
 
+# v2.10.6
+
+## 🔒 Security 🔒
+
+- `deps`: Update github.com/apache/thrift to v0.23.0 to pick up upstream security fixes. ([#7120](https://github.com/grafana/tempo/issues/7120)) (@renovate)
+- `deps`: Update golang.org/x/crypto to v0.52.0 to pick up upstream security fixes. ([#7262](https://github.com/grafana/tempo/issues/7262)) (@renovate)
+- `deps`: Update golang.org/x/net to v0.55.0 to pick up upstream security fixes. ([#7129](https://github.com/grafana/tempo/issues/7129), [#7263](https://github.com/grafana/tempo/issues/7263)) (@renovate)
+
+## 🛑 Breaking changes 🛑
+
+- `distributor`: Dropped support for the OpenCensus receiver. ([#7322](https://github.com/grafana/tempo/issues/7322)) (@zhxiaogg)
+
+## 🔧 Changes 🔧
+
+- `deps`: Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others). ([#7298](https://github.com/grafana/tempo/issues/7298)) (@zhxiaogg)
+
 # v2.10.5
 
 * [ENHANCEMENT] Updated go dependency version to v1.16.2. [#7040](https://github.com/grafana/tempo/pull/7040) (@ie-pham)

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -227,7 +227,7 @@ Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
 
    tempo {
        _images+:: {
-           tempo: 'grafana/tempo:2.10.5',
+           tempo: 'grafana/tempo:2.10.6',
            tempo_query: 'grafana/tempo-query:latest',
        },
 

--- a/example/docker-compose/alloy/docker-compose.yaml
+++ b/example/docker-compose/alloy/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/alloy/readme.md
+++ b/example/docker-compose/alloy/readme.md
@@ -18,7 +18,7 @@ alloy-alloy-1        grafana/alloy:v1.3.1                        "/bin/alloy run
 alloy-grafana-1      grafana/grafana:12.0.0                      "/run.sh"                grafana      48 seconds ago   Up 5 seconds   0.0.0.0:3000->3000/tcp
 alloy-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.9   "/k6-tracing run /ex…"   k6-tracing   48 seconds ago   Up 4 seconds   
 alloy-prometheus-1   prom/prometheus:latest                      "/bin/prometheus --c…"   prometheus   48 seconds ago   Up 5 seconds   0.0.0.0:9090->9090/tcp
-alloy-tempo-1        grafana/tempo:2.10.5                        "/tempo -config.file…"   tempo        48 seconds ago   Up 5 seconds   0.0.0.0:57508->3200/tcp, 0.0.0.0:57509->4317/tcp, 0.0.0.0:57505->4318/tcp, 0.0.0.0:57506->9411/tcp, 0.0.0.0:57507->14268/tcp
+alloy-tempo-1        grafana/tempo:2.10.6                        "/tempo -config.file…"   tempo        48 seconds ago   Up 5 seconds   0.0.0.0:57508->3200/tcp, 0.0.0.0:57509->4317/tcp, 0.0.0.0:57505->4318/tcp, 0.0.0.0:57506->9411/tcp, 0.0.0.0:57507->14268/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.

--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
 
   # tempo - a
   distributor-a:
-    image: &tempoImage grafana/tempo:2.10.5
+    image: &tempoImage grafana/tempo:2.10.6
     command: "-target=distributor -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -3,7 +3,7 @@
 
 services:
   distributor:
-    image: &tempoImage grafana/tempo:2.10.5
+    image: &tempoImage grafana/tempo:2.10.6
     command: "-target=distributor -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/example/docker-compose/ingest-storage-single-binary/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage-single-binary/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     depends_on:
       - redpanda
     command: "-target=all-3.0 -config.file=/etc/tempo.yaml"

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - ./tempo-data:/var/tempo
 
   distributor:
-    image: &tempoImage grafana/tempo:2.10.5
+    image: &tempoImage grafana/tempo:2.10.6
     depends_on:
       - redpanda
     command: "-target=distributor -config.file=/etc/tempo.yaml"

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - MEMCACHED_THREADS=4 # Number of threads to use
 
   tempo:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: [ "-config.file=/etc/tempo.yaml" ]
     environment:
       - GRPC_TRACE=api

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: [ "-multitenancy.enabled=true", "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/readme.md
+++ b/example/docker-compose/readme.md
@@ -32,7 +32,7 @@ This example uses the `local` backend, suitable for local testing and developmen
 This step is not necessary, but it can be nice for local testing.  For any of the above examples rebuilding these
 images will cause docker compose to use your local code when running the examples.
 
-Run the following from the project root folder to build the `grafana/tempo:2.10.5` image that is used in all the examples:
+Run the following from the project root folder to build the `grafana/tempo:2.10.6` image that is used in all the examples:
 
 ```console
 make docker-images

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   tempo1:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml
@@ -16,7 +16,7 @@ services:
       - 3200:3200
 
   tempo2:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml
@@ -29,7 +29,7 @@ services:
       - minio
 
   tempo3:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml

--- a/example/docker-compose/vulture/docker-compose.yaml
+++ b/example/docker-compose/vulture/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.10.5
+    image: grafana/tempo:2.10.6
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/vulture/readme.md
+++ b/example/docker-compose/vulture/readme.md
@@ -16,7 +16,7 @@ docker compose ps
 ```
 ```
 NAME                IMAGE                          COMMAND                  SERVICE   CREATED         STATUS         PORTS
-vulture-tempo-1     grafana/tempo:2.10.5           "/tempo -config.file…"   tempo     2 minutes ago   Up 2 minutes   0.0.0.0:3200->3200/tcp, 0.0.0.0:14250->14250/tcp
+vulture-tempo-1     grafana/tempo:2.10.6           "/tempo -config.file…"   tempo     2 minutes ago   Up 2 minutes   0.0.0.0:3200->3200/tcp, 0.0.0.0:14250->14250/tcp
 vulture-vulture-1   grafana/tempo-vulture:latest   "/tempo-vulture -tem…"   vulture   2 minutes ago   Up 2 minutes  
 ```
 

--- a/example/tk/readme.md
+++ b/example/tk/readme.md
@@ -22,7 +22,7 @@ k3d cluster create tempo --api-port 6443 --port "3000:80@loadbalancer"
 If you wish to use a local image, you can import these into k3d
 
 ```console
-k3d image import grafana/tempo:2.10.5 --cluster tempo
+k3d image import grafana/tempo:2.10.6 --cluster tempo
 ```
 
 Next either deploy the microservices or the single binary. You can also use tanka [inline environments](https://tanka.dev/inline-environments) to deploy Tempo with either of the two.

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-compactor.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-compactor.yaml
@@ -31,7 +31,7 @@ spec:
         env:
         - name: GOMEMLIMIT
           value: 5GiB
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-distributor.yaml
@@ -30,7 +30,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=distributor
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-metrics-generator.yaml
@@ -28,7 +28,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-querier.yaml
@@ -30,7 +30,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=querier
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: querier
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/Deployment-query-frontend.yaml
@@ -28,7 +28,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=query-frontend
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-scheduler.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=backend-scheduler
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: backend-scheduler
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-backend-worker.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=backend-worker
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: backend-worker
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-block-builder.yaml
@@ -25,7 +25,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=block-builder
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: block-builder
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-ingester.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-ingester.yaml
@@ -33,7 +33,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=ingester
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         name: ingester
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-a.yaml
@@ -54,7 +54,7 @@ spec:
         - -live-store.instance-availability-zone=zone-a
         - -mem-ballast-size-mbs=1024
         - -target=live-store
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-live-store-zone-b.yaml
@@ -55,7 +55,7 @@ spec:
         - -live-store.instance-availability-zone=zone-b
         - -mem-ballast-size-mbs=1024
         - -target=live-store
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/microservices/gen/StatefulSet-metrics-generator.yaml
@@ -33,7 +33,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
-        image: grafana/tempo:2.10.5
+        image: grafana/tempo:2.10.6
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/microservices/main.jsonnet
+++ b/operations/jsonnet-compiled/microservices/main.jsonnet
@@ -4,7 +4,7 @@ local tempo = import 'microservices/tempo.libsonnet';
 
 tempo {
   _images+:: {
-    tempo: 'grafana/tempo:2.10.5',
+    tempo: 'grafana/tempo:2.10.6',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     tempo_query: 'grafana/tempo-query:latest',
   },

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:2.10.5',
+    tempo: 'grafana/tempo:2.10.6',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     rollout_operator: 'grafana/rollout-operator:v0.23.0',

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:2.10.5',
+    tempo: 'grafana/tempo:2.10.6',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
   },


### PR DESCRIPTION
Release-prep PR for **v2.10.6** (security patch release off `release-v2.10`), per [RELEASES.MD](https://github.com/grafana/tempo/blob/main/RELEASES.MD#patch-releases).

## What's in v2.10.6
Security and dependency fixes backported to `release-v2.10` since `v2.10.5`:

**🔒 Security**
- Go runtime → 1.26.3 ([#7422](https://github.com/grafana/tempo/pull/7422))
- `golang.org/x/crypto` → v0.52.0 ([#7262](https://github.com/grafana/tempo/pull/7262))
- `golang.org/x/net` → v0.55.0 ([#7129](https://github.com/grafana/tempo/pull/7129), [#7263](https://github.com/grafana/tempo/pull/7263))
- `github.com/apache/thrift` → v0.23.0 ([#7120](https://github.com/grafana/tempo/pull/7120))

**🛑 Breaking**
- Dropped support for the OpenCensus receiver ([#7322](https://github.com/grafana/tempo/pull/7322))

**🔧 Changes**
- Updated Prometheus to v0.311.3 and OTel Collector deps to v1.52 ([#7298](https://github.com/grafana/tempo/pull/7298))

## Changes in this PR
- **CHANGELOG.md**: add the `# v2.10.6` section. The Prometheus and OpenCensus changes already had migrated `.chloggen/` entries; this PR adds the missing `.chloggen/` security entries for the Go 1.26.3, x/crypto, x/net, and thrift bumps, then collates everything via `make chlog-update VERSION=v2.10.6`.
- **Image tag bump to 2.10.6**: `make bump-tempo-image-tag TEMPO_IMAGE_TAG=2.10.6` + `make jsonnet`, updating example configs, docs, and compiled jsonnet. Done before tagging per the release process.

Rebased onto the latest `release-v2.10` (now including the Go 1.26.3 upgrade #7422). Unrelated jsonnet lib/lock churn from `jb update` was reverted; the only effective change outside CHANGELOG is the image tag.

Once merged, the `v2.10.6` tag will be cut on the merge commit to trigger the `release`/`docker` workflows.