### PR TITLE
docs: add v2.10.6 release notes and backfill 2.10.1/2.10.5 Go versions

### DIFF
--- a/docs/sources/tempo/release-notes/v2-10.md
+++ b/docs/sources/tempo/release-notes/v2-10.md
@@ -276,6 +276,9 @@ Be aware of these breaking changes when upgrading to Tempo 2.10:
 - Tenant ID validation: Tempo now validates tenant IDs in the frontend and distributor components, using the same validation rules as Grafana Mimir. Previously, Tempo accepted any tenant ID value. Valid tenant IDs may only contain alphanumeric characters (a-z, A-Z, 0-9) and special characters (`!`, `-`, `_`, `.`, `*`, `'`, `(`, `)`), with a maximum length of 150 characters. Empty tenant IDs and the values `.` or `..` are rejected. Requests with invalid tenant IDs return an error. [[PR 5786](https://github.com/grafana/tempo/pull/5786)]
 - SearchTagsV2WithRange API change: The Tempo HTTP client `SearchTagsV2WithRange` function signature has changed. The function previously accepted only `start` and `end` parameters. It now requires two additional parameters: `scope` and `query`. This change affects Go code that imports the `pkg/httpclient` package. To maintain existing behavior, pass empty strings for the new parameters: `SearchTagsV2WithRange("", "", start, end)`. [[PR 6088](https://github.com/grafana/tempo/pull/6088)]
 - Go version upgrade: Tempo 2.10 upgrades to Go 1.25.5, which may affect custom builds or deployments with specific Go version requirements. (PRs [#5939](https://github.com/grafana/tempo/pull/5939) [#6001](https://github.com/grafana/tempo/pull/6001), [#6096](https://github.com/grafana/tempo/pull/6096), [#6089](https://github.com/grafana/tempo/pull/6089))
+- Go version upgrade: Tempo 2.10.1 upgrades to Go 1.25.7, which may affect custom builds or deployments with specific Go version requirements. (PR [#6449](https://github.com/grafana/tempo/pull/6449))
+- Go version upgrade: Tempo 2.10.5 upgrades to Go 1.26.2, which may affect custom builds or deployments with specific Go version requirements. [[PR 7040](https://github.com/grafana/tempo/pull/7040)]
+- OpenCensus receiver removed: Tempo 2.10.6 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7322](https://github.com/grafana/tempo/pull/7322)]
 
 ## Project Rhythm: New Tempo architecture
 
@@ -313,6 +316,11 @@ Refer to the [Tempo rearchitecture](https://github.com/grafana/tempo/releases/ta
 ## Security fixes
 
 The following updates were made to address security issues.
+
+### 2.10.6
+
+- Updated `github.com/apache/thrift` to v0.23.0, `golang.org/x/crypto` to v0.52.0, and `golang.org/x/net` to v0.55.0 to pick up upstream security fixes. (PRs [#7120](https://github.com/grafana/tempo/pull/7120), [#7262](https://github.com/grafana/tempo/pull/7262), [#7129](https://github.com/grafana/tempo/pull/7129), [#7263](https://github.com/grafana/tempo/pull/7263))
+- Built Tempo with Go 1.26.3, which includes upstream security and bug fixes. [[PR 7422](https://github.com/grafana/tempo/pull/7422)]
 
 ### 2.10.3
 

--- a/docs/sources/tempo/release-notes/v2-10.md
+++ b/docs/sources/tempo/release-notes/v2-10.md
@@ -275,9 +275,10 @@ Be aware of these breaking changes when upgrading to Tempo 2.10:
 
 - Tenant ID validation: Tempo now validates tenant IDs in the frontend and distributor components, using the same validation rules as Grafana Mimir. Previously, Tempo accepted any tenant ID value. Valid tenant IDs may only contain alphanumeric characters (a-z, A-Z, 0-9) and special characters (`!`, `-`, `_`, `.`, `*`, `'`, `(`, `)`), with a maximum length of 150 characters. Empty tenant IDs and the values `.` or `..` are rejected. Requests with invalid tenant IDs return an error. [[PR 5786](https://github.com/grafana/tempo/pull/5786)]
 - SearchTagsV2WithRange API change: The Tempo HTTP client `SearchTagsV2WithRange` function signature has changed. The function previously accepted only `start` and `end` parameters. It now requires two additional parameters: `scope` and `query`. This change affects Go code that imports the `pkg/httpclient` package. To maintain existing behavior, pass empty strings for the new parameters: `SearchTagsV2WithRange("", "", start, end)`. [[PR 6088](https://github.com/grafana/tempo/pull/6088)]
-- Go version upgrade: Tempo 2.10 upgrades to Go 1.25.5, which may affect custom builds or deployments with specific Go version requirements. (PRs [#5939](https://github.com/grafana/tempo/pull/5939) [#6001](https://github.com/grafana/tempo/pull/6001), [#6096](https://github.com/grafana/tempo/pull/6096), [#6089](https://github.com/grafana/tempo/pull/6089))
-- Go version upgrade: Tempo 2.10.1 upgrades to Go 1.25.7, which may affect custom builds or deployments with specific Go version requirements. (PR [#6449](https://github.com/grafana/tempo/pull/6449))
-- Go version upgrade: Tempo 2.10.5 upgrades to Go 1.26.2, which may affect custom builds or deployments with specific Go version requirements. [[PR 7040](https://github.com/grafana/tempo/pull/7040)]
+- Go version upgrades, which may affect custom builds or deployments with specific Go version requirements:
+  - Tempo 2.10 upgrades to Go 1.25.5. (PRs [#5939](https://github.com/grafana/tempo/pull/5939) [#6001](https://github.com/grafana/tempo/pull/6001), [#6096](https://github.com/grafana/tempo/pull/6096), [#6089](https://github.com/grafana/tempo/pull/6089))
+  - Tempo 2.10.1 upgrades to Go 1.25.7. (PR [#6449](https://github.com/grafana/tempo/pull/6449))
+  - Tempo 2.10.5 upgrades to Go 1.26.2. [[PR 7040](https://github.com/grafana/tempo/pull/7040)]
 - OpenCensus receiver removed: Tempo 2.10.6 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7322](https://github.com/grafana/tempo/pull/7322)]
 
 ## Project Rhythm: New Tempo architecture


### PR DESCRIPTION
**What this PR does**:
Updates the Tempo 2.10 release notes on the release branch (the source for the published versioned/latest docs) for the v2.10.6 patch:

- **Security fixes** — adds a `### 2.10.6` subsection: thrift v0.23.0, x/crypto v0.52.0, x/net v0.55.0, and Go 1.26.3.
- **Upgrade considerations** — notes the OpenCensus receiver removal in 2.10.6 (senders must switch to OTLP), and backfills the previously-missing 2.10.1 (Go 1.25.7) and 2.10.5 (Go 1.26.2) Go-version-upgrade entries.

Versions and the receiver removal were verified against `release-v2.10` `go.mod` and source. The CHANGELOG backfill for these versions is a separate PR to `main` (#7441).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` (N/A — release-notes docs for an already-released patch)