### PR TITLE
Upgrade goreleaser to v2.16.0

### DIFF
--- a/.chloggen/upgrade-goreleaser.yaml
+++ b/.chloggen/upgrade-goreleaser.yaml
@@ -1,0 +1,6 @@
+change_type: change
+component: deps
+note: Upgrade goreleaser from v1.25.1 to v2.16.0
+issues: []
+subtext:
+user: mapno

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,8 @@
+version: 2
+
 archives:
   - id: default
-    builds:
+    ids:
       - tempo
       - tempo-query
       - tempo-cli
@@ -81,7 +83,7 @@ builds:
       - -X main.Version={{ .Version }}
     mod_timestamp: '{{ .CommitTimestamp }}'
 changelog:
-  skip: true
+  disable: true
   sort: asc
   filters:
     exclude:
@@ -95,10 +97,10 @@ release:
   draft: true
   prerelease: auto
 snapshot:
-  name_template: "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}"
+  version_template: "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}"
 # RPM (yum) and deb (apt) packages
 nfpms:
-  - builds:
+  - ids:
       - tempo
       - tempo-cli
       - tempo-query

--- a/Makefile
+++ b/Makefile
@@ -367,15 +367,15 @@ update-mod: tools-update-mod ## Update module
 
 ### Release (intended to be used in the .github/workflows/release.yml)
 $(GORELEASER):
-	go install github.com/goreleaser/goreleaser@v1.25.1
+	go install github.com/goreleaser/goreleaser/v2@v2.16.0
 
 .PHONY: release
 release: $(GORELEASER)  ## Release 
-	$(GORELEASER) release --rm-dist 
+	$(GORELEASER) release --clean
 
 .PHONY: release-snapshot
 release-snapshot: $(GORELEASER) ## Release snapshot
-	$(GORELEASER) release --skip-validate --rm-dist --snapshot
+	$(GORELEASER) release --skip=validate --clean --snapshot
 
 ##@ Docs
 .PHONY: docs


### PR DESCRIPTION
**What this PR does**:

Upgrades goreleaser from v1.25.1 to v2.16.0.

- Module path changed to `github.com/goreleaser/goreleaser/v2`
- CLI flags: `--rm-dist` to `--clean`, `--skip-validate` to `--skip=validate`
- Config migrated to v2 schema: added `version: 2` header, `changelog.skip` to `changelog.disable`, `snapshot.name_template` to `snapshot.version_template`, `archives[].builds`/`nfpms[].builds` to `ids`

I've validated this by running `release --snapshot` with both versions on the same commit and comparing outputs: all 9 binaries and all 3 `.tar.gz` archives are **byte-identical** (SHA256). The `.deb`/`.rpm` payloads are identical file-for-file; only nfpm package metadata differs (new `Architecture-Variant` control field, `md5sums` path format).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated (n/a — build tooling only)
- [ ] Documentation added (n/a)
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)