### PR TITLE
chore(renovate): group go.mod patch updates into a single PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -83,6 +83,17 @@
       enabled: true,
     },
     {
+      description: 'Group all Go module patch updates into a single PR',
+      matchManagers: [
+        'gomod',
+      ],
+      matchUpdateTypes: [
+        'patch',
+        'digest',
+      ],
+      groupName: 'gomod patch updates',
+    },
+    {
       description: 'Group OpenTelemetry OTEL updates',
       matchManagers: [
         'gomod',


### PR DESCRIPTION
**What this PR does**:

Adds a Renovate rule that groups all go.mod patch + digest bumps into a single `gomod patch updates` PR per base branch, instead of one PR per module. The rule is placed before the otel/k8s family groups so those keep their own grouping; minor and major updates are unaffected.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)