### PR TITLE
spanfilter: fast paths for intrinsic policy matching

### DIFF
--- a/.chloggen/spanfilter-fast-path.yaml
+++ b/.chloggen/spanfilter-fast-path.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 component: metrics-generator
 note: Fast-path span filter matching for the default span-kind regex and evaluate intrinsic filters before attribute filters.
-issues: [7124]
+issues: [7465]
 subtext:
 user: carles-grafana

--- a/.chloggen/spanfilter-fast-path.yaml
+++ b/.chloggen/spanfilter-fast-path.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: metrics-generator
+note: Fast-path span filter matching for the default span-kind regex and evaluate intrinsic filters before attribute filters.
+issues: [7124]
+subtext:
+user: carles-grafana

--- a/pkg/spanfilter/policymatch/intrinsic.go
+++ b/pkg/spanfilter/policymatch/intrinsic.go
@@ -38,6 +38,7 @@ type IntrinsicFilter struct {
 	statusCode tracev1.Status_StatusCode
 	kind       tracev1.Span_SpanKind
 	regex      *regexp.Regexp
+	kindMask   uint8
 }
 
 // NewStrictIntrinsicFilter returns a new IntrinsicFilter that matches spans based on the given intrinsic and value.
@@ -98,7 +99,12 @@ func NewRegexpIntrinsicFilter(intrinsic traceql.Intrinsic, value interface{}) (I
 		return IntrinsicFilter{}, fmt.Errorf("invalid intrinsic filter regex: %v", err)
 	}
 	switch intrinsic {
-	case traceql.IntrinsicName, traceql.IntrinsicStatus, traceql.IntrinsicKind:
+	case traceql.IntrinsicName, traceql.IntrinsicStatus:
+		return IntrinsicFilter{intrinsic: intrinsic, regex: r}, nil
+	case traceql.IntrinsicKind:
+		if mask := kindRegexMask(stringValue); mask != 0 {
+			return IntrinsicFilter{intrinsic: intrinsic, kindMask: mask}, nil
+		}
 		return IntrinsicFilter{intrinsic: intrinsic, regex: r}, nil
 	default:
 		return IntrinsicFilter{}, fmt.Errorf("intrinsic not supported %s", intrinsic)
@@ -119,11 +125,52 @@ func (a *IntrinsicFilter) Matches(span *tracev1.Span) bool {
 		}
 		return a.statusCode == span.GetStatus().GetCode()
 	case traceql.IntrinsicKind:
+		if a.kindMask != 0 {
+			return a.kindMask&spanKindMask(span.Kind) != 0
+		}
 		if a.regex != nil {
 			return a.regex.MatchString(span.Kind.String())
 		}
 		return a.kind == span.Kind
 	default:
 		return false
+	}
+}
+
+const (
+	spanKindServerBit uint8 = 1 << iota
+	spanKindClientBit
+	spanKindProducerBit
+	spanKindConsumerBit
+)
+
+// kindRegexMask returns a bitmask for the regex if the regex is one of the
+// hard-coded canonical alternations matching all real span kinds. Any other
+// regex (including semantically equivalent ones with different ordering,
+// anchors, or whitespace) returns 0 and forces a fallback to the regexp engine.
+// This is intentionally narrow: it accelerates only the default service-graph
+// filter shipped in pkg/spanfilter/config defaults. Operators who customize the
+// kind filter will silently lose this fast path.
+func kindRegexMask(regex string) uint8 {
+	switch regex {
+	case "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)":
+		return spanKindServerBit | spanKindConsumerBit | spanKindClientBit | spanKindProducerBit
+	default:
+		return 0
+	}
+}
+
+func spanKindMask(kind tracev1.Span_SpanKind) uint8 {
+	switch kind {
+	case tracev1.Span_SPAN_KIND_SERVER:
+		return spanKindServerBit
+	case tracev1.Span_SPAN_KIND_CLIENT:
+		return spanKindClientBit
+	case tracev1.Span_SPAN_KIND_PRODUCER:
+		return spanKindProducerBit
+	case tracev1.Span_SPAN_KIND_CONSUMER:
+		return spanKindConsumerBit
+	default:
+		return 0
 	}
 }

--- a/pkg/spanfilter/policymatch/intrinsic_test.go
+++ b/pkg/spanfilter/policymatch/intrinsic_test.go
@@ -218,3 +218,35 @@ func TestIntrinsicPolicyMatch_Matches(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkIntrinsicFilterMatches(b *testing.B) {
+	span := &tracev1.Span{
+		Kind: tracev1.Span_SPAN_KIND_SERVER,
+		Name: "GET /api/users",
+		Status: &tracev1.Status{
+			Code: tracev1.Status_STATUS_CODE_OK,
+		},
+	}
+
+	// The default service-graphs filter shape: takes the bitmask fast path.
+	b.Run("kind_default_alternation", func(b *testing.B) {
+		f, err := NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")
+		require.NoError(b, err)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = f.Matches(span)
+		}
+	})
+
+	// A custom pattern: falls back to the regexp engine.
+	b.Run("kind_custom_regex", func(b *testing.B) {
+		f, err := NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(CLIENT|SERVER)")
+		require.NoError(b, err)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = f.Matches(span)
+		}
+	})
+}

--- a/pkg/spanfilter/policymatch/intrinsic_test.go
+++ b/pkg/spanfilter/policymatch/intrinsic_test.go
@@ -138,6 +138,77 @@ func TestIntrinsicPolicyMatch_Matches(t *testing.T) {
 				Name: "test",
 			},
 		},
+		{
+			name:   "optimized regex kind matches SERVER",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_SERVER},
+		},
+		{
+			name:   "optimized regex kind matches CLIENT",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_CLIENT},
+		},
+		{
+			name:   "optimized regex kind matches PRODUCER",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_PRODUCER},
+		},
+		{
+			name:   "optimized regex kind matches CONSUMER",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_CONSUMER},
+		},
+		{
+			name:   "optimized regex kind rejects INTERNAL",
+			expect: false,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_INTERNAL},
+		},
+		{
+			name:   "optimized regex kind rejects UNSPECIFIED",
+			expect: false,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_UNSPECIFIED},
+		},
+		{
+			name:   "non-canonical regex kind falls back to engine and matches SERVER",
+			expect: true,
+			policy: &IntrinsicPolicyMatch{
+				filters: []IntrinsicFilter{
+					// Different alternation order — must NOT take the bitmask fast path.
+					must(NewRegexpIntrinsicFilter(traceql.IntrinsicKind, "SPAN_KIND_(CLIENT|SERVER)")),
+				},
+			},
+			span: &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_SERVER},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/spanfilter/splitpolicy.go
+++ b/pkg/spanfilter/splitpolicy.go
@@ -84,7 +84,7 @@ func newSplitPolicy(policy *config.PolicyMatch) (*splitPolicy, error) {
 
 // Match returns true when the resource attributes and span attributes match the policy.
 func (p *splitPolicy) Match(rs *v1.Resource, span *tracev1.Span) bool {
-	return (p.ResourceMatch == nil || p.ResourceMatch.Matches(rs.Attributes)) &&
-		(p.SpanMatch == nil || p.SpanMatch.Matches(span.Attributes)) &&
-		(p.IntrinsicMatch == nil || p.IntrinsicMatch.Matches(span))
+	return (p.IntrinsicMatch == nil || p.IntrinsicMatch.Matches(span)) &&
+		(p.ResourceMatch == nil || p.ResourceMatch.Matches(rs.Attributes)) &&
+		(p.SpanMatch == nil || p.SpanMatch.Matches(span.Attributes))
 }


### PR DESCRIPTION
- Match the canonical default span-kind alternation SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER) with a bitmask instead of the regexp engine. Only that exact pattern takes the fast path; any custom pattern falls back to the regex with identical results.
- Evaluate intrinsic filters before resource/span attribute filters; the conjunction is result-equivalent and the kind check is the cheapest rejection for the default service-graphs filter.

Split from #7124.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)