### PR TITLE
chore: stop pushing the :latest image tag on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,12 +106,6 @@ jobs:
           	--amend $IMAGE_NAME:$TAG-arm64
           docker manifest push $IMAGE_NAME:$TAG
 
-          docker manifest create \
-          	$IMAGE_NAME:latest            \
-          	--amend $IMAGE_NAME:$TAG-amd64   \
-          	--amend $IMAGE_NAME:$TAG-arm64
-          docker manifest push $IMAGE_NAME:latest
-
   cd-to-dev-env:
     # This job deploys the latest main commit to the dev environment
     if: github.repository == 'grafana/tempo' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
**What this PR does**:

The `docker` workflow's `manifest` job fails when releasing because it tries to push the mutable `:latest` tag to GAR, which has **tag immutability** enabled (`cannot update tag latest. The repository has enabled tag immutability`). The versioned `:$TAG` manifest pushes fine.

This drops the `:latest` manifest create/push so only the immutable versioned tag is published — matching the behaviour already on `main`.

**Which issue(s) this PR fixes**:

N/A — release CI fix.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/`