### PR TITLE
chore: stop publishing 32-bit ARM binary archives

### DIFF
--- a/.chloggen/7106-drop-32bit-arm.yaml
+++ b/.chloggen/7106-drop-32bit-arm.yaml
@@ -1,0 +1,6 @@
+change_type: change
+component: tempo
+note: Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries.
+issues: [7106]
+subtext:
+user: javiermolinar

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,12 +17,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
-      - goarch: arm
-        goos: darwin
-      - goarch: arm
-        goos: windows
       - goarch: arm64
         goos: windows
     flags:
@@ -47,12 +42,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
-      - goarch: arm
-        goos: darwin
-      - goarch: arm
-        goos: windows
       - goarch: arm64
         goos: windows
     flags:
@@ -77,12 +67,7 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
     ignore:
-      - goarch: arm
-        goos: darwin
-      - goarch: arm
-        goos: windows
       - goarch: arm64
         goos: windows
     flags:


### PR DESCRIPTION
**What this PR does**:

Backports #7106 to `release-v2.10` to fix the failing `release` (GoReleaser) job.

The thrift security update to v0.23.0 (included in v2.10.6) uses `math.MaxUint32` as an `int` in `framed_transport.go`, which overflows the 32-bit `int` on the `linux/arm` (`GOARM=6`) target and fails `make release`. `release-v3.0`/`main` don't hit this because they already dropped 32-bit ARM in #7106.

This drops the 32-bit ARM build target from `.goreleaser.yml`. Release artifacts continue to include amd64 and arm64. A `.chloggen/` entry is added (CHANGELOG.md left untouched).

**Which issue(s) this PR fixes**:

N/A — release CI fix.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`