### PR TITLE
[DOC] Add line for 32-bit ARM binary.

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/locally/linux.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/deploy/locally/linux.md
@@ -79,6 +79,8 @@ You need administrator privileges to do this by running as the `root` user or vi
 
 Be sure to [download the correct package](https://github.com/grafana/tempo/releases/) for your OS and architecture. Replace `<TEMPO_VERSION_NUMBER>` with the version you want to install, for example `3.0.0`.
 
+Tempo publishes release binaries for the AMD64 (`amd64`) and 64-bit ARM (`arm64`) architectures. It doesn't publish 32-bit ARM (`arm`) binaries. To run Tempo on 32-bit ARM hardware, build it from source.
+
 1. Download the Tempo binary. The following example downloads Tempo for the AMD64 (x86_64) processor architecture on a Linux distribution supporting deb packages:
 
    ```bash


### PR DESCRIPTION
**What this PR does**:

Adds a note for the deploy locally doc that the 32-bit ARM binary is removed. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)