### PR TITLE
chore: prepare v2.9.3 release

### DIFF
--- a/.chloggen/_migrated_00_7338.yaml
+++ b/.chloggen/_migrated_00_7338.yaml
@@ -1,6 +1,0 @@
-change_type: change
-component: deps
-note: Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others).
-issues: [7338]
-subtext:
-user: zhxiaogg

--- a/.chloggen/_migrated_01_7323.yaml
+++ b/.chloggen/_migrated_01_7323.yaml
@@ -1,6 +1,0 @@
-change_type: breaking
-component: distributor
-note: Dropped support for the OpenCensus receiver.
-issues: [7323]
-subtext:
-user: zhxiaogg

--- a/.chloggen/_migrated_02_7338.yaml
+++ b/.chloggen/_migrated_02_7338.yaml
@@ -1,6 +1,0 @@
-change_type: bug_fix
-component: metrics-generator
-note: Fix panic when `write_relabel_configs` is configured on remote write endpoints.
-issues: [7338]
-subtext:
-user: carles-grafana

--- a/.chloggen/backport-5717-to-release-v2.9.yaml
+++ b/.chloggen/backport-5717-to-release-v2.9.yaml
@@ -1,6 +1,0 @@
-change_type: change
-component: tempo
-note: Remove busybox from Tempo image to make it more minimal and prevent future vulnerabilities.
-issues: [5717]
-subtext:
-user: carles-grafana

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 <!-- next version -->
 
+# v2.9.3
+
+## 🔒 Security 🔒
+
+- `deps`: Update github.com/apache/thrift to v0.23.0 to pick up upstream security fixes. ([#7119](https://github.com/grafana/tempo/issues/7119)) (@renovate)
+- `deps`: Update golang.org/x/crypto to v0.52.0 to pick up upstream security fixes. ([#7258](https://github.com/grafana/tempo/issues/7258), [#7343](https://github.com/grafana/tempo/issues/7343)) (@renovate)
+- `deps`: Update golang.org/x/net to v0.55.0 to pick up upstream security fixes. ([#7128](https://github.com/grafana/tempo/issues/7128), [#7259](https://github.com/grafana/tempo/issues/7259), [#7371](https://github.com/grafana/tempo/issues/7371)) (@renovate)
+- `deps`: Update golang.org/x/sys to v0.44.0 to pick up upstream security fixes. ([#7260](https://github.com/grafana/tempo/issues/7260)) (@renovate)
+- `deps`: Build Tempo with Go 1.26.3, which includes upstream security and bug fixes. ([#7421](https://github.com/grafana/tempo/issues/7421)) (@ie-pham)
+
+## 🛑 Breaking changes 🛑
+
+- `distributor`: Dropped support for the OpenCensus receiver. ([#7323](https://github.com/grafana/tempo/issues/7323)) (@zhxiaogg)
+
+## 🧰 Bug fixes 🧰
+
+- `metrics-generator`: Fix panic when `write_relabel_configs` is configured on remote write endpoints. ([#7338](https://github.com/grafana/tempo/issues/7338)) (@carles-grafana)
+
+## 🔧 Changes 🔧
+
+- `deps`: Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others). ([#7338](https://github.com/grafana/tempo/issues/7338)) (@zhxiaogg)
+- `tempo`: Remove busybox from Tempo image to make it more minimal and prevent future vulnerabilities. ([#5717](https://github.com/grafana/tempo/issues/5717)) (@carles-grafana)
+
 # v2.9.2
 
 * [BUGFIX] updated go version to 1.26.2 for CVE-2026-25679 fix [#6779](https://github.com/grafana/tempo/pull/6779) (@ie-pham)

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/kubernetes/tanka.md
@@ -227,7 +227,7 @@ Install the `k.libsonnet`, Jsonnet, and Memcachd libraries.
 
    tempo {
        _images+:: {
-           tempo: 'grafana/tempo:2.9.2',
+           tempo: 'grafana/tempo:2.9.3',
            tempo_query: 'grafana/tempo-query:latest',
        },
 

--- a/example/docker-compose/alloy/docker-compose.yaml
+++ b/example/docker-compose/alloy/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/alloy/readme.md
+++ b/example/docker-compose/alloy/readme.md
@@ -18,7 +18,7 @@ alloy-alloy-1        grafana/alloy:v1.3.1                        "/bin/alloy run
 alloy-grafana-1      grafana/grafana:12.0.0                      "/run.sh"                grafana      48 seconds ago   Up 5 seconds   0.0.0.0:3000->3000/tcp
 alloy-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.7   "/k6-tracing run /ex…"   k6-tracing   48 seconds ago   Up 4 seconds   
 alloy-prometheus-1   prom/prometheus:latest                      "/bin/prometheus --c…"   prometheus   48 seconds ago   Up 5 seconds   0.0.0.0:9090->9090/tcp
-alloy-tempo-1        grafana/tempo:2.9.2                        "/tempo -config.file…"   tempo        48 seconds ago   Up 5 seconds   0.0.0.0:57508->3200/tcp, 0.0.0.0:57509->4317/tcp, 0.0.0.0:57505->4318/tcp, 0.0.0.0:57506->9411/tcp, 0.0.0.0:57507->14268/tcp
+alloy-tempo-1        grafana/tempo:2.9.3                        "/tempo -config.file…"   tempo        48 seconds ago   Up 5 seconds   0.0.0.0:57508->3200/tcp, 0.0.0.0:57509->4317/tcp, 0.0.0.0:57505->4318/tcp, 0.0.0.0:57506->9411/tcp, 0.0.0.0:57507->14268/tcp
 ```
 
 2. If you're interested you can see the wal/blocks as they are being created.

--- a/example/docker-compose/cross-cluster/docker-compose.yaml
+++ b/example/docker-compose/cross-cluster/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
 
   # tempo - a
   distributor-a:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: &tempoImage grafana/tempo:2.9.3
     command: "-target=distributor -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/example/docker-compose/distributed/docker-compose.yaml
+++ b/example/docker-compose/distributed/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   distributor:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: &tempoImage grafana/tempo:2.9.3
     command: "-target=distributor -config.file=/etc/tempo.yaml"
     restart: always
     volumes:

--- a/example/docker-compose/ingest-storage/docker-compose.yaml
+++ b/example/docker-compose/ingest-storage/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - ./tempo-data:/var/tempo
 
   distributor:
-    image: &tempoImage grafana/tempo:2.9.2
+    image: &tempoImage grafana/tempo:2.9.3
     depends_on:
       - kafka
     command: "-target=distributor -config.file=/etc/tempo.yaml"

--- a/example/docker-compose/local/docker-compose.yaml
+++ b/example/docker-compose/local/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - MEMCACHED_THREADS=4 # Number of threads to use
 
   tempo:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/multi-tenant/docker-compose.yaml
+++ b/example/docker-compose/multi-tenant/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: [ "-config.file=/etc/tempo.yaml" ]
     environment:
       - GRPC_TRACE=api

--- a/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
+++ b/example/docker-compose/otel-collector-multitenant/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: [ "-multitenancy.enabled=true", "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/otel-collector/docker-compose.yaml
+++ b/example/docker-compose/otel-collector/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/readme.md
+++ b/example/docker-compose/readme.md
@@ -32,7 +32,7 @@ This example uses the `local` backend, suitable for local testing and developmen
 This step is not necessary, but it can be nice for local testing.  For any of the above examples rebuilding these
 images will cause docker compose to use your local code when running the examples.
 
-Run the following from the project root folder to build the `grafana/tempo:2.9.2` image that is used in all the examples:
+Run the following from the project root folder to build the `grafana/tempo:2.9.3` image that is used in all the examples:
 
 ```console
 make docker-images

--- a/example/docker-compose/scalable-single-binary/docker-compose.yaml
+++ b/example/docker-compose/scalable-single-binary/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   tempo1:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml
@@ -16,7 +16,7 @@ services:
       - 3200:3200
 
   tempo2:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml
@@ -29,7 +29,7 @@ services:
       - minio
 
   tempo3:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: "-target=scalable-single-binary -config.file=/etc/tempo.yaml"
     volumes:
       - ./tempo-scalable-single-binary.yaml:/etc/tempo.yaml

--- a/example/docker-compose/vulture/docker-compose.yaml
+++ b/example/docker-compose/vulture/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - ./tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo:2.9.2
+    image: grafana/tempo:2.9.3
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ../shared/tempo.yaml:/etc/tempo.yaml

--- a/example/docker-compose/vulture/readme.md
+++ b/example/docker-compose/vulture/readme.md
@@ -16,7 +16,7 @@ docker compose ps
 ```
 ```
 NAME                IMAGE                          COMMAND                  SERVICE   CREATED         STATUS         PORTS
-vulture-tempo-1     grafana/tempo:2.9.2           "/tempo -config.file…"   tempo     2 minutes ago   Up 2 minutes   0.0.0.0:3200->3200/tcp, 0.0.0.0:14250->14250/tcp
+vulture-tempo-1     grafana/tempo:2.9.3           "/tempo -config.file…"   tempo     2 minutes ago   Up 2 minutes   0.0.0.0:3200->3200/tcp, 0.0.0.0:14250->14250/tcp
 vulture-vulture-1   grafana/tempo-vulture:latest   "/tempo-vulture -tem…"   vulture   2 minutes ago   Up 2 minutes  
 ```
 

--- a/example/tk/readme.md
+++ b/example/tk/readme.md
@@ -22,7 +22,7 @@ k3d cluster create tempo --api-port 6443 --port "3000:80@loadbalancer"
 If you wish to use a local image, you can import these into k3d
 
 ```console
-k3d image import grafana/tempo:2.9.2 --cluster tempo
+k3d image import grafana/tempo:2.9.3 --cluster tempo
 ```
 
 Next either deploy the microservices or the single binary. You can also use tanka [inline environments](https://tanka.dev/inline-environments) to deploy Tempo with either of the two.

--- a/operations/jsonnet-compiled/Deployment-compactor.yaml
+++ b/operations/jsonnet-compiled/Deployment-compactor.yaml
@@ -31,7 +31,7 @@ spec:
         env:
         - name: GOMEMLIMIT
           value: 5GiB
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: compactor
         ports:

--- a/operations/jsonnet-compiled/Deployment-distributor.yaml
+++ b/operations/jsonnet-compiled/Deployment-distributor.yaml
@@ -30,7 +30,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=distributor
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: distributor
         ports:

--- a/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/Deployment-metrics-generator.yaml
@@ -28,7 +28,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/Deployment-querier.yaml
+++ b/operations/jsonnet-compiled/Deployment-querier.yaml
@@ -30,7 +30,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=querier
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: querier
         ports:

--- a/operations/jsonnet-compiled/Deployment-query-frontend.yaml
+++ b/operations/jsonnet-compiled/Deployment-query-frontend.yaml
@@ -28,7 +28,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=query-frontend
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: query-frontend
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-backend-scheduler.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-backend-scheduler.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=backend-scheduler
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: backend-scheduler
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-backend-worker.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-backend-worker.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=backend-worker
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: backend-worker
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-block-builder.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-block-builder.yaml
@@ -24,7 +24,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=block-builder
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: block-builder
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-ingester.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-ingester.yaml
@@ -33,7 +33,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=ingester
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         name: ingester
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/StatefulSet-live-store-zone-a.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-live-store-zone-a.yaml
@@ -43,7 +43,7 @@ spec:
         - -live-store.instance-availability-zone=zone-a
         - -mem-ballast-size-mbs=1024
         - -target=live-store
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-live-store-zone-b.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-live-store-zone-b.yaml
@@ -43,7 +43,7 @@ spec:
         - -live-store.instance-availability-zone=zone-b
         - -mem-ballast-size-mbs=1024
         - -target=live-store
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         imagePullPolicy: IfNotPresent
         name: live-store
         ports:

--- a/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
+++ b/operations/jsonnet-compiled/StatefulSet-metrics-generator.yaml
@@ -33,7 +33,7 @@ spec:
         - -config.file=/conf/tempo.yaml
         - -mem-ballast-size-mbs=1024
         - -target=metrics-generator
-        image: grafana/tempo:2.9.2
+        image: grafana/tempo:2.9.3
         name: metrics-generator
         ports:
         - containerPort: 3200

--- a/operations/jsonnet-compiled/util/example/main.jsonnet
+++ b/operations/jsonnet-compiled/util/example/main.jsonnet
@@ -4,7 +4,7 @@ local tempo = import 'microservices/tempo.libsonnet';
 
 tempo {
   _images+:: {
-    tempo: 'grafana/tempo:2.9.2',
+    tempo: 'grafana/tempo:2.9.3',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     tempo_query: 'grafana/tempo-query:latest',
   },

--- a/operations/jsonnet/microservices/config.libsonnet
+++ b/operations/jsonnet/microservices/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:2.9.2',
+    tempo: 'grafana/tempo:2.9.3',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
     rollout_operator: 'grafana/rollout-operator:v0.23.0',

--- a/operations/jsonnet/single-binary/config.libsonnet
+++ b/operations/jsonnet/single-binary/config.libsonnet
@@ -1,6 +1,6 @@
 {
   _images+:: {
-    tempo: 'grafana/tempo:2.9.2',
+    tempo: 'grafana/tempo:2.9.3',
     tempo_query: 'grafana/tempo-query:latest',
     tempo_vulture: 'grafana/tempo-vulture:latest',
   },


### PR DESCRIPTION
**What this PR does**:

Prepares the v2.9.3 patch release:
- Adds the `# v2.9.3` section to `CHANGELOG.md` (security dependency updates, Go 1.26.3, busybox removal, Prometheus/OTel bump, metrics-generator panic fix, OpenCensus receiver removal).
- Bumps the `grafana/tempo` image tag to 2.9.3 in example configs, docs, and compiled jsonnet (`make bump-tempo-image-tag` + `make jsonnet`).

**Which issue(s) this PR fixes**:

N/A — release preparation.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`