### PR TITLE
Add enable_connection_info and enable_red_metrics config overrides for service graphs

### DIFF
--- a/.chloggen/lightweight-connection-info-crd.yaml
+++ b/.chloggen/lightweight-connection-info-crd.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: metrics-generator
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Add enable_connection_info and enable_red_metrics per-tenant config overrides for the service graphs processor
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: jereenv

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -275,5 +275,14 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 	}
 	copyCfg.ServiceGraphs.Subprocessors = copyServiceGraphSubprocessors
 
+	if enableConnectionInfo, ok  := o.MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID); ok {
+		copyCfg.ServiceGraphs.Subprocessors[servicegraphs.ConnectionInfo] = enableConnectionInfo
+	}
+
+	if enableRedMetrics, ok  := o.MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID); ok {
+		copyCfg.ServiceGraphs.Subprocessors[servicegraphs.Request] = enableRedMetrics
+		copyCfg.ServiceGraphs.Subprocessors[servicegraphs.Latency] = enableRedMetrics
+	}
+
 	return copyCfg, nil
 }

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -275,11 +275,11 @@ func (cfg *ProcessorConfig) copyWithOverrides(o metricsGeneratorOverrides, userI
 	}
 	copyCfg.ServiceGraphs.Subprocessors = copyServiceGraphSubprocessors
 
-	if enableConnectionInfo, ok  := o.MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID); ok {
+	if enableConnectionInfo, ok := o.MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID); ok {
 		copyCfg.ServiceGraphs.Subprocessors[servicegraphs.ConnectionInfo] = enableConnectionInfo
 	}
 
-	if enableRedMetrics, ok  := o.MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID); ok {
+	if enableRedMetrics, ok := o.MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID); ok {
 		copyCfg.ServiceGraphs.Subprocessors[servicegraphs.Request] = enableRedMetrics
 		copyCfg.ServiceGraphs.Subprocessors[servicegraphs.Latency] = enableRedMetrics
 	}

--- a/modules/generator/config_test.go
+++ b/modules/generator/config_test.go
@@ -236,6 +236,101 @@ func TestProcessorConfig_copyWithOverrides(t *testing.T) {
 		assert.True(t, copied.SpanMetrics.EnableTraceStateSpanMultiplier)
 	})
 
+	t.Run("enable_connection_info true enables ConnectionInfo subprocessor", func(t *testing.T) {
+		o := &mockOverrides{
+			serviceGraphsEnableConnectionInfo: boolPtr(true),
+		}
+
+		copied, err := original.copyWithOverrides(o, "tenant")
+		require.NoError(t, err)
+
+		assert.True(t, copied.ServiceGraphs.Subprocessors[servicegraphs.ConnectionInfo])
+	})
+
+	t.Run("enable_connection_info false disables ConnectionInfo subprocessor", func(t *testing.T) {
+		originalWithConnectionInfo := &ProcessorConfig{
+			ServiceGraphs: servicegraphs.Config{
+				Subprocessors: map[servicegraphs.Subprocessor]bool{
+					servicegraphs.ConnectionInfo: true,
+				},
+			},
+			SpanMetrics: spanmetrics.Config{
+				Subprocessors: map[spanmetrics.Subprocessor]bool{},
+			},
+		}
+
+		o := &mockOverrides{
+			serviceGraphsEnableConnectionInfo: boolPtr(false),
+		}
+
+		copied, err := originalWithConnectionInfo.copyWithOverrides(o, "tenant")
+		require.NoError(t, err)
+
+		assert.False(t, copied.ServiceGraphs.Subprocessors[servicegraphs.ConnectionInfo])
+	})
+
+	t.Run("enable_red_metrics false disables Request and Latency subprocessors", func(t *testing.T) {
+		originalWithRED := &ProcessorConfig{
+			ServiceGraphs: servicegraphs.Config{
+				Subprocessors: map[servicegraphs.Subprocessor]bool{
+					servicegraphs.Request: true,
+					servicegraphs.Latency: true,
+				},
+			},
+			SpanMetrics: spanmetrics.Config{
+				Subprocessors: map[spanmetrics.Subprocessor]bool{},
+			},
+		}
+
+		o := &mockOverrides{
+			serviceGraphsEnableRedMetrics: boolPtr(false),
+		}
+
+		copied, err := originalWithRED.copyWithOverrides(o, "tenant")
+		require.NoError(t, err)
+
+		assert.False(t, copied.ServiceGraphs.Subprocessors[servicegraphs.Request])
+		assert.False(t, copied.ServiceGraphs.Subprocessors[servicegraphs.Latency])
+	})
+
+	t.Run("enable_red_metrics true enables Request and Latency subprocessors", func(t *testing.T) {
+		o := &mockOverrides{
+			serviceGraphsEnableRedMetrics: boolPtr(true),
+		}
+
+		copied, err := original.copyWithOverrides(o, "tenant")
+		require.NoError(t, err)
+
+		assert.True(t, copied.ServiceGraphs.Subprocessors[servicegraphs.Request])
+		assert.True(t, copied.ServiceGraphs.Subprocessors[servicegraphs.Latency])
+	})
+
+	t.Run("subprocessor overrides do not mutate original config", func(t *testing.T) {
+		originalWithSubprocessors := &ProcessorConfig{
+			ServiceGraphs: servicegraphs.Config{
+				Subprocessors: map[servicegraphs.Subprocessor]bool{
+					servicegraphs.Request: true,
+					servicegraphs.Latency: true,
+				},
+			},
+			SpanMetrics: spanmetrics.Config{
+				Subprocessors: map[spanmetrics.Subprocessor]bool{},
+			},
+		}
+
+		o := &mockOverrides{
+			serviceGraphsEnableConnectionInfo: boolPtr(true),
+			serviceGraphsEnableRedMetrics:     boolPtr(false),
+		}
+
+		_, err := originalWithSubprocessors.copyWithOverrides(o, "tenant")
+		require.NoError(t, err)
+
+		assert.True(t, originalWithSubprocessors.ServiceGraphs.Subprocessors[servicegraphs.Request])
+		assert.True(t, originalWithSubprocessors.ServiceGraphs.Subprocessors[servicegraphs.Latency])
+		assert.False(t, originalWithSubprocessors.ServiceGraphs.Subprocessors[servicegraphs.ConnectionInfo])
+	})
+
 	t.Run("dimension_mappings preserved when no override", func(t *testing.T) {
 		// Create original config with dimension_mappings set
 		originalWithMappings := &ProcessorConfig{

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -38,6 +38,8 @@ type metricsGeneratorOverrides interface {
 	MetricsGeneratorProcessorHostInfoMetricName(userID string) string
 	MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey(userID string) string
 	MetricsGeneratorProcessorServiceGraphsEnableTraceStateSpanMultiplier(userID string) (bool, bool)
+	MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID string) (bool, bool)
+	MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID string) (bool, bool)
 	MetricsGeneratorProcessorSpanMetricsSpanMultiplierKey(userID string) string
 	MetricsGeneratorProcessorSpanMetricsEnableTraceStateSpanMultiplier(userID string) (bool, bool)
 	DedicatedColumns(userID string) backend.DedicatedColumns

--- a/modules/generator/overrides_test.go
+++ b/modules/generator/overrides_test.go
@@ -21,6 +21,8 @@ type mockOverrides struct {
 	serviceGraphsEnableClientServerPrefix              bool
 	serviceGraphsEnableMessagingSystemLatencyHistogram *bool
 	serviceGraphsEnableVirtualNodeLabel                *bool
+	serviceGraphsEnableConnectionInfo                  *bool
+	serviceGraphsEnableRedMetrics                      *bool
 	spanMetricsHistogramBuckets                        []float64
 	spanMetricsDimensions                              []string
 	spanMetricsIntrinsicDimensions                     map[string]bool
@@ -162,6 +164,22 @@ func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeL
 	serviceGraphsEnableVirtualNodeLabel := m.serviceGraphsEnableVirtualNodeLabel
 	if serviceGraphsEnableVirtualNodeLabel != nil {
 		return *serviceGraphsEnableVirtualNodeLabel, true
+	}
+	return false, false
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(string) (bool, bool) {
+	serviceGraphsEnableConnectionInfo := m.serviceGraphsEnableConnectionInfo
+	if serviceGraphsEnableConnectionInfo != nil {
+		return *serviceGraphsEnableConnectionInfo, true
+	}
+	return false, false
+}
+
+func (m *mockOverrides) MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(string) (bool, bool) {
+	serviceGraphsEnableRedMetrics := m.serviceGraphsEnableRedMetrics
+	if serviceGraphsEnableRedMetrics != nil {
+		return *serviceGraphsEnableRedMetrics, true
 	}
 	return false, false
 }

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -97,6 +97,8 @@ type ServiceGraphsOverrides struct {
 	EnableVirtualNodeLabel                *bool                       `yaml:"enable_virtual_node_label,omitempty" json:"enable_virtual_node_label,omitempty"`
 	SpanMultiplierKey                     string                      `yaml:"span_multiplier_key,omitempty" json:"span_multiplier_key,omitempty"`
 	EnableTraceStateSpanMultiplier        *bool                       `yaml:"enable_tracestate_span_multiplier,omitempty" json:"enable_tracestate_span_multiplier,omitempty"`
+	EnableConnectionInfo                  *bool                       `yaml:"enable_connection_info,omitempty" json:"enable_connection_info,omitempty"`
+	EnableRedMetrics                      *bool                       `yaml:"enable_red_metrics,omitempty" json:"enable_red_metrics,omitempty"`
 }
 
 type SpanMetricsOverrides struct {

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -51,6 +51,8 @@ func (c *Overrides) toLegacy() LegacyOverrides {
 		MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel:                c.MetricsGenerator.Processor.ServiceGraphs.EnableVirtualNodeLabel,
 		MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey:                     c.MetricsGenerator.Processor.ServiceGraphs.SpanMultiplierKey,
 		MetricsGeneratorProcessorServiceGraphsEnableTraceStateSpanMultiplier:        c.MetricsGenerator.Processor.ServiceGraphs.EnableTraceStateSpanMultiplier,
+		MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo:                  c.MetricsGenerator.Processor.ServiceGraphs.EnableConnectionInfo,
+		MetricsGeneratorProcessorServiceGraphsEnableRedMetrics:                      c.MetricsGenerator.Processor.ServiceGraphs.EnableRedMetrics,
 		MetricsGeneratorProcessorSpanMetricsHistogramBuckets:                        c.MetricsGenerator.Processor.SpanMetrics.HistogramBuckets,
 		MetricsGeneratorProcessorSpanMetricsDimensions:                              c.MetricsGenerator.Processor.SpanMetrics.Dimensions,
 		MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions:                     c.MetricsGenerator.Processor.SpanMetrics.IntrinsicDimensions,
@@ -139,6 +141,8 @@ type LegacyOverrides struct {
 	MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel                *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_virtual_node_label" json:"metrics_generator_processor_service_graphs_enable_virtual_node_label"`
 	MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey                     string                           `yaml:"metrics_generator_processor_service_graphs_span_multiplier_key" json:"metrics_generator_processor_service_graphs_span_multiplier_key"`
 	MetricsGeneratorProcessorServiceGraphsEnableTraceStateSpanMultiplier        *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_tracestate_span_multiplier" json:"metrics_generator_processor_service_graphs_enable_tracestate_span_multiplier"`
+	MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo                  *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_connection_info" json:"metrics_generator_processor_service_graphs_enable_connection_info"`
+	MetricsGeneratorProcessorServiceGraphsEnableRedMetrics                      *bool                            `yaml:"metrics_generator_processor_service_graphs_enable_red_metrics" json:"metrics_generator_processor_service_graphs_enable_red_metrics"`
 	MetricsGeneratorProcessorSpanMetricsHistogramBuckets                        []float64                        `yaml:"metrics_generator_processor_span_metrics_histogram_buckets" json:"metrics_generator_processor_span_metrics_histogram_buckets"`
 	MetricsGeneratorProcessorSpanMetricsDimensions                              []string                         `yaml:"metrics_generator_processor_span_metrics_dimensions" json:"metrics_generator_processor_span_metrics_dimensions"`
 	MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions                     map[string]bool                  `yaml:"metrics_generator_processor_span_metrics_intrinsic_dimensions" json:"metrics_generator_processor_span_metrics_intrinsic_dimensions"`
@@ -356,6 +360,8 @@ func (l *LegacyOverrides) toNewLimits() *Overrides {
 					EnableVirtualNodeLabel:                l.MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel,
 					SpanMultiplierKey:                     l.MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey,
 					EnableTraceStateSpanMultiplier:        l.MetricsGeneratorProcessorServiceGraphsEnableTraceStateSpanMultiplier,
+					EnableConnectionInfo:                  l.MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo,
+					EnableRedMetrics:                      l.MetricsGeneratorProcessorServiceGraphsEnableRedMetrics,
 				},
 				SpanMetrics: SpanMetricsOverrides{
 					HistogramBuckets:               l.MetricsGeneratorProcessorSpanMetricsHistogramBuckets,

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -423,6 +423,8 @@ func generateTestLegacyOverrides() LegacyOverrides {
 		MetricsGeneratorProcessorServiceGraphsEnableVirtualNodeLabel:                boolPtr(true),
 		MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey:                     "custom_key",
 		MetricsGeneratorProcessorServiceGraphsEnableTraceStateSpanMultiplier:        boolPtr(true),
+		MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo:                  boolPtr(true),
+		MetricsGeneratorProcessorServiceGraphsEnableRedMetrics:                      boolPtr(false),
 		MetricsGeneratorProcessorSpanMetricsHistogramBuckets:                        []float64{1.0, 2.0, 5.0},
 		MetricsGeneratorProcessorSpanMetricsDimensions:                              []string{"dimension-1", "dimension-2"},
 		MetricsGeneratorProcessorSpanMetricsIntrinsicDimensions:                     map[string]bool{"dim-1": true, "dim-2": false},

--- a/modules/overrides/interface.go
+++ b/modules/overrides/interface.go
@@ -76,6 +76,8 @@ type Interface interface {
 	MetricsGeneratorProcessorHostInfoMetricName(userID string) string
 	MetricsGeneratorProcessorServiceGraphsSpanMultiplierKey(userID string) string
 	MetricsGeneratorProcessorServiceGraphsEnableTraceStateSpanMultiplier(userID string) (bool, bool)
+	MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID string) (bool, bool)
+	MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID string) (bool, bool)
 	MetricsGeneratorProcessorSpanMetricsSpanMultiplierKey(userID string) string
 	MetricsGeneratorProcessorSpanMetricsEnableTraceStateSpanMultiplier(userID string) (bool, bool)
 	MetricsGeneratorNativeHistogramBucketFactor(userID string) float64

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -659,6 +659,22 @@ func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEn
 	return false, false
 }
 
+func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID string) (bool, bool) {
+	enableConnectionInfo := o.getOverridesForUser(userID).MetricsGenerator.Processor.ServiceGraphs.EnableConnectionInfo
+	if enableConnectionInfo != nil {
+		return *enableConnectionInfo, true
+	}
+	return false, false
+}
+
+func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID string) (bool, bool) {
+	enableRedMetrics := o.getOverridesForUser(userID).MetricsGenerator.Processor.ServiceGraphs.EnableRedMetrics
+	if enableRedMetrics != nil {
+		return *enableRedMetrics, true
+	}
+	return false, false
+}
+
 func (o *runtimeConfigOverridesManager) MetricsGeneratorProcessorSpanMetricsSpanMultiplierKey(userID string) string {
 	return o.getOverridesForUser(userID).MetricsGenerator.Processor.SpanMetrics.SpanMultiplierKey
 }

--- a/modules/overrides/user_configurable_overrides.go
+++ b/modules/overrides/user_configurable_overrides.go
@@ -357,6 +357,20 @@ func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraph
 	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableTraceStateSpanMultiplier(userID)
 }
 
+func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID string) (bool, bool) {
+	if enableConnectionInfo, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetEnableConnectionInfo(); ok {
+		return enableConnectionInfo, true
+	}
+	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableConnectionInfo(userID)
+}
+
+func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID string) (bool, bool) {
+	if enableRedMetrics, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetServiceGraphs().GetEnableRedMetrics(); ok {
+		return enableRedMetrics, true
+	}
+	return o.Interface.MetricsGeneratorProcessorServiceGraphsEnableRedMetrics(userID)
+}
+
 func (o *userConfigurableOverridesManager) MetricsGeneratorProcessorSpanMetricsDimensions(userID string) []string {
 	if dimensions, ok := o.getTenantLimits(userID).GetMetricsGenerator().GetProcessor().GetSpanMetrics().GetDimensions(); ok {
 		return dimensions

--- a/modules/overrides/userconfigurable/client/limits.go
+++ b/modules/overrides/userconfigurable/client/limits.go
@@ -166,6 +166,8 @@ type LimitsMetricsGeneratorProcessorServiceGraphs struct {
 	HistogramBuckets                      *[]float64                   `yaml:"histogram_buckets,omitempty" json:"histogram_buckets,omitempty"`
 	SpanMultiplierKey                     *string                      `yaml:"span_multiplier_key,omitempty" json:"span_multiplier_key,omitempty"`
 	EnableTraceStateSpanMultiplier        *bool                        `yaml:"enable_tracestate_span_multiplier,omitempty" json:"enable_tracestate_span_multiplier,omitempty"`
+	EnableConnectionInfo                  *bool                        `yaml:"enable_connection_info,omitempty" json:"enable_connection_info,omitempty"`
+	EnableRedMetrics                      *bool                        `yaml:"enable_red_metrics,omitempty" json:"enable_red_metrics,omitempty"`
 }
 
 func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetDimensions() ([]string, bool) {
@@ -220,6 +222,20 @@ func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetSpanMultiplierKey() (s
 func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableTraceStateSpanMultiplier() (bool, bool) {
 	if l != nil && l.EnableTraceStateSpanMultiplier != nil {
 		return *l.EnableTraceStateSpanMultiplier, true
+	}
+	return false, false
+}
+
+func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableConnectionInfo() (bool, bool) {
+	if l != nil && l.EnableConnectionInfo != nil {
+		return *l.EnableConnectionInfo, true
+	}
+	return false, false
+}
+
+func (l *LimitsMetricsGeneratorProcessorServiceGraphs) GetEnableRedMetrics() (bool, bool) {
+	if l != nil && l.EnableRedMetrics != nil {
+		return *l.EnableRedMetrics, true
 	}
 	return false, false
 }


### PR DESCRIPTION
## What

Extends Tempo's per-tenant configuration override CRD with two new boolean options for the service graphs processor:

- `enable_connection_info` — toggles the new lightweight connection info metric (opt-in)
- `enable_red_metrics` — toggles the existing RED (request/latency) metrics (opt-out)

## Why

Part of the lightweight connection info initiative.  added the subprocessor logic — these config fields expose that as explicit per-tenant overrides, so operators can toggle them via YAML config or the per-tenant API instead of managing processor name strings.

## Changes

- `modules/overrides/` — new fields in config struct, legacy format, interface, and both override implementations
- `modules/overrides/userconfigurable/client/limits.go` — per-tenant API support
- `modules/generator/overrides.go` + `config.go` — wired into the subprocessors map