### PR TITLE
docs: add v3.0.2 release notes

### DIFF
--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -312,6 +312,12 @@ Tempo 3.0 upgrades to Go 1.26.2. [[PR 6443](https://github.com/grafana/tempo/pul
 
 ## Security fixes
 
+### 3.0.2
+
+- Built Tempo with Go 1.26.3, which includes upstream security and bug fixes. [[PR 7423](https://github.com/grafana/tempo/pull/7423)]
+
+### 3.0.0
+
 - Fixed division by zero error in TraceQL expressions that could cause query failures. [[PR 6580](https://github.com/grafana/tempo/pull/6580)]
 - Fixed `intPow` function hanging for certain inputs, which could cause unbounded CPU consumption. [[PR 6581](https://github.com/grafana/tempo/pull/6581)]
 - Fixed integer overflow in query parameters by using `strconv.ParseUint` instead of `strconv.Atoi`/`strconv.ParseInt` for unsigned integer fields. [[PR 6612](https://github.com/grafana/tempo/pull/6612)]


### PR DESCRIPTION
**What this PR does**:
Updates the Tempo 3.0 release notes on the release branch (the source for the published versioned/latest docs) for the v3.0.2 patch. Versions the **Security fixes** section with a `### 3.0.2` subsection (built with Go 1.26.3) and a `### 3.0.0` subsection wrapping the existing entries.

Verified against `release-v3.0` `go.mod` (1.26.2 in v3.0.0 → 1.26.3 in v3.0.2). The CHANGELOG backfill is a separate PR to `main` (#7441). v3.0.1 had no separate release-notes content (its Go bump was collated under the v3.0.2 changelog).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` (N/A — release-notes docs for an already-released patch)