### PR TITLE
docs: fix Go version typo in v2.10.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 # v2.10.5
 
-* [ENHANCEMENT] Updated go dependency version to v1.16.2. [#7040](https://github.com/grafana/tempo/pull/7040) (@ie-pham)
+* [ENHANCEMENT] Updated go dependency version to v1.26.2. [#7040](https://github.com/grafana/tempo/pull/7040) (@ie-pham)
 
 # v2.10.4
 


### PR DESCRIPTION
**What this PR does**:
Fixes a typo in the v2.10.5 changelog entry: the Go version is `1.26.2`, not `1.16.2`. PR #7040 upgraded Tempo to Go 1.26.2, and the v2.10.5 release notes already state this.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (N/A — corrects an already-released changelog section)