### PR TITLE
feat(traceql): extrapolate metrics queries from W3C tracestate sampling

### DIFF
--- a/.chloggen/traceql-metrics-extrapolation.yaml
+++ b/.chloggen/traceql-metrics-extrapolation.yaml
@@ -21,4 +21,4 @@ subtext: |
   vparquet5 blocks.
 
 # The GitHub handle (without the leading @) of the change's author.
-user: cmarchbanks
+user: csmarchbanks

--- a/.chloggen/traceql-metrics-extrapolation.yaml
+++ b/.chloggen/traceql-metrics-extrapolation.yaml
@@ -18,7 +18,7 @@ subtext: |
   `histogram_over_time`, `quantile_over_time`, and `compare` aggregates —
   matching the metrics generator's existing per-span multiplier behaviour.
   `min_over_time` and `max_over_time` are unaffected. Only supported on
-  vparquet5 blocks.
+  vparquet4 and later.
 
 # The GitHub handle (without the leading @) of the change's author.
 user: csmarchbanks

--- a/.chloggen/traceql-metrics-extrapolation.yaml
+++ b/.chloggen/traceql-metrics-extrapolation.yaml
@@ -1,0 +1,24 @@
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: feature
+
+# Component or area of the change.
+component: traceql
+
+# A brief description of the change.
+note: TraceQL metrics queries can extrapolate counts from the W3C tracestate sampling probability. Opt in via the `metrics_traceql_extrapolation` per-tenant override or the `with(extrapolate=true)` query hint.
+
+# (Optional) PR number(s). Leave blank to auto-fill at release.
+issues: []
+
+# (Optional) Additional lines rendered under the note.
+subtext: |
+  When a span carries an OpenTelemetry probability threshold in its tracestate
+  (`ot=th:...`), each matched span contributes `1 / sampling_probability` to
+  `rate`, `count_over_time`, `sum_over_time`, `avg_over_time`,
+  `histogram_over_time`, `quantile_over_time`, and `compare` aggregates —
+  matching the metrics generator's existing per-span multiplier behaviour.
+  `min_over_time` and `max_over_time` are unaffected. Only supported on
+  vparquet5 blocks.
+
+# The GitHub handle (without the leading @) of the change's author.
+user: cmarchbanks

--- a/.chloggen/traceql-metrics-extrapolation.yaml
+++ b/.chloggen/traceql-metrics-extrapolation.yaml
@@ -5,7 +5,7 @@ change_type: feature
 component: traceql
 
 # A brief description of the change.
-note: TraceQL metrics queries can extrapolate counts from the W3C tracestate sampling probability. Opt in via the `metrics_traceql_extrapolation` per-tenant override or the `with(extrapolate=true)` query hint.
+note: TraceQL metrics queries can extrapolate counts from the W3C tracestate sampling probability. Opt in per query via the `with(extrapolate=true)` hint.
 
 # (Optional) PR number(s). Leave blank to auto-fill at release.
 issues: []

--- a/docs/sources/tempo/metrics-from-traces/metrics-queries/functions.md
+++ b/docs/sources/tempo/metrics-from-traces/metrics-queries/functions.md
@@ -557,6 +557,27 @@ Samples a fixed percentage of traces for trace-level aggregations.
 { } | count_over_time() by (resource.service.name) with(trace_sample=0.05)
 ```
 
+## Extrapolation from ingest-time sampling: `with(extrapolate=true)`
+
+If your traces were sampled at ingest time by an OpenTelemetry probability
+sampler (for example, an OTel Collector `probabilistic_sampler` in
+`proportional` mode), each surviving span carries a W3C tracestate value that
+encodes the sampling probability. `with(extrapolate=true)` scales each matched
+span's contribution by `1 / sampling_probability` so the emitted metric
+represents the un-sampled population rather than what actually reached storage.
+
+For example, at 15% ingest sampling, the extrapolated rate is roughly 6.7 times
+the stored rate:
+
+```traceql
+{ resource.service.name="api" } | rate() with(extrapolate=true)
+```
+
+Applies to `rate`, `count_over_time`, `sum_over_time`, `avg_over_time`,
+`histogram_over_time`, `quantile_over_time`, and `compare`. `min_over_time`
+and `max_over_time` are intentionally unaffected because extremes don't
+scale with sampling.
+
 ## The `compare` function
 
 {{< admonition type="note">}}

--- a/docs/sources/tempo/metrics-from-traces/metrics-queries/functions.md
+++ b/docs/sources/tempo/metrics-from-traces/metrics-queries/functions.md
@@ -557,7 +557,9 @@ Samples a fixed percentage of traces for trace-level aggregations.
 { } | count_over_time() by (resource.service.name) with(trace_sample=0.05)
 ```
 
-## Extrapolation from ingest-time sampling: `with(extrapolate=true)`
+## Extrapolation from ingest-time sampling: `with(extrapolate=true)` (experimental)
+
+{{< docs/experimental product="Tempo" >}}
 
 If your traces were sampled at ingest time by an OpenTelemetry probability
 sampler (for example, an OTel Collector `probabilistic_sampler` in

--- a/modules/generator/processor/util/util.go
+++ b/modules/generator/processor/util/util.go
@@ -1,11 +1,9 @@
 package util
 
 import (
-	"strings"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
+	"github.com/grafana/tempo/pkg/sampling"
 	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	v1_resource "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
@@ -71,7 +69,7 @@ func FindAttributeValue(key string, attributes ...[]*v1_common.KeyValue) (string
 
 func GetSpanMultiplier(ratioKey string, span *v1.Span, rs *v1_resource.Resource, enableTraceState bool) float64 {
 	if enableTraceState {
-		if m := getSpanMultiplierFromTraceState(span.GetTraceState()); m > 0 {
+		if m := sampling.MultiplierFromTraceState(span.GetTraceState()); m > 0 {
 			return m
 		}
 	}
@@ -95,48 +93,4 @@ func GetSpanMultiplier(ratioKey string, span *v1.Span, rs *v1_resource.Resource,
 		}
 	}
 	return 1.0
-}
-
-// getSpanMultiplierFromTraceState extracts a span multiplier from the W3C tracestate
-// OTel probability sampling threshold.
-// Returns 0 if the tracestate is empty, invalid, or has no OTel sampling data.
-func getSpanMultiplierFromTraceState(traceState string) float64 {
-	// Manual parsing of trace state is about twice as fast
-	// sampling.NewW3CTraceState as we only care about the ot key.
-	ot := extractOpenTelemetryTraceState(traceState)
-	if ot == "" {
-		return 0
-	}
-
-	otts, err := sampling.NewOpenTelemetryTraceState(ot)
-	if err != nil {
-		return 0
-	}
-
-	return otts.AdjustedCount()
-}
-
-// extractOpenTelemetryTraceState parses the tracestate for the ot vendor key
-// and returns the value of the key (or empty if it does not exist). It is
-// about twice as fast as `sampling.NewW3CTraceState` and does no allocations.
-func extractOpenTelemetryTraceState(traceState string) string {
-	// tracestate is formatted like vendor1=value1,vendor2=value2. See
-	// https://www.w3.org/TR/trace-context/#list.
-	for {
-		// Trim any optional white space surrounding vendor elements.
-		traceState = strings.TrimSpace(traceState)
-		nextComma := strings.IndexByte(traceState, ',')
-		if strings.HasPrefix(traceState, "ot=") {
-			end := len(traceState)
-			if nextComma > 0 {
-				end = nextComma
-			}
-			return traceState[3:end]
-		}
-
-		if nextComma == -1 {
-			return ""
-		}
-		traceState = strings.TrimSpace(traceState[nextComma+1:])
-	}
 }

--- a/modules/generator/processor/util/util_test.go
+++ b/modules/generator/processor/util/util_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 	"github.com/stretchr/testify/assert"
 
 	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
@@ -189,102 +188,6 @@ func TestFindServiceLabels(t *testing.T) {
 	}
 }
 
-func TestGetSpanMultiplierFromTraceState(t *testing.T) {
-	tests := []struct {
-		name       string
-		traceState string
-		expected   float64
-	}{
-		{
-			name:       "empty tracestate",
-			traceState: "",
-			expected:   0,
-		},
-		{
-			name:       "th:0 means always sampled",
-			traceState: "ot=th:0",
-			expected:   1.0,
-		},
-		{
-			name:       "th:8 means 50% sampling, multiplier 2",
-			traceState: "ot=th:8",
-			expected:   2.0,
-		},
-		{
-			name:       "th:c means 25% sampling, multiplier 4",
-			traceState: "ot=th:c",
-			expected:   4.0,
-		},
-		{
-			name:       "th:fd70a4 means ~1% sampling, multiplier ~100",
-			traceState: "ot=th:fd70a4",
-			expected:   100.0,
-		},
-		{
-			name:       "multiple vendors in tracestate",
-			traceState: "vendor1=value1,ot=th:8,vendor2=value2",
-			expected:   2.0,
-		},
-		{
-			name:       "ot value with multiple subkeys",
-			traceState: "ot=rv:00112233445566;th:8",
-			expected:   2.0,
-		},
-		{
-			name:       "invalid hex in threshold",
-			traceState: "ot=th:xyz",
-			expected:   0,
-		},
-		{
-			name:       "no ot key",
-			traceState: "vendor1=value1,vendor2=value2",
-			expected:   0,
-		},
-		{
-			name:       "ot without th subkey",
-			traceState: "ot=rv:00112233445566",
-			expected:   0,
-		},
-		{
-			name:       "threshold too long",
-			traceState: "ot=th:123456789abcdef",
-			expected:   0,
-		},
-		{
-			name:       "empty threshold value",
-			traceState: "ot=th:",
-			expected:   0,
-		},
-		{
-			name:       "vendor key ending with ot",
-			traceState: "not=foo:bar",
-			expected:   0,
-		},
-		{
-			name:       "vendor key ending with ot with th",
-			traceState: "not=th:c",
-			expected:   0,
-		},
-		{
-			name:       "not and ot vendor keys each with th",
-			traceState: "not=th:8,ot=th:c",
-			expected:   4.00,
-		},
-		{
-			name:       "not and ot vendor keys each with th and whitespace",
-			traceState: "not=th:8, ot=th:c",
-			expected:   4.00,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := getSpanMultiplierFromTraceState(tc.traceState)
-			assert.InDelta(t, tc.expected, result, 0.001, "tracestate: %s", tc.traceState)
-		})
-	}
-}
-
 func BenchmarkGetSpanMultiplier(b *testing.B) {
 	rs := &v1_resource.Resource{}
 
@@ -319,34 +222,6 @@ func BenchmarkGetSpanMultiplier(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			GetSpanMultiplier("sampling.ratio", spanWithoutTraceState, rs, false)
 		}
-	})
-}
-
-func FuzzGetSpanMultiplierFromTraceState(f *testing.F) {
-	f.Add("")
-	f.Add("ot=th:8")
-	f.Add("ot=th:c")
-	f.Add("ot=th:")
-	f.Add("vendor1=value1,ot=th:8,vendor2=value2")
-	f.Add("ot=rv:00112233445566;th:8")
-	f.Add("not=th:8,ot=th:c")
-	f.Add("not=th:8, ot=th:c")
-	f.Add("ot=th:xyz")
-	f.Add("vendor1=value1,vendor2=value2")
-	f.Add("  ot=th:8  ")
-	f.Add(",,,")
-	f.Add("ot=")
-	f.Add("=value")
-
-	f.Fuzz(func(t *testing.T, traceState string) {
-		// Verify that our multiplier matches what is done from the sampling package.
-		result := getSpanMultiplierFromTraceState(traceState)
-		w3c, err := sampling.NewW3CTraceState(traceState)
-		if err == nil {
-			assert.Equal(t, w3c.OTelValue().AdjustedCount(), result, "traceState: %s", traceState)
-		}
-		// We are looser with trace state errors where we can still parse ot=,
-		// so no assertions when there is an error as the results may differ.
 	})
 }
 

--- a/pkg/sampling/multiplier.go
+++ b/pkg/sampling/multiplier.go
@@ -1,0 +1,53 @@
+// Package sampling provides helpers for extracting per-span sampling
+// extrapolation multipliers from OpenTelemetry-style W3C tracestate.
+package sampling
+
+import (
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+)
+
+// MultiplierFromTraceState extracts the OpenTelemetry probability-sampling
+// multiplier (= 1 / sampling probability) from a W3C tracestate string.
+//
+// It returns 0 when the tracestate is empty, has no ot= segment, or fails to
+// parse — callers should treat 0 as "unknown" and fall back to 1.0 (or to a
+// configured attribute key) themselves.
+func MultiplierFromTraceState(traceState string) float64 {
+	ot := extractOpenTelemetryTraceState(traceState)
+	if ot == "" {
+		return 0
+	}
+
+	otts, err := sampling.NewOpenTelemetryTraceState(ot)
+	if err != nil {
+		return 0
+	}
+
+	return otts.AdjustedCount()
+}
+
+// extractOpenTelemetryTraceState parses the tracestate for the ot vendor key
+// and returns the value of the key (or empty if it does not exist). It is
+// about twice as fast as sampling.NewW3CTraceState and does no allocations.
+func extractOpenTelemetryTraceState(traceState string) string {
+	// tracestate is formatted like vendor1=value1,vendor2=value2. See
+	// https://www.w3.org/TR/trace-context/#list.
+	for {
+		traceState = strings.TrimSpace(traceState)
+		nextComma := strings.IndexByte(traceState, ',')
+		if strings.HasPrefix(traceState, "ot=") {
+			end := len(traceState)
+			if nextComma > 0 {
+				end = nextComma
+			}
+			return traceState[3:end]
+		}
+
+		if nextComma == -1 {
+			return ""
+		}
+		traceState = strings.TrimSpace(traceState[nextComma+1:])
+	}
+}

--- a/pkg/sampling/multiplier.go
+++ b/pkg/sampling/multiplier.go
@@ -3,29 +3,53 @@
 package sampling
 
 import (
+	"math"
 	"strings"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 )
 
-// MultiplierFromTraceState extracts the OpenTelemetry probability-sampling
-// multiplier (= 1 / sampling probability) from a W3C tracestate string.
+// MultiplierFromTraceState returns the OpenTelemetry probability-sampling
+// multiplier (= 1 / sampling probability) parsed from a W3C tracestate
+// string. When the tracestate also carries an OTEP-235 R-value (`rv:`
+// field), the multiplier is stochastically rounded to an integer using
+// that R-value as the random source — E[result] equals the underlying
+// multiplier, so aggregates over many spans converge to the same
+// expected value as the raw float, but each per-span contribution is
+// integer-valued (a cleaner UX for count-style aggregates and Prometheus
+// counter increments).
 //
-// It returns 0 when the tracestate is empty, has no ot= segment, or fails to
-// parse — callers should treat 0 as "unknown" and fall back to 1.0 (or to a
-// configured attribute key) themselves.
+// Falls back to the raw float multiplier when the tracestate has a
+// threshold but no R-value (for example, the SDK relies on the trace
+// ID's random flag per W3C trace context v2). Returns 0 when the
+// tracestate has no usable probability-sampling data — callers should
+// treat 0 as "unknown" and fall back to 1.0 (or to a configured ratio
+// attribute) themselves.
 func MultiplierFromTraceState(traceState string) float64 {
 	ot := extractOpenTelemetryTraceState(traceState)
 	if ot == "" {
 		return 0
 	}
-
 	otts, err := sampling.NewOpenTelemetryTraceState(ot)
 	if err != nil {
 		return 0
 	}
-
-	return otts.AdjustedCount()
+	m := otts.AdjustedCount()
+	rnd, hasRV := otts.RValueRandomness()
+	if m <= 0 || !hasRV {
+		return m
+	}
+	i := math.Floor(m)
+	frac := m - i
+	if frac == 0 {
+		return i
+	}
+	// Top 53 bits of the 56-bit R-value as a uniform float64 in [0, 1).
+	r := float64(rnd.Unsigned()>>3) / (1 << 53)
+	if r < frac {
+		return i + 1
+	}
+	return i
 }
 
 // extractOpenTelemetryTraceState parses the tracestate for the ot vendor key

--- a/pkg/sampling/multiplier_test.go
+++ b/pkg/sampling/multiplier_test.go
@@ -1,0 +1,147 @@
+package sampling
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiplierFromTraceState(t *testing.T) {
+	tests := []struct {
+		name       string
+		traceState string
+		expected   float64
+	}{
+		{
+			name:       "empty tracestate",
+			traceState: "",
+			expected:   0,
+		},
+		{
+			name:       "th:0 means always sampled",
+			traceState: "ot=th:0",
+			expected:   1.0,
+		},
+		{
+			name:       "th:8 means 50% sampling, multiplier 2",
+			traceState: "ot=th:8",
+			expected:   2.0,
+		},
+		{
+			name:       "th:c means 25% sampling, multiplier 4",
+			traceState: "ot=th:c",
+			expected:   4.0,
+		},
+		{
+			name:       "th:fd70a4 means ~1% sampling, multiplier ~100",
+			traceState: "ot=th:fd70a4",
+			expected:   100.0,
+		},
+		{
+			name:       "multiple vendors in tracestate",
+			traceState: "vendor1=value1,ot=th:8,vendor2=value2",
+			expected:   2.0,
+		},
+		{
+			name:       "ot value with multiple subkeys",
+			traceState: "ot=rv:00112233445566;th:8",
+			expected:   2.0,
+		},
+		{
+			name:       "invalid hex in threshold",
+			traceState: "ot=th:xyz",
+			expected:   0,
+		},
+		{
+			name:       "no ot key",
+			traceState: "vendor1=value1,vendor2=value2",
+			expected:   0,
+		},
+		{
+			name:       "ot without th subkey",
+			traceState: "ot=rv:00112233445566",
+			expected:   0,
+		},
+		{
+			name:       "threshold too long",
+			traceState: "ot=th:123456789abcdef",
+			expected:   0,
+		},
+		{
+			name:       "empty threshold value",
+			traceState: "ot=th:",
+			expected:   0,
+		},
+		{
+			name:       "vendor key ending with ot",
+			traceState: "not=foo:bar",
+			expected:   0,
+		},
+		{
+			name:       "vendor key ending with ot with th",
+			traceState: "not=th:c",
+			expected:   0,
+		},
+		{
+			name:       "not and ot vendor keys each with th",
+			traceState: "not=th:8,ot=th:c",
+			expected:   4.00,
+		},
+		{
+			name:       "not and ot vendor keys each with th and whitespace",
+			traceState: "not=th:8, ot=th:c",
+			expected:   4.00,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := MultiplierFromTraceState(tc.traceState)
+			assert.InDelta(t, tc.expected, result, 0.001, "tracestate: %s", tc.traceState)
+		})
+	}
+}
+
+func BenchmarkMultiplierFromTraceState(b *testing.B) {
+	b.Run("ot=th:8", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			MultiplierFromTraceState("ot=th:8")
+		}
+	})
+	b.Run("no ot segment", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			MultiplierFromTraceState("vendor1=value1,vendor2=value2")
+		}
+	})
+	b.Run("empty", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			MultiplierFromTraceState("")
+		}
+	})
+}
+
+func FuzzMultiplierFromTraceState(f *testing.F) {
+	f.Add("")
+	f.Add("ot=th:8")
+	f.Add("ot=th:c")
+	f.Add("ot=th:")
+	f.Add("vendor1=value1,ot=th:8,vendor2=value2")
+	f.Add("ot=rv:00112233445566;th:8")
+	f.Add("not=th:8,ot=th:c")
+	f.Add("not=th:8, ot=th:c")
+	f.Add("ot=th:xyz")
+	f.Add("vendor1=value1,vendor2=value2")
+	f.Add("  ot=th:8  ")
+	f.Add(",,,")
+	f.Add("ot=")
+	f.Add("=value")
+
+	f.Fuzz(func(t *testing.T, traceState string) {
+		result := MultiplierFromTraceState(traceState)
+		w3c, err := sampling.NewW3CTraceState(traceState)
+		if err == nil {
+			assert.Equal(t, w3c.OTelValue().AdjustedCount(), result, "traceState: %s", traceState)
+		}
+	})
+}

--- a/pkg/sampling/multiplier_test.go
+++ b/pkg/sampling/multiplier_test.go
@@ -1,10 +1,14 @@
 package sampling
 
 import (
+	"fmt"
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMultiplierFromTraceState(t *testing.T) {
@@ -101,6 +105,44 @@ func TestMultiplierFromTraceState(t *testing.T) {
 			assert.InDelta(t, tc.expected, result, 0.001, "tracestate: %s", tc.traceState)
 		})
 	}
+
+	// Integer multipliers with an R-value stay integer (frac == 0, no
+	// rounding decision needed).
+	t.Run("integer multiplier with rv is unchanged", func(t *testing.T) {
+		require.InDelta(t, 2.0, MultiplierFromTraceState("ot=th:8;rv:12345678901234"), 0.001)
+		require.InDelta(t, 4.0, MultiplierFromTraceState("ot=th:c;rv:12345678901234"), 0.001)
+	})
+
+	// For non-integer multipliers with an R-value present, verify each
+	// result is floor/ceil and E[result] converges to the raw multiplier.
+	t.Run("fractional multiplier is stochastically rounded and unbiased", func(t *testing.T) {
+		// th:4 → probability = (2^56 - 4*2^52) / 2^56 = 0.75 → multiplier = 1.333...
+		raw := MultiplierFromTraceState("ot=th:4")
+		require.InDelta(t, 4.0/3.0, raw, 1e-9)
+
+		const n = 4096
+		var sum float64
+		for i := 0; i < n; i++ {
+			// Vary the low bits of the R-value across the full 56-bit range.
+			rv := uint64(i) * (1 << 44)
+			ts := fmt.Sprintf("ot=th:4;rv:%014x", rv&((1<<56)-1))
+			r := MultiplierFromTraceState(ts)
+			// Every result must be either floor(4/3)=1 or ceil(4/3)=2.
+			require.True(t, r == 1 || r == 2, "expected 1 or 2, got %v for ts=%q", r, ts)
+			sum += r
+		}
+		mean := sum / float64(n)
+		require.InDelta(t, raw, mean, 0.02, "mean over %d samples should track the raw multiplier", n)
+	})
+
+	// Same R-value → same rounding decision.
+	t.Run("deterministic for a given rv", func(t *testing.T) {
+		ts := "ot=th:4;rv:0123456789abcd"
+		first := MultiplierFromTraceState(ts)
+		for i := 0; i < 10; i++ {
+			require.Equal(t, first, MultiplierFromTraceState(ts))
+		}
+	})
 }
 
 func BenchmarkMultiplierFromTraceState(b *testing.B) {
@@ -140,8 +182,28 @@ func FuzzMultiplierFromTraceState(f *testing.F) {
 	f.Fuzz(func(t *testing.T, traceState string) {
 		result := MultiplierFromTraceState(traceState)
 		w3c, err := sampling.NewW3CTraceState(traceState)
-		if err == nil {
-			assert.Equal(t, w3c.OTelValue().AdjustedCount(), result, "traceState: %s", traceState)
+		if err != nil {
+			return
 		}
+		// Our fast path finds the first `ot=` key; the strict parser applies
+		// list-vendor semantics. When multiple `ot=` entries exist the two
+		// paths can pick different values — skip cross-validation there.
+		if strings.Count(traceState, "ot=") > 1 {
+			return
+		}
+		raw := w3c.OTelValue().AdjustedCount()
+		// When there's no R-value, our result equals the raw AdjustedCount.
+		// When an R-value is present, our result is stochastically rounded
+		// and must be floor(raw) or ceil(raw). E[result] still equals raw
+		// but each individual call may differ.
+		if _, ok := w3c.OTelValue().RValueRandomness(); !ok {
+			assert.Equal(t, raw, result, "traceState: %s", traceState)
+			return
+		}
+		floor, ceil := math.Floor(raw), math.Floor(raw)
+		if raw > floor {
+			ceil = floor + 1
+		}
+		assert.True(t, result == floor || result == ceil, "traceState: %s — expected %v or %v, got %v", traceState, floor, ceil, result)
 	})
 }

--- a/pkg/traceql/ast_metrics.go
+++ b/pkg/traceql/ast_metrics.go
@@ -157,12 +157,6 @@ func (a *MetricsAggregate) extractConditions(request *FetchSpansRequest) {
 		})
 	}
 
-	if a.extrapolate && !request.HasAttribute(IntrinsicSpanMultiplierAttribute) {
-		request.SecondPassConditions = append(request.SecondPassConditions, Condition{
-			Attribute: IntrinsicSpanMultiplierAttribute,
-		})
-	}
-
 	for _, b := range a.by {
 		// In the case of the AllConditions, it is enough to check that the
 		// attribute is present in any of the passes.

--- a/pkg/traceql/ast_metrics.go
+++ b/pkg/traceql/ast_metrics.go
@@ -112,6 +112,16 @@ type MetricsAggregate struct {
 	exemplarFn getExemplar
 	// Type of operation for simple aggregatation in layers 2 and 3
 	simpleAggregationOp SimpleAggregationOp
+	// When true, each observed span contributes its IntrinsicSpanMultiplier
+	// (= 1 / sampling probability) to count/sum aggregates instead of 1. Must
+	// be set before init() so the constructed inner aggregators see it.
+	extrapolate bool
+}
+
+// SetExtrapolate enables per-span sampling extrapolation. Must be called
+// before init().
+func (a *MetricsAggregate) SetExtrapolate(extrapolate bool) {
+	a.extrapolate = extrapolate
 }
 
 func newMetricsAggregate(agg MetricsAggregateOp, by []Attribute) *MetricsAggregate {
@@ -147,6 +157,12 @@ func (a *MetricsAggregate) extractConditions(request *FetchSpansRequest) {
 		})
 	}
 
+	if a.extrapolate && !request.HasAttribute(IntrinsicSpanMultiplierAttribute) {
+		request.SecondPassConditions = append(request.SecondPassConditions, Condition{
+			Attribute: IntrinsicSpanMultiplierAttribute,
+		})
+	}
+
 	for _, b := range a.by {
 		// In the case of the AllConditions, it is enough to check that the
 		// attribute is present in any of the passes.
@@ -177,9 +193,16 @@ func (a *MetricsAggregate) init(q *tempopb.QueryRangeRequest, mode AggregateMode
 	var byFunc func(Span) (Static, bool)
 	var byFuncLabel string
 
+	extrapolate := a.extrapolate
+	newCount := func() VectorAggregator {
+		agg := NewCountOverTimeAggregator()
+		agg.SetExtrapolate(extrapolate)
+		return agg
+	}
+
 	switch a.op {
 	case metricsAggregateCountOverTime:
-		innerAgg = func() VectorAggregator { return NewCountOverTimeAggregator() }
+		innerAgg = newCount
 		a.simpleAggregationOp = sumAggregation
 		a.exemplarFn = exemplarNaN
 
@@ -194,24 +217,33 @@ func (a *MetricsAggregate) init(q *tempopb.QueryRangeRequest, mode AggregateMode
 		a.exemplarFn = exemplarFnFor(a.attr)
 
 	case metricsAggregateSumOverTime:
-		innerAgg = func() VectorAggregator { return NewOverTimeAggregator(a.attr, sumOverTimeAggregation) }
+		innerAgg = func() VectorAggregator {
+			agg := NewOverTimeAggregator(a.attr, sumOverTimeAggregation)
+			agg.SetExtrapolate(extrapolate)
+			return agg
+		}
 		a.simpleAggregationOp = sumOverTimeAggregation
 		a.exemplarFn = exemplarFnFor(a.attr)
 
 	case metricsAggregateRate:
-		innerAgg = func() VectorAggregator { return NewRateAggregator(1.0 / time.Duration(q.Step).Seconds()) }
+		rateMult := 1.0 / time.Duration(q.Step).Seconds()
+		innerAgg = func() VectorAggregator {
+			agg := NewRateAggregator(rateMult)
+			agg.SetExtrapolate(extrapolate)
+			return agg
+		}
 		a.simpleAggregationOp = sumAggregation
 		a.exemplarFn = exemplarNaN
 
 	case metricsAggregateHistogramOverTime:
-		innerAgg = func() VectorAggregator { return NewCountOverTimeAggregator() }
+		innerAgg = newCount
 		byFunc = bucketizeFnFor(a.attr)
 		byFuncLabel = internalLabelBucket
 		a.simpleAggregationOp = sumAggregation
 		a.exemplarFn = exemplarNaN // Histogram final series are counts so exemplars are placeholders
 
 	case metricsAggregateQuantileOverTime:
-		innerAgg = func() VectorAggregator { return NewCountOverTimeAggregator() }
+		innerAgg = newCount
 		byFunc = bucketizeFnFor(a.attr)
 		byFuncLabel = internalLabelBucket
 		a.simpleAggregationOp = sumAggregation

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -478,35 +478,6 @@ func spanExtrapolation(s Span) float64 {
 	return f
 }
 
-// stochasticRoundExtrapolation returns floor(m) with probability 1 - frac, or
-// ceil(m) with probability frac, where frac = m - floor(m). E[result] == m, so
-// large-sample averages converge to the deterministic-multiplier value but
-// each per-span contribution stays integer. Use this for count-style
-// aggregators (count_over_time, rate, histogram buckets, compare) where the
-// integer-ness of per-bucket values is part of the contract.
-//
-// The random bit source is derived from the span ID (OTel SDKs generate
-// random 64-bit span IDs uniformly, per the spec), so the decision is
-// deterministic per span — repeated queries against the same data return
-// the same counts, and one span's outcome is independent of others.
-func stochasticRoundExtrapolation(s Span) float64 {
-	m := spanExtrapolation(s)
-	i := math.Floor(m)
-	frac := m - i
-	if frac == 0 {
-		return i
-	}
-
-	// Top 53 bits of the span ID as a uniform float64 in [0, 1). Span IDs
-	// are uniformly-random 64-bit values from the SDK, and util.SpanIDToUint64
-	// zero-pads shorter IDs (only relevant for synthetic test spans).
-	r := float64(util.SpanIDToUint64(s.ID())>>11) / (1 << 53)
-	if r < frac {
-		return i + 1
-	}
-	return i
-}
-
 // CountOverTimeAggregator counts the number of spans. It can also
 // calculate the rate when given a multiplier.
 // TODO - Rewrite me to be []float64 which is more efficient
@@ -538,9 +509,11 @@ func (c *CountOverTimeAggregator) SetExtrapolate(extrapolate bool) {
 
 func (c *CountOverTimeAggregator) Observe(s Span) {
 	if c.extrapolate {
-		// Stochastic rounding keeps per-span contributions integer (so the
-		// emitted count is also an integer) while preserving expected value.
-		c.count += stochasticRoundExtrapolation(s)
+		// The value returned by spanExtrapolation is already stochastically
+		// rounded at storage decode time when the tracestate carries an
+		// OTEP-235 R-value, so the per-span contribution is integer whenever
+		// the SDK gave us the randomness to make that decision.
+		c.count += spanExtrapolation(s)
 		return
 	}
 	c.count++

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1109,8 +1109,8 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 		storageReq := storageReqs[key]
 
 		// Per-span sampling extrapolation. Hint in the query takes precedence
-		// over the tenant default passed in via WithExtrapolation. Must apply
-		// before sp.init() so inner aggregators capture the flag.
+		// over the default passed in via WithExtrapolation. Must apply before
+		// sp.init() so inner aggregators capture the flag.
 		extrapolate := false
 		if cfg.extrapolate != nil {
 			extrapolate = *cfg.extrapolate

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -462,12 +462,29 @@ type SpanAggregator interface {
 	Length() int
 }
 
+// spanExtrapolation returns the per-span sampling multiplier (= 1 / sampling
+// probability) surfaced by the storage layer as IntrinsicSpanMultiplier.
+// Falls back to 1.0 when the storage layer didn't expose a value or it is
+// invalid — callers may safely call this on every span.
+func spanExtrapolation(s Span) float64 {
+	v, ok := s.AttributeFor(IntrinsicSpanMultiplierAttribute)
+	if !ok {
+		return 1.0
+	}
+	f := v.Float()
+	if math.IsNaN(f) || f <= 0 {
+		return 1.0
+	}
+	return f
+}
+
 // CountOverTimeAggregator counts the number of spans. It can also
 // calculate the rate when given a multiplier.
 // TODO - Rewrite me to be []float64 which is more efficient
 type CountOverTimeAggregator struct {
-	count    float64
-	rateMult float64
+	count       float64
+	rateMult    float64
+	extrapolate bool
 }
 
 var _ VectorAggregator = (*CountOverTimeAggregator)(nil)
@@ -484,7 +501,17 @@ func NewRateAggregator(rateMult float64) *CountOverTimeAggregator {
 	}
 }
 
-func (c *CountOverTimeAggregator) Observe(_ Span) {
+// SetExtrapolate toggles per-span sampling extrapolation. When true, each
+// observed span contributes spanExtrapolation(span) instead of 1.
+func (c *CountOverTimeAggregator) SetExtrapolate(extrapolate bool) {
+	c.extrapolate = extrapolate
+}
+
+func (c *CountOverTimeAggregator) Observe(s Span) {
+	if c.extrapolate {
+		c.count += spanExtrapolation(s)
+		return
+	}
 	c.count++
 }
 
@@ -498,6 +525,8 @@ type OverTimeAggregator struct {
 	getSpanAttValue func(s Span) float64
 	agg             func(current, n float64) float64
 	val             float64
+	op              SimpleAggregationOp
+	extrapolate     bool
 }
 
 var _ VectorAggregator = (*OverTimeAggregator)(nil)
@@ -534,11 +563,25 @@ func NewOverTimeAggregator(attr Attribute, op SimpleAggregationOp) *OverTimeAggr
 		getSpanAttValue: fn,
 		agg:             agg,
 		val:             math.Float64frombits(normalNaN),
+		op:              op,
+	}
+}
+
+// SetExtrapolate toggles per-span sampling extrapolation. Only applies to
+// sum_over_time; min/max remain unscaled (population extremes don't scale
+// with sampling).
+func (c *OverTimeAggregator) SetExtrapolate(extrapolate bool) {
+	if c.op == sumOverTimeAggregation {
+		c.extrapolate = extrapolate
 	}
 }
 
 func (c *OverTimeAggregator) Observe(s Span) {
-	c.val = c.agg(c.val, c.getSpanAttValue(s))
+	v := c.getSpanAttValue(s)
+	if c.extrapolate {
+		v *= spanExtrapolation(s)
+	}
+	c.val = c.agg(c.val, v)
 }
 
 func (c *OverTimeAggregator) Sample() float64 {
@@ -996,6 +1039,26 @@ func (e *Engine) CompileMetricsQueryRangeNonRaw(req *tempopb.QueryRangeRequest, 
 	}, nil
 }
 
+// metricsPipelineExtrapolator is implemented by metrics pipelines that
+// support per-span sampling extrapolation.
+type metricsPipelineExtrapolator interface {
+	SetExtrapolate(bool)
+}
+
+// applyExtrapolation toggles per-span extrapolation on the pipeline if it
+// supports it, and adds the multiplier intrinsic to the storage request so
+// the storage layer surfaces it. Must be called before sp.init().
+func applyExtrapolation(pipeline spanProcessor, req *FetchSpansRequest) {
+	if ext, ok := pipeline.(metricsPipelineExtrapolator); ok {
+		ext.SetExtrapolate(true)
+	}
+	if !req.HasAttribute(IntrinsicSpanMultiplierAttribute) {
+		req.SecondPassConditions = append(req.SecondPassConditions, Condition{
+			Attribute: IntrinsicSpanMultiplierAttribute,
+		})
+	}
+}
+
 // CompileMetricsQueryRange returns an evaluator that can be reused across multiple data sources.
 func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts ...CompileOption) (MetricsEvaluator, error) {
 	cfg := applyCompileOptions(opts...)
@@ -1042,10 +1105,26 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 		if sp == nil {
 			return nil, fmt.Errorf("not a metrics query")
 		}
+
+		storageReq := storageReqs[key]
+
+		// Per-span sampling extrapolation. Hint in the query takes precedence
+		// over the tenant default passed in via WithExtrapolation. Must apply
+		// before sp.init() so inner aggregators capture the flag.
+		extrapolate := false
+		if cfg.extrapolate != nil {
+			extrapolate = *cfg.extrapolate
+		}
+		if b, ok := expr.Hints.GetBool(HintExtrapolate, cfg.allowUnsafeHints); ok {
+			extrapolate = b
+		}
+		if extrapolate {
+			applyExtrapolation(sp, &storageReq)
+		}
+
 		// This initializes all step buffers, counters, etc
 		sp.init(req, AggregateModeRaw)
 
-		storageReq := storageReqs[key]
 		e.applySampleHints(expr, pipeline, &storageReq, cfg.allowUnsafeHints)
 
 		exemplars := exemplars

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1100,6 +1100,17 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 	watchers := &spanWatchers{}
 	watchers.Add(cfg.watchers...)
 
+	// Per-span sampling extrapolation. Hint in the query takes precedence
+	// over the default passed in via WithExtrapolation. Must apply before
+	// sp.init() so inner aggregators capture the flag.
+	extrapolate := false
+	if cfg.extrapolate != nil {
+		extrapolate = *cfg.extrapolate
+	}
+	if b, ok := expr.Hints.GetBool(HintExtrapolate, cfg.allowUnsafeHints); ok {
+		extrapolate = b
+	}
+
 	bme := &batchMetricsEvaluator{
 		evals:    make(map[string]*metricsEvaluator, len(expr.Pipeline)),
 		watchers: watchers,
@@ -1112,16 +1123,6 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 
 		storageReq := storageReqs[key]
 
-		// Per-span sampling extrapolation. Hint in the query takes precedence
-		// over the default passed in via WithExtrapolation. Must apply before
-		// sp.init() so inner aggregators capture the flag.
-		extrapolate := false
-		if cfg.extrapolate != nil {
-			extrapolate = *cfg.extrapolate
-		}
-		if b, ok := expr.Hints.GetBool(HintExtrapolate, cfg.allowUnsafeHints); ok {
-			extrapolate = b
-		}
 		if extrapolate {
 			applyExtrapolation(sp, &storageReq)
 		}

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -478,6 +478,35 @@ func spanExtrapolation(s Span) float64 {
 	return f
 }
 
+// stochasticRoundExtrapolation returns floor(m) with probability 1 - frac, or
+// ceil(m) with probability frac, where frac = m - floor(m). E[result] == m, so
+// large-sample averages converge to the deterministic-multiplier value but
+// each per-span contribution stays integer. Use this for count-style
+// aggregators (count_over_time, rate, histogram buckets, compare) where the
+// integer-ness of per-bucket values is part of the contract.
+//
+// The random bit source is derived from the span ID (OTel SDKs generate
+// random 64-bit span IDs uniformly, per the spec), so the decision is
+// deterministic per span — repeated queries against the same data return
+// the same counts, and one span's outcome is independent of others.
+func stochasticRoundExtrapolation(s Span) float64 {
+	m := spanExtrapolation(s)
+	i := math.Floor(m)
+	frac := m - i
+	if frac == 0 {
+		return i
+	}
+
+	// Top 53 bits of the span ID as a uniform float64 in [0, 1). Span IDs
+	// are uniformly-random 64-bit values from the SDK, and util.SpanIDToUint64
+	// zero-pads shorter IDs (only relevant for synthetic test spans).
+	r := float64(util.SpanIDToUint64(s.ID())>>11) / (1 << 53)
+	if r < frac {
+		return i + 1
+	}
+	return i
+}
+
 // CountOverTimeAggregator counts the number of spans. It can also
 // calculate the rate when given a multiplier.
 // TODO - Rewrite me to be []float64 which is more efficient
@@ -509,7 +538,9 @@ func (c *CountOverTimeAggregator) SetExtrapolate(extrapolate bool) {
 
 func (c *CountOverTimeAggregator) Observe(s Span) {
 	if c.extrapolate {
-		c.count += spanExtrapolation(s)
+		// Stochastic rounding keeps per-span contributions integer (so the
+		// emitted count is also an integer) while preserving expected value.
+		c.count += stochasticRoundExtrapolation(s)
 		return
 	}
 	c.count++

--- a/pkg/traceql/engine_metrics_average.go
+++ b/pkg/traceql/engine_metrics_average.go
@@ -141,12 +141,6 @@ func (a *averageOverTimeAggregator) extractConditions(request *FetchSpansRequest
 			})
 		}
 	}
-
-	if a.extrapolate && !request.HasAttribute(IntrinsicSpanMultiplierAttribute) {
-		request.SecondPassConditions = append(request.SecondPassConditions, Condition{
-			Attribute: IntrinsicSpanMultiplierAttribute,
-		})
-	}
 }
 
 func (a *averageOverTimeAggregator) validate() error {

--- a/pkg/traceql/engine_metrics_average.go
+++ b/pkg/traceql/engine_metrics_average.go
@@ -18,9 +18,10 @@ type averageOverTimeAggregator struct {
 	// Average over time span aggregator
 	agg SpanAggregator
 	// Average over time series aggregator
-	seriesAgg  SeriesAggregator
-	exemplarFn getExemplar
-	mode       AggregateMode
+	seriesAgg   SeriesAggregator
+	exemplarFn  getExemplar
+	mode        AggregateMode
+	extrapolate bool
 }
 
 var (
@@ -36,6 +37,13 @@ func newAverageOverTimeMetricsAggregator(attr Attribute, by []Attribute) *averag
 	}
 }
 
+// SetExtrapolate toggles per-span sampling extrapolation. When true, each
+// observed value is weighted by spanExtrapolation(span) in the weighted-mean
+// accumulator so the count series reflects the un-sampled population.
+func (a *averageOverTimeAggregator) SetExtrapolate(extrapolate bool) {
+	a.extrapolate = extrapolate
+}
+
 func (a *averageOverTimeAggregator) init(q *tempopb.QueryRangeRequest, mode AggregateMode) {
 	intervalMapper := NewIntervalMapperFromReq(q)
 
@@ -47,7 +55,7 @@ func (a *averageOverTimeAggregator) init(q *tempopb.QueryRangeRequest, mode Aggr
 	}
 
 	if mode == AggregateModeRaw {
-		a.agg = newAvgOverTimeSpanAggregator(a.attr, a.by, q.Start, q.End, q.Step, IsInstant(q), q.Exemplars)
+		a.agg = newAvgOverTimeSpanAggregator(a.attr, a.by, q.Start, q.End, q.Step, IsInstant(q), q.Exemplars, a.extrapolate)
 	}
 
 	a.mode = mode
@@ -132,6 +140,12 @@ func (a *averageOverTimeAggregator) extractConditions(request *FetchSpansRequest
 				Attribute: b,
 			})
 		}
+	}
+
+	if a.extrapolate && !request.HasAttribute(IntrinsicSpanMultiplierAttribute) {
+		request.SecondPassConditions = append(request.SecondPassConditions, Condition{
+			Attribute: IntrinsicSpanMultiplierAttribute,
+		})
 	}
 }
 
@@ -411,6 +425,7 @@ type avgOverTimeSpanAggregator[F FastStatic, S StaticVals] struct {
 	start, end, step uint64
 	instant          bool
 	exemplars        uint32
+	extrapolate      bool
 
 	// Data
 	series     map[F]avgOverTimeSeries[S]
@@ -421,7 +436,7 @@ type avgOverTimeSpanAggregator[F FastStatic, S StaticVals] struct {
 
 var _ SpanAggregator = (*avgOverTimeSpanAggregator[FastStatic1, StaticVals1])(nil)
 
-func newAvgOverTimeSpanAggregator(attr Attribute, by []Attribute, start, end, step uint64, instant bool, exemplars uint32) SpanAggregator {
+func newAvgOverTimeSpanAggregator(attr Attribute, by []Attribute, start, end, step uint64, instant bool, exemplars uint32, extrapolate bool) SpanAggregator {
 	lookups := make([][]Attribute, len(by))
 	for i, attr := range by {
 		if attr.Intrinsic == IntrinsicNone && attr.Scope == AttributeScopeNone {
@@ -440,19 +455,19 @@ func newAvgOverTimeSpanAggregator(attr Attribute, by []Attribute, start, end, st
 
 	switch aggNum {
 	case 2:
-		return newAvgAggregator[FastStatic2, StaticVals2](attr, by, lookups, start, end, step, instant, exemplars)
+		return newAvgAggregator[FastStatic2, StaticVals2](attr, by, lookups, start, end, step, instant, exemplars, extrapolate)
 	case 3:
-		return newAvgAggregator[FastStatic3, StaticVals3](attr, by, lookups, start, end, step, instant, exemplars)
+		return newAvgAggregator[FastStatic3, StaticVals3](attr, by, lookups, start, end, step, instant, exemplars, extrapolate)
 	case 4:
-		return newAvgAggregator[FastStatic4, StaticVals4](attr, by, lookups, start, end, step, instant, exemplars)
+		return newAvgAggregator[FastStatic4, StaticVals4](attr, by, lookups, start, end, step, instant, exemplars, extrapolate)
 	case 5:
-		return newAvgAggregator[FastStatic5, StaticVals5](attr, by, lookups, start, end, step, instant, exemplars)
+		return newAvgAggregator[FastStatic5, StaticVals5](attr, by, lookups, start, end, step, instant, exemplars, extrapolate)
 	default:
-		return newAvgAggregator[FastStatic1, StaticVals1](attr, by, lookups, start, end, step, instant, exemplars)
+		return newAvgAggregator[FastStatic1, StaticVals1](attr, by, lookups, start, end, step, instant, exemplars, extrapolate)
 	}
 }
 
-func newAvgAggregator[F FastStatic, S StaticVals](attr Attribute, by []Attribute, lookups [][]Attribute, start, end, step uint64, instant bool, exemplars uint32) SpanAggregator {
+func newAvgAggregator[F FastStatic, S StaticVals](attr Attribute, by []Attribute, lookups [][]Attribute, start, end, step uint64, instant bool, exemplars uint32, extrapolate bool) SpanAggregator {
 	var fn func(s Span) float64
 
 	switch attr {
@@ -481,6 +496,7 @@ func newAvgAggregator[F FastStatic, S StaticVals](attr Attribute, by []Attribute
 		step:            step,
 		instant:         instant,
 		exemplars:       exemplars,
+		extrapolate:     extrapolate,
 	}
 }
 
@@ -496,7 +512,11 @@ func (g *avgOverTimeSpanAggregator[F, S]) Observe(span Span) {
 	}
 
 	s := g.getSeries(span)
-	s.average.addIncrementMean(interval, inc)
+	if g.extrapolate {
+		s.average.addWeigthedMean(interval, inc, spanExtrapolation(span))
+	} else {
+		s.average.addIncrementMean(interval, inc)
+	}
 }
 
 func (g *avgOverTimeSpanAggregator[F, S]) ObserveExemplar(span Span, value float64, ts uint64) {

--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -82,9 +82,6 @@ func (m *MetricsCompare) extractConditions(request *FetchSpansRequest) {
 	if !request.HasAttribute(IntrinsicSpanStartTimeAttribute) {
 		request.SecondPassConditions = append(request.SecondPassConditions, Condition{Attribute: IntrinsicSpanStartTimeAttribute})
 	}
-	if m.extrapolate && !request.HasAttribute(IntrinsicSpanMultiplierAttribute) {
-		request.SecondPassConditions = append(request.SecondPassConditions, Condition{Attribute: IntrinsicSpanMultiplierAttribute})
-	}
 	// We don't need to extract conditions from the comparison expression
 	// because we're already selecting all.
 }

--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -136,7 +136,9 @@ func (m *MetricsCompare) observe(span Span) {
 	m.interval = m.intervalMapper.Interval(st)
 
 	if m.extrapolate {
-		m.currentMultiplier = spanExtrapolation(span)
+		// Stochastic rounding keeps per-attribute counts integer (the
+		// observed value is the same for every attribute on this span).
+		m.currentMultiplier = stochasticRoundExtrapolation(span)
 	} else {
 		m.currentMultiplier = 1
 	}

--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -42,13 +42,15 @@ type MetricsCompare struct {
 	selectionExemplars []Exemplar
 	seriesAgg          SeriesAggregator
 	maxExemplars       uint32
+	extrapolate        bool
 
 	// Runtime fields to avoid allocating closures
 	// and escaping to the heap when we call span.AllAttributesFunc.
-	dest         map[Attribute]map[StaticMapKey]*staticWithCounts
-	destTotals   map[Attribute][]float64
-	interval     int
-	attrCallback func(Attribute, Static)
+	dest              map[Attribute]map[StaticMapKey]*staticWithCounts
+	destTotals        map[Attribute][]float64
+	interval          int
+	currentMultiplier float64
+	attrCallback      func(Attribute, Static)
 }
 
 type staticWithCounts struct {
@@ -58,19 +60,30 @@ type staticWithCounts struct {
 
 func newMetricsCompare(f *SpansetFilter, topN, start, end int) *MetricsCompare {
 	m := &MetricsCompare{
-		f:     f,
-		topN:  topN,
-		start: start,
-		end:   end,
+		f:                 f,
+		topN:              topN,
+		start:             start,
+		end:               end,
+		currentMultiplier: 1,
 	}
 	m.attrCallback = m.processAttribute
 	return m
+}
+
+// SetExtrapolate toggles per-span sampling extrapolation for compare(). When
+// true, each span contributes its IntrinsicSpanMultiplier value to the
+// per-attribute counts and totals instead of 1.
+func (m *MetricsCompare) SetExtrapolate(extrapolate bool) {
+	m.extrapolate = extrapolate
 }
 
 func (m *MetricsCompare) extractConditions(request *FetchSpansRequest) {
 	request.SecondPassSelectAll = true
 	if !request.HasAttribute(IntrinsicSpanStartTimeAttribute) {
 		request.SecondPassConditions = append(request.SecondPassConditions, Condition{Attribute: IntrinsicSpanStartTimeAttribute})
+	}
+	if m.extrapolate && !request.HasAttribute(IntrinsicSpanMultiplierAttribute) {
+		request.SecondPassConditions = append(request.SecondPassConditions, Condition{Attribute: IntrinsicSpanMultiplierAttribute})
 	}
 	// We don't need to extract conditions from the comparison expression
 	// because we're already selecting all.
@@ -122,6 +135,12 @@ func (m *MetricsCompare) observe(span Span) {
 	st := span.StartTimeUnixNanos()
 	m.interval = m.intervalMapper.Interval(st)
 
+	if m.extrapolate {
+		m.currentMultiplier = spanExtrapolation(span)
+	} else {
+		m.currentMultiplier = 1
+	}
+
 	// Determine if this span is inside the selection
 	// and choose destination buffers
 	if m.isSelection(span, st).Equals(&StaticTrue) {
@@ -171,7 +190,7 @@ func (m *MetricsCompare) processAttribute(a Attribute, v Static) {
 		sc = &staticWithCounts{val: v, counts: make([]float64, m.intervalMapper.IntervalCount())}
 		values[vk] = sc
 	}
-	sc.counts[m.interval]++
+	sc.counts[m.interval] += m.currentMultiplier
 
 	// TODO - It's probably faster to aggregate these at the end
 	// instead of incrementing in the hotpath twice
@@ -180,7 +199,7 @@ func (m *MetricsCompare) processAttribute(a Attribute, v Static) {
 		totals = make([]float64, m.intervalMapper.IntervalCount())
 		m.destTotals[a] = totals
 	}
-	totals[m.interval]++
+	totals[m.interval] += m.currentMultiplier
 }
 
 func (m *MetricsCompare) observeExemplar(span Span) {

--- a/pkg/traceql/engine_metrics_compare.go
+++ b/pkg/traceql/engine_metrics_compare.go
@@ -133,9 +133,10 @@ func (m *MetricsCompare) observe(span Span) {
 	m.interval = m.intervalMapper.Interval(st)
 
 	if m.extrapolate {
-		// Stochastic rounding keeps per-attribute counts integer (the
-		// observed value is the same for every attribute on this span).
-		m.currentMultiplier = stochasticRoundExtrapolation(span)
+		// spanExtrapolation already returns a stochastically-rounded integer
+		// when the tracestate carried an OTEP-235 R-value, so per-attribute
+		// counts stay integer without any extra work here.
+		m.currentMultiplier = spanExtrapolation(span)
 	} else {
 		m.currentMultiplier = 1
 	}

--- a/pkg/traceql/engine_metrics_extrapolate_test.go
+++ b/pkg/traceql/engine_metrics_extrapolate_test.go
@@ -1,0 +1,128 @@
+package traceql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCountOverTimeAggregator_Extrapolate verifies that, with extrapolation
+// enabled, each observed span contributes its IntrinsicSpanMultiplier value
+// instead of 1.
+func TestCountOverTimeAggregator_Extrapolate(t *testing.T) {
+	cases := []struct {
+		name       string
+		multiplier float64
+		want       float64
+	}{
+		{"no multiplier attribute -> 1.0", 0, 5}, // 5 spans, no multiplier => 5
+		{"multiplier 2.0 -> 2x", 2, 10},
+		{"multiplier 4.0 -> 4x", 4, 20},
+		{"multiplier 100.0 -> 100x", 100, 500},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agg := NewCountOverTimeAggregator()
+			agg.SetExtrapolate(true)
+
+			for i := 0; i < 5; i++ {
+				sp := newMockSpan(nil)
+				if tc.multiplier > 0 {
+					sp.attributes[IntrinsicSpanMultiplierAttribute] = NewStaticFloat(tc.multiplier)
+				}
+				agg.Observe(sp)
+			}
+			require.Equal(t, tc.want, agg.Sample())
+		})
+	}
+}
+
+// TestCountOverTimeAggregator_DefaultUnaffected ensures the default (no
+// extrapolation) path is unchanged.
+func TestCountOverTimeAggregator_DefaultUnaffected(t *testing.T) {
+	agg := NewCountOverTimeAggregator()
+
+	for i := 0; i < 5; i++ {
+		sp := newMockSpan(nil)
+		sp.attributes[IntrinsicSpanMultiplierAttribute] = NewStaticFloat(4.0)
+		agg.Observe(sp)
+	}
+	require.Equal(t, 5.0, agg.Sample(), "extrapolation must be opt-in")
+}
+
+// benchSpan mimics the production vparquet5 span: AttributeFor short-circuits
+// the IntrinsicSpanMultiplier lookup to a direct field access, instead of the
+// generic map lookup used by mockSpan. This makes the benchmark more
+// representative of real per-span hot-path cost.
+type benchSpan struct {
+	mult float64
+}
+
+func (b *benchSpan) AttributeFor(a Attribute) (Static, bool) {
+	if a.Intrinsic == IntrinsicSpanMultiplier {
+		return NewStaticFloat(b.mult), true
+	}
+	return StaticNil, false
+}
+
+func (b *benchSpan) AllAttributes() map[Attribute]Static       { return nil }
+func (b *benchSpan) AllAttributesFunc(func(Attribute, Static)) {}
+func (b *benchSpan) ID() []byte                                { return nil }
+func (b *benchSpan) StartTimeUnixNanos() uint64                { return 0 }
+func (b *benchSpan) DurationNanos() uint64                     { return 0 }
+func (b *benchSpan) SiblingOf([]Span, []Span, bool, bool, []Span) []Span {
+	return nil
+}
+func (b *benchSpan) DescendantOf([]Span, []Span, bool, bool, bool, []Span) []Span {
+	return nil
+}
+func (b *benchSpan) ChildOf([]Span, []Span, bool, bool, bool, []Span) []Span {
+	return nil
+}
+
+// BenchmarkCountOverTimeAggregator measures the hot-path cost of
+// extrapolation toggled off vs on, using both a generic mockSpan and a
+// production-like benchSpan.
+func BenchmarkCountOverTimeAggregator(b *testing.B) {
+	mock := newMockSpan(nil)
+	mock.attributes[IntrinsicSpanMultiplierAttribute] = NewStaticFloat(2.0)
+
+	prod := &benchSpan{mult: 2.0}
+	prodNoMult := &benchSpan{mult: 0}
+
+	b.Run("default (no extrapolation)", func(b *testing.B) {
+		agg := NewCountOverTimeAggregator()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			agg.Observe(prod)
+		}
+	})
+
+	b.Run("extrapolation on, prod-like span", func(b *testing.B) {
+		agg := NewCountOverTimeAggregator()
+		agg.SetExtrapolate(true)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			agg.Observe(prod)
+		}
+	})
+
+	b.Run("extrapolation on, prod-like, no multiplier", func(b *testing.B) {
+		agg := NewCountOverTimeAggregator()
+		agg.SetExtrapolate(true)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			agg.Observe(prodNoMult)
+		}
+	})
+
+	b.Run("extrapolation on, mockSpan (map lookup)", func(b *testing.B) {
+		agg := NewCountOverTimeAggregator()
+		agg.SetExtrapolate(true)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			agg.Observe(mock)
+		}
+	})
+}

--- a/pkg/traceql/engine_metrics_extrapolate_test.go
+++ b/pkg/traceql/engine_metrics_extrapolate_test.go
@@ -74,9 +74,11 @@ func (b *benchSpan) DurationNanos() uint64                     { return 0 }
 func (b *benchSpan) SiblingOf([]Span, []Span, bool, bool, []Span) []Span {
 	return nil
 }
+
 func (b *benchSpan) DescendantOf([]Span, []Span, bool, bool, bool, []Span) []Span {
 	return nil
 }
+
 func (b *benchSpan) ChildOf([]Span, []Span, bool, bool, bool, []Span) []Span {
 	return nil
 }

--- a/pkg/traceql/enum_attributes.go
+++ b/pkg/traceql/enum_attributes.go
@@ -120,6 +120,13 @@ const (
 	IntrinsicSpanStartTime
 
 	IntrinsicServiceStats
+
+	// IntrinsicSpanMultiplier is a synthetic per-span value that resolves to
+	// 1 / sampling_probability when the span carries an OpenTelemetry probability
+	// sampling threshold in its W3C tracestate (or a configured ratio attribute).
+	// It is used by TraceQL metrics queries to extrapolate observed counts/sums
+	// back to the un-sampled population. It is not parseable from query text.
+	IntrinsicSpanMultiplier
 )
 
 var (
@@ -145,6 +152,7 @@ var (
 	IntrinsicEventTimeSinceStartAttribute    = NewIntrinsic(IntrinsicEventTimeSinceStart)
 	IntrinsicInstrumentationNameAttribute    = NewIntrinsic(IntrinsicInstrumentationName)
 	IntrinsicInstrumentationVersionAttribute = NewIntrinsic(IntrinsicInstrumentationVersion)
+	IntrinsicSpanMultiplierAttribute         = NewIntrinsic(IntrinsicSpanMultiplier)
 )
 
 func (i Intrinsic) String() string {
@@ -216,6 +224,8 @@ func (i Intrinsic) String() string {
 		return "nestedSetRight"
 	case IntrinsicNestedSetParent:
 		return "nestedSetParent"
+	case IntrinsicSpanMultiplier:
+		return "span:multiplier"
 	}
 
 	return fmt.Sprintf("intrinsic(%d)", i)

--- a/pkg/traceql/enum_hints.go
+++ b/pkg/traceql/enum_hints.go
@@ -23,11 +23,12 @@ const (
 	HintDebugDataFactor        = "debug_data_factor"        // performance testing hint to control the possibility of non-empty fake data
 	HintSkipASTTransformations = "skip_ast_transformations" // list of AST transformation names to skip; unsafe hint
 	HintNewFetch               = "spanonly_fetch"           // metrics: new fetch layer (only in vParquet5)
+	HintExtrapolate            = "extrapolate"              // metrics: scale counts by per-span sampling probability from tracestate
 )
 
 func isUnsafe(h string) bool {
 	switch h {
-	case HintSample, HintTraceSample, HintSpanSample, HintExemplars, HintMostRecent:
+	case HintSample, HintTraceSample, HintSpanSample, HintExemplars, HintMostRecent, HintExtrapolate:
 		return false
 	default:
 		return true

--- a/pkg/traceql/options.go
+++ b/pkg/traceql/options.go
@@ -66,12 +66,12 @@ func WithWatchers(watchers ...SpanWatcher) CompileOption {
 	}
 }
 
-// WithExtrapolation sets the tenant default for per-span sampling
-// extrapolation. When not set the default (off) is used, and this may be
-// overridden by the `with(extrapolate=true|false)` query hint. When
-// extrapolation is on, matched spans contribute their IntrinsicSpanMultiplier
-// (= 1 / sampling probability, parsed from the W3C tracestate by the storage
-// layer) to count/sum/rate aggregates instead of 1. min/max are unaffected.
+// WithExtrapolation sets the default for per-span sampling extrapolation.
+// When not set the default (off) is used, and this may be overridden by the
+// `with(extrapolate=true|false)` query hint. When extrapolation is on,
+// matched spans contribute their IntrinsicSpanMultiplier (= 1 / sampling
+// probability, parsed from the W3C tracestate by the storage layer) to
+// count/sum/rate aggregates instead of 1. min/max are unaffected.
 func WithExtrapolation(v bool) CompileOption {
 	return func(o *compileOptions) {
 		o.extrapolate = &v

--- a/pkg/traceql/options.go
+++ b/pkg/traceql/options.go
@@ -11,6 +11,7 @@ type compileOptions struct {
 	// metrics query only
 	spanOnlyFetch     *bool
 	timeOverlapCutoff float64
+	extrapolate       *bool
 
 	watchers []SpanWatcher
 }
@@ -62,5 +63,17 @@ func WithTimeOverlapCutoff(v float64) CompileOption {
 func WithWatchers(watchers ...SpanWatcher) CompileOption {
 	return func(o *compileOptions) {
 		o.watchers = append(o.watchers, watchers...)
+	}
+}
+
+// WithExtrapolation sets the tenant default for per-span sampling
+// extrapolation. When not set the default (off) is used, and this may be
+// overridden by the `with(extrapolate=true|false)` query hint. When
+// extrapolation is on, matched spans contribute their IntrinsicSpanMultiplier
+// (= 1 / sampling probability, parsed from the W3C tracestate by the storage
+// layer) to count/sum/rate aggregates instead of 1. min/max are unaffected.
+func WithExtrapolation(v bool) CompileOption {
+	return func(o *compileOptions) {
+		o.extrapolate = &v
 	}
 }

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -3224,11 +3224,14 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 				sp.addSpanAttr(traceql.IntrinsicNestedSetRightAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 			}
 		case columnPathSpanTraceState:
-			// Parse OTel probability sampling threshold once per span. Surface
-			// as a span attribute (falling back to 1.0 when the tracestate is
-			// absent or unparseable) — the engine reads it via AttributeFor,
-			// and it also counts toward attributesMatched() so the higher
-			// minAttributes threshold from the extra condition is satisfied.
+			// Parse OTel probability sampling threshold once per span. When
+			// the tracestate carries an OTEP-235 R-value (`rv:` field), we
+			// use it to stochastically round the multiplier to an integer
+			// so count-style aggregates emit whole-number contributions.
+			// Falls back to the raw float multiplier when no R-value is
+			// present, and to 1.0 when the tracestate is absent or
+			// unparseable. Also surfaced as a span attribute so the engine
+			// reads it via AttributeFor and it counts toward attributesMatched().
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -52,7 +52,6 @@ type span struct {
 	id                 []byte
 	startTimeUnixNanos uint64
 	durationNanos      uint64
-	spanMultiplier     float64 // sampling extrapolation (1.0 default); populated from TraceState column when requested
 	nestedSetParent    int32
 	nestedSetLeft      int32
 	nestedSetRight     int32
@@ -226,9 +225,6 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 		}
 		if a.Intrinsic == traceql.IntrinsicNestedSetParent {
 			return traceql.NewStaticInt(int(s.nestedSetParent)), true
-		}
-		if a.Intrinsic == traceql.IntrinsicSpanMultiplier {
-			return traceql.NewStaticFloat(s.spanMultiplier), true
 		}
 
 		// intrinsics are always on the span, trace, event, or link ... for now
@@ -840,7 +836,6 @@ func putSpan(s *span) {
 	s.id = nil
 	s.startTimeUnixNanos = 0
 	s.durationNanos = 0
-	s.spanMultiplier = 0
 	s.rowNum = parquetquery.EmptyRowNumber()
 	s.cbSpansetFinal = false
 	s.cbSpanset = nil
@@ -3229,15 +3224,15 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 				sp.addSpanAttr(traceql.IntrinsicNestedSetRightAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 			}
 		case columnPathSpanTraceState:
-			// Parse OTel probability sampling threshold once per span. Default
-			// to 1.0 when the tracestate is absent or unparseable. Also surface
-			// as a span attribute so attributesMatched() counts it toward the
-			// spanCollector's minAttributes threshold.
+			// Parse OTel probability sampling threshold once per span. Surface
+			// as a span attribute (falling back to 1.0 when the tracestate is
+			// absent or unparseable) — the engine reads it via AttributeFor,
+			// and it also counts toward attributesMatched() so the higher
+			// minAttributes threshold from the extra condition is satisfied.
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0
 			}
-			sp.spanMultiplier = m
 			sp.addSpanAttr(traceql.IntrinsicSpanMultiplierAttribute, traceql.NewStaticFloat(m))
 		default:
 			// TODO - This exists for span-level dedicated columns like http.status_code

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/sampling"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
@@ -51,6 +52,7 @@ type span struct {
 	id                 []byte
 	startTimeUnixNanos uint64
 	durationNanos      uint64
+	spanMultiplier     float64 // sampling extrapolation (1.0 default); populated from TraceState column when requested
 	nestedSetParent    int32
 	nestedSetLeft      int32
 	nestedSetRight     int32
@@ -224,6 +226,9 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 		}
 		if a.Intrinsic == traceql.IntrinsicNestedSetParent {
 			return traceql.NewStaticInt(int(s.nestedSetParent)), true
+		}
+		if a.Intrinsic == traceql.IntrinsicSpanMultiplier {
+			return traceql.NewStaticFloat(s.spanMultiplier), true
 		}
 
 		// intrinsics are always on the span, trace, event, or link ... for now
@@ -835,6 +840,7 @@ func putSpan(s *span) {
 	s.id = nil
 	s.startTimeUnixNanos = 0
 	s.durationNanos = 0
+	s.spanMultiplier = 0
 	s.rowNum = parquetquery.EmptyRowNumber()
 	s.cbSpansetFinal = false
 	s.cbSpanset = nil
@@ -927,6 +933,7 @@ const (
 	columnPathInstrumentationAttrDouble = "rs.list.element.ss.list.element.Scope.Attrs.list.element.ValueDouble.list.element"
 	columnPathInstrumentationAttrBool   = "rs.list.element.ss.list.element.Scope.Attrs.list.element.ValueBool.list.element"
 
+	columnPathSpanTraceState      = "rs.list.element.ss.list.element.Spans.list.element.TraceState"
 	columnPathSpanID              = "rs.list.element.ss.list.element.Spans.list.element.SpanID"
 	ColumnPathSpanName            = "rs.list.element.ss.list.element.Spans.list.element.Name"
 	columnPathSpanStartTime       = "rs.list.element.ss.list.element.Spans.list.element.StartTimeUnixNano"
@@ -995,6 +1002,7 @@ var intrinsicColumnLookups = map[traceql.Intrinsic]struct {
 	traceql.IntrinsicNestedSetLeft:        {intrinsicScopeSpan, traceql.TypeInt, columnPathSpanNestedSetLeft},
 	traceql.IntrinsicNestedSetRight:       {intrinsicScopeSpan, traceql.TypeInt, columnPathSpanNestedSetRight},
 	traceql.IntrinsicNestedSetParent:      {intrinsicScopeSpan, traceql.TypeInt, columnPathSpanParentID},
+	traceql.IntrinsicSpanMultiplier:       {intrinsicScopeSpan, traceql.TypeFloat, columnPathSpanTraceState},
 
 	traceql.IntrinsicTraceRootService: {intrinsicScopeTrace, traceql.TypeString, columnPathRootServiceName},
 	traceql.IntrinsicTraceRootSpan:    {intrinsicScopeTrace, traceql.TypeString, columnPathRootSpanName},
@@ -2107,6 +2115,13 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 			addPredicate(columnPathSpanParentID, pred)
 			columnSelectAs[columnPathSpanParentID] = columnPathSpanParentID
 			continue
+		case traceql.IntrinsicSpanMultiplier:
+			// Synthetic float intrinsic; the iterator reads the raw TraceState
+			// column and the collector parses it into a per-span multiplier.
+			// Only OpNone (projection) is supported.
+			addPredicate(columnPathSpanTraceState, nil)
+			columnSelectAs[columnPathSpanTraceState] = columnPathSpanTraceState
+			continue
 		}
 
 		// Well-known attribute?
@@ -2183,7 +2198,8 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 				traceql.IntrinsicStructuralSibling,
 				traceql.IntrinsicNestedSetLeft,
 				traceql.IntrinsicNestedSetRight,
-				traceql.IntrinsicNestedSetParent:
+				traceql.IntrinsicNestedSetParent,
+				traceql.IntrinsicSpanMultiplier: // synthetic; explicitly requested by metrics queries
 				continue
 			}
 			addPredicate(entry.columnPath, nil)
@@ -3212,6 +3228,17 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			if c.nestedSetRightExplicit {
 				sp.addSpanAttr(traceql.IntrinsicNestedSetRightAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 			}
+		case columnPathSpanTraceState:
+			// Parse OTel probability sampling threshold once per span. Default
+			// to 1.0 when the tracestate is absent or unparseable. Also surface
+			// as a span attribute so attributesMatched() counts it toward the
+			// spanCollector's minAttributes threshold.
+			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
+			if m <= 0 {
+				m = 1.0
+			}
+			sp.spanMultiplier = m
+			sp.addSpanAttr(traceql.IntrinsicSpanMultiplierAttribute, traceql.NewStaticFloat(m))
 		default:
 			// TODO - This exists for span-level dedicated columns like http.status_code
 			// Are nils possible here?

--- a/tempodb/encoding/vparquet5/block_extrapolation_test.go
+++ b/tempodb/encoding/vparquet5/block_extrapolation_test.go
@@ -14,6 +14,100 @@ import (
 	"github.com/grafana/tempo/tempodb/encoding/common"
 )
 
+// TestExtrapolationFilterEndToEnd reproduces the docker-compose symptom via
+// the real CompileMetricsQueryRange + Do flow. Two services: shop-backend
+// (tracestate ot=th:8 -> multiplier 2) and tempo-vulture (no tracestate).
+// `{resource.service.name="shop-backend"} | count_over_time() with(extrapolate=true)`
+// must return exactly 2x the count of shop-backend spans only — not all spans.
+func TestExtrapolationFilterEndToEnd(t *testing.T) {
+	startTime := time.Now().Add(-1 * time.Minute)
+	makeTrace := func(svc, traceState string, n int) *Trace {
+		spans := make([]Span, n)
+		for i := range spans {
+			spans[i] = Span{
+				SpanID:            []byte(svc + "/span00000000")[:12],
+				Name:              svc,
+				StartTimeUnixNano: uint64(startTime.UnixNano()) + uint64(i),
+				DurationNano:      uint64(time.Second),
+				TraceState:        traceState,
+				Attrs:             []Attribute{attr("foo", "y")},
+			}
+		}
+		return &Trace{
+			TraceID: test.ValidTraceID(nil),
+			ResourceSpans: []ResourceSpans{{
+				Resource: Resource{
+					ServiceName: svc,
+					Attrs:       []Attribute{attr("foo", "x")},
+				},
+				ScopeSpans: []ScopeSpans{{
+					SpanCount: int32(n),
+					Spans:     spans,
+				}},
+			}},
+		}
+	}
+
+	shop := makeTrace("shop-backend", "ot=th:8", 5)
+	vulture := makeTrace("tempo-vulture", "", 10)
+
+	block := makeBackendBlockWithTraces(t, []*Trace{shop, vulture})
+
+	opts := common.DefaultSearchOptions()
+	fetcher := traceql.NewSpansetFetcherWrapperBoth(
+		func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+			return block.Fetch(ctx, req, opts)
+		},
+		func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansOnlyResponse, error) {
+			return block.FetchSpans(ctx, req, opts)
+		},
+	)
+
+	ctx := context.Background()
+	st := uint64(startTime.Add(-10 * time.Second).UnixNano())
+	end := uint64(startTime.Add(10 * time.Second).UnixNano())
+
+	cases := []struct {
+		query    string
+		want     float64
+		descr    string
+	}{
+		{`{resource.service.name="shop-backend"} | count_over_time()`, 5, "naive shop"},
+		{`{resource.service.name="shop-backend"} | count_over_time() with(extrapolate=true)`, 10, "extrap shop = 2x"},
+		{`{resource.service.name="tempo-vulture"} | count_over_time()`, 10, "naive vulture"},
+		{`{resource.service.name="tempo-vulture"} | count_over_time() with(extrapolate=true)`, 10, "extrap vulture = 1x (no tracestate)"},
+		{`{} | count_over_time()`, 15, "naive all"},
+		{`{} | count_over_time() with(extrapolate=true)`, 20, "extrap all = 5*2 + 10*1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.descr, func(t *testing.T) {
+			req := &tempopb.QueryRangeRequest{
+				Query:     tc.query,
+				Step:      uint64(time.Minute),
+				Start:     st,
+				End:       end,
+				MaxSeries: 1000,
+			}
+			eng := traceql.NewEngine()
+			eval, err := eng.CompileMetricsQueryRange(req)
+			require.NoError(t, err)
+			err = eval.Do(ctx, fetcher, st, end, int(req.MaxSeries))
+			require.NoError(t, err)
+
+			ss := eval.Results()
+			var total float64
+			for _, s := range ss {
+				for _, v := range s.Values {
+					total += v
+				}
+			}
+			t.Logf("query=%q total=%v want=%v", tc.query, total, tc.want)
+			require.Equal(t, tc.want, total, tc.descr)
+		})
+	}
+}
+
 // TestExtrapolationFilterInteraction reproduces the docker-compose symptom:
 // `{resource.service.name="shop-backend"} | rate() with(extrapolate=true)`
 // returns all spans instead of only shop-backend spans.

--- a/tempodb/encoding/vparquet5/block_extrapolation_test.go
+++ b/tempodb/encoding/vparquet5/block_extrapolation_test.go
@@ -1,0 +1,164 @@
+package vparquet5
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+// TestExtrapolationFilterInteraction reproduces the docker-compose symptom:
+// `{resource.service.name="shop-backend"} | rate() with(extrapolate=true)`
+// returns all spans instead of only shop-backend spans.
+func TestExtrapolationFilterInteraction(t *testing.T) {
+	shopBackendID := test.ValidTraceID(nil)
+	otherID := test.ValidTraceID(nil)
+
+	shopBackend := &Trace{
+		TraceID: shopBackendID,
+		ResourceSpans: []ResourceSpans{{
+			Resource: Resource{
+				ServiceName: "shop-backend",
+				Attrs:       []Attribute{attr("foo", "x")},
+			},
+			ScopeSpans: []ScopeSpans{{
+				SpanCount: 2,
+				Spans: []Span{
+					{
+						SpanID:            []byte("shopspan001"),
+						Name:              "shop-a",
+						StartTimeUnixNano: uint64(time.Now().UnixNano()),
+						DurationNano:      uint64(time.Second),
+						TraceState:        "ot=th:8",
+						Attrs:             []Attribute{attr("foo", "y")},
+					},
+					{
+						SpanID:            []byte("shopspan002"),
+						Name:              "shop-b",
+						StartTimeUnixNano: uint64(time.Now().UnixNano()),
+						DurationNano:      uint64(time.Second),
+						TraceState:        "ot=th:8",
+						Attrs:             []Attribute{attr("foo", "y")},
+					},
+				},
+			}},
+		}},
+	}
+
+	other := &Trace{
+		TraceID: otherID,
+		ResourceSpans: []ResourceSpans{{
+			Resource: Resource{
+				ServiceName: "other-service",
+				Attrs:       []Attribute{attr("foo", "x")},
+			},
+			ScopeSpans: []ScopeSpans{{
+				SpanCount: 3,
+				Spans: []Span{
+					{
+						SpanID:            []byte("other000001"),
+						Name:              "other-a",
+						StartTimeUnixNano: uint64(time.Now().UnixNano()),
+						DurationNano:      uint64(time.Second),
+						Attrs:             []Attribute{attr("foo", "y")},
+					},
+					{
+						SpanID:            []byte("other000002"),
+						Name:              "other-b",
+						StartTimeUnixNano: uint64(time.Now().UnixNano()),
+						DurationNano:      uint64(time.Second),
+						Attrs:             []Attribute{attr("foo", "y")},
+					},
+					{
+						SpanID:            []byte("other000003"),
+						Name:              "other-c",
+						StartTimeUnixNano: uint64(time.Now().UnixNano()),
+						DurationNano:      uint64(time.Second),
+						Attrs:             []Attribute{attr("foo", "y")},
+					},
+				},
+			}},
+		}},
+	}
+
+	block := makeBackendBlockWithTraces(t, []*Trace{shopBackend, other})
+	ctx := context.Background()
+
+	// Build the FetchSpansRequest the engine would build for the query
+	// `{resource.service.name="shop-backend"} | rate() with(extrapolate=true)`
+	// after extractConditions + applyExtrapolation + optimize().
+	req := traceql.FetchSpansRequest{
+		AllConditions: true,
+		Conditions: []traceql.Condition{
+			{
+				Attribute: traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
+				Op:        traceql.OpEqual,
+				Operands:  []traceql.Static{traceql.NewStaticString("shop-backend")},
+			},
+			{Attribute: traceql.IntrinsicSpanMultiplierAttribute},
+			{Attribute: traceql.IntrinsicSpanStartTimeAttribute},
+		},
+	}
+
+	resp, err := block.FetchSpans(ctx, req, common.DefaultSearchOptions())
+	require.NoError(t, err)
+	defer resp.Results.Close()
+
+	var (
+		matched      []*span
+		multipliers  []float64
+	)
+	for {
+		s, err := resp.Results.Next(ctx)
+		require.NoError(t, err)
+		if s == nil {
+			break
+		}
+		sp := s.(*span)
+		// Clone the relevant fields because the iterator reuses the buffer.
+		clone := *sp
+		matched = append(matched, &clone)
+
+		v, ok := sp.AttributeFor(traceql.IntrinsicSpanMultiplierAttribute)
+		require.True(t, ok, "multiplier intrinsic should be surfaced when requested")
+		multipliers = append(multipliers, v.Float())
+	}
+
+	t.Logf("matched %d spans", len(matched))
+	for i, sp := range matched {
+		var svc string
+		for _, a := range sp.resourceAttrs {
+			if a.a.Name == "service.name" {
+				svc, _ = a.s.String(), true
+			}
+		}
+		t.Logf("  %d: name=%s service=%s mult=%v",
+			i, spanNameOf(sp), svc, multipliers[i])
+	}
+
+	require.Equal(t, 2, len(matched), "should match only the 2 shop-backend spans")
+	for _, m := range multipliers {
+		require.Equal(t, 2.0, m, "shop-backend spans carry ot=th:8 -> multiplier 2")
+	}
+}
+
+func spanNameOf(s *span) string {
+	for _, a := range s.spanAttrs {
+		if a.a.Intrinsic == traceql.IntrinsicName {
+			str, _ := a.s.String(), true
+			return str
+		}
+	}
+	return ""
+}
+
+// Keep import used.
+var _ = (*v1.Span)(nil)
+var _ = (*tempopb.QueryRangeRequest)(nil)

--- a/tempodb/encoding/vparquet5/block_extrapolation_test.go
+++ b/tempodb/encoding/vparquet5/block_extrapolation_test.go
@@ -68,9 +68,9 @@ func TestExtrapolationFilterEndToEnd(t *testing.T) {
 	end := uint64(startTime.Add(10 * time.Second).UnixNano())
 
 	cases := []struct {
-		query    string
-		want     float64
-		descr    string
+		query string
+		want  float64
+		descr string
 	}{
 		{`{resource.service.name="shop-backend"} | count_over_time()`, 5, "naive shop"},
 		{`{resource.service.name="shop-backend"} | count_over_time() with(extrapolate=true)`, 10, "extrap shop = 2x"},
@@ -206,8 +206,8 @@ func TestExtrapolationFilterInteraction(t *testing.T) {
 	defer resp.Results.Close()
 
 	var (
-		matched      []*span
-		multipliers  []float64
+		matched     []*span
+		multipliers []float64
 	)
 	for {
 		s, err := resp.Results.Next(ctx)
@@ -254,5 +254,7 @@ func spanNameOf(s *span) string {
 }
 
 // Keep import used.
-var _ = (*v1.Span)(nil)
-var _ = (*tempopb.QueryRangeRequest)(nil)
+var (
+	_ = (*v1.Span)(nil)
+	_ = (*tempopb.QueryRangeRequest)(nil)
+)

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -3317,11 +3317,14 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case columnPathSpanChildCount:
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 		case columnPathSpanTraceState:
-			// Parse OTel probability sampling threshold once per span. Surface
-			// as a span attribute (falling back to 1.0 when the tracestate is
-			// absent or unparseable) — the engine reads it via AttributeFor,
-			// and it also counts toward attributesMatched() so the higher
-			// minAttributes threshold from the extra condition is satisfied.
+			// Parse OTel probability sampling threshold once per span. When
+			// the tracestate carries an OTEP-235 R-value (`rv:` field), we
+			// use it to stochastically round the multiplier to an integer
+			// so count-style aggregates emit whole-number contributions.
+			// Falls back to the raw float multiplier when no R-value is
+			// present, and to 1.0 when the tracestate is absent or
+			// unparseable. Also surfaced as a span attribute so the engine
+			// reads it via AttributeFor and it counts toward attributesMatched().
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/sampling"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
@@ -56,6 +57,7 @@ type span struct {
 	id                 []byte
 	startTimeUnixNanos uint64
 	durationNanos      uint64
+	spanMultiplier     float64 // sampling extrapolation (1.0 default); populated from TraceState column when requested
 	nestedSetParent    int32
 	nestedSetLeft      int32
 	nestedSetRight     int32
@@ -229,6 +231,9 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 		}
 		if a.Intrinsic == traceql.IntrinsicNestedSetParent {
 			return traceql.NewStaticInt(int(s.nestedSetParent)), true
+		}
+		if a.Intrinsic == traceql.IntrinsicSpanMultiplier {
+			return traceql.NewStaticFloat(s.spanMultiplier), true
 		}
 
 		// intrinsics are always on the span, trace, event, or link ... for now
@@ -917,6 +922,7 @@ func putSpan(s *span) {
 	s.id = nil
 	s.startTimeUnixNanos = 0
 	s.durationNanos = 0
+	s.spanMultiplier = 0
 	s.rowNum = parquetquery.EmptyRowNumber()
 	s.cbSpansetFinal = false
 	s.cbSpanset = nil
@@ -1002,6 +1008,7 @@ const (
 	columnPathInstrumentationAttrDouble = "rs.ss.Scope.Attrs.ValueDouble"
 	columnPathInstrumentationAttrBool   = "rs.ss.Scope.Attrs.ValueBool"
 
+	columnPathSpanTraceState       = "rs.ss.Spans.TraceState"
 	columnPathSpanID               = "rs.ss.Spans.SpanID"
 	ColumnPathSpanName             = "rs.ss.Spans.Name"
 	columnPathSpanStartTime        = "rs.ss.Spans.StartTimeUnixNano"
@@ -1073,6 +1080,7 @@ var intrinsicColumnLookups = map[traceql.Intrinsic]struct {
 	traceql.IntrinsicNestedSetRight:       {intrinsicScopeSpan, traceql.TypeInt, columnPathSpanNestedSetRight},
 	traceql.IntrinsicNestedSetParent:      {intrinsicScopeSpan, traceql.TypeInt, columnPathSpanParentID},
 	traceql.IntrinsicChildCount:           {intrinsicScopeSpan, traceql.TypeInt, columnPathSpanChildCount},
+	traceql.IntrinsicSpanMultiplier:       {intrinsicScopeSpan, traceql.TypeFloat, columnPathSpanTraceState},
 
 	traceql.IntrinsicTraceRootService: {intrinsicScopeTrace, traceql.TypeString, columnPathRootServiceName},
 	traceql.IntrinsicTraceRootSpan:    {intrinsicScopeTrace, traceql.TypeString, columnPathRootSpanName},
@@ -2213,6 +2221,14 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 			addPredicate(columnPathSpanChildCount, pred)
 			columnSelectAs[columnPathSpanChildCount] = columnPathSpanChildCount
 			continue
+		case traceql.IntrinsicSpanMultiplier:
+			// IntrinsicSpanMultiplier is a synthetic float intrinsic derived from
+			// the W3C tracestate (ot=th:...). Storage just surfaces the raw
+			// TraceState column; the iterator callback parses it into a float.
+			// Only OpNone (projection) is supported.
+			addPredicate(columnPathSpanTraceState, nil)
+			columnSelectAs[columnPathSpanTraceState] = columnPathSpanTraceState
+			continue
 		}
 
 		// Attributes stored in dedicated columns
@@ -2271,7 +2287,8 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 				traceql.IntrinsicStructuralSibling,
 				traceql.IntrinsicNestedSetLeft,
 				traceql.IntrinsicNestedSetRight,
-				traceql.IntrinsicNestedSetParent:
+				traceql.IntrinsicNestedSetParent,
+				traceql.IntrinsicSpanMultiplier: // synthetic; explicitly requested by metrics queries
 				continue
 			}
 			addPredicate(entry.columnPath, nil)
@@ -3304,6 +3321,14 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			}
 		case columnPathSpanChildCount:
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
+		case columnPathSpanTraceState:
+			// Parse OTel probability sampling threshold once per span. Falls
+			// back to 1.0 when the tracestate is absent or unparseable.
+			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
+			if m <= 0 {
+				m = 1.0
+			}
+			sp.spanMultiplier = m
 		default:
 			// TODO - This exists for span-level dedicated columns like http.status_code
 			// Are nils possible here?

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -3323,12 +3323,15 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 		case columnPathSpanTraceState:
 			// Parse OTel probability sampling threshold once per span. Falls
-			// back to 1.0 when the tracestate is absent or unparseable.
+			// back to 1.0 when the tracestate is absent or unparseable. We
+			// also surface it as a span attribute so attributesMatched()
+			// counts it toward the spanCollector's minAttributes threshold.
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0
 			}
 			sp.spanMultiplier = m
+			sp.addSpanAttr(traceql.IntrinsicSpanMultiplierAttribute, traceql.NewStaticFloat(m))
 		default:
 			// TODO - This exists for span-level dedicated columns like http.status_code
 			// Are nils possible here?

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -57,7 +57,6 @@ type span struct {
 	id                 []byte
 	startTimeUnixNanos uint64
 	durationNanos      uint64
-	spanMultiplier     float64 // sampling extrapolation (1.0 default); populated from TraceState column when requested
 	nestedSetParent    int32
 	nestedSetLeft      int32
 	nestedSetRight     int32
@@ -231,9 +230,6 @@ func (s *span) AttributeFor(a traceql.Attribute) (traceql.Static, bool) {
 		}
 		if a.Intrinsic == traceql.IntrinsicNestedSetParent {
 			return traceql.NewStaticInt(int(s.nestedSetParent)), true
-		}
-		if a.Intrinsic == traceql.IntrinsicSpanMultiplier {
-			return traceql.NewStaticFloat(s.spanMultiplier), true
 		}
 
 		// intrinsics are always on the span, trace, event, or link ... for now
@@ -922,7 +918,6 @@ func putSpan(s *span) {
 	s.id = nil
 	s.startTimeUnixNanos = 0
 	s.durationNanos = 0
-	s.spanMultiplier = 0
 	s.rowNum = parquetquery.EmptyRowNumber()
 	s.cbSpansetFinal = false
 	s.cbSpanset = nil
@@ -3322,15 +3317,15 @@ func (c *spanCollector) KeepGroup(res *parquetquery.IteratorResult) bool {
 		case columnPathSpanChildCount:
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 		case columnPathSpanTraceState:
-			// Parse OTel probability sampling threshold once per span. Falls
-			// back to 1.0 when the tracestate is absent or unparseable. We
-			// also surface it as a span attribute so attributesMatched()
-			// counts it toward the spanCollector's minAttributes threshold.
+			// Parse OTel probability sampling threshold once per span. Surface
+			// as a span attribute (falling back to 1.0 when the tracestate is
+			// absent or unparseable) — the engine reads it via AttributeFor,
+			// and it also counts toward attributesMatched() so the higher
+			// minAttributes threshold from the extra condition is satisfied.
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0
 			}
-			sp.spanMultiplier = m
 			sp.addSpanAttr(traceql.IntrinsicSpanMultiplierAttribute, traceql.NewStaticFloat(m))
 		default:
 			// TODO - This exists for span-level dedicated columns like http.status_code

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -1449,12 +1449,15 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 		case columnPathSpanTraceState:
 			// Parse OTel probability sampling threshold once per span; default
-			// to 1.0 when the tracestate is absent or unparseable.
+			// to 1.0 when the tracestate is absent or unparseable. Also surface
+			// as a span attribute so attributesMatched() counts it toward the
+			// spanCollector's minAttributes threshold.
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0
 			}
 			sp.spanMultiplier = m
+			sp.addSpanAttr(traceql.IntrinsicSpanMultiplierAttribute, traceql.NewStaticFloat(m))
 		case columnPathSpanDuration:
 			durationNanos = kv.Value.Uint64()
 			sp.durationNanos = durationNanos

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -1446,11 +1446,14 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		case columnPathSpanChildCount:
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 		case columnPathSpanTraceState:
-			// Parse OTel probability sampling threshold once per span. Surface
-			// as a span attribute (falling back to 1.0 when the tracestate is
-			// absent or unparseable) — the engine reads it via AttributeFor,
-			// and it also counts toward attributesMatched() so the higher
-			// minAttributes threshold from the extra condition is satisfied.
+			// Parse OTel probability sampling threshold once per span. When
+			// the tracestate carries an OTEP-235 R-value (`rv:` field), we
+			// use it to stochastically round the multiplier to an integer
+			// so count-style aggregates emit whole-number contributions.
+			// Falls back to the raw float multiplier when no R-value is
+			// present, and to 1.0 when the tracestate is absent or
+			// unparseable. Also surfaced as a span attribute so the engine
+			// reads it via AttributeFor and it counts toward attributesMatched().
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -1329,7 +1329,6 @@ func (c *spanCollector2) Reset(rowNumber parquetquery.RowNumber) {
 		c.at.id = nil
 		c.at.startTimeUnixNanos = 0
 		c.at.durationNanos = 0
-		c.at.spanMultiplier = 0
 		c.at.nestedSetParent = 0
 		c.at.nestedSetLeft = 0
 		c.at.nestedSetRight = 0
@@ -1353,7 +1352,6 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.id = v.id
 			sp.startTimeUnixNanos = v.startTimeUnixNanos
 			sp.durationNanos = v.durationNanos
-			sp.spanMultiplier = v.spanMultiplier
 			sp.spanAttrs = append(sp.spanAttrs, v.spanAttrs...)
 			sp.traceAttrs = append(sp.traceAttrs, v.traceAttrs...)
 			sp.resourceAttrs = append(sp.resourceAttrs, v.resourceAttrs...)
@@ -1448,15 +1446,15 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 		case columnPathSpanChildCount:
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
 		case columnPathSpanTraceState:
-			// Parse OTel probability sampling threshold once per span; default
-			// to 1.0 when the tracestate is absent or unparseable. Also surface
-			// as a span attribute so attributesMatched() counts it toward the
-			// spanCollector's minAttributes threshold.
+			// Parse OTel probability sampling threshold once per span. Surface
+			// as a span attribute (falling back to 1.0 when the tracestate is
+			// absent or unparseable) — the engine reads it via AttributeFor,
+			// and it also counts toward attributesMatched() so the higher
+			// minAttributes threshold from the extra condition is satisfied.
 			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
 			if m <= 0 {
 				m = 1.0
 			}
-			sp.spanMultiplier = m
 			sp.addSpanAttr(traceql.IntrinsicSpanMultiplierAttribute, traceql.NewStaticFloat(m))
 		case columnPathSpanDuration:
 			durationNanos = kv.Value.Uint64()

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/tempo/pkg/parquetquery"
+	"github.com/grafana/tempo/pkg/sampling"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -673,6 +674,12 @@ func createSpanIterators(
 			addPredicate(columnPathSpanChildCount, pred)
 			columnSelectAs[columnPathSpanChildCount] = columnPathSpanChildCount
 			continue
+		case traceql.IntrinsicSpanMultiplier:
+			// Synthetic float intrinsic; the iterator reads the raw TraceState
+			// column and the collector parses it into a per-span multiplier.
+			addPredicate(columnPathSpanTraceState, nil)
+			columnSelectAs[columnPathSpanTraceState] = columnPathSpanTraceState
+			continue
 		default:
 			panic("unhandled intrinsic: " + cond.Attribute.String())
 		}
@@ -733,7 +740,8 @@ func createSpanIterators(
 				traceql.IntrinsicStructuralSibling,
 				traceql.IntrinsicNestedSetLeft,
 				traceql.IntrinsicNestedSetRight,
-				traceql.IntrinsicNestedSetParent:
+				traceql.IntrinsicNestedSetParent,
+				traceql.IntrinsicSpanMultiplier: // synthetic; explicitly requested by metrics queries
 				continue
 			}
 			addPredicate(entry.columnPath, nil)
@@ -1321,6 +1329,7 @@ func (c *spanCollector2) Reset(rowNumber parquetquery.RowNumber) {
 		c.at.id = nil
 		c.at.startTimeUnixNanos = 0
 		c.at.durationNanos = 0
+		c.at.spanMultiplier = 0
 		c.at.nestedSetParent = 0
 		c.at.nestedSetLeft = 0
 		c.at.nestedSetRight = 0
@@ -1344,6 +1353,7 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.id = v.id
 			sp.startTimeUnixNanos = v.startTimeUnixNanos
 			sp.durationNanos = v.durationNanos
+			sp.spanMultiplier = v.spanMultiplier
 			sp.spanAttrs = append(sp.spanAttrs, v.spanAttrs...)
 			sp.traceAttrs = append(sp.traceAttrs, v.traceAttrs...)
 			sp.resourceAttrs = append(sp.resourceAttrs, v.resourceAttrs...)
@@ -1437,6 +1447,14 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.startTimeUnixNanos = intervalMapper3600Seconds.TimestampOf(int(kv.Value.Int64()))
 		case columnPathSpanChildCount:
 			sp.addSpanAttr(traceql.IntrinsicChildCountAttribute, traceql.NewStaticInt(int(kv.Value.Int32())))
+		case columnPathSpanTraceState:
+			// Parse OTel probability sampling threshold once per span; default
+			// to 1.0 when the tracestate is absent or unparseable.
+			m := sampling.MultiplierFromTraceState(unsafeToString(kv.Value.Bytes()))
+			if m <= 0 {
+				m = 1.0
+			}
+			sp.spanMultiplier = m
 		case columnPathSpanDuration:
 			durationNanos = kv.Value.Uint64()
 			sp.durationNanos = durationNanos


### PR DESCRIPTION
## Summary

TraceQL metrics queries (`rate`, `count_over_time`, `sum_over_time`, `avg_over_time`, `histogram_over_time`, `quantile_over_time`, `compare`) can now scale each matched span by `1 / sampling_probability` when the span carries an OpenTelemetry probability threshold in its W3C tracestate (`ot=th:...`). This mirrors the metrics generator's existing per-span multiplier behaviour, so ad-hoc TraceQL queries against probabilistically-sampled traces produce numbers consistent with the generator's pre-aggregated `tempo_spanmetrics_*` series.

## Opt-in

Per query via the safe `with(extrapolate=true|false)` hint — works without `--allow-unsafe-query-hints`.

`min_over_time` / `max_over_time` are deliberately unscaled (extremes don't scale with sampling). Exemplar values are unaffected.

## Implementation

- New `pkg/sampling` package extracted from `modules/generator/processor/util/util.go`. Both the generator and the storage iterator now use `sampling.MultiplierFromTraceState`.
- New synthetic intrinsic `IntrinsicSpanMultiplier` (not user-typable). The storage layer parses the W3C tracestate column once per span into a `float64` and surfaces it via `AttributeFor`.
- Aggregators in `pkg/traceql/engine_metrics{,_compare,_average}.go` gain a `SetExtrapolate(bool)` setter. When on, count/sum/rate/histogram/compare contributions multiply by the per-span multiplier; `avg_over_time` uses the existing weighted-mean helper with `weight = multiplier`.
- Compile-time wiring in `CompileMetricsQueryRange` resolves the hint, then calls `applyExtrapolation` which sets the pipeline flag and adds `IntrinsicSpanMultiplier` to `SecondPassConditions` before `init()`.
- Storage layer also calls `sp.addSpanAttr(IntrinsicSpanMultiplierAttribute, ...)` so the multiplier counts toward `attributesMatched()` — otherwise the higher `minAttributes` threshold from the extra condition can drop spans that should match, and in vparquet4 the unknown intrinsic categorizes as "mingled scope" which silently disables `AllConditions` and bypasses filters entirely.

## Storage

Implemented for both vparquet4 (current default in Tempo 3.0) and vparquet5. `TraceState` is already in the vparquet3/4/5 schemas (always written), so no data migration is needed. The TraceState column is only **read** when extrapolation is enabled — zero I/O cost for queries that don't opt in. vparquet3 is intentionally not covered as it is deprecated.

## TODO

- [ ] Documentation in `docs/sources/tempo/traceql/metrics-queries/` covering the hint.

Example of how this is working with a 50% tracestate threshold
<img width="1450" height="750" alt="Screenshot 2026-06-09 at 10 30 03 PM" src="https://github.com/user-attachments/assets/273e59da-574d-4645-9868-e207d5baf7a8" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)