### PR TITLE
docs: backfill v2.10.5/v2.10.6/v3.0.2 changelog and release notes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 <!-- next version -->
 
+# v3.0.2
+
+## 🔒 Security 🔒
+
+- `deps`: Build Tempo with Go 1.26.3, which includes upstream security and bug fixes. ([#7423](https://github.com/grafana/tempo/issues/7423)) (@ie-pham)
+
 # v3.0.0
 
 * [CHANGE] **BREAKING CHANGE** Recent data queries guarantee complete results by failing when an instance is lagging. Defaults `query_frontend.query_end_cutoff` to `30s` and `live_store.fail_on_high_lag` to `true`. [#7210](https://github.com/grafana/tempo/pull/7210) (@mapno)
@@ -138,6 +144,27 @@
 * [CHANGE] **BREAKING CHANGE** Sets the `all` target to be 3.0 compatible and removes the `scalable-single-binary` target [#6283](https://github.com/grafana/tempo/pull/6283) (@joe-elliott)
 * [CHANGE] **BREAKING CHANGE** Clean up enterprise jsonnet [#6505](https://github.com/grafana/tempo/pull/6505) (@javiermolinar)
 * [CHANGE] Expose otlp http and grpc ports for Docker examples [#6296](https://github.com/grafana/tempo/pull/6296) (@javiermolinar)
+
+# v2.10.6
+
+## 🔒 Security 🔒
+
+- `deps`: Update github.com/apache/thrift to v0.23.0 to pick up upstream security fixes. ([#7120](https://github.com/grafana/tempo/issues/7120)) (@renovate)
+- `deps`: Update golang.org/x/crypto to v0.52.0 to pick up upstream security fixes. ([#7262](https://github.com/grafana/tempo/issues/7262)) (@renovate)
+- `deps`: Update golang.org/x/net to v0.55.0 to pick up upstream security fixes. ([#7129](https://github.com/grafana/tempo/issues/7129), [#7263](https://github.com/grafana/tempo/issues/7263)) (@renovate)
+- `deps`: Build Tempo with Go 1.26.3, which includes upstream security and bug fixes. ([#7422](https://github.com/grafana/tempo/issues/7422)) (@ie-pham)
+
+## 🛑 Breaking changes 🛑
+
+- `distributor`: Dropped support for the OpenCensus receiver. ([#7322](https://github.com/grafana/tempo/issues/7322)) (@zhxiaogg)
+
+## 🔧 Changes 🔧
+
+- `deps`: Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others). ([#7298](https://github.com/grafana/tempo/issues/7298)) (@zhxiaogg)
+
+# v2.10.5
+
+* [ENHANCEMENT] Updated go dependency version to v1.26.2. [#7040](https://github.com/grafana/tempo/pull/7040) (@ie-pham)
 
 # v2.10.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 # v3.0.2
 
-## 🔒 Security 🔒
-
-- `deps`: Build Tempo with Go 1.26.3, which includes upstream security and bug fixes. ([#7423](https://github.com/grafana/tempo/issues/7423)) (@ie-pham)
+* [CHANGE] Upgrade Tempo to Go 1.26.3 [#7423](https://github.com/grafana/tempo/pull/7423) (@ie-pham)
 
 # v3.0.0
 
@@ -147,24 +145,16 @@
 
 # v2.10.6
 
-## 🔒 Security 🔒
-
-- `deps`: Update github.com/apache/thrift to v0.23.0 to pick up upstream security fixes. ([#7120](https://github.com/grafana/tempo/issues/7120)) (@renovate)
-- `deps`: Update golang.org/x/crypto to v0.52.0 to pick up upstream security fixes. ([#7262](https://github.com/grafana/tempo/issues/7262)) (@renovate)
-- `deps`: Update golang.org/x/net to v0.55.0 to pick up upstream security fixes. ([#7129](https://github.com/grafana/tempo/issues/7129), [#7263](https://github.com/grafana/tempo/issues/7263)) (@renovate)
-- `deps`: Build Tempo with Go 1.26.3, which includes upstream security and bug fixes. ([#7422](https://github.com/grafana/tempo/issues/7422)) (@ie-pham)
-
-## 🛑 Breaking changes 🛑
-
-- `distributor`: Dropped support for the OpenCensus receiver. ([#7322](https://github.com/grafana/tempo/issues/7322)) (@zhxiaogg)
-
-## 🔧 Changes 🔧
-
-- `deps`: Updated Prometheus to v0.311.3 and the OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others). ([#7298](https://github.com/grafana/tempo/issues/7298)) (@zhxiaogg)
+* [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#7322](https://github.com/grafana/tempo/pull/7322) (@zhxiaogg)
+* [CHANGE] Upgrade Tempo to Go 1.26.3 [#7422](https://github.com/grafana/tempo/pull/7422) (@ie-pham)
+* [CHANGE] Update Prometheus to v0.311.3 and OpenTelemetry Collector dependencies to v1.52, along with related transitive dependencies (dskit and others) [#7298](https://github.com/grafana/tempo/pull/7298) (@zhxiaogg)
+* [SECURITY] Update github.com/apache/thrift to v0.23.0 to pick up upstream security fixes [#7120](https://github.com/grafana/tempo/pull/7120) (@renovate)
+* [SECURITY] Update golang.org/x/crypto to v0.52.0 to pick up upstream security fixes [#7262](https://github.com/grafana/tempo/pull/7262) (@renovate)
+* [SECURITY] Update golang.org/x/net to v0.55.0 to pick up upstream security fixes [#7129](https://github.com/grafana/tempo/pull/7129) [#7263](https://github.com/grafana/tempo/pull/7263) (@renovate)
 
 # v2.10.5
 
-* [ENHANCEMENT] Updated go dependency version to v1.26.2. [#7040](https://github.com/grafana/tempo/pull/7040) (@ie-pham)
+* [CHANGE] Upgrade Tempo to Go 1.26.2 [#7040](https://github.com/grafana/tempo/pull/7040) (@ie-pham)
 
 # v2.10.4
 

--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -312,6 +312,12 @@ Tempo 3.0 upgrades to Go 1.26.2. [[PR 6443](https://github.com/grafana/tempo/pul
 
 ## Security fixes
 
+### 3.0.2
+
+- Built Tempo with Go 1.26.3, which includes upstream security and bug fixes. [[PR 7423](https://github.com/grafana/tempo/pull/7423)]
+
+### 3.0.0
+
 - Fixed division by zero error in TraceQL expressions that could cause query failures. [[PR 6580](https://github.com/grafana/tempo/pull/6580)]
 - Fixed `intPow` function hanging for certain inputs, which could cause unbounded CPU consumption. [[PR 6581](https://github.com/grafana/tempo/pull/6581)]
 - Fixed integer overflow in query parameters by using `strconv.ParseUint` instead of `strconv.Atoi`/`strconv.ParseInt` for unsigned integer fields. [[PR 6612](https://github.com/grafana/tempo/pull/6612)]

--- a/docs/sources/tempo/release-notes/version-2/v2-10.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-10.md
@@ -280,6 +280,7 @@ Be aware of these breaking changes when upgrading to Tempo 2.10:
 - Go version upgrade: Tempo 2.10 upgrades to Go 1.25.5, which may affect custom builds or deployments with specific Go version requirements. (PRs [#5939](https://github.com/grafana/tempo/pull/5939) [#6001](https://github.com/grafana/tempo/pull/6001), [#6096](https://github.com/grafana/tempo/pull/6096), [#6089](https://github.com/grafana/tempo/pull/6089))
 - Go version upgrade: Tempo 2.10.1 upgrades to Go 1.25.7, which may affect custom builds or deployments with specific Go version requirements. (PR [#6449](https://github.com/grafana/tempo/pull/6449))
 - Go version upgrade: Tempo 2.10.5 upgrades to Go 1.26.2, which may affect custom builds or deployments with specific Go version requirements. [[PR 7040](https://github.com/grafana/tempo/pull/7040)]
+- OpenCensus receiver removed: Tempo 2.10.6 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7322](https://github.com/grafana/tempo/pull/7322)]
 
 ## Project Rhythm: New Tempo architecture
 
@@ -317,6 +318,11 @@ Refer to the [Tempo rearchitecture](https://github.com/grafana/tempo/releases/ta
 ## Security fixes
 
 The following updates were made to address security issues.
+
+### 2.10.6
+
+- Updated `github.com/apache/thrift` to v0.23.0, `golang.org/x/crypto` to v0.52.0, and `golang.org/x/net` to v0.55.0 to pick up upstream security fixes. (PRs [#7120](https://github.com/grafana/tempo/pull/7120), [#7262](https://github.com/grafana/tempo/pull/7262), [#7129](https://github.com/grafana/tempo/pull/7129), [#7263](https://github.com/grafana/tempo/pull/7263))
+- Built Tempo with Go 1.26.3, which includes upstream security and bug fixes. [[PR 7422](https://github.com/grafana/tempo/pull/7422)]
 
 ### 2.10.3
 


### PR DESCRIPTION
**What this PR does**:
`main` was missing the `v2.10.5`, `v2.10.6`, and `v3.0.2` sections that already shipped on the release branches, so the released notes aren't reflected on `main` (per `RELEASES.MD` Patch Releases step 8). This backfills:

- `CHANGELOG.md`: adds the `v3.0.2`, `v2.10.6`, and `v2.10.5` sections (copied from the release branches; the `v2.10.5` Go version is written as `1.26.2`).
- `release-notes/version-2/v2-10.md`: adds a `### 2.10.6` security-fixes entry (thrift, x/crypto, x/net, Go 1.26.3) and an OpenCensus-receiver-removal note under breaking changes.
- `release-notes/v3-0.md`: versions the security-fixes section with `### 3.0.2` (Go 1.26.3) and `### 3.0.0`.

All version numbers and the receiver removal were verified against the `release-v2.10`/`release-v3.0` `go.mod` and source.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` (N/A — backfills already-released sections onto `main`)