### PR TITLE
generator: reduce per-span overhead in spanmetrics and servicegraphs

### DIFF
--- a/.chloggen/generator-per-span-wins.yaml
+++ b/.chloggen/generator-per-span-wins.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: metrics-generator
+note: Reduce the per-span CPU and memory overhead of the span-metrics and service-graphs processors.
+issues: [7462]
+subtext:
+user: carles-grafana

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -516,6 +516,9 @@ func (d *Distributor) pushTracesKafka(ctx context.Context, userID string, keys [
 	return d.sendToKafka(ctx, userID, keys, traces, skipMetricsGeneration)
 }
 
+// pushLocal pushes traces to the in-process live-store and generator.
+// Order matters: the generator filters spans in place (instance.preprocessSpans),
+// so the live-store push, which marshals the traces, must finish first.
 func (d *Distributor) pushLocal(ctx context.Context, userID string, keys []uint32, traces []*rebatchedTrace) error {
 	if err := d.pushTracesToLiveStore(ctx, userID, traces); err != nil {
 		return err
@@ -560,6 +563,8 @@ func (d *Distributor) pushTracesToLiveStore(ctx context.Context, userID string, 
 	return nil
 }
 
+// sendToGenerators passes the traces to the in-process generator, which filters
+// spans in place (see instance.preprocessSpans). Do not reuse the batches after.
 func (d *Distributor) sendToGenerators(ctx context.Context, userID string, _ []uint32, traces []*rebatchedTrace, noGenerateMetrics bool) error {
 	req := tempopb.PushSpansRequest{
 		Batches:               nil,

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -25,7 +25,6 @@ import (
 	"github.com/grafana/tempo/modules/generator/storage"
 	"github.com/grafana/tempo/modules/generator/validation"
 	"github.com/grafana/tempo/pkg/tempopb"
-	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 
 	"go.uber.org/atomic"
 )
@@ -161,7 +160,7 @@ func (i *instance) updateSubprocessors(desiredProcessors map[string]struct{}, de
 func (i *instance) updateSpanMetricsSubprocessors(desiredProcessors map[string]struct{}, desiredCfg ProcessorConfig) (map[string]struct{}, ProcessorConfig) {
 	desiredProcessorsFound := false
 	for d := range desiredProcessors {
-		if (d == processor.SpanMetricsName) || (spanmetrics.ParseSubprocessor(d)) {
+		if (d == processor.SpanMetricsName) || spanmetrics.ParseSubprocessor(d) {
 			desiredProcessorsFound = true
 		}
 	}
@@ -210,7 +209,7 @@ func (i *instance) updateSpanMetricsSubprocessors(desiredProcessors map[string]s
 func (i *instance) updateServiceGraphsSubprocessors(desiredProcessors map[string]struct{}, desiredCfg ProcessorConfig) (map[string]struct{}, ProcessorConfig) {
 	desiredProcessorsFound := false
 	for d := range desiredProcessors {
-		if (d == processor.ServiceGraphsName) || (servicegraphs.ParseSubprocessor(d)) {
+		if (d == processor.ServiceGraphsName) || servicegraphs.ParseSubprocessor(d) {
 			desiredProcessorsFound = true
 		}
 	}
@@ -468,6 +467,8 @@ func (i *instance) pushSpansFromQueue(ctx context.Context, _ time.Time, req *tem
 	}
 }
 
+// preprocessSpans filters req's spans in place, so the caller must not share
+// the request (or its batches) with any other consumer.
 func (i *instance) preprocessSpans(req *tempopb.PushSpansRequest) {
 	// TODO - uniqify all strings?
 	// Doesn't help allocs, but should greatly reduce inuse space
@@ -475,27 +476,28 @@ func (i *instance) preprocessSpans(req *tempopb.PushSpansRequest) {
 	spanCount := 0
 	expiredSpanCount := 0
 	ingestionSlackNano := i.ingestionSlackOverride.Load()
+	nowNano := time.Now().UnixNano()
+	maxTimePast := uint64(nowNano - ingestionSlackNano)
+	maxTimeFuture := uint64(nowNano + ingestionSlackNano)
 
 	for _, b := range req.Batches {
 		size += b.Size()
 		for _, ss := range b.ScopeSpans {
 			spanCount += len(ss.Spans)
 			// filter spans that have end time > max_age and end time more than 5 days in the future
-			newSpansArr := make([]*v1.Span, len(ss.Spans))
-			timeNow := time.Now()
-			maxTimePast := uint64(timeNow.UnixNano() - ingestionSlackNano)
-			maxTimeFuture := uint64(timeNow.UnixNano() + ingestionSlackNano)
+			spans := ss.Spans
 
 			index := 0
-			for _, span := range ss.Spans {
+			for _, span := range spans {
 				if span.EndTimeUnixNano >= maxTimePast && span.EndTimeUnixNano <= maxTimeFuture {
-					newSpansArr[index] = span
+					spans[index] = span
 					index++
 				} else {
 					expiredSpanCount++
 				}
 			}
-			ss.Spans = newSpansArr[0:index]
+			clear(spans[index:])
+			ss.Spans = spans[0:index]
 		}
 	}
 	i.updatePushMetrics(size, spanCount, expiredSpanCount)

--- a/modules/generator/instance_test.go
+++ b/modules/generator/instance_test.go
@@ -139,6 +139,84 @@ tempo_metrics_generator_metrics_generation_skipped_processor_pushes_total{tenant
 	})
 }
 
+// Test_instance_preprocessSpans covers the in-place ingestion-slack filtering:
+// spans outside the slack window are dropped by compacting each span slice in
+// place, the stale tail is nil-cleared so dropped spans are not retained, and
+// the discarded-spans counter is incremented.
+func Test_instance_preprocessSpans(t *testing.T) {
+	const tenantID = "preprocess-spans-test"
+
+	inst := &instance{instanceID: tenantID}
+	inst.ingestionSlackOverride.Store((30 * time.Second).Nanoseconds())
+
+	makeSpan := func(name string, end time.Time) *v1.Span {
+		return &v1.Span{Name: name, EndTimeUnixNano: uint64(end.UnixNano())}
+	}
+
+	now := time.Now()
+	keepA1 := makeSpan("keep-a1", now)
+	dropA2 := makeSpan("drop-a2", now.Add(-time.Hour)) // too far in the past
+	keepA3 := makeSpan("keep-a3", now)
+	dropA4 := makeSpan("drop-a4", now.Add(time.Hour)) // too far in the future
+	dropB1 := makeSpan("drop-b1", now.Add(-time.Hour))
+	dropB2 := makeSpan("drop-b2", now.Add(time.Hour))
+	keepC1 := makeSpan("keep-c1", now)
+	keepC2 := makeSpan("keep-c2", now)
+
+	scopeMixed := &v1.ScopeSpans{Spans: []*v1.Span{keepA1, dropA2, keepA3, dropA4}}
+	scopeAllDropped := &v1.ScopeSpans{Spans: []*v1.Span{dropB1, dropB2}}
+	scopeAllKept := &v1.ScopeSpans{Spans: []*v1.Span{keepC1, keepC2}}
+	scopeEmpty := &v1.ScopeSpans{}
+
+	req := &tempopb.PushSpansRequest{Batches: []*v1.ResourceSpans{
+		{ScopeSpans: []*v1.ScopeSpans{scopeMixed, scopeAllDropped}},
+		{ScopeSpans: []*v1.ScopeSpans{scopeAllKept, scopeEmpty}},
+	}}
+
+	// Keep the original slice headers to verify in-place compaction and the
+	// nil-cleared tails afterwards.
+	originalMixed := scopeMixed.Spans
+	originalAllDropped := scopeAllDropped.Spans
+
+	discarded := metricSpansDiscarded.WithLabelValues(tenantID, reasonOutsideTimeRangeSlack, "all")
+	received := metricSpansIngested.WithLabelValues(tenantID)
+	discardedBefore := testutil.ToFloat64(discarded)
+	receivedBefore := testutil.ToFloat64(received)
+
+	inst.preprocessSpans(req)
+
+	// Mixed scope: survivors compacted in place, order preserved, tail nil-cleared.
+	require.Len(t, scopeMixed.Spans, 2)
+	require.Same(t, keepA1, scopeMixed.Spans[0])
+	require.Same(t, keepA3, scopeMixed.Spans[1])
+	require.Same(t, &originalMixed[0], &scopeMixed.Spans[0], "filtering must reuse the original backing array")
+	require.Nil(t, originalMixed[2], "dropped tail must be nil-cleared to release span pointers")
+	require.Nil(t, originalMixed[3], "dropped tail must be nil-cleared to release span pointers")
+
+	// All dropped: empty result, fully nil-cleared backing array.
+	require.Empty(t, scopeAllDropped.Spans)
+	require.Nil(t, originalAllDropped[0])
+	require.Nil(t, originalAllDropped[1])
+
+	// All kept: untouched.
+	require.Len(t, scopeAllKept.Spans, 2)
+	require.Same(t, keepC1, scopeAllKept.Spans[0])
+	require.Same(t, keepC2, scopeAllKept.Spans[1])
+
+	require.Equal(t, float64(4), testutil.ToFloat64(discarded)-discardedBefore, "4 spans outside the slack window")
+	require.Equal(t, float64(8), testutil.ToFloat64(received)-receivedBefore, "all 8 spans count as received")
+
+	// Re-pushing the already-filtered request drops nothing further.
+	inst.preprocessSpans(req)
+	require.Len(t, scopeMixed.Spans, 2)
+	require.Empty(t, scopeAllDropped.Spans)
+	require.Len(t, scopeAllKept.Spans, 2)
+	require.Equal(t, float64(4), testutil.ToFloat64(discarded)-discardedBefore)
+
+	// An empty request is a no-op.
+	require.NotPanics(t, func() { inst.preprocessSpans(&tempopb.PushSpansRequest{}) })
+}
+
 func Test_instance_updateProcessors(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -93,7 +93,8 @@ type Processor struct {
 	serviceGraphRequestClientSecondsHistogram          registry.Histogram
 	serviceGraphRequestMessagingSystemSecondsHistogram registry.Histogram
 	serviceGraphConnectionInfo                         registry.Gauge
-	sanitizeCache                                      reclaimable.Cache[string, string]
+	dimensionLabels                                    []dimensionLabel
+	usesSpanMultiplier                                 bool
 	filter                                             *spanfilter.SpanFilter
 
 	filteredSpansCounter                prometheus.Counter
@@ -106,12 +107,37 @@ type Processor struct {
 	logger                              log.Logger
 }
 
+// dimensionLabel holds the precomputed label names for a dimension so the
+// per-edge path does not sanitize them on every span.
+type dimensionLabel struct {
+	name        string
+	label       string
+	clientName  string
+	clientLabel string
+	serverName  string
+	serverLabel string
+}
+
 func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, filteredSpansCounter, invalidUTF8Counter prometheus.Counter) (gen.Processor, error) {
 	if cfg.EnableVirtualNodeLabel {
 		cfg.Dimensions = append(cfg.Dimensions, virtualNodeLabel)
 	}
 
 	sanitizeCache := reclaimable.New(validation.SanitizeLabelName, 10000)
+	dimensionLabels := make([]dimensionLabel, len(cfg.Dimensions))
+	for i, dim := range cfg.Dimensions {
+		clientName := "client_" + dim
+		serverName := "server_" + dim
+		dimensionLabels[i] = dimensionLabel{
+			name:        dim,
+			label:       sanitizeCache.Get(dim),
+			clientName:  clientName,
+			clientLabel: sanitizeCache.Get(clientName),
+			serverName:  serverName,
+			serverLabel: sanitizeCache.Get(serverName),
+		}
+	}
+
 	filter, err := spanfilter.NewSpanFilter(cfg.FilterPolicies)
 	if err != nil {
 		return nil, err
@@ -122,8 +148,9 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, fi
 		registry: reg,
 		closeCh:  make(chan struct{}, 1),
 
-		sanitizeCache: sanitizeCache,
-		filter:        filter,
+		dimensionLabels:    dimensionLabels,
+		usesSpanMultiplier: cfg.SpanMultiplierKey != "" || cfg.EnableTraceStateSpanMultiplier,
+		filter:             filter,
 
 		filteredSpansCounter:                filteredSpansCounter,
 		metricDroppedSpans:                  metricDroppedSpans.WithLabelValues(tenant),
@@ -212,14 +239,17 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 				}
 
 				connectionType := store.Unknown
-				spanMultiplier := processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs.Resource, p.Cfg.EnableTraceStateSpanMultiplier)
+				spanMultiplier := 1.0
+				if p.usesSpanMultiplier {
+					spanMultiplier = processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs.Resource, p.Cfg.EnableTraceStateSpanMultiplier)
+				}
 				switch span.Kind {
 				case v1_trace.Span_SPAN_KIND_PRODUCER:
 					// override connection type and continue processing as span kind client
 					connectionType = store.MessagingSystem
 					fallthrough
 				case v1_trace.Span_SPAN_KIND_CLIENT:
-					key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.SpanId))
+					key := buildKeyFromBytes(span.TraceId, span.SpanId)
 					isNew, err = p.store.UpsertEdge(key, store.Client, func(e *store.Edge) {
 						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
 						e.ConnectionType = connectionType
@@ -238,7 +268,7 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 					connectionType = store.MessagingSystem
 					fallthrough
 				case v1_trace.Span_SPAN_KIND_SERVER:
-					key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.ParentSpanId))
+					key := buildKeyFromBytes(span.TraceId, span.ParentSpanId)
 					isNew, err = p.store.UpsertEdge(key, store.Server, func(e *store.Edge) {
 						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
 						e.ConnectionType = connectionType
@@ -281,12 +311,16 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 }
 
 func (p *Processor) upsertDimensions(prefix string, m map[string]string, resourceAttr, spanAttr []*v1_common.KeyValue) {
-	for _, dim := range p.Cfg.Dimensions {
-		if v, ok := processor_util.FindAttributeValue(dim, resourceAttr, spanAttr); ok {
+	for _, dim := range p.dimensionLabels {
+		if v, ok := processor_util.FindAttributeValue(dim.name, resourceAttr, spanAttr); ok {
 			if p.Cfg.EnableClientServerPrefix {
-				m[prefix+dim] = v
+				if prefix == "client_" {
+					m[dim.clientName] = v
+				} else {
+					m[dim.serverName] = v
+				}
 			} else {
-				m[dim] = v
+				m[dim.name] = v
 			}
 		}
 	}
@@ -372,19 +406,19 @@ func (p *Processor) onComplete(e *store.Edge) {
 	builder.Add("server", e.ServerService)
 	builder.Add("connection_type", string(e.ConnectionType))
 
-	for _, dimension := range p.Cfg.Dimensions {
+	for _, dimension := range p.dimensionLabels {
 		if p.Cfg.EnableClientServerPrefix {
 			if p.Cfg.EnableVirtualNodeLabel {
 				// leave the extra label for this feature as-is
-				if dimension == virtualNodeLabel {
-					builder.Add(virtualNodeLabel, e.Dimensions[dimension])
+				if dimension.name == virtualNodeLabel {
+					builder.Add(virtualNodeLabel, e.Dimensions[dimension.name])
 					continue
 				}
 			}
-			builder.Add(p.sanitizeCache.Get("client_"+dimension), e.Dimensions["client_"+dimension])
-			builder.Add(p.sanitizeCache.Get("server_"+dimension), e.Dimensions["server_"+dimension])
+			builder.Add(dimension.clientLabel, e.Dimensions[dimension.clientName])
+			builder.Add(dimension.serverLabel, e.Dimensions[dimension.serverName])
 		} else {
-			builder.Add(p.sanitizeCache.Get(dimension), e.Dimensions[dimension])
+			builder.Add(dimension.label, e.Dimensions[dimension.name])
 		}
 	}
 
@@ -471,7 +505,7 @@ func (p *Processor) onExpire(e *store.Edge) {
 
 func (p *Processor) addDroppedSpanSide(span *v1_trace.Span) {
 	if isClient(span.Kind) {
-		key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.SpanId))
+		key := buildKeyFromBytes(span.TraceId, span.SpanId)
 		if p.store.AddDroppedSpanSide(key, store.Client) {
 			p.metricDroppedEdges.Inc()
 		}
@@ -484,7 +518,7 @@ func (p *Processor) addDroppedSpanSide(span *v1_trace.Span) {
 			return
 		}
 
-		key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.ParentSpanId))
+		key := buildKeyFromBytes(span.TraceId, span.ParentSpanId)
 		if p.store.AddDroppedSpanSide(key, store.Server) {
 			p.metricDroppedEdges.Inc()
 		}
@@ -514,6 +548,17 @@ func unixNanosDiffSec(unixNanoStart uint64, unixNanoEnd uint64) float64 {
 
 func spanDurationSec(span *v1_trace.Span) float64 {
 	return unixNanosDiffSec(span.StartTimeUnixNano, span.EndTimeUnixNano)
+}
+
+// buildKeyFromBytes hex-encodes both IDs straight into the key, avoiding the
+// intermediate string allocations of buildKey(hex(...), hex(...)).
+func buildKeyFromBytes(k1, k2 []byte) string {
+	k1Len := hex.EncodedLen(len(k1))
+	buf := make([]byte, k1Len+1+hex.EncodedLen(len(k2)))
+	hex.Encode(buf[:k1Len], k1)
+	buf[k1Len] = '-'
+	hex.Encode(buf[k1Len+1:], k2)
+	return string(buf)
 }
 
 func buildKey(k1, k2 string) string {

--- a/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
@@ -1,0 +1,168 @@
+package servicegraphs
+
+import (
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BenchmarkServiceGraphsPushSpansSynthetic(b *testing.B) {
+	for _, tc := range []struct {
+		name           string
+		tune           func(*Config)
+		spanMultiplier bool
+	}{
+		{name: "default"},
+		{
+			name: "dimensions",
+			tune: func(cfg *Config) {
+				cfg.Dimensions = []string{"beast", "god"}
+			},
+		},
+		{
+			name: "client_server_prefix",
+			tune: func(cfg *Config) {
+				cfg.Dimensions = []string{"beast", "god"}
+				cfg.EnableClientServerPrefix = true
+			},
+		},
+		{
+			name: "span_multiplier",
+			tune: func(cfg *Config) {
+				cfg.SpanMultiplierKey = "sample.rate"
+			},
+			spanMultiplier: true,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.HistogramBuckets = []float64{0.04, 0.1, 1}
+			if tc.tune != nil {
+				tc.tune(&cfg)
+			}
+
+			p, err := New(
+				cfg,
+				"bench",
+				registry.NewTestRegistry(),
+				log.NewNopLogger(),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer p.Shutdown(context.Background())
+
+			req := benchmarkServiceGraphRequest(100, tc.spanMultiplier)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				p.PushSpans(context.Background(), req)
+			}
+		})
+	}
+}
+
+func benchmarkServiceGraphRequest(edges int, spanMultiplier bool) *tempopb.PushSpansRequest {
+	client := &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{Attributes: []*common_v1.KeyValue{
+			benchmarkSGStringAttr("service.name", "client"),
+			benchmarkSGStringAttr("beast", "manticore"),
+		}},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+	server := &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{Attributes: []*common_v1.KeyValue{
+			benchmarkSGStringAttr("service.name", "server"),
+			benchmarkSGStringAttr("god", "athena"),
+		}},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+
+	for i := 0; i < edges; i++ {
+		traceID := benchmarkSGTraceID(i)
+		clientSpanID := benchmarkSGSpanID(i*2 + 1)
+		client.ScopeSpans[0].Spans = append(client.ScopeSpans[0].Spans, &trace_v1.Span{
+			TraceId:           traceID,
+			SpanId:            clientSpanID,
+			Name:              "GET /api/:id",
+			Kind:              trace_v1.Span_SPAN_KIND_CLIENT,
+			StartTimeUnixNano: uint64(1_700_000_000_000_000_000 + i),
+			EndTimeUnixNano:   uint64(1_700_000_000_050_000_000 + i),
+			Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+			Attributes: []*common_v1.KeyValue{
+				benchmarkSGStringAttr("peer.service", "server"),
+				benchmarkSGStringAttr("beast", "client-"+strconv.Itoa(i%4)),
+			},
+		})
+		if spanMultiplier {
+			client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes = append(
+				client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkSGDoubleAttr("sample.rate", 0.5),
+			)
+		}
+
+		server.ScopeSpans[0].Spans = append(server.ScopeSpans[0].Spans, &trace_v1.Span{
+			TraceId:           traceID,
+			SpanId:            benchmarkSGSpanID(i*2 + 2),
+			ParentSpanId:      clientSpanID,
+			Name:              "GET /api/:id",
+			Kind:              trace_v1.Span_SPAN_KIND_SERVER,
+			StartTimeUnixNano: uint64(1_700_000_000_010_000_000 + i),
+			EndTimeUnixNano:   uint64(1_700_000_000_040_000_000 + i),
+			Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+			Attributes: []*common_v1.KeyValue{
+				benchmarkSGStringAttr("god", "server-"+strconv.Itoa(i%4)),
+			},
+		})
+		if spanMultiplier {
+			server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes = append(
+				server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkSGDoubleAttr("sample.rate", 0.5),
+			)
+		}
+	}
+
+	return &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{client, server}}
+}
+
+func benchmarkSGTraceID(i int) []byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSGSpanID(i int) []byte {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSGStringAttr(key, value string) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{
+			StringValue: value,
+		}},
+	}
+}
+
+func benchmarkSGDoubleAttr(key string, value float64) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_DoubleValue{
+			DoubleValue: value,
+		}},
+	}
+}

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -2,7 +2,6 @@ package spanmetrics
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/grafana/tempo/modules/generator/validation"
@@ -25,6 +24,10 @@ const (
 	metricDurationSeconds = "traces_spanmetrics_latency"
 	metricSizeTotal       = "traces_spanmetrics_size_total"
 	targetInfo            = "traces_target_info"
+
+	serviceNameKey       = "service.name"
+	serviceNamespaceKey  = "service.namespace"
+	serviceInstanceIDKey = "service.instance.id"
 )
 
 type Processor struct {
@@ -37,10 +40,14 @@ type Processor struct {
 	spanMetricsSizeTotal       registry.Counter
 	spanMetricsTargetInfo      registry.Gauge
 
-	filter               *spanfilter.SpanFilter
-	filteredSpansCounter prometheus.Counter
-	invalidUTF8Counter   prometheus.Counter
-	sanitizeCache        reclaimable.Cache[string, string]
+	filter                 *spanfilter.SpanFilter
+	filteredSpansCounter   prometheus.Counter
+	invalidUTF8Counter     prometheus.Counter
+	sanitizeCache          reclaimable.Cache[string, string]
+	targetInfoExcluded     map[string]struct{}
+	dimensionLabels        []string
+	dimensionMappingLabels []string
+	usesSpanMultiplier     bool
 
 	// for testing
 	now func() time.Time
@@ -72,14 +79,30 @@ func New(cfg Config, reg registry.Registry, filteredSpansCounter, invalidUTF8Cou
 		return nil, err
 	}
 
+	// Label names are deterministic, so sanitize them once here instead of
+	// once per span.
+	dimensionLabels := make([]string, len(cfg.Dimensions))
+	for i, d := range cfg.Dimensions {
+		dimensionLabels[i] = validation.SanitizeLabelNameWithCollisions(d, validation.SupportedIntrinsicDimensionsSet, c.Get)
+	}
+
+	dimensionMappingLabels := make([]string, len(cfg.DimensionMappings))
+	for i, m := range cfg.DimensionMappings {
+		dimensionMappingLabels[i] = validation.SanitizeLabelNameWithCollisions(m.Name, validation.SupportedIntrinsicDimensionsSet, c.Get)
+	}
+
 	p := &Processor{
-		Cfg:                   cfg,
-		registry:              reg,
-		spanMetricsTargetInfo: reg.NewGauge(targetInfo),
-		now:                   time.Now,
-		filteredSpansCounter:  filteredSpansCounter,
-		invalidUTF8Counter:    invalidUTF8Counter,
-		sanitizeCache:         c,
+		Cfg:                    cfg,
+		registry:               reg,
+		spanMetricsTargetInfo:  reg.NewGauge(targetInfo),
+		now:                    time.Now,
+		filteredSpansCounter:   filteredSpansCounter,
+		invalidUTF8Counter:     invalidUTF8Counter,
+		sanitizeCache:          c,
+		targetInfoExcluded:     excludedDimensionsSet(cfg.TargetInfoExcludedDimensions),
+		dimensionLabels:        dimensionLabels,
+		dimensionMappingLabels: dimensionMappingLabels,
+		usesSpanMultiplier:     cfg.SpanMultiplierKey != "" || cfg.EnableTraceStateSpanMultiplier,
 	}
 
 	if cfg.Subprocessors[Latency] {
@@ -117,11 +140,9 @@ func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
 	resourceValues := make([]string, 0)
 	for _, rs := range resourceSpans {
 		// already extract job name & instance id, so we only have to do it once per batch of spans
-		svcName, _ := processor_util.FindServiceName(rs.Resource.Attributes)
-		jobName := processor_util.GetJobValue(rs.Resource.Attributes)
-		instanceID, _ := processor_util.FindInstanceID(rs.Resource.Attributes)
+		svcName, jobName, instanceID := getResourceServiceLabels(rs.Resource.Attributes)
 		if p.Cfg.EnableTargetInfo {
-			getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.Cfg.TargetInfoExcludedDimensions, p.sanitizeCache.Get)
+			getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.targetInfoExcluded, p.sanitizeCache.Get)
 		}
 		for _, ils := range rs.ScopeSpans {
 			for _, span := range ils.Spans {
@@ -155,36 +176,36 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 		builder.Add(gen.DimSpanName, span.GetName())
 	}
 	if p.Cfg.IntrinsicDimensions.SpanKind {
-		builder.Add(gen.DimSpanKind, span.GetKind().String())
+		builder.Add(gen.DimSpanKind, spanKindString(span.GetKind()))
 	}
 	if p.Cfg.IntrinsicDimensions.StatusCode {
-		builder.Add(gen.DimStatusCode, span.GetStatus().GetCode().String())
+		builder.Add(gen.DimStatusCode, statusCodeString(span.GetStatus().GetCode()))
 	}
 	if p.Cfg.IntrinsicDimensions.StatusMessage {
 		builder.Add(gen.DimStatusMessage, span.GetStatus().GetMessage())
 	}
 
-	for _, d := range p.Cfg.Dimensions {
+	for i, d := range p.Cfg.Dimensions {
 		value, _ := processor_util.FindAttributeValue(d, rs.Attributes, span.Attributes)
-		label := validation.SanitizeLabelNameWithCollisions(d, validation.SupportedIntrinsicDimensionsSet, p.sanitizeCache.Get)
 		// if there is a collision, for example deployment.environment and deployment_environment,
 		// both sanitized to deployment_environment, we just take the last one configured.
-		builder.Add(label, value)
+		builder.Add(p.dimensionLabels[i], value)
 	}
 
-	for _, m := range p.Cfg.DimensionMappings {
+	for i, m := range p.Cfg.DimensionMappings {
+		// Plain concatenation: source lists are short (1-3 entries), where
+		// strings.Builder allocates more than simple concatenation.
 		values := ""
 		for _, s := range m.SourceLabel {
 			if value, _ := processor_util.FindAttributeValue(s, rs.Attributes, span.Attributes); value != "" {
 				if values == "" {
-					values += value
+					values = value
 				} else {
 					values = values + m.Join + value
 				}
 			}
 		}
-		label := validation.SanitizeLabelNameWithCollisions(m.Name, validation.SupportedIntrinsicDimensionsSet, p.sanitizeCache.Get)
-		builder.Add(label, values)
+		builder.Add(p.dimensionMappingLabels[i], values)
 	}
 
 	// add job label only if job is not blank and target_info is enabled
@@ -199,7 +220,10 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 		identifyingLabels++
 	}
 
-	spanMultiplier := processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs, p.Cfg.EnableTraceStateSpanMultiplier)
+	spanMultiplier := 1.0
+	if p.usesSpanMultiplier {
+		spanMultiplier = processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs, p.Cfg.EnableTraceStateSpanMultiplier)
+	}
 
 	registryLabelValues, validUTF8 := builder.CloseAndBuildLabels()
 	if !validUTF8 {
@@ -249,10 +273,54 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 	}
 }
 
-func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude []string, sanitizeFn validation.SanitizeFn) {
-	// TODO allocate with known length, or take new params for existing buffers
-	*keys = (*keys)[:0]
-	*values = (*values)[:0]
+func getResourceServiceLabels(attributes []*v1_common.KeyValue) (svcName string, jobName string, instanceID string) {
+	var (
+		namespace       string
+		foundSvcName    bool
+		foundNamespace  bool
+		foundInstanceID bool
+	)
+
+	for _, kv := range attributes {
+		switch kv.Key {
+		case serviceNameKey:
+			if !foundSvcName {
+				svcName = tempo_util.StringifyAnyValue(kv.Value)
+				foundSvcName = true
+			}
+		case serviceNamespaceKey:
+			if !foundNamespace {
+				namespace = tempo_util.StringifyAnyValue(kv.Value)
+				foundNamespace = true
+			}
+		case serviceInstanceIDKey:
+			if !foundInstanceID {
+				instanceID = tempo_util.StringifyAnyValue(kv.Value)
+				foundInstanceID = true
+			}
+		}
+	}
+
+	if svcName == "" {
+		return svcName, "", instanceID
+	}
+	if namespace == "" {
+		return svcName, svcName, instanceID
+	}
+	return svcName, namespace + "/" + svcName, instanceID
+}
+
+func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude map[string]struct{}, sanitizeFn validation.SanitizeFn) {
+	if cap(*keys) < len(attributes) {
+		*keys = make([]string, 0, len(attributes))
+	} else {
+		*keys = (*keys)[:0]
+	}
+	if cap(*values) < len(attributes) {
+		*values = make([]string, 0, len(attributes))
+	} else {
+		*values = (*values)[:0]
+	}
 	for _, attrs := range attributes {
 		// ignoring job and instance
 		key := attrs.Key
@@ -262,10 +330,55 @@ func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_comm
 		if key == "" || (key[0] >= '0' && key[0] <= '9') {
 			continue
 		}
-		if key != "service.name" && key != "service.namespace" && key != "service.instance.id" && !slices.Contains(exclude, key) {
+		if _, ok := exclude[key]; key != serviceNameKey && key != serviceNamespaceKey && key != serviceInstanceIDKey && !ok {
 			*keys = append(*keys, validation.SanitizeLabelNameWithCollisions(key, targetInfoIntrinsicLabelsSet, sanitizeFn))
 			value := tempo_util.StringifyAnyValue(attrs.Value)
 			*values = append(*values, value)
 		}
+	}
+}
+
+func excludedDimensionsSet(exclude []string) map[string]struct{} {
+	if len(exclude) == 0 {
+		return nil
+	}
+	m := make(map[string]struct{}, len(exclude))
+	for _, dim := range exclude {
+		m[dim] = struct{}{}
+	}
+	return m
+}
+
+// spanKindString and statusCodeString return the enum's .String() value
+// without the map lookup, falling back to .String() for unknown values.
+func spanKindString(kind v1_trace.Span_SpanKind) string {
+	switch kind {
+	case v1_trace.Span_SPAN_KIND_UNSPECIFIED:
+		return "SPAN_KIND_UNSPECIFIED"
+	case v1_trace.Span_SPAN_KIND_INTERNAL:
+		return "SPAN_KIND_INTERNAL"
+	case v1_trace.Span_SPAN_KIND_SERVER:
+		return "SPAN_KIND_SERVER"
+	case v1_trace.Span_SPAN_KIND_CLIENT:
+		return "SPAN_KIND_CLIENT"
+	case v1_trace.Span_SPAN_KIND_PRODUCER:
+		return "SPAN_KIND_PRODUCER"
+	case v1_trace.Span_SPAN_KIND_CONSUMER:
+		return "SPAN_KIND_CONSUMER"
+	default:
+		return kind.String()
+	}
+}
+
+func statusCodeString(code v1_trace.Status_StatusCode) string {
+	switch code {
+	case v1_trace.Status_STATUS_CODE_UNSET:
+		return "STATUS_CODE_UNSET"
+	case v1_trace.Status_STATUS_CODE_OK:
+		return "STATUS_CODE_OK"
+	case v1_trace.Status_STATUS_CODE_ERROR:
+		return "STATUS_CODE_ERROR"
+	default:
+		return code.String()
 	}
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
@@ -1,0 +1,182 @@
+package spanmetrics
+
+import (
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/pkg/sharedconfig"
+	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func BenchmarkSpanMetricsPushSpans(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		tune    func(*Config)
+		request *tempopb.PushSpansRequest
+	}{
+		{
+			name:    "default",
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "target_info",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = true
+				cfg.TargetInfoExcludedDimensions = []string{"excluded"}
+			},
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "target_info_all_filtered",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = true
+				cfg.TargetInfoExcludedDimensions = []string{"excluded"}
+				cfg.FilterPolicies = []filterconfig.FilterPolicy{{
+					Exclude: &filterconfig.PolicyMatch{
+						MatchType: filterconfig.Strict,
+						Attributes: []filterconfig.MatchPolicyAttribute{{
+							Key:   "span.http.method",
+							Value: "GET",
+						}},
+					},
+				}}
+			},
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "dimensions_and_mappings",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = false
+				cfg.Dimensions = []string{
+					"k8s.cluster.name",
+					"k8s.namespace.name",
+					"http.method",
+					"http.status_code",
+					"span.attr.1",
+					"span.attr.2",
+				}
+				cfg.DimensionMappings = []sharedconfig.DimensionMappings{
+					{Name: "route_key", SourceLabel: []string{"http.method", "http.route", "http.status_code"}, Join: ":"},
+					{Name: "pod_key", SourceLabel: []string{"k8s.namespace.name", "k8s.pod.name"}, Join: "/"},
+				}
+			},
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "count_only",
+			tune: func(cfg *Config) {
+				cfg.Subprocessors[Latency] = false
+				cfg.Subprocessors[Size] = false
+			},
+			request: benchmarkSpanMetricsRequest(false),
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			if tc.tune != nil {
+				tc.tune(&cfg)
+			}
+
+			p, err := New(
+				cfg,
+				registry.NewTestRegistry(),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer p.Shutdown(context.Background())
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				p.PushSpans(context.Background(), tc.request)
+			}
+		})
+	}
+}
+
+func benchmarkSpanMetricsRequest(sameTracePerResource bool) *tempopb.PushSpansRequest {
+	const (
+		resources        = 4
+		spansPerResource = 100
+	)
+
+	req := &tempopb.PushSpansRequest{
+		Batches: make([]*trace_v1.ResourceSpans, 0, resources),
+	}
+	for r := 0; r < resources; r++ {
+		rs := &trace_v1.ResourceSpans{
+			Resource: &resource_v1.Resource{
+				Attributes: []*common_v1.KeyValue{
+					benchmarkStringAttr("service.name", "svc-"+strconv.Itoa(r)),
+					benchmarkStringAttr("service.namespace", "ns-"+strconv.Itoa(r%2)),
+					benchmarkStringAttr("service.instance.id", "instance-"+strconv.Itoa(r)),
+					benchmarkStringAttr("k8s.cluster.name", "cluster-a"),
+					benchmarkStringAttr("k8s.namespace.name", "namespace-"+strconv.Itoa(r%4)),
+					benchmarkStringAttr("k8s.pod.name", "pod-"+strconv.Itoa(r)),
+					benchmarkStringAttr("k8s.node.name", "node-"+strconv.Itoa(r%8)),
+					benchmarkStringAttr("telemetry.sdk.language", "go"),
+					benchmarkStringAttr("telemetry.sdk.version", "1.0.0"),
+					benchmarkStringAttr("excluded", "drop-me"),
+				},
+			},
+			ScopeSpans: []*trace_v1.ScopeSpans{{}},
+		}
+		for s := 0; s < spansPerResource; s++ {
+			traceID := benchmarkTraceID(r)
+			if !sameTracePerResource {
+				traceID = benchmarkTraceID(r*spansPerResource + s)
+			}
+			rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, &trace_v1.Span{
+				TraceId:           traceID,
+				SpanId:            benchmarkSpanID(r*spansPerResource + s + 1),
+				Name:              "GET /api/:id",
+				Kind:              trace_v1.Span_SPAN_KIND_SERVER,
+				StartTimeUnixNano: uint64(1_700_000_000_000_000_000 + s),
+				EndTimeUnixNano:   uint64(1_700_000_000_100_000_000 + s),
+				Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+				Attributes: []*common_v1.KeyValue{
+					benchmarkStringAttr("http.method", "GET"),
+					benchmarkStringAttr("http.route", "/api/:id"),
+					benchmarkStringAttr("http.status_code", "200"),
+					benchmarkStringAttr("span.attr.1", "one"),
+					benchmarkStringAttr("span.attr.2", "two"),
+				},
+			})
+		}
+		req.Batches = append(req.Batches, rs)
+	}
+	return req
+}
+
+func benchmarkTraceID(i int) []byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSpanID(i int) []byte {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkStringAttr(key, value string) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{
+			StringValue: value,
+		}},
+	}
+}

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -1873,3 +1873,73 @@ func TestSpanMetricsTraceStateMultiplier(t *testing.T) {
 	// With 50% sampling (th:8), span multiplier is 2, so 1 span → count of 2
 	assert.Equal(t, 2.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
 }
+
+func TestGetResourceServiceLabels(t *testing.T) {
+	strAttr := func(key, value string) *common_v1.KeyValue {
+		return &common_v1.KeyValue{Key: key, Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: value}}}
+	}
+
+	testCases := []struct {
+		name           string
+		attrs          []*common_v1.KeyValue
+		wantSvcName    string
+		wantJobName    string
+		wantInstanceID string
+	}{
+		{
+			name:        "service name only",
+			attrs:       []*common_v1.KeyValue{strAttr("service.name", "svc")},
+			wantSvcName: "svc",
+			wantJobName: "svc",
+		},
+		{
+			name: "service name, namespace and instance id",
+			attrs: []*common_v1.KeyValue{
+				strAttr("service.name", "svc"),
+				strAttr("service.namespace", "ns"),
+				strAttr("service.instance.id", "instance-1"),
+			},
+			wantSvcName:    "svc",
+			wantJobName:    "ns/svc",
+			wantInstanceID: "instance-1",
+		},
+		{
+			name:  "namespace without service name yields empty job",
+			attrs: []*common_v1.KeyValue{strAttr("service.namespace", "ns")},
+		},
+		{
+			name:        "first occurrence wins",
+			attrs:       []*common_v1.KeyValue{strAttr("service.name", "first"), strAttr("service.name", "second")},
+			wantSvcName: "first",
+			wantJobName: "first",
+		},
+		{
+			// regression: a KeyValue with an absent value is valid proto3 and
+			// must not panic, see StringifyAnyValue
+			name:  "nil-valued service.namespace without service.name",
+			attrs: []*common_v1.KeyValue{{Key: "service.namespace", Value: nil}},
+		},
+		{
+			name:  "nil-valued service.name",
+			attrs: []*common_v1.KeyValue{{Key: "service.name", Value: nil}},
+		},
+		{
+			name: "nil-valued service.instance.id",
+			attrs: []*common_v1.KeyValue{
+				strAttr("service.name", "svc"),
+				{Key: "service.instance.id", Value: nil},
+			},
+			wantSvcName: "svc",
+			wantJobName: "svc",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svcName, jobName, instanceID := getResourceServiceLabels(tc.attrs)
+			assert.Equal(t, tc.wantSvcName, svcName)
+			assert.Equal(t, tc.wantJobName, jobName)
+			assert.Equal(t, tc.wantInstanceID, instanceID)
+		})
+	}
+}

--- a/pkg/util/attributes.go
+++ b/pkg/util/attributes.go
@@ -6,7 +6,12 @@ import (
 	v1common "github.com/grafana/tempo/pkg/tempopb/common/v1"
 )
 
+// StringifyAnyValue renders an attribute value as a string. A nil value is
+// valid proto3 (a KeyValue with no value) and stringifies to "".
 func StringifyAnyValue(anyValue *v1common.AnyValue) string {
+	if anyValue == nil {
+		return ""
+	}
 	switch anyValue.Value.(type) {
 	case *v1common.AnyValue_BoolValue:
 		return strconv.FormatBool(anyValue.GetBoolValue())

--- a/pkg/util/attributes_test.go
+++ b/pkg/util/attributes_test.go
@@ -82,6 +82,43 @@ func TestStringifyAnyValue(t *testing.T) {
 			},
 			expected: "{key:value}",
 		},
+		{
+			name:     "nil value",
+			v:        nil,
+			expected: "",
+		},
+		{
+			name:     "unset value",
+			v:        &v1common.AnyValue{},
+			expected: "",
+		},
+		{
+			name: "array with nil element",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_ArrayValue{
+					ArrayValue: &v1common.ArrayValue{
+						Values: []*v1common.AnyValue{
+							nil,
+							{Value: &v1common.AnyValue_StringValue{StringValue: "test"}},
+						},
+					},
+				},
+			},
+			expected: "[test]",
+		},
+		{
+			name: "map with nil value",
+			v: &v1common.AnyValue{
+				Value: &v1common.AnyValue_KvlistValue{
+					KvlistValue: &v1common.KeyValueList{
+						Values: []*v1common.KeyValue{
+							{Key: "key", Value: nil},
+						},
+					},
+				},
+			},
+			expected: "{key:}",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Behavior-preserving micro-optimizations on the per-span path:
- precompute sanitized dimension label names at construction
- scan resource attributes once for service.name/namespace/instance.id
- skip the enum-map lookup for span kind and status code
- skip span-multiplier resolution when none is configured
- build service-graph edge keys without intermediate hex-string allocations
- filter expired spans in place instead of allocating a new slice per scope

Also harden StringifyAnyValue with a nil-value guard: a nil attribute value
(valid proto3) now returns "" rather than relying on the value being set.
Defensive only - this path has run for years without an issue.

No metric names, labels, or span-filtering behavior change. Adds
per-processor benchmarks and unit tests for the new paths.

Split from #7124.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)