### PR TITLE
chore(ci): automate Tempo releases (RC, minor, patch)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,12 @@ on:
       - 'r[0-9]+'
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to build (e.g. v2.10.6)'
+        type: string
+        required: true
 
 # Needed to authenticate to GAR with OIDC.
 permissions:
@@ -25,18 +31,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: fetch tags
         run: git fetch --tags --force
 
       - id: get-tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          TAG="$(./tools/image-tag)"
-          if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
-            TAG="$TAG-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
+          if [ -n "$INPUT_TAG" ]; then
+            echo "tag=${INPUT_TAG#v}" >> "$GITHUB_OUTPUT"
+          else
+            TAG="$(./tools/image-tag)"
+            if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
+              TAG="$TAG-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
+            fi
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
   docker:
     if: github.repository == 'grafana/tempo'
@@ -55,6 +68,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: fetch tags
@@ -96,6 +110,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Login to GAR

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,190 @@
+name: release-prep
+# Dispatch-triggered prep for any release, detected from the version string:
+#   - release candidate (X.Y.Z-rc.N): prepped on main, NO image-tag bump,
+#     published later as a pre-release.
+#   - minor / patch (X.Y.Z): prepped on release-vX.Y, WITH image-tag bump,
+#     published later as latest.
+# Opens a labeled release-prep PR against the appropriate base branch.
+# Merging that PR triggers release-tag.yml.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, e.g. 2.10.7 or 3.1.0-rc.0 (no leading v)'
+        type: string
+        required: true
+      validate_only:
+        description: 'Run validation checks only; do not open a PR'
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  prep:
+    if: github.repository == 'grafana/tempo'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Validate version and derive release parameters
+        id: vars
+        run: |
+          set -euo pipefail
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+            echo "ERROR: version must be X.Y.Z or X.Y.Z-rc.N with no leading v, got: '$VERSION'"
+            exit 1
+          fi
+          base="${VERSION%%-*}"   # strip -rc.N  -> X.Y.Z
+          minor="${base%.*}"      # X.Y
+          patch="${base##*.}"     # Z
+          is_rc=false
+          case "$VERSION" in *-rc.*) is_rc=true ;; esac
+          # minor (.0, non-rc) may legitimately have 0 pending entries because the
+          # preceding RC already consumed them; its changelog section is produced by
+          # renaming the RC heading (a manual step) rather than by collation.
+          is_minor=false
+          if [ "$is_rc" = false ] && [ "$patch" = "0" ]; then is_minor=true; fi
+          if [ "$is_rc" = true ]; then
+            base_branch="main"
+            bump=false
+          else
+            base_branch="release-v${minor}"
+            bump=true
+          fi
+          {
+            echo "base_branch=${base_branch}"
+            echo "prep_branch=release-prep/v${VERSION}"
+            echo "tag=v${VERSION}"
+            echo "image_tag=${base}"
+            echo "is_minor=${is_minor}"
+            echo "bump=${bump}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Get GitHub App token
+        id: app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        with:
+          github_app: tempo-ci-app
+
+      - name: Checkout base branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.vars.outputs.base_branch }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: fetch tags
+        run: git fetch --tags --force
+
+      - name: Validate tag does not already exist
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "ERROR: tag ${TAG} already exists"
+            exit 1
+          fi
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Validate pending changelog entries
+        env:
+          BASE_BRANCH: ${{ steps.vars.outputs.base_branch }}
+          IS_MINOR: ${{ steps.vars.outputs.is_minor }}
+        run: |
+          set -euo pipefail
+          pending=$(find .chloggen -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) \
+            ! -name 'config.yaml' ! -name 'TEMPLATE.yaml' | wc -l | tr -d ' ')
+          echo "Found ${pending} pending changelog entr(y/ies)."
+          if [ "$pending" -lt 1 ] && [ "$IS_MINOR" != "true" ]; then
+            echo "ERROR: no pending .chloggen entries; nothing to release."
+            exit 1
+          fi
+          last_tag=$(git describe --tags --abbrev=0)
+          echo "Commits on ${BASE_BRANCH} since ${last_tag}:"
+          git log --oneline "${last_tag}..HEAD" | tee /tmp/commits.txt
+          make chlog-validate
+
+      - name: Generate changelog, bump image tag, regenerate jsonnet
+        if: ${{ ! inputs.validate_only }}
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+          IMAGE_TAG: ${{ steps.vars.outputs.image_tag }}
+          BUMP: ${{ steps.vars.outputs.bump }}
+        run: |
+          set -euo pipefail
+          pending=$(find .chloggen -maxdepth 1 -type f \( -name '*.yaml' -o -name '*.yml' \) \
+            ! -name 'config.yaml' ! -name 'TEMPLATE.yaml' | wc -l | tr -d ' ')
+          if [ "$pending" -ge 1 ]; then
+            make chlog-update VERSION="${TAG}"
+          else
+            echo "No pending entries; skipping chlog-update (changelog section expected to be prepared manually, e.g. RC heading renamed)."
+          fi
+          if [ "$BUMP" = true ]; then
+            make bump-tempo-image-tag TEMPO_IMAGE_TAG="${IMAGE_TAG}"
+            make jsonnet
+          fi
+
+      - name: Verify changelog section exists
+        if: ${{ ! inputs.validate_only }}
+        env:
+          TAG: ${{ steps.vars.outputs.tag }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          if ! grep -qxF "# v${version}" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md has no '# v${version}' section."
+            echo "For a minor release, rename the '# v${version}-rc.N' heading(s) to '# v${version}' on the release branch first, then re-run."
+            exit 1
+          fi
+
+      - name: Open release prep PR
+        if: ${{ ! inputs.validate_only }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.vars.outputs.tag }}
+          PREP_BRANCH: ${{ steps.vars.outputs.prep_branch }}
+          BASE_BRANCH: ${{ steps.vars.outputs.base_branch }}
+          IMAGE_TAG: ${{ steps.vars.outputs.image_tag }}
+          BUMP: ${{ steps.vars.outputs.bump }}
+        run: |
+          set -euo pipefail
+          git config user.name "tempo-ci-app[bot]"
+          git config user.email "209701675+tempo-ci-app[bot]@users.noreply.github.com"
+          git checkout -b "$PREP_BRANCH"
+          git add -A
+          git commit -m "chore: prepare release ${TAG}"
+          git push --force-with-lease origin "$PREP_BRANCH"
+          {
+            echo "Automated release prep for **${TAG}** (base: \`${BASE_BRANCH}\`)."
+            echo
+            echo "- Changelog collated via \`make chlog-update VERSION=${TAG}\` (skipped if no pending entries)"
+            if [ "$BUMP" = true ]; then
+              echo "- Image tag bumped via \`make bump-tempo-image-tag TEMPO_IMAGE_TAG=${IMAGE_TAG}\` + \`make jsonnet\`"
+            else
+              echo "- Image tag bump skipped (release candidate)"
+            fi
+            echo
+            echo "Merging this PR triggers \`release-tag\`, which tags ${TAG}, builds binaries +"
+            echo "images, and publishes the GitHub Release ($([ "$BUMP" = true ] && echo 'latest' || echo 'pre-release'))."
+            echo
+            echo "Commits since the last tag (verify each has a changelog entry):"
+            echo '```'
+            cat /tmp/commits.txt
+            echo '```'
+          } > /tmp/pr-body.md
+          gh pr create \
+            --base "$BASE_BRANCH" \
+            --head "$PREP_BRANCH" \
+            --title "chore: prepare release ${TAG}" \
+            --body-file /tmp/pr-body.md \
+            --label "release-prep"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,152 @@
+name: release-tag
+# Triggered when a release-prep PR is merged. Handles any release type:
+#   - RC (tag X.Y.Z-rc.N, based on main): published as a pre-release.
+#   - minor / patch (tag X.Y.Z, based on release-vX.Y): published as latest.
+# NOTE: pull_request workflows run from the BASE branch's copy of this file, so
+# this workflow must exist on every branch that release-prep PRs target — i.e.
+# main (for RCs) and each active release-vX.Y branch (for minor/patch).
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  guard-and-tag:
+    # Author check is the primary safeguard: release-prep PRs are only ever opened by the
+    # tempo-ci-app bot (its PRs have user.login 'tempo-ci-app[bot]', confirmed against the
+    # repo's existing bot PRs), and a human/forged PR cannot spoof that login — so a forged
+    # PR is rejected even if correctly named, labeled, and merged. The branch/base checks
+    # below are defense in depth.
+    if: >-
+      github.repository == 'grafana/tempo' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.user.login == 'tempo-ci-app[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'release-prep')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.guard.outputs.tag }}
+    steps:
+      - name: Verify provenance and parse version
+        id: guard
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          if ! echo "$HEAD_REF" | grep -qE '^release-prep/v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+            echo "ERROR: head branch '$HEAD_REF' is not release-prep/vX.Y.Z[-rc.N]"
+            exit 1
+          fi
+          version="${HEAD_REF#release-prep/v}"
+          base="${version%%-*}"
+          minor="${base%.*}"
+          if echo "$version" | grep -q -- '-rc\.'; then
+            # release candidate: must be based on main
+            if [ "$BASE_REF" != "main" ]; then
+              echo "ERROR: RC v${version} must be based on main, got '$BASE_REF'"
+              exit 1
+            fi
+          else
+            # minor / patch: must be based on the matching release branch
+            if [ "release-v${minor}" != "$BASE_REF" ]; then
+              echo "ERROR: v${version} must be based on release-v${minor}, got '$BASE_REF'"
+              exit 1
+            fi
+          fi
+          echo "tag=v${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Tag the exact PR merge commit, not the branch tip (main moves under RCs).
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          # persist-credentials defaults true: keep GITHUB_TOKEN for the tag push
+          # so the push: tags triggers in release.yml/docker.yml stay dormant.
+
+      - name: fetch tags
+        run: git fetch --tags --force
+
+      - name: Create and push tag
+        env:
+          TAG: ${{ steps.guard.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "ERROR: tag ${TAG} already exists"
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "$TAG"
+
+  build-release:
+    needs: guard-and-tag
+    permissions:
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.guard-and-tag.outputs.tag }}
+    secrets: inherit
+
+  build-docker:
+    needs: guard-and-tag
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/docker.yml
+    with:
+      tag: ${{ needs.guard-and-tag.outputs.tag }}
+    secrets: inherit
+
+  publish:
+    needs: [guard-and-tag, build-release, build-docker]
+    if: github.repository == 'grafana/tempo'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ needs.guard-and-tag.outputs.tag }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.guard-and-tag.outputs.tag }}
+          persist-credentials: false
+
+      - name: Extract changelog section
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          awk -v tag="# v${version}" '
+            $0 == tag {found=1; next}
+            found && /^# v/ {exit}
+            found {print}
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "ERROR: no CHANGELOG section found for ${TAG}"
+            exit 1
+          fi
+          echo "----- release notes -----"
+          cat release-notes.md
+
+      - name: Publish GitHub Release
+        run: |
+          set -euo pipefail
+          # RC tags publish as a pre-release; final tags as latest. goreleaser's
+          # prerelease: auto already sets the prerelease bit from the tag.
+          flags=(--draft=false)
+          case "$TAG" in
+            *-rc.*) flags+=(--prerelease --latest=false) ;;
+            *)      flags+=(--latest) ;;
+          esac
+          gh release edit "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --notes-file release-notes.md \
+            "${flags[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to build (e.g. v2.10.6)'
+        type: string
+        required: true
 
 # No default token permissions; the release job grants only what it needs.
 permissions: {}
@@ -17,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: fetch tags

--- a/Makefile
+++ b/Makefile
@@ -409,7 +409,7 @@ bump-tempo-image-tag: ## Bump grafana/tempo image tag in docker-compose and json
 		-print0 \
 		| xargs -0 grep -l "grafana/tempo:" \
 		| tr '\n' '\0' \
-		| xargs -0 -I{} sed -i '' -E "s#grafana/tempo:(latest|[0-9]+\.[0-9]+\.[0-9]+)#grafana/tempo:$(TEMPO_IMAGE_TAG)#g" {}
+		| xargs -0 -I{} sed -i $(SED_OPTS) -E "s#grafana/tempo:(latest|[0-9]+\.[0-9]+\.[0-9]+)#grafana/tempo:$(TEMPO_IMAGE_TAG)#g" {}
 	@echo "Done. Re-run 'make jsonnet' to regenerate compiled jsonnet if needed."
 
 ##@ jsonnet

--- a/RELEASES.MD
+++ b/RELEASES.MD
@@ -95,3 +95,70 @@ In [GitHub Releases](https://github.com/grafana/tempo/releases) there should be 
 
 ## 8. Submit a changelog PR to main
 Submit a PR to `main` adding the new version's section to `CHANGELOG.md` so the released notes are reflected on `main`. Either cherry-pick the changelog commit from the release branch (step 3), or run `make chlog-update VERSION=vX.Y.Z` against the corresponding `.chloggen/` entries on `main`.
+
+# Automated Releases (experimental)
+
+> **Status:** new and not yet verified end to end. The manual procedures above remain the
+> source of truth until this flow has been proven on a real release. Both can coexist.
+
+This flow drives release candidates, minor releases, and patch releases with two GitHub
+Actions workflows that reuse the existing `release.yml` and `docker.yml` build pipelines:
+
+- **`release-prep`** (`workflow_dispatch`) — prepares the changelog and (for non-RC
+  releases) the image-tag bump, then opens a labeled `release-prep` PR.
+- **`release-tag`** (triggered when that PR is merged) — tags the merge commit, builds
+  binaries and multi-arch images, then publishes the GitHub Release.
+
+The release type is detected from the version string passed to `release-prep`:
+
+| Version input | Type | Base branch | Image-tag bump | Published as |
+|---------------|------|-------------|----------------|--------------|
+| `X.Y.Z-rc.N`  | Release candidate | `main` | no | pre-release |
+| `X.Y.0`       | Minor | `release-vX.Y` | yes | latest |
+| `X.Y.Z` (Z>0) | Patch | `release-vX.Y` | yes | latest |
+
+> **Prerequisite:** because `pull_request` workflows run from the **base branch's** copy of
+> the workflow file, `release-tag.yml` (plus the reusable `release.yml`/`docker.yml` and the
+> portable `bump-tempo-image-tag` Makefile target) must exist on every branch that
+> `release-prep` PRs target: `main` (for RCs) and each active `release-vX.Y` branch (for
+> minor/patch). Backport these to active release branches before using the flow there.
+
+## Steps
+
+1. **Run `release-prep`.** Actions → `release-prep` → Run workflow, enter the version (no
+   leading `v`, e.g. `3.1.0-rc.0`, `3.1.0`, or `3.0.3`). It validates the version, collates
+   pending `.chloggen/` entries into `CHANGELOG.md`, bumps the image tag + regenerates
+   jsonnet for non-RC releases, and opens a `release-prep` PR against the correct base
+   branch. The `validate_only` option dry-runs the checks without opening a PR.
+2. **Review and merge the prep PR.** Merging is the human gate. **Merging auto-tags and
+   publishes** — only merge when you intend to release.
+3. **`release-tag` takes over** (triggered by the merge): it verifies the PR is a genuine
+   release-prep PR (see Security below), tags the merge commit, builds binaries and
+   multi-arch images, then un-drafts and publishes the GitHub Release — `--latest` for
+   minor/patch, `--prerelease` for RCs — using the `CHANGELOG.md` section.
+4. **Verify** the `release-tag` run succeeded and the images appear in GAR, then on Docker
+   Hub after the mirror catches up.
+
+## Security
+
+`release-tag` triggers on any merged PR, so before tagging it verifies the PR is a genuine,
+bot-generated release-prep PR and aborts otherwise:
+
+- the PR was authored by the `tempo-ci-app` bot (a human cannot open a PR as the bot, so a
+  forged PR is rejected even if it is correctly named, labeled, and merged);
+- the `release-prep` label is present;
+- the head branch matches `release-prep/vX.Y.Z[-rc.N]`;
+- the base branch matches the release type (`main` for RCs, `release-vX.Y` otherwise).
+
+The workflow that runs is always the base branch's copy of `release-tag.yml`, so the guard
+cannot be weakened from within a PR.
+
+## Steps that remain manual
+
+- **Minor release changelog consolidation.** A minor (`X.Y.0`) is preceded by RCs whose
+  `chlog-update` already consumed the `.chloggen/` entries, so there are usually none left
+  to collate. Before running `release-prep` for the minor, rename the `# vX.Y.0-rc.N`
+  heading(s) in `CHANGELOG.md` on the release branch to `# vX.Y.0`. `release-prep` verifies
+  that section exists and fails with guidance if it doesn't.
+- Release notes documentation, helm-chart PRs, and the changelog PR back to `main` (see the
+  manual sections above).


### PR DESCRIPTION
## What

Automates Tempo **releases — release candidates, minor, and patch** — with two GitHub Actions workflows that reuse the existing `release.yml` and `docker.yml` build pipelines. The release type is derived from the version string; there is no separate type input.

| Version input | Type | Base branch | Image bump | Published as |
|---|---|---|---|---|
| `X.Y.Z-rc.N` | RC | `main` | no | pre-release |
| `X.Y.0` | minor | `release-vX.Y` | yes | latest |
| `X.Y.Z` (Z>0) | patch | `release-vX.Y` | yes | latest |

- **`release-prep`** (`workflow_dispatch`, version input): validates, collates `.chloggen/` into `CHANGELOG.md`, bumps the image tag + regenerates jsonnet (non-RC), and opens a labeled `release-prep` PR against the correct base branch. `validate_only` dry-runs the checks.
- **`release-tag`** (on merged `release-prep` PR): verifies provenance (label + base/head branch match), tags the **PR merge commit** with `GITHUB_TOKEN` (so the `push: tags` triggers stay dormant — no double build), calls `release.yml` + `docker.yml` as reusable workflows, then publishes the GitHub Release (`--latest` for minor/patch, `--prerelease` for RCs) from the `CHANGELOG.md` section.

Merging the prep PR is the single human gate.

## Supporting changes

- `Makefile`: `bump-tempo-image-tag` now uses the portable `$(SED_OPTS)` instead of BSD-only `sed -i ''` (was broken on Linux runners).
- `release.yml` / `docker.yml`: add a `workflow_call` trigger with a `tag` input alongside the existing `push: tags`; pin checkouts to the tag when called. Manual push-tag path is unchanged.
- `RELEASES.MD`: documents the automated flow and the steps that remain manual.

## Left manual (judgment / out of repo)

- **Minor changelog consolidation:** a minor `.0` is preceded by RCs whose `chlog-update` already consumed the `.chloggen/` entries, so the final section is produced by renaming the `# vX.Y.0-rc.N` heading(s) — done by hand on the release branch. `release-prep` verifies the `# vX.Y.0` section exists and fails with guidance otherwise.
- Release-notes docs, helm-chart PRs, and the changelog PR back to `main`.

## Notes

- **Backport prerequisite:** `pull_request` workflows run from the *base* branch's copy, so `release-tag.yml` (+ reusable `release.yml`/`docker.yml` + Makefile fix) must exist on `main` (for RCs) and each active `release-vX.Y` branch (for minor/patch).
- Reuses the `tempo-ci-app` token (as in `backport.yml`) to open the prep PR.
- End-to-end only runs on `grafana/tempo` (the `if: github.repository == 'grafana/tempo'` guards skip forks). `actionlint` passes on all four workflows.
