### PR TITLE
chore: publish release images to GAR via OIDC

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,13 +3,15 @@ on:
   push:
     branches:
       - 'main'
-      - 'r[0-9]+'
     tags:
       - 'v*'
 
-# Needed to login to DockerHub
+# Needed to authenticate to GAR with OIDC.
 permissions:
   contents: read
+
+env:
+  DOCKERHUB_MIRROR_REPOSITORY: us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror
 
 jobs:
 
@@ -20,7 +22,7 @@ jobs:
       tag: ${{ steps.get-tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -40,12 +42,13 @@ jobs:
         runner_arch: [ { runner: ubuntu-24.04, arch: amd64 }, { runner: github-hosted-ubuntu-arm64, arch: arm64 } ]
     runs-on: ${{ matrix.runner_arch.runner }}
     permissions:
+      contents: read
       id-token: write
     env:
       TAG: ${{ needs.get-tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -59,20 +62,23 @@ jobs:
       - name: docker-build
         run: |
           TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"
-          docker build --provenance false --platform linux/${{ matrix.runner_arch.arch }} -f cmd/${{ matrix.component }}/Dockerfile -t grafana/${{ matrix.component }}:$TAG_ARCH .
+          docker build --provenance false --platform linux/${{ matrix.runner_arch.arch }} -f cmd/${{ matrix.component }}/Dockerfile -t $DOCKERHUB_MIRROR_REPOSITORY/${{ matrix.component }}:$TAG_ARCH .
 
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: docker-push
         run: |
-          TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"          
-          docker push grafana/${{ matrix.component }}:$TAG_ARCH
+          TAG_ARCH="$TAG-${{ matrix.runner_arch.arch }}"
+          docker push $DOCKERHUB_MIRROR_REPOSITORY/${{ matrix.component }}:$TAG_ARCH
 
   manifest:
     if: github.repository == 'grafana/tempo'
     needs: ['get-tag', 'docker']
     permissions:
+      contents: read
       id-token: write
     strategy:
       matrix:
@@ -80,15 +86,17 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       TAG: ${{ needs.get-tag.outputs.tag }}
-      IMAGE_NAME: grafana/${{ matrix.component }}
+      IMAGE_NAME: us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/${{ matrix.component }}
     steps:
       - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
 
       - name: docker-manifest-create-and-push
         run: |
@@ -98,91 +106,18 @@ jobs:
           	--amend $IMAGE_NAME:$TAG-arm64
           docker manifest push $IMAGE_NAME:$TAG
 
-          docker manifest create \
-          	$IMAGE_NAME:latest            \
-          	--amend $IMAGE_NAME:$TAG-amd64   \
-          	--amend $IMAGE_NAME:$TAG-arm64
-          docker manifest push $IMAGE_NAME:latest
-
   cd-to-dev-env:
     # This job deploys the latest main commit to the dev environment
     if: github.repository == 'grafana/tempo' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
-    needs: manifest
+    needs: ['manifest', 'get-tag']
     permissions:
       id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - name: Trigger Argo Workflow
+        uses: grafana/shared-workflows/actions/trigger-argo-workflow@b513eb1dfd9becfa671a41e55063cdd5c0a08031 # trigger-argo-workflow/v1.2.2
         with:
-          persist-credentials: false
-
-      - name: fetch tags
-        run: git fetch --tags --force
-
-      - name: get-tag
-        run: |
-          echo "grafana/tempo:$(./tools/image-tag)" > tags_for_cd_tempo
-          echo "grafana/tempo-query:$(./tools/image-tag)" > tags_for_cd_tempo_query
-          echo "grafana/tempo-vulture:$(./tools/image-tag)" > tags_for_cd_tempo_vulture
-
-      - name: Authenticate to GAR
-        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
-        id: login-to-gar
-        with:
-          registry: us-docker.pkg.dev
-          environment: prod
-
-      - name: Get Vault secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
-        with:
-          export_env: false
-          common_secrets: |
-            GITHUB_APP_ID=updater-app:app-id
-            GITHUB_APP_INSTALLATION_ID=updater-app:app-installation-id
-            GITHUB_APP_PRIVATE_KEY=updater-app:private-key
-
-      - name: Update jsonnet
-        env:
-          GITHUB_APP_ID: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          GITHUB_APP_INSTALLATION_ID: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_INSTALLATION_ID }}
-          GITHUB_APP_PRIVATE_KEY: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-        run: |
-          set -e -o pipefail
-
-          cat << EOF > config.json
-          {
-            "destination_branch": "master",
-            "pull_request_branch_prefix": "auto-merge/cd-tempo-dev",
-            "pull_request_enabled": true,
-            "pull_request_existing_strategy": "ignore",
-            "repo_name": "deployment_tools",
-            "update_jsonnet_attribute_configs": [
-              {
-                "file_path": "ksonnet/environments/tempo/dev-us-east-0.tempo-dev-02/images.libsonnet",
-                "jsonnet_key": "tempo",
-                "jsonnet_value_file": "tags_for_cd_tempo"
-              },
-              {
-                "file_path": "ksonnet/environments/tempo/dev-us-east-0.tempo-dev-02/images.libsonnet",
-                "jsonnet_key": "tempo_query",
-                "jsonnet_value_file": "tags_for_cd_tempo_query"
-              },
-              {
-                "file_path": "ksonnet/environments/tempo/dev-us-east-0.tempo-dev-02/images.libsonnet",
-                "jsonnet_key": "tempo_vulture",
-                "jsonnet_value_file": "tags_for_cd_tempo_vulture"
-              }
-            ]
-          }
-          EOF
-
-          docker run --rm \
-          -e GITHUB_APP_ID \
-          -e GITHUB_APP_INSTALLATION_ID \
-          -e GITHUB_APP_PRIVATE_KEY \
-          -e CONFIG_JSON="$(cat config.json)" \
-          -v ./tags_for_cd_tempo:/app/tags_for_cd_tempo \
-          -v ./tags_for_cd_tempo_query:/app/tags_for_cd_tempo_query \
-          -v ./tags_for_cd_tempo_vulture:/app/tags_for_cd_tempo_vulture us-docker.pkg.dev/grafanalabs-global/docker-deployment-tools-prod/updater
+          namespace: tempo-cd
+          workflow_template: tempo-continuous-deployment
+          parameters: |
+            imageTag=${{ needs.get-tag.outputs.tag }}


### PR DESCRIPTION
**What this PR does**:

Backports the GAR-based `docker` workflow from `release-v3.0`/`main` to `release-v2.10`. The legacy workflow on this branch pushed images **directly to Docker Hub**, which now fails with `unauthorized: access token has insufficient scopes`.

The workflow now builds per-arch images and pushes them, plus the versioned multi-arch manifest, to **GAR via OIDC** (`us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror`), from where they are mirrored to Docker Hub. The `:latest` tag is intentionally not pushed (GAR has tag immutability), matching `main`.

**Which issue(s) this PR fixes**:

N/A — release CI fix.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/`