### PR TITLE
chore: correct version detection

### DIFF
--- a/tools/version-tag.sh
+++ b/tools/version-tag.sh
@@ -17,8 +17,15 @@ is_valid_semver() {
 }
 
 
-VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
-if is_valid_semver "$VERSION"; then
+# 1. Release build: HEAD itself is tagged — that tag is the version.
+VERSION=$(git describe --exact-match --tags HEAD 2>/dev/null) ||
+# 2. Build from an untagged commit: nearest release tag in HEAD's ancestry.
+VERSION=$(git describe --tags --abbrev=0 2>/dev/null) ||
+# 3. Shallow clone (no ancestry to walk): newest tag in the repo by commit date.
+VERSION=$(git describe --tags "$(git rev-list --tags --max-count=1)" 2>/dev/null) ||
+VERSION=""
+
+if [ -n "$VERSION" ] && is_valid_semver "$VERSION"; then
       echo "$VERSION"
       exit 0
 fi

--- a/tools/version-tag.sh
+++ b/tools/version-tag.sh
@@ -9,10 +9,10 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 is_valid_semver() {
       local version=$1
       # regex taken from https://semver.org/
-      if [[ $version =~ ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$ ]] ;then
-            return 1
-      else
+      if echo "$version" | grep -qP '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$' ;then
             return 0
+      else
+            return 1
       fi
 }
 

--- a/tools/version-tag_test.sh
+++ b/tools/version-tag_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Tests for is_valid_semver in tools/version-tag.sh
+
+set -o nounset
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck disable=SC1090
+source <(sed -n '/^is_valid_semver/,/^}/p' "$SCRIPT_DIR/version-tag.sh")
+
+PASS=0
+FAIL=0
+
+expect_valid() {
+    if is_valid_semver "$1"; then
+        echo "PASS  accepts '$1'"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL  '$1' should be accepted, was rejected"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+expect_invalid() {
+    if is_valid_semver "$1"; then
+        echo "FAIL  '$1' should be rejected, was accepted"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS  rejects '$1'"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# valid versions
+expect_valid "v2.10.6" # multi-digit component
+expect_valid "v2.9.3"
+expect_valid "v0.1.0"
+expect_valid "v3.0.0-rc.1" # prerelease
+expect_valid "v1.0.0-rc.0"
+expect_valid "v1.2.3-alpha.beta-x.7"
+expect_valid "v1.2.3+build.42" # build metadata
+expect_valid "v1.2.3-rc.1+sha.974d430"
+
+# invalid versions
+expect_invalid "v11234" # no dots
+expect_invalid "abc"
+expect_invalid "HEAD-abc-wip" # shape of the image-tag fallback output
+expect_invalid "main-927ed1b"
+expect_invalid "v01.2.3"  # leading zero
+expect_invalid "v1.2"     # missing patch
+expect_invalid "v1.2.3.4" # extra component
+expect_invalid "2.10.6"   # missing v prefix
+expect_invalid "v1.2.3-"  # empty prerelease
+expect_invalid " v1.2.3"  # leading whitespace
+expect_invalid ""
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**: the script is used in Makefile to pass version into tempo binary. It fetches latest changed version, which may raise race condition when a couple of version is being prepared. I change logic:
1. if current commit is tagged, use it. Branch `release-v2.0` gives `v2.10.5`. 
2. otherwise, use closest tag in history. New commit on top of `release-v2.0` gives `v2.10.5`
3. Fallback to previous version. Currently, running the previous version of the script, gives `v3.0.2`

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/tempo/issues/7460

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)