### PR TITLE
feat: add experimental trace diff command to Tempo CLI

### DIFF
--- a/.chloggen/trace-diff-v0.yaml
+++ b/.chloggen/trace-diff-v0.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: tempo-cli
+note: Add an experimental trace diff command that compares two local trace JSON files and emits trace-patch-v0 output.
+issues: []
+subtext:
+user: javiermolinar

--- a/cmd/tempo-cli/cmd-experimental-trace-diff.go
+++ b/cmd/tempo-cli/cmd-experimental-trace-diff.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/gogo/protobuf/jsonpb"
+
+	"github.com/grafana/tempo/pkg/model/tracediff"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+type experimentalTraceDiffCmd struct {
+	TraceA string `name:"trace-a" type:"path" required:"" help:"Baseline trace JSON file"`
+	TraceB string `name:"trace-b" type:"path" required:"" help:"Comparison trace JSON file"`
+	Format string `help:"Output format" default:"trace-patch-v0" enum:"trace-patch-v0"`
+	Out    string `short:"o" type:"path" help:"File to write output to, instead of stdout" default:""`
+	Pretty bool   `help:"Pretty-print JSON output"`
+}
+
+func (cmd *experimentalTraceDiffCmd) Run(_ *globalOptions) error {
+	base, err := readTraceJSONFile(cmd.TraceA)
+	if err != nil {
+		return fmt.Errorf("read trace-a: %w", err)
+	}
+	compare, err := readTraceJSONFile(cmd.TraceB)
+	if err != nil {
+		return fmt.Errorf("read trace-b: %w", err)
+	}
+
+	result, err := tracediff.Diff(base, compare, tracediff.Format(cmd.Format))
+	if err != nil {
+		return err
+	}
+
+	out := io.Writer(os.Stdout)
+	var file *os.File
+	if cmd.Out != "" {
+		file, err = os.Create(cmd.Out)
+		if err != nil {
+			return fmt.Errorf("create output file: %w", err)
+		}
+		defer file.Close()
+		out = file
+	}
+
+	enc := json.NewEncoder(out)
+	if cmd.Pretty {
+		enc.SetIndent("", "  ")
+	}
+	return enc.Encode(result)
+}
+
+func readTraceJSONFile(path string) (*tempopb.Trace, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if trace, ok := unmarshalTraceByIDResponse(bytes); ok {
+		return trace, nil
+	}
+
+	trace := &tempopb.Trace{}
+	if err := tempopb.UnmarshalFromJSONV1(bytes, trace); err != nil {
+		return nil, err
+	}
+	return trace, nil
+}
+
+func unmarshalTraceByIDResponse(bytes []byte) (*tempopb.Trace, bool) {
+	resp := &tempopb.TraceByIDResponse{}
+	if err := jsonpb.UnmarshalString(string(bytes), resp); err != nil {
+		return nil, false
+	}
+	if resp.Trace == nil {
+		return nil, false
+	}
+	return resp.Trace, true
+}

--- a/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
+++ b/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/tempo/pkg/model/tracediff"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExperimentalTraceDiffWritesTracePatch(t *testing.T) {
+	dir := t.TempDir()
+	traceA := filepath.Join(dir, "trace-a.json")
+	traceB := filepath.Join(dir, "trace-b.json")
+	out := filepath.Join(dir, "diff.json")
+	require.NoError(t, os.WriteFile(traceA, []byte(`{}`), 0o600))
+	require.NoError(t, os.WriteFile(traceB, []byte(`{}`), 0o600))
+
+	cmd := experimentalTraceDiffCmd{
+		TraceA: traceA,
+		TraceB: traceB,
+		Format: string(tracediff.FormatTracePatchV0),
+		Out:    out,
+	}
+	require.NoError(t, cmd.Run(nil))
+
+	bytes, err := os.ReadFile(out)
+	require.NoError(t, err)
+
+	var result tracediff.Result
+	require.NoError(t, json.Unmarshal(bytes, &result))
+	require.Equal(t, tracediff.VersionTracePatchV0, result.Version)
+	require.Empty(t, result.Modified)
+	require.Empty(t, result.Added)
+	require.Empty(t, result.Removed)
+}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -93,6 +93,10 @@ var cli struct {
 		Columns suggestColumnsCmd `cmd:"" help:"Suggest columns for a tenant"`
 	} `cmd:""`
 
+	Experimental struct {
+		TraceDiff experimentalTraceDiffCmd `cmd:"" help:"Compare two local trace JSON files and emit an experimental trace-aware patch"`
+	} `cmd:""`
+
 	Redact redactCmd `cmd:"" help:"Submit a redaction request to the backend scheduler"`
 }
 

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -1,0 +1,244 @@
+package tracediff
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+var ErrNilTrace = errors.New("trace is nil")
+var ErrUnsupportedFormat = errors.New("unsupported trace diff format")
+
+// Diff compares base and compare and returns the requested diff format.
+func Diff(base, compare *tempopb.Trace, format Format) (*Result, error) {
+	if base == nil {
+		return nil, fmt.Errorf("base: %w", ErrNilTrace)
+	}
+	if compare == nil {
+		return nil, fmt.Errorf("compare: %w", ErrNilTrace)
+	}
+	if format != FormatTracePatchV0 {
+		return nil, fmt.Errorf("%q: %w", format, ErrUnsupportedFormat)
+	}
+
+	baseTrace := normalizeTrace(base)
+	compareTrace := normalizeTrace(compare)
+	matched, modified, added, removed := diffSpanPresence(baseTrace, compareTrace)
+
+	return &Result{
+		Version: VersionTracePatchV0,
+		Base:    baseTrace.meta,
+		Compare: compareTrace.meta,
+		Stats: Stats{
+			SpanCountA:       baseTrace.meta.SpanCount,
+			SpanCountB:       compareTrace.meta.SpanCount,
+			MatchedSpans:     matched,
+			ModifiedSpans:    len(modified),
+			AddedSpans:       len(added),
+			RemovedSpans:     len(removed),
+			FieldChanges:     countChanges(modified, TargetField),
+			AttributeChanges: countChanges(modified, TargetAttribute),
+		},
+		Modified: modified,
+		Added:    added,
+		Removed:  removed,
+		Warnings: []Warning{},
+	}, nil
+}
+
+func diffSpanPresence(base, compare normalizedTrace) (int, []ModifiedSpan, []SpanChange, []SpanChange) {
+	baseByKey := indexByMatchKey(base)
+	compareByKey := indexByMatchKey(compare)
+
+	var matched int
+	modified := make([]ModifiedSpan, 0)
+	added := make([]SpanChange, 0)
+	removed := make([]SpanChange, 0)
+	for _, span := range compare.spans {
+		baseSpan, ok := baseByKey[span.matchKey]
+		if ok {
+			matched++
+			changes := fieldChanges(baseSpan, span)
+			changes = append(changes, attributeChanges(baseSpan, span)...)
+			if len(changes) > 0 {
+				modified = append(modified, ModifiedSpan{
+					Span:    span.ref,
+					Changes: changes,
+				})
+			}
+			continue
+		}
+		added = append(added, SpanChange{
+			Target: addedSpanTarget(span.snapshot.Path),
+			Span:   span.snapshot,
+		})
+	}
+	for _, span := range base.spans {
+		if _, ok := compareByKey[span.matchKey]; ok {
+			continue
+		}
+		removed = append(removed, SpanChange{
+			Target: SpanTarget{Type: TargetSpan, Path: span.snapshot.Path},
+			Span:   span.snapshot,
+		})
+	}
+	return matched, modified, added, removed
+}
+
+func fieldChanges(base, compare normalizedSpan) []Change {
+	changes := make([]Change, 0, 2)
+	if base.snapshot.DurationMs != compare.snapshot.DurationMs {
+		changes = append(changes, Change{
+			Op:     OperationModify,
+			Target: Target{Type: TargetField, Name: "duration_ms"},
+			Before: base.snapshot.DurationMs,
+			After:  compare.snapshot.DurationMs,
+		})
+	}
+	if base.snapshot.Status != compare.snapshot.Status {
+		changes = append(changes, Change{
+			Op:     OperationModify,
+			Target: Target{Type: TargetField, Name: "status"},
+			Before: base.snapshot.Status,
+			After:  compare.snapshot.Status,
+		})
+	}
+	return changes
+}
+
+func attributeChanges(base, compare normalizedSpan) []Change {
+	changes := make([]Change, 0)
+
+	baseAttrs := base.spanAttrs
+	compareAttrs := compare.spanAttrs
+	for _, key := range sortedAttributeKeys(baseAttrs, compareAttrs) {
+		before, inBase := baseAttrs[key]
+		after, inCompare := compareAttrs[key]
+		target := Target{Type: TargetAttribute, Scope: "span", Key: key}
+
+		switch {
+		case !inBase:
+			changes = append(changes, Change{Op: OperationAdd, Target: target, Before: nil, After: after})
+		case !inCompare:
+			changes = append(changes, Change{Op: OperationRemove, Target: target, Before: before, After: nil})
+		case !valuesEqual(before, after):
+			changes = append(changes, Change{Op: OperationModify, Target: target, Before: before, After: after})
+		}
+	}
+	return changes
+}
+
+func valuesEqual(a, b any) bool {
+	switch av := a.(type) {
+	case nil:
+		return b == nil
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case int64:
+		bv, ok := b.(int64)
+		return ok && av == bv
+	case float64:
+		bv, ok := b.(float64)
+		return ok && av == bv
+	case []byte:
+		bv, ok := b.([]byte)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if av[i] != bv[i] {
+				return false
+			}
+		}
+		return true
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !valuesEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for key, val := range av {
+			other, ok := bv[key]
+			if !ok || !valuesEqual(val, other) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func sortedAttributeKeys(base, compare map[string]any) []string {
+	seen := make(map[string]struct{}, len(base)+len(compare))
+	keys := make([]string, 0, len(base)+len(compare))
+	for key := range base {
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	for key := range compare {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func countChanges(modified []ModifiedSpan, targetType TargetType) int {
+	var count int
+	for _, span := range modified {
+		for _, change := range span.Changes {
+			if change.Target.Type == targetType {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func indexByMatchKey(trace normalizedTrace) map[spanMatchKey]normalizedSpan {
+	out := make(map[spanMatchKey]normalizedSpan, len(trace.spans))
+	for _, span := range trace.spans {
+		out[span.matchKey] = span
+	}
+	return out
+}
+
+func addedSpanTarget(path []int) SpanTarget {
+	index := 0
+	if len(path) > 0 {
+		index = path[len(path)-1]
+	}
+	return SpanTarget{
+		Type:       TargetSpan,
+		ParentPath: parentPath(path),
+		Index:      &index,
+	}
+}
+
+func parentPath(path []int) []int {
+	if len(path) == 0 {
+		return nil
+	}
+	out := make([]int, len(path)-1)
+	copy(out, path[:len(path)-1])
+	return out
+}

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -25,9 +25,10 @@ func Diff(base, compare *tempopb.Trace, format Format) (*Result, error) {
 		return nil, fmt.Errorf("%q: %w", format, ErrUnsupportedFormat)
 	}
 
-	baseTrace := normalizeTrace(base)
-	compareTrace := normalizeTrace(compare)
-	matched, modified, added, removed := diffSpanPresence(baseTrace, compareTrace)
+	baseTrace, baseWarnings := normalizeTrace(base)
+	compareTrace, compareWarnings := normalizeTrace(compare)
+	matched, modified, added, removed := computeDiff(baseTrace, compareTrace)
+	warnings := mergeWarnings(baseWarnings, compareWarnings)
 
 	return &Result{
 		Version: VersionTracePatchV0,
@@ -46,39 +47,35 @@ func Diff(base, compare *tempopb.Trace, format Format) (*Result, error) {
 		Modified: modified,
 		Added:    added,
 		Removed:  removed,
-		Warnings: []Warning{},
+		Warnings: warnings,
 	}, nil
 }
 
-func diffSpanPresence(base, compare normalizedTrace) (int, []ModifiedSpan, []SpanChange, []SpanChange) {
-	baseByKey := indexByMatchKey(base)
-	compareByKey := indexByMatchKey(compare)
+func computeDiff(base, compare normalizedTrace) (int, []ModifiedSpan, []SpanChange, []SpanChange) {
+	baseSpanByCompareSpanID := matchSpans(base, compare)
+	matchedBaseSpanIDs := make(map[string]struct{}, len(baseSpanByCompareSpanID))
 
-	var matched int
 	modified := make([]ModifiedSpan, 0)
 	added := make([]SpanChange, 0)
 	removed := make([]SpanChange, 0)
+
 	for _, span := range compare.spans {
-		baseSpan, ok := baseByKey[span.matchKey]
-		if ok {
-			matched++
-			changes := fieldChanges(baseSpan, span)
-			changes = append(changes, attributeChanges(baseSpan, span)...)
-			if len(changes) > 0 {
-				modified = append(modified, ModifiedSpan{
-					Span:    span.ref,
-					Changes: changes,
-				})
-			}
+		baseSpan, ok := baseSpanByCompareSpanID[span.spanID]
+		if !ok {
+			added = append(added, SpanChange{Target: addedSpanTarget(span.snapshot.Path), Span: span.snapshot})
 			continue
 		}
-		added = append(added, SpanChange{
-			Target: addedSpanTarget(span.snapshot.Path),
-			Span:   span.snapshot,
-		})
+
+		matchedBaseSpanIDs[baseSpan.spanID] = struct{}{}
+		changes := fieldChanges(baseSpan, span)
+		changes = append(changes, attributeChanges(baseSpan, span)...)
+		if len(changes) > 0 {
+			modified = append(modified, ModifiedSpan{Span: span.ref, Changes: changes})
+		}
 	}
+
 	for _, span := range base.spans {
-		if _, ok := compareByKey[span.matchKey]; ok {
+		if _, ok := matchedBaseSpanIDs[span.spanID]; ok {
 			continue
 		}
 		removed = append(removed, SpanChange{
@@ -86,7 +83,77 @@ func diffSpanPresence(base, compare normalizedTrace) (int, []ModifiedSpan, []Spa
 			Span:   span.snapshot,
 		})
 	}
-	return matched, modified, added, removed
+
+	return len(matchedBaseSpanIDs), modified, added, removed
+}
+
+// matchSpans decides which base span, if any, matches each compare span.
+func matchSpans(base, compare normalizedTrace) map[string]normalizedSpan {
+	baseSpanByCompareSpanID := make(map[string]normalizedSpan)
+	usedBaseSpanIDs := make(map[string]struct{})
+	baseByID := bucketByIdentity(base)
+
+	for _, compareSpan := range compare.spans {
+		baseSpan, ok := findMatch(baseByID[compareSpan.identity()], compareSpan, usedBaseSpanIDs)
+		if !ok {
+			continue
+		}
+		baseSpanByCompareSpanID[compareSpan.spanID] = baseSpan
+		usedBaseSpanIDs[baseSpan.spanID] = struct{}{}
+	}
+	return baseSpanByCompareSpanID
+}
+
+// findMatch receives base spans with the same identity as compareSpan. Parent
+// identity is only a duplicate tie-breaker: if it cannot disambiguate, the first
+// unused candidate preserves the ancestor-insert behavior.
+func findMatch(baseCandidates []normalizedSpan, compareSpan normalizedSpan, usedBaseSpanIDs map[string]struct{}) (normalizedSpan, bool) {
+	var fallback normalizedSpan
+	fallbackSet := false
+	for _, baseSpan := range baseCandidates {
+		if _, ok := usedBaseSpanIDs[baseSpan.spanID]; ok {
+			continue
+		}
+		// Both spans share the same parent identity
+		if sameParentIdentity(baseSpan, compareSpan) {
+			return baseSpan, true
+		}
+		// If not we choose the first one as a fallback
+		if !fallbackSet {
+			fallback = baseSpan
+			fallbackSet = true
+		}
+	}
+	return fallback, fallbackSet
+}
+
+func sameParentIdentity(a, b normalizedSpan) bool {
+	return a.hasParent && b.hasParent && a.parentIdentity == b.parentIdentity
+}
+
+// bucketByIdentity groups spans by their flat identity.
+func bucketByIdentity(trace normalizedTrace) map[spanLogicalKey][]normalizedSpan {
+	out := make(map[spanLogicalKey][]normalizedSpan, len(trace.spans))
+	for _, s := range trace.spans {
+		id := s.identity()
+		out[id] = append(out[id], s)
+	}
+	return out
+}
+
+func mergeWarnings(warningGroups ...[]Warning) []Warning {
+	out := make([]Warning, 0)
+	seen := make(map[string]struct{})
+	for _, group := range warningGroups {
+		for _, warning := range group {
+			if _, ok := seen[warning.Code]; ok {
+				continue
+			}
+			seen[warning.Code] = struct{}{}
+			out = append(out, warning)
+		}
+	}
+	return out
 }
 
 func fieldChanges(base, compare normalizedSpan) []Change {
@@ -94,7 +161,7 @@ func fieldChanges(base, compare normalizedSpan) []Change {
 	if base.snapshot.DurationMs != compare.snapshot.DurationMs {
 		changes = append(changes, Change{
 			Op:     OperationModify,
-			Target: Target{Type: TargetField, Name: "duration_ms"},
+			Target: Target{Type: TargetField, Name: FieldDurationMs},
 			Before: base.snapshot.DurationMs,
 			After:  compare.snapshot.DurationMs,
 		})
@@ -102,7 +169,7 @@ func fieldChanges(base, compare normalizedSpan) []Change {
 	if base.snapshot.Status != compare.snapshot.Status {
 		changes = append(changes, Change{
 			Op:     OperationModify,
-			Target: Target{Type: TargetField, Name: "status"},
+			Target: Target{Type: TargetField, Name: FieldStatus},
 			Before: base.snapshot.Status,
 			After:  compare.snapshot.Status,
 		})
@@ -118,7 +185,7 @@ func attributeChanges(base, compare normalizedSpan) []Change {
 	for _, key := range sortedAttributeKeys(baseAttrs, compareAttrs) {
 		before, inBase := baseAttrs[key]
 		after, inCompare := compareAttrs[key]
-		target := Target{Type: TargetAttribute, Scope: "span", Key: key}
+		target := Target{Type: TargetAttribute, Scope: ScopeSpan, Key: key}
 
 		switch {
 		case !inBase:
@@ -214,14 +281,6 @@ func countChanges(modified []ModifiedSpan, targetType TargetType) int {
 		}
 	}
 	return count
-}
-
-func indexByMatchKey(trace normalizedTrace) map[spanMatchKey]normalizedSpan {
-	out := make(map[spanMatchKey]normalizedSpan, len(trace.spans))
-	for _, span := range trace.spans {
-		out[span.matchKey] = span
-	}
-	return out
 }
 
 func addedSpanTarget(path []int) SpanTarget {

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -8,8 +8,10 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 )
 
-var ErrNilTrace = errors.New("trace is nil")
-var ErrUnsupportedFormat = errors.New("unsupported trace diff format")
+var (
+	ErrNilTrace          = errors.New("trace is nil")
+	ErrUnsupportedFormat = errors.New("unsupported trace diff format")
+)
 
 // Diff compares base and compare and returns the requested diff format.
 func Diff(base, compare *tempopb.Trace, format Format) (*Result, error) {

--- a/pkg/model/tracediff/diff_test.go
+++ b/pkg/model/tracediff/diff_test.go
@@ -1,0 +1,320 @@
+package tracediff
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffRejectsNilInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    *tempopb.Trace
+		compare *tempopb.Trace
+	}{
+		{
+			name:    "nil base",
+			base:    nil,
+			compare: &tempopb.Trace{},
+		},
+		{
+			name:    "nil compare",
+			base:    &tempopb.Trace{},
+			compare: nil,
+		},
+		{
+			name:    "both nil",
+			base:    nil,
+			compare: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Diff(tt.base, tt.compare, FormatTracePatchV0)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrNilTrace))
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func TestDiffEmptyTracesReturnsEmptyResult(t *testing.T) {
+	got, err := Diff(&tempopb.Trace{}, &tempopb.Trace{}, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, &Result{
+		Version:  VersionTracePatchV0,
+		Modified: []ModifiedSpan{},
+		Added:    []SpanChange{},
+		Removed:  []SpanChange{},
+		Warnings: []Warning{},
+	}, got)
+}
+
+func TestDiffPopulatesTraceMeta(t *testing.T) {
+	base := traceWithSpans(
+		[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		[]byte{0x01},
+		[]byte{0x02},
+	)
+	compare := traceWithSpans(
+		[]byte{0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01},
+		[]byte{0x03},
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, TraceMeta{TraceID: "0102030405060708090a0b0c0d0e0f10", SpanCount: 2}, got.Base)
+	assert.Equal(t, TraceMeta{TraceID: "100f0e0d0c0b0a090807060504030201", SpanCount: 1}, got.Compare)
+}
+
+func TestDiffIdenticalTracesHaveNoChanges(t *testing.T) {
+	base := traceWithSpans(
+		[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		[]byte("root"),
+		[]byte("child"),
+	)
+	compare := traceWithSpans(
+		[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		[]byte("root"),
+		[]byte("child"),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:   2,
+		SpanCountB:   2,
+		MatchedSpans: 2,
+	}, got.Stats)
+	assert.Empty(t, got.Modified)
+	assert.Empty(t, got.Added)
+	assert.Empty(t, got.Removed)
+}
+
+func TestDiffReportsAddedAndRemovedSpans(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "old_child", "root", "inventory", "old reserve", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "new_child", "root", "inventory", "new reserve", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:   2,
+		SpanCountB:   2,
+		MatchedSpans: 1,
+		AddedSpans:   1,
+		RemovedSpans: 1,
+	}, got.Stats)
+	require.Len(t, got.Added, 1)
+	assert.Equal(t, "new reserve", got.Added[0].Span.Name)
+	assert.Equal(t, SpanTarget{Type: TargetSpan, ParentPath: []int{0}, Index: intPtr(0)}, got.Added[0].Target)
+	require.Len(t, got.Removed, 1)
+	assert.Equal(t, "old reserve", got.Removed[0].Span.Name)
+	assert.Equal(t, SpanTarget{Type: TargetSpan, Path: []int{0, 0}}, got.Removed[0].Target)
+}
+
+func TestDiffMatchesUnchangedSiblingsAfterInsertedSibling(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "base-root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "base-a", "base-root", "auth", "authorize", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "base-b", "base-root", "inventory", "reserve", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "compare-root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "compare-x", "compare-root", "cache", "warm", tracev1.Span_SPAN_KIND_CLIENT, 5, 10, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "compare-a", "compare-root", "auth", "authorize", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "compare-b", "compare-root", "inventory", "reserve", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:   3,
+		SpanCountB:   4,
+		MatchedSpans: 3,
+		AddedSpans:   1,
+	}, got.Stats)
+	require.Len(t, got.Added, 1)
+	assert.Equal(t, "warm", got.Added[0].Span.Name)
+	assert.Equal(t, SpanTarget{Type: TargetSpan, ParentPath: []int{0}, Index: intPtr(0)}, got.Added[0].Target)
+	assert.Empty(t, got.Removed)
+	assert.Empty(t, got.Modified)
+}
+
+func TestDiffReportsModifiedSpanFields(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 250, tracev1.Status_STATUS_CODE_ERROR),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:    1,
+		SpanCountB:    1,
+		MatchedSpans:  1,
+		ModifiedSpans: 1,
+		FieldChanges:  2,
+	}, got.Stats)
+	require.Len(t, got.Modified, 1)
+	assert.Equal(t, SpanRef{Path: []int{0}, Service: "checkout", Name: "POST /checkout", Kind: "server"}, got.Modified[0].Span)
+	assert.Equal(t, []Change{
+		{
+			Op:     OperationModify,
+			Target: Target{Type: TargetField, Name: "duration_ms"},
+			Before: int64(100),
+			After:  int64(250),
+		},
+		{
+			Op:     OperationModify,
+			Target: Target{Type: TargetField, Name: "status"},
+			Before: "ok",
+			After:  "error",
+		},
+	}, got.Modified[0].Changes)
+}
+
+func TestDiffReportsSpanAttributeChanges(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	baseSpan := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	baseSpan.Attributes = append(baseSpan.Attributes,
+		stringAttribute("removed.attr", "gone"),
+		stringAttribute("version", "v1"),
+	)
+	compareSpan := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	compareSpan.Attributes = append(compareSpan.Attributes,
+		stringAttribute("added.attr", "new"),
+		stringAttribute("version", "v2"),
+	)
+
+	got, err := Diff(traceWithNamedSpans(baseSpan), traceWithNamedSpans(compareSpan), FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:       1,
+		SpanCountB:       1,
+		MatchedSpans:     1,
+		ModifiedSpans:    1,
+		AttributeChanges: 3,
+	}, got.Stats)
+	require.Len(t, got.Modified, 1)
+	assert.Equal(t, []Change{
+		{
+			Op:     OperationAdd,
+			Target: Target{Type: TargetAttribute, Scope: "span", Key: "added.attr"},
+			Before: nil,
+			After:  "new",
+		},
+		{
+			Op:     OperationRemove,
+			Target: Target{Type: TargetAttribute, Scope: "span", Key: "removed.attr"},
+			Before: "gone",
+			After:  nil,
+		},
+		{
+			Op:     OperationModify,
+			Target: Target{Type: TargetAttribute, Scope: "span", Key: "version"},
+			Before: "v1",
+			After:  "v2",
+		},
+	}, got.Modified[0].Changes)
+}
+
+func TestDiffReportsArraySpanAttributeChanges(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	baseSpan := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	baseSpan.Attributes = append(baseSpan.Attributes,
+		stringArrayAttribute("feature.flags", "a", "b"),
+	)
+	compareSpan := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	compareSpan.Attributes = append(compareSpan.Attributes,
+		stringArrayAttribute("feature.flags", "a", "c"),
+	)
+
+	got, err := Diff(traceWithNamedSpans(baseSpan), traceWithNamedSpans(compareSpan), FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:       1,
+		SpanCountB:       1,
+		MatchedSpans:     1,
+		ModifiedSpans:    1,
+		AttributeChanges: 1,
+	}, got.Stats)
+	require.Len(t, got.Modified, 1)
+	assert.Equal(t, []Change{
+		{
+			Op:     OperationModify,
+			Target: Target{Type: TargetAttribute, Scope: "span", Key: "feature.flags"},
+			Before: []any{"a", "b"},
+			After:  []any{"a", "c"},
+		},
+	}, got.Modified[0].Changes)
+}
+
+func traceWithSpans(traceID []byte, spanIDs ...[]byte) *tempopb.Trace {
+	spans := make([]*tracev1.Span, 0, len(spanIDs))
+	for _, spanID := range spanIDs {
+		spans = append(spans, &tracev1.Span{
+			TraceId: traceID,
+			SpanId:  spanID,
+		})
+	}
+
+	return traceWithNamedSpans(spans...)
+}
+
+func traceWithNamedSpans(spans ...*tracev1.Span) *tempopb.Trace {
+	return &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				ScopeSpans: []*tracev1.ScopeSpans{
+					{Spans: spans},
+				},
+			},
+		},
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func stringArrayAttribute(key string, values ...string) *commonv1.KeyValue {
+	arrayValues := make([]*commonv1.AnyValue, 0, len(values))
+	for _, value := range values {
+		arrayValues = append(arrayValues, &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_StringValue{StringValue: value},
+		})
+	}
+	return &commonv1.KeyValue{
+		Key: key,
+		Value: &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_ArrayValue{
+				ArrayValue: &commonv1.ArrayValue{Values: arrayValues},
+			},
+		},
+	}
+}

--- a/pkg/model/tracediff/diff_test.go
+++ b/pkg/model/tracediff/diff_test.go
@@ -159,6 +159,154 @@ func TestDiffMatchesUnchangedSiblingsAfterInsertedSibling(t *testing.T) {
 	assert.Empty(t, got.Modified)
 }
 
+func TestDiffMatchesUnchangedSubtreeAfterInsertedAncestor(t *testing.T) {
+	// root -> A -> B -> C   vs   root -> X -> A -> B -> C
+	// X is inserted between the root and A; A, B, C are byte-identical, just one
+	// level deeper. The only real change is "X added". A matcher that keys on the
+	// full root-to-span path shifts every descendant's key and reports them all as
+	// removed+added (a cascade). The correct result is 1 added, the rest matched.
+	baseTraceID := []byte("trace-id-0000001")
+	cmpTraceID := []byte("trace-id-0000002")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(baseTraceID, "base-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-a", "base-root", "auth", "authorize", tracev1.Span_SPAN_KIND_SERVER, 10, 180, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-b", "base-a", "inventory", "reserve", tracev1.Span_SPAN_KIND_SERVER, 20, 150, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-c", "base-b", "db", "persist", tracev1.Span_SPAN_KIND_SERVER, 30, 120, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(cmpTraceID, "cmp-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(cmpTraceID, "cmp-x", "cmp-root", "proxy", "forward", tracev1.Span_SPAN_KIND_SERVER, 5, 190, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(cmpTraceID, "cmp-a", "cmp-x", "auth", "authorize", tracev1.Span_SPAN_KIND_SERVER, 10, 180, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(cmpTraceID, "cmp-b", "cmp-a", "inventory", "reserve", tracev1.Span_SPAN_KIND_SERVER, 20, 150, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(cmpTraceID, "cmp-c", "cmp-b", "db", "persist", tracev1.Span_SPAN_KIND_SERVER, 30, 120, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:   4,
+		SpanCountB:   5,
+		MatchedSpans: 4, // root, authorize, reserve, persist
+		AddedSpans:   1, // forward (X)
+	}, got.Stats)
+	require.Len(t, got.Added, 1)
+	assert.Equal(t, "forward", got.Added[0].Span.Name)
+	assert.Empty(t, got.Removed)
+	assert.Empty(t, got.Modified)
+}
+
+func TestDiffReportsAddedSubtreeInParentBeforeChildOrder(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "base-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "cmp-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "cmp-recommend", "cmp-root", "recommendations", "recommend", tracev1.Span_SPAN_KIND_SERVER, 10, 120, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "cmp-cache", "cmp-recommend", "cache", "lookup recommendations", tracev1.Span_SPAN_KIND_CLIENT, 20, 60, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "cmp-db", "cmp-cache", "db", "SELECT recommendations", tracev1.Span_SPAN_KIND_CLIENT, 30, 50, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:   1,
+		SpanCountB:   4,
+		MatchedSpans: 1,
+		AddedSpans:   3,
+	}, got.Stats)
+	require.Len(t, got.Added, 3)
+	assert.Equal(t, []string{"recommend", "lookup recommendations", "SELECT recommendations"}, []string{
+		got.Added[0].Span.Name,
+		got.Added[1].Span.Name,
+		got.Added[2].Span.Name,
+	})
+	assert.Equal(t, SpanTarget{Type: TargetSpan, ParentPath: []int{0}, Index: intPtr(0)}, got.Added[0].Target)
+	assert.Equal(t, SpanTarget{Type: TargetSpan, ParentPath: []int{0, 0}, Index: intPtr(0)}, got.Added[1].Target)
+	assert.Equal(t, SpanTarget{Type: TargetSpan, ParentPath: []int{0, 0, 0}, Index: intPtr(0)}, got.Added[2].Target)
+	assert.Empty(t, got.Removed)
+	assert.Empty(t, got.Modified)
+}
+
+func TestDiffMatchesDuplicateSpanIdentityByParent(t *testing.T) {
+	// Both branches contain a db span with the same logical identity. When the
+	// alpha branch is removed, the db span under beta should match the db span
+	// under beta, not the first db span in pre-order.
+	baseTraceID := []byte("trace-id-0000001")
+	cmpTraceID := []byte("trace-id-0000002")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(baseTraceID, "base-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-alpha", "base-root", "alpha", "call alpha", tracev1.Span_SPAN_KIND_SERVER, 10, 80, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-alpha-db", "base-alpha", "db", "SELECT users", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-beta", "base-root", "beta", "call beta", tracev1.Span_SPAN_KIND_SERVER, 100, 180, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-beta-db", "base-beta", "db", "SELECT users", tracev1.Span_SPAN_KIND_CLIENT, 110, 150, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(cmpTraceID, "cmp-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(cmpTraceID, "cmp-beta", "cmp-root", "beta", "call beta", tracev1.Span_SPAN_KIND_SERVER, 100, 180, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(cmpTraceID, "cmp-beta-db", "cmp-beta", "db", "SELECT users", tracev1.Span_SPAN_KIND_CLIENT, 110, 150, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:   5,
+		SpanCountB:   3,
+		MatchedSpans: 3,
+		RemovedSpans: 2,
+	}, got.Stats)
+	assert.Empty(t, got.Added)
+	assert.Empty(t, got.Modified)
+	require.Len(t, got.Removed, 2)
+	removedDBDurations := make([]int64, 0, 1)
+	for _, removed := range got.Removed {
+		if removed.Span.Service == "db" && removed.Span.Name == "SELECT users" {
+			removedDBDurations = append(removedDBDurations, removed.Span.DurationMs)
+		}
+	}
+	assert.Equal(t, []int64{10}, removedDBDurations)
+}
+
+func TestDiffWarnsAndUsesRawHighCardinalitySpanName(t *testing.T) {
+	// The span name embeds a per-request ID. That is an instrumentation problem:
+	// IDs belong in attributes, not span names. The diff should preserve raw-name
+	// matching for correctness and warn that equivalent operations may be reported
+	// as added/removed.
+	baseTraceID := []byte("trace-id-0000001")
+	cmpTraceID := []byte("trace-id-0000002")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(baseTraceID, "base-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(baseTraceID, "base-db", "base-root", "db", "SELECT id=3f2a1b9c-0001", tracev1.Span_SPAN_KIND_CLIENT, 10, 80, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(cmpTraceID, "cmp-root", "", "gateway", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 200, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(cmpTraceID, "cmp-db", "cmp-root", "db", "SELECT id=7c4e88d0-0002", tracev1.Span_SPAN_KIND_CLIENT, 10, 80, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:   2,
+		SpanCountB:   2,
+		MatchedSpans: 1,
+		AddedSpans:   1,
+		RemovedSpans: 1,
+	}, got.Stats)
+	require.Len(t, got.Added, 1)
+	assert.Equal(t, "SELECT id=7c4e88d0-0002", got.Added[0].Span.Name)
+	require.Len(t, got.Removed, 1)
+	assert.Equal(t, "SELECT id=3f2a1b9c-0001", got.Removed[0].Span.Name)
+	assert.Empty(t, got.Modified)
+	require.Len(t, got.Warnings, 1)
+	assert.Equal(t, WarningHighCardinalitySpanName, got.Warnings[0].Code)
+	assert.Contains(t, got.Warnings[0].Message, "SELECT id=3f2a1b9c-0001")
+	assert.Contains(t, got.Warnings[0].Message, "raw span names")
+}
+
 func TestDiffReportsModifiedSpanFields(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
 	base := traceWithNamedSpans(

--- a/pkg/model/tracediff/normalize.go
+++ b/pkg/model/tracediff/normalize.go
@@ -194,20 +194,6 @@ func spanIDKey(id []byte) string {
 	return string(id)
 }
 
-func pathKey(path []int) string {
-	if len(path) == 0 {
-		return ""
-	}
-	var b strings.Builder
-	for i, p := range path {
-		if i > 0 {
-			b.WriteByte('/')
-		}
-		b.WriteString(strconv.Itoa(p))
-	}
-	return b.String()
-}
-
 func attributeString(attrs []*commonv1.KeyValue, key string) string {
 	for _, attr := range attrs {
 		if attr.GetKey() == key {

--- a/pkg/model/tracediff/normalize.go
+++ b/pkg/model/tracediff/normalize.go
@@ -1,0 +1,233 @@
+package tracediff
+
+import (
+	"bytes"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+
+	modeltrace "github.com/grafana/tempo/pkg/model/trace"
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+)
+
+const serviceNameAttribute = "service.name"
+
+type normalizedTrace struct {
+	meta  TraceMeta
+	spans []normalizedSpan
+}
+
+type normalizedSpan struct {
+	spanID    string
+	matchKey  spanMatchKey
+	ref       SpanRef
+	snapshot  SpanSnapshot
+	spanAttrs map[string]any
+}
+
+type spanMatchKey struct {
+	path    string
+	service string
+	name    string
+	kind    string
+}
+
+type spanWithResource struct {
+	span            *tracev1.Span
+	resourceService string
+}
+
+func normalizeTrace(trace *tempopb.Trace) normalizedTrace {
+	if trace == nil {
+		return normalizedTrace{}
+	}
+
+	spans, meta := flattenSpans(trace)
+	byID := make(map[string]spanWithResource, len(spans))
+	children := map[string][]spanWithResource{}
+	for _, span := range spans {
+		spanID := spanIDKey(span.span.GetSpanId())
+		byID[spanID] = span
+	}
+	for _, span := range spans {
+		parentID := spanIDKey(span.span.GetParentSpanId())
+		if _, ok := byID[parentID]; parentID != "" && !ok {
+			parentID = ""
+		}
+		children[parentID] = append(children[parentID], span)
+	}
+	for parentID := range children {
+		sortSpans(children[parentID])
+	}
+
+	out := normalizedTrace{meta: meta, spans: make([]normalizedSpan, 0, len(spans))}
+	visited := make(map[string]struct{}, len(spans))
+	// First assign paths from normal roots and orphans.
+	rootIndex := assignPaths(&out, children, children[""], nil, 0, visited)
+	// Then assign remaining cycle-only/disconnected spans as extra roots.
+	assignPaths(&out, children, spans, nil, rootIndex, visited)
+	return out
+}
+
+func flattenSpans(trace *tempopb.Trace) ([]spanWithResource, TraceMeta) {
+	var meta TraceMeta
+	var spans []spanWithResource
+	for _, rs := range trace.ResourceSpans {
+		resourceService := attributeString(rs.GetResource().GetAttributes(), serviceNameAttribute)
+		for _, ss := range rs.ScopeSpans {
+			for _, span := range ss.Spans {
+				meta.SpanCount++
+				if meta.TraceID == "" && len(span.TraceId) > 0 {
+					meta.TraceID = hex.EncodeToString(span.TraceId)
+				}
+				spans = append(spans, spanWithResource{
+					span:            span,
+					resourceService: resourceService,
+				})
+			}
+		}
+	}
+	return spans, meta
+}
+
+func assignPaths(out *normalizedTrace, children map[string][]spanWithResource, spans []spanWithResource, parentPath []int, startIndex int, visited map[string]struct{}) int {
+	nextIndex := startIndex
+	for _, span := range spans {
+		spanID := spanIDKey(span.span.GetSpanId())
+		if _, ok := visited[spanID]; ok {
+			continue
+		}
+
+		path := make([]int, len(parentPath)+1)
+		copy(path, parentPath)
+		path[len(parentPath)] = nextIndex
+		nextIndex++
+
+		out.spans = append(out.spans, normalizeSpan(span, path))
+		visited[spanID] = struct{}{}
+		assignPaths(out, children, children[spanID], path, 0, visited)
+	}
+	return nextIndex
+}
+
+func normalizeSpan(span spanWithResource, path []int) normalizedSpan {
+	service := attributeString(span.span.GetAttributes(), serviceNameAttribute)
+	if service == "" {
+		service = span.resourceService
+	}
+	ref := SpanRef{
+		Path:    path,
+		Service: service,
+		Name:    span.span.GetName(),
+		Kind:    modeltrace.KindToString(span.span.GetKind()),
+	}
+	return normalizedSpan{
+		spanID: spanIDKey(span.span.GetSpanId()),
+		matchKey: spanMatchKey{
+			path:    pathKey(path),
+			service: ref.Service,
+			name:    ref.Name,
+			kind:    ref.Kind,
+		},
+		ref:       ref,
+		spanAttrs: attributesMap(span.span.GetAttributes()),
+		snapshot: SpanSnapshot{
+			Path:       path,
+			Service:    ref.Service,
+			Name:       ref.Name,
+			Kind:       ref.Kind,
+			DurationMs: durationMs(span.span),
+			Status:     statusToString(span.span.GetStatus()),
+		},
+	}
+}
+
+func sortSpans(spans []spanWithResource) {
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].span.GetStartTimeUnixNano() != spans[j].span.GetStartTimeUnixNano() {
+			return spans[i].span.GetStartTimeUnixNano() < spans[j].span.GetStartTimeUnixNano()
+		}
+		return bytes.Compare(spans[i].span.GetSpanId(), spans[j].span.GetSpanId()) < 0
+	})
+}
+
+func spanIDKey(id []byte) string {
+	return string(id)
+}
+
+func pathKey(path []int) string {
+	if len(path) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, p := range path {
+		if i > 0 {
+			b.WriteByte('/')
+		}
+		b.WriteString(strconv.Itoa(p))
+	}
+	return b.String()
+}
+
+func attributeString(attrs []*commonv1.KeyValue, key string) string {
+	for _, attr := range attrs {
+		if attr.GetKey() == key {
+			return attr.GetValue().GetStringValue()
+		}
+	}
+	return ""
+}
+
+func attributesMap(attrs []*commonv1.KeyValue) map[string]any {
+	out := make(map[string]any, len(attrs))
+	for _, attr := range attrs {
+		out[attr.GetKey()] = anyValue(attr.GetValue())
+	}
+	return out
+}
+
+func anyValue(value *commonv1.AnyValue) any {
+	if value == nil {
+		return nil
+	}
+	switch v := value.GetValue().(type) {
+	case *commonv1.AnyValue_StringValue:
+		return v.StringValue
+	case *commonv1.AnyValue_BoolValue:
+		return v.BoolValue
+	case *commonv1.AnyValue_IntValue:
+		return v.IntValue
+	case *commonv1.AnyValue_DoubleValue:
+		return v.DoubleValue
+	case *commonv1.AnyValue_ArrayValue:
+		values := v.ArrayValue.GetValues()
+		out := make([]any, 0, len(values))
+		for _, item := range values {
+			out = append(out, anyValue(item))
+		}
+		return out
+	case *commonv1.AnyValue_KvlistValue:
+		return attributesMap(v.KvlistValue.GetValues())
+	case *commonv1.AnyValue_BytesValue:
+		return v.BytesValue
+	default:
+		return nil
+	}
+}
+
+func durationMs(span *tracev1.Span) int64 {
+	if span.GetEndTimeUnixNano() < span.GetStartTimeUnixNano() {
+		return 0
+	}
+	return int64((span.GetEndTimeUnixNano() - span.GetStartTimeUnixNano()) / 1_000_000)
+}
+
+func statusToString(status *tracev1.Status) string {
+	if status == nil {
+		return modeltrace.StatusToString(tracev1.Status_STATUS_CODE_UNSET)
+	}
+	return modeltrace.StatusToString(status.GetCode())
+}

--- a/pkg/model/tracediff/normalize.go
+++ b/pkg/model/tracediff/normalize.go
@@ -29,7 +29,10 @@ type normalizedSpan struct {
 }
 
 type spanMatchKey struct {
-	path    string
+	logicalPath string
+}
+
+type spanLogicalKey struct {
 	service string
 	name    string
 	kind    string
@@ -65,10 +68,11 @@ func normalizeTrace(trace *tempopb.Trace) normalizedTrace {
 
 	out := normalizedTrace{meta: meta, spans: make([]normalizedSpan, 0, len(spans))}
 	visited := make(map[string]struct{}, len(spans))
+	rootOrdinals := map[spanLogicalKey]int{}
 	// First assign paths from normal roots and orphans.
-	rootIndex := assignPaths(&out, children, children[""], nil, 0, visited)
+	rootIndex := assignPaths(&out, children, children[""], nil, "", rootOrdinals, 0, visited)
 	// Then assign remaining cycle-only/disconnected spans as extra roots.
-	assignPaths(&out, children, spans, nil, rootIndex, visited)
+	assignPaths(&out, children, spans, nil, "", rootOrdinals, rootIndex, visited)
 	return out
 }
 
@@ -93,8 +97,11 @@ func flattenSpans(trace *tempopb.Trace) ([]spanWithResource, TraceMeta) {
 	return spans, meta
 }
 
-func assignPaths(out *normalizedTrace, children map[string][]spanWithResource, spans []spanWithResource, parentPath []int, startIndex int, visited map[string]struct{}) int {
+func assignPaths(out *normalizedTrace, children map[string][]spanWithResource, spans []spanWithResource, parentPath []int, parentMatchPath string, ordinals map[spanLogicalKey]int, startIndex int, visited map[string]struct{}) int {
 	nextIndex := startIndex
+	if ordinals == nil {
+		ordinals = map[spanLogicalKey]int{}
+	}
 	for _, span := range spans {
 		spanID := spanIDKey(span.span.GetSpanId())
 		if _, ok := visited[spanID]; ok {
@@ -106,32 +113,28 @@ func assignPaths(out *normalizedTrace, children map[string][]spanWithResource, s
 		path[len(parentPath)] = nextIndex
 		nextIndex++
 
-		out.spans = append(out.spans, normalizeSpan(span, path))
+		logicalKey := logicalKey(span)
+		ordinal := ordinals[logicalKey]
+		ordinals[logicalKey]++
+		matchPath := appendLogicalPath(parentMatchPath, logicalKey, ordinal)
+
+		out.spans = append(out.spans, normalizeSpan(span, path, logicalKey, matchPath))
 		visited[spanID] = struct{}{}
-		assignPaths(out, children, children[spanID], path, 0, visited)
+		assignPaths(out, children, children[spanID], path, matchPath, nil, 0, visited)
 	}
 	return nextIndex
 }
 
-func normalizeSpan(span spanWithResource, path []int) normalizedSpan {
-	service := attributeString(span.span.GetAttributes(), serviceNameAttribute)
-	if service == "" {
-		service = span.resourceService
-	}
+func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey, matchPath string) normalizedSpan {
 	ref := SpanRef{
 		Path:    path,
-		Service: service,
-		Name:    span.span.GetName(),
-		Kind:    modeltrace.KindToString(span.span.GetKind()),
+		Service: logicalKey.service,
+		Name:    logicalKey.name,
+		Kind:    logicalKey.kind,
 	}
 	return normalizedSpan{
-		spanID: spanIDKey(span.span.GetSpanId()),
-		matchKey: spanMatchKey{
-			path:    pathKey(path),
-			service: ref.Service,
-			name:    ref.Name,
-			kind:    ref.Kind,
-		},
+		spanID:    spanIDKey(span.span.GetSpanId()),
+		matchKey:  spanMatchKey{logicalPath: matchPath},
 		ref:       ref,
 		spanAttrs: attributesMap(span.span.GetAttributes()),
 		snapshot: SpanSnapshot{
@@ -143,6 +146,39 @@ func normalizeSpan(span spanWithResource, path []int) normalizedSpan {
 			Status:     statusToString(span.span.GetStatus()),
 		},
 	}
+}
+
+func logicalKey(span spanWithResource) spanLogicalKey {
+	service := attributeString(span.span.GetAttributes(), serviceNameAttribute)
+	if service == "" {
+		service = span.resourceService
+	}
+	return spanLogicalKey{
+		service: service,
+		name:    span.span.GetName(),
+		kind:    modeltrace.KindToString(span.span.GetKind()),
+	}
+}
+
+func appendLogicalPath(parent string, key spanLogicalKey, ordinal int) string {
+	var b strings.Builder
+	if parent != "" {
+		b.WriteString(parent)
+		b.WriteByte('/')
+	}
+	writeLogicalPathPart(&b, key.service)
+	writeLogicalPathPart(&b, key.name)
+	writeLogicalPathPart(&b, key.kind)
+	b.WriteByte('#')
+	b.WriteString(strconv.Itoa(ordinal))
+	return b.String()
+}
+
+func writeLogicalPathPart(b *strings.Builder, value string) {
+	b.WriteString(strconv.Itoa(len(value)))
+	b.WriteByte(':')
+	b.WriteString(value)
+	b.WriteByte('|')
 }
 
 func sortSpans(spans []spanWithResource) {

--- a/pkg/model/tracediff/normalize.go
+++ b/pkg/model/tracediff/normalize.go
@@ -3,9 +3,9 @@ package tracediff
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
+	"regexp"
 	"sort"
-	"strconv"
-	"strings"
 
 	modeltrace "github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -21,15 +21,12 @@ type normalizedTrace struct {
 }
 
 type normalizedSpan struct {
-	spanID    string
-	matchKey  spanMatchKey
-	ref       SpanRef
-	snapshot  SpanSnapshot
-	spanAttrs map[string]any
-}
-
-type spanMatchKey struct {
-	logicalPath string
+	spanID         string
+	parentIdentity spanLogicalKey
+	hasParent      bool
+	ref            SpanRef
+	snapshot       SpanSnapshot
+	spanAttrs      map[string]any
 }
 
 type spanLogicalKey struct {
@@ -43,12 +40,13 @@ type spanWithResource struct {
 	resourceService string
 }
 
-func normalizeTrace(trace *tempopb.Trace) normalizedTrace {
+func normalizeTrace(trace *tempopb.Trace) (normalizedTrace, []Warning) {
 	if trace == nil {
-		return normalizedTrace{}
+		return normalizedTrace{}, nil
 	}
 
 	spans, meta := flattenSpans(trace)
+	warnings := highCardinalitySpanNameWarnings(spans)
 	byID := make(map[string]spanWithResource, len(spans))
 	children := map[string][]spanWithResource{}
 	for _, span := range spans {
@@ -66,14 +64,14 @@ func normalizeTrace(trace *tempopb.Trace) normalizedTrace {
 		sortSpans(children[parentID])
 	}
 
+	// out.spans is built in pre-order (a node, then its children).
 	out := normalizedTrace{meta: meta, spans: make([]normalizedSpan, 0, len(spans))}
 	visited := make(map[string]struct{}, len(spans))
-	rootOrdinals := map[spanLogicalKey]int{}
 	// First assign paths from normal roots and orphans.
-	rootIndex := assignPaths(&out, children, children[""], nil, "", rootOrdinals, 0, visited)
+	rootIndex := assignPaths(&out, children, children[""], nil, spanLogicalKey{}, false, 0, visited)
 	// Then assign remaining cycle-only/disconnected spans as extra roots.
-	assignPaths(&out, children, spans, nil, "", rootOrdinals, rootIndex, visited)
-	return out
+	assignPaths(&out, children, spans, nil, spanLogicalKey{}, false, rootIndex, visited)
+	return out, warnings
 }
 
 func flattenSpans(trace *tempopb.Trace) ([]spanWithResource, TraceMeta) {
@@ -97,11 +95,8 @@ func flattenSpans(trace *tempopb.Trace) ([]spanWithResource, TraceMeta) {
 	return spans, meta
 }
 
-func assignPaths(out *normalizedTrace, children map[string][]spanWithResource, spans []spanWithResource, parentPath []int, parentMatchPath string, ordinals map[spanLogicalKey]int, startIndex int, visited map[string]struct{}) int {
+func assignPaths(out *normalizedTrace, children map[string][]spanWithResource, spans []spanWithResource, parentPath []int, parentIdentity spanLogicalKey, hasParent bool, startIndex int, visited map[string]struct{}) int {
 	nextIndex := startIndex
-	if ordinals == nil {
-		ordinals = map[spanLogicalKey]int{}
-	}
 	for _, span := range spans {
 		spanID := spanIDKey(span.span.GetSpanId())
 		if _, ok := visited[spanID]; ok {
@@ -114,18 +109,14 @@ func assignPaths(out *normalizedTrace, children map[string][]spanWithResource, s
 		nextIndex++
 
 		logicalKey := logicalKey(span)
-		ordinal := ordinals[logicalKey]
-		ordinals[logicalKey]++
-		matchPath := appendLogicalPath(parentMatchPath, logicalKey, ordinal)
-
-		out.spans = append(out.spans, normalizeSpan(span, path, logicalKey, matchPath))
+		out.spans = append(out.spans, normalizeSpan(span, path, logicalKey, parentIdentity, hasParent))
 		visited[spanID] = struct{}{}
-		assignPaths(out, children, children[spanID], path, matchPath, nil, 0, visited)
+		assignPaths(out, children, children[spanID], path, logicalKey, true, 0, visited)
 	}
 	return nextIndex
 }
 
-func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey, matchPath string) normalizedSpan {
+func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey, parentIdentity spanLogicalKey, hasParent bool) normalizedSpan {
 	ref := SpanRef{
 		Path:    path,
 		Service: logicalKey.service,
@@ -133,10 +124,11 @@ func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey,
 		Kind:    logicalKey.kind,
 	}
 	return normalizedSpan{
-		spanID:    spanIDKey(span.span.GetSpanId()),
-		matchKey:  spanMatchKey{logicalPath: matchPath},
-		ref:       ref,
-		spanAttrs: attributesMap(span.span.GetAttributes()),
+		spanID:         spanIDKey(span.span.GetSpanId()),
+		parentIdentity: parentIdentity,
+		hasParent:      hasParent,
+		ref:            ref,
+		spanAttrs:      attributesMap(span.span.GetAttributes()),
 		snapshot: SpanSnapshot{
 			Path:       path,
 			Service:    ref.Service,
@@ -160,25 +152,35 @@ func logicalKey(span spanWithResource) spanLogicalKey {
 	}
 }
 
-func appendLogicalPath(parent string, key spanLogicalKey, ordinal int) string {
-	var b strings.Builder
-	if parent != "" {
-		b.WriteString(parent)
-		b.WriteByte('/')
-	}
-	writeLogicalPathPart(&b, key.service)
-	writeLogicalPathPart(&b, key.name)
-	writeLogicalPathPart(&b, key.kind)
-	b.WriteByte('#')
-	b.WriteString(strconv.Itoa(ordinal))
-	return b.String()
+func (s normalizedSpan) identity() spanLogicalKey {
+	return spanLogicalKey{service: s.ref.Service, name: s.ref.Name, kind: s.ref.Kind}
 }
 
-func writeLogicalPathPart(b *strings.Builder, value string) {
-	b.WriteString(strconv.Itoa(len(value)))
-	b.WriteByte(':')
-	b.WriteString(value)
-	b.WriteByte('|')
+func highCardinalitySpanNameWarnings(spans []spanWithResource) []Warning {
+	for _, span := range spans {
+		key := logicalKey(span)
+		if !spanNameHasHighCardinalityToken(key.name) {
+			continue
+		}
+		return []Warning{{
+			Code: WarningHighCardinalitySpanName,
+			Message: fmt.Sprintf(
+				"span name %q for service %q kind %q appears to contain a high-cardinality token; matching uses raw span names, so equivalent operations with request-specific IDs may be reported as added/removed. Move request-specific IDs to span attributes.",
+				key.name,
+				key.service,
+				key.kind,
+			),
+		}}
+	}
+	return nil
+}
+
+// Warn on obvious request-specific IDs without rewriting the span name:
+// long numeric tokens or long hex/UUID-like tokens.
+var reHighCardinalitySpanNameToken = regexp.MustCompile(`(?i)\b(?:[0-9]{6,}|[0-9a-f][0-9a-f-]{7,})\b`)
+
+func spanNameHasHighCardinalityToken(name string) bool {
+	return reHighCardinalitySpanNameToken.MatchString(name)
 }
 
 func sortSpans(spans []spanWithResource) {

--- a/pkg/model/tracediff/normalize_test.go
+++ b/pkg/model/tracediff/normalize_test.go
@@ -1,0 +1,136 @@
+package tracediff
+
+import (
+	"testing"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeTraceAssignsStructuralPaths(t *testing.T) {
+	trace := traceForNormalizeTest()
+
+	got := normalizeTrace(trace)
+
+	paths := map[string][]int{}
+	for _, span := range got.spans {
+		paths[span.spanID] = span.ref.Path
+	}
+
+	require.Len(t, paths, 5)
+	assert.Equal(t, []int{0}, paths["root"])
+	assert.Equal(t, []int{0, 0}, paths["auth"])
+	assert.Equal(t, []int{0, 1}, paths["inventory"])
+	assert.Equal(t, []int{0, 1, 0}, paths["reserve"])
+	assert.Equal(t, []int{0, 2}, paths["payment"])
+}
+
+func TestNormalizeTraceBuildsSpanRefsAndSnapshots(t *testing.T) {
+	trace := traceForNormalizeTest()
+
+	got := normalizeTrace(trace)
+
+	byID := map[string]normalizedSpan{}
+	for _, span := range got.spans {
+		byID[span.spanID] = span
+	}
+
+	reserve := byID["reserve"]
+	assert.Equal(t, SpanRef{
+		Path:    []int{0, 1, 0},
+		Service: "inventory",
+		Name:    "reserve",
+		Kind:    "client",
+	}, reserve.ref)
+	assert.Equal(t, SpanSnapshot{
+		Path:       []int{0, 1, 0},
+		Service:    "inventory",
+		Name:       "reserve",
+		Kind:       "client",
+		DurationMs: 25,
+		Status:     "error",
+	}, reserve.snapshot)
+}
+
+func TestNormalizeTraceHandlesCyclicParents(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				ScopeSpans: []*tracev1.ScopeSpans{
+					{
+						Spans: []*tracev1.Span{
+							spanForNormalizeTest(traceID, "a", "b", "svc-a", "a", tracev1.Span_SPAN_KIND_CLIENT, 0, 10, tracev1.Status_STATUS_CODE_OK),
+							spanForNormalizeTest(traceID, "b", "a", "svc-b", "b", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := normalizeTrace(trace)
+
+	paths := map[string][]int{}
+	for _, span := range got.spans {
+		paths[span.spanID] = span.ref.Path
+	}
+	require.Len(t, paths, 2)
+	assert.NotEmpty(t, paths["a"])
+	assert.NotEmpty(t, paths["b"])
+}
+
+func traceForNormalizeTest() *tempopb.Trace {
+	traceID := []byte("trace-id-0000001")
+	return &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						stringAttribute("service.name", "checkout"),
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{
+					{
+						Spans: []*tracev1.Span{
+							spanForNormalizeTest(traceID, "payment", "root", "payment", "charge", tracev1.Span_SPAN_KIND_CLIENT, 30, 45, tracev1.Status_STATUS_CODE_OK),
+							spanForNormalizeTest(traceID, "reserve", "inventory", "inventory", "reserve", tracev1.Span_SPAN_KIND_CLIENT, 20, 45, tracev1.Status_STATUS_CODE_ERROR),
+							spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+							spanForNormalizeTest(traceID, "inventory", "root", "inventory", "reserve inventory", tracev1.Span_SPAN_KIND_CLIENT, 20, 50, tracev1.Status_STATUS_CODE_OK),
+							spanForNormalizeTest(traceID, "auth", "root", "auth", "authorize", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func spanForNormalizeTest(traceID []byte, spanID, parentID, service, name string, kind tracev1.Span_SpanKind, start, end uint64, status tracev1.Status_StatusCode) *tracev1.Span {
+	return &tracev1.Span{
+		TraceId:           traceID,
+		SpanId:            []byte(spanID),
+		ParentSpanId:      []byte(parentID),
+		Name:              name,
+		Kind:              kind,
+		StartTimeUnixNano: start * 1_000_000,
+		EndTimeUnixNano:   end * 1_000_000,
+		Attributes: []*commonv1.KeyValue{
+			stringAttribute("service.name", service),
+		},
+		Status: &tracev1.Status{Code: status},
+	}
+}
+
+func stringAttribute(key, value string) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key: key,
+		Value: &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_StringValue{StringValue: value},
+		},
+	}
+}

--- a/pkg/model/tracediff/normalize_test.go
+++ b/pkg/model/tracediff/normalize_test.go
@@ -14,7 +14,8 @@ import (
 func TestNormalizeTraceAssignsStructuralPaths(t *testing.T) {
 	trace := traceForNormalizeTest()
 
-	got := normalizeTrace(trace)
+	got, warnings := normalizeTrace(trace)
+	require.Empty(t, warnings)
 
 	paths := map[string][]int{}
 	for _, span := range got.spans {
@@ -32,7 +33,8 @@ func TestNormalizeTraceAssignsStructuralPaths(t *testing.T) {
 func TestNormalizeTraceBuildsSpanRefsAndSnapshots(t *testing.T) {
 	trace := traceForNormalizeTest()
 
-	got := normalizeTrace(trace)
+	got, warnings := normalizeTrace(trace)
+	require.Empty(t, warnings)
 
 	byID := map[string]normalizedSpan{}
 	for _, span := range got.spans {
@@ -73,7 +75,8 @@ func TestNormalizeTraceHandlesCyclicParents(t *testing.T) {
 		},
 	}
 
-	got := normalizeTrace(trace)
+	got, warnings := normalizeTrace(trace)
+	require.Empty(t, warnings)
 
 	paths := map[string][]int{}
 	for _, span := range got.spans {
@@ -132,5 +135,28 @@ func stringAttribute(key, value string) *commonv1.KeyValue {
 		Value: &commonv1.AnyValue{
 			Value: &commonv1.AnyValue_StringValue{StringValue: value},
 		},
+	}
+}
+
+func TestSpanNameHasHighCardinalityToken(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "canonical UUID", in: "GET /users/550e8400-e29b-41d4-a716-446655440000", want: true},
+		{name: "trace ID hex token", in: "GET /user/3f2a1b9c0d1e2f3a", want: true},
+		{name: "explicit ID key with hex value", in: "SELECT id=3f2a1b9c-0001", want: true},
+		{name: "explicit ID key with numeric value", in: "SELECT id=123456", want: true},
+		{name: "long numeric path segment", in: "GET /orders/123456", want: true},
+		{name: "low-cardinality route", in: "GET /checkout", want: false},
+		{name: "short numeric path segment", in: "GET /orders/42", want: false},
+		{name: "versioned route", in: "GET /api/v10/users", want: false},
+		{name: "single-digit product name", in: "s3 upload", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, spanNameHasHighCardinalityToken(tc.in))
+		})
 	}
 }

--- a/pkg/model/tracediff/types.go
+++ b/pkg/model/tracediff/types.go
@@ -27,6 +27,19 @@ const (
 	TargetSpan      TargetType = "span"
 )
 
+// Field names (Target.Name) and attribute scopes (Target.Scope) in the
+// trace-patch-v0 vocabulary.
+const (
+	FieldDurationMs = "duration_ms"
+	FieldStatus     = "status"
+	ScopeSpan       = "span"
+)
+
+// Warning codes in the trace-patch-v0 vocabulary.
+const (
+	WarningHighCardinalitySpanName = "high_cardinality_span_name"
+)
+
 // Result is the trace-patch-v0 diff document.
 type Result struct {
 	Version  string         `json:"version"`

--- a/pkg/model/tracediff/types.go
+++ b/pkg/model/tracediff/types.go
@@ -1,0 +1,121 @@
+package tracediff
+
+const VersionTracePatchV0 = "trace-patch-v0"
+
+// Format selects the output representation.
+type Format string
+
+const (
+	FormatTracePatchV0 Format = VersionTracePatchV0
+)
+
+// Operation is a mechanical change verb.
+type Operation string
+
+const (
+	OperationAdd    Operation = "add"
+	OperationRemove Operation = "remove"
+	OperationModify Operation = "modify"
+)
+
+// TargetType identifies what a change affects.
+type TargetType string
+
+const (
+	TargetAttribute TargetType = "attribute"
+	TargetField     TargetType = "field"
+	TargetSpan      TargetType = "span"
+)
+
+// Result is the trace-patch-v0 diff document.
+type Result struct {
+	Version  string         `json:"version"`
+	Base     TraceMeta      `json:"base"`
+	Compare  TraceMeta      `json:"compare"`
+	Stats    Stats          `json:"stats"`
+	Modified []ModifiedSpan `json:"modified"`
+	Added    []SpanChange   `json:"added"`
+	Removed  []SpanChange   `json:"removed"`
+	Warnings []Warning      `json:"warnings"`
+}
+
+// TraceMeta identifies one side of the comparison.
+type TraceMeta struct {
+	TraceID   string `json:"traceId"`
+	SpanCount int    `json:"spanCount"`
+}
+
+// Stats contains factual counts for the diff.
+type Stats struct {
+	SpanCountA       int  `json:"spanCountA"`
+	SpanCountB       int  `json:"spanCountB"`
+	MatchedSpans     int  `json:"matchedSpans"`
+	ModifiedSpans    int  `json:"modifiedSpans"`
+	AddedSpans       int  `json:"addedSpans"`
+	RemovedSpans     int  `json:"removedSpans"`
+	FieldChanges     int  `json:"fieldChanges"`
+	AttributeChanges int  `json:"attributeChanges"`
+	EventChanges     int  `json:"eventChanges"`
+	Truncated        bool `json:"truncated"`
+}
+
+// ModifiedSpan groups field and attribute changes for one matched span.
+type ModifiedSpan struct {
+	Span    SpanRef  `json:"span"`
+	Changes []Change `json:"changes"`
+}
+
+// SpanRef is a stable-ish logical span locator.
+type SpanRef struct {
+	// Path is zero-based sibling indexes from root to span.
+	Path    []int  `json:"path"`
+	Service string `json:"service"`
+	Name    string `json:"name"`
+	Kind    string `json:"kind"`
+}
+
+// Change describes one change inside a matched span.
+type Change struct {
+	Op     Operation `json:"op"`
+	Target Target    `json:"target"`
+	Before any       `json:"before"`
+	After  any       `json:"after"`
+}
+
+// Target identifies the field or attribute being changed.
+type Target struct {
+	Type  TargetType `json:"type"`
+	Name  string     `json:"name,omitempty"`
+	Scope string     `json:"scope,omitempty"`
+	Key   string     `json:"key,omitempty"`
+}
+
+// SpanChange describes a whole-span add or remove.
+type SpanChange struct {
+	Target SpanTarget   `json:"target"`
+	Span   SpanSnapshot `json:"span"`
+}
+
+// SpanTarget locates where a span is added or removed.
+type SpanTarget struct {
+	Type       TargetType `json:"type"`
+	Path       []int      `json:"path,omitempty"`
+	ParentPath []int      `json:"parentPath,omitempty"`
+	Index      *int       `json:"index,omitempty"`
+}
+
+// SpanSnapshot is the minimal span data needed to render an add/remove.
+type SpanSnapshot struct {
+	Path       []int  `json:"path"`
+	Service    string `json:"service"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	DurationMs int64  `json:"duration_ms"`
+	Status     string `json:"status"`
+}
+
+// Warning reports non-fatal limits or matcher caveats.
+type Warning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/pkg/model/tracediff/types_test.go
+++ b/pkg/model/tracediff/types_test.go
@@ -1,0 +1,183 @@
+package tracediff
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracePatchV0JSONShape(t *testing.T) {
+	idx := 0
+	changes := Result{
+		Version: VersionTracePatchV0,
+		Base: TraceMeta{
+			TraceID:   "trace-a",
+			SpanCount: 5,
+		},
+		Compare: TraceMeta{
+			TraceID:   "trace-b",
+			SpanCount: 6,
+		},
+		Stats: Stats{
+			SpanCountA:       5,
+			SpanCountB:       6,
+			MatchedSpans:     4,
+			ModifiedSpans:    1,
+			AddedSpans:       1,
+			RemovedSpans:     1,
+			FieldChanges:     2,
+			AttributeChanges: 3,
+			EventChanges:     0,
+			Truncated:        false,
+		},
+		Modified: []ModifiedSpan{
+			{
+				Span: SpanRef{
+					Path:    []int{0, 1},
+					Service: "inventory",
+					Name:    "reserve",
+					Kind:    "client",
+				},
+				Changes: []Change{
+					{
+						Op: OperationModify,
+						Target: Target{
+							Type: TargetField,
+							Name: "duration_ms",
+						},
+						Before: float64(80),
+						After:  float64(390),
+					},
+					{
+						Op: OperationModify,
+						Target: Target{
+							Type: TargetField,
+							Name: "status",
+						},
+						Before: "ok",
+						After:  "error",
+					},
+					{
+						Op: OperationAdd,
+						Target: Target{
+							Type:  TargetAttribute,
+							Scope: "span",
+							Key:   "error.type",
+						},
+						Before: nil,
+						After:  "timeout",
+					},
+					{
+						Op: OperationModify,
+						Target: Target{
+							Type:  TargetAttribute,
+							Scope: "span",
+							Key:   "http.request.header.accept",
+						},
+						Before: []any{"text/html", "application/json"},
+						After:  []any{"application/json", "image/webp"},
+					},
+					{
+						Op: OperationRemove,
+						Target: Target{
+							Type:  TargetAttribute,
+							Scope: "span",
+							Key:   "cache.hit",
+						},
+						Before: true,
+						After:  nil,
+					},
+				},
+			},
+		},
+		Added: []SpanChange{
+			{
+				Target: SpanTarget{
+					Type:       TargetSpan,
+					ParentPath: []int{0, 1},
+					Index:      &idx,
+				},
+				Span: SpanSnapshot{
+					Path:       []int{0, 1, 0},
+					Service:    "inventory",
+					Name:       "retry reserve",
+					Kind:       "client",
+					DurationMs: 120,
+					Status:     "ok",
+				},
+			},
+		},
+		Removed: []SpanChange{
+			{
+				Target: SpanTarget{
+					Type: TargetSpan,
+					Path: []int{0, 2},
+				},
+				Span: SpanSnapshot{
+					Path:       []int{0, 2},
+					Service:    "fraud",
+					Name:       "check_risk",
+					Kind:       "client",
+					DurationMs: 35,
+					Status:     "ok",
+				},
+			},
+		},
+		Warnings: []Warning{
+			{
+				Code:    "low_match_confidence",
+				Message: "some spans were not matched by structural path",
+			},
+		},
+	}
+
+	got, err := json.Marshal(changes)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"version": "trace-patch-v0",
+		"base": {"traceId": "trace-a", "spanCount": 5},
+		"compare": {"traceId": "trace-b", "spanCount": 6},
+		"stats": {
+			"spanCountA": 5,
+			"spanCountB": 6,
+			"matchedSpans": 4,
+			"modifiedSpans": 1,
+			"addedSpans": 1,
+			"removedSpans": 1,
+			"fieldChanges": 2,
+			"attributeChanges": 3,
+			"eventChanges": 0,
+			"truncated": false
+		},
+		"modified": [
+			{
+				"span": {"path": [0, 1], "service": "inventory", "name": "reserve", "kind": "client"},
+				"changes": [
+					{"op": "modify", "target": {"type": "field", "name": "duration_ms"}, "before": 80, "after": 390},
+					{"op": "modify", "target": {"type": "field", "name": "status"}, "before": "ok", "after": "error"},
+					{"op": "add", "target": {"type": "attribute", "scope": "span", "key": "error.type"}, "before": null, "after": "timeout"},
+					{"op": "modify", "target": {"type": "attribute", "scope": "span", "key": "http.request.header.accept"}, "before": ["text/html", "application/json"], "after": ["application/json", "image/webp"]},
+					{"op": "remove", "target": {"type": "attribute", "scope": "span", "key": "cache.hit"}, "before": true, "after": null}
+				]
+			}
+		],
+		"added": [
+			{
+				"target": {"type": "span", "parentPath": [0, 1], "index": 0},
+				"span": {"path": [0, 1, 0], "service": "inventory", "name": "retry reserve", "kind": "client", "duration_ms": 120, "status": "ok"}
+			}
+		],
+		"removed": [
+			{
+				"target": {"type": "span", "path": [0, 2]},
+				"span": {"path": [0, 2], "service": "fraud", "name": "check_risk", "kind": "client", "duration_ms": 35, "status": "ok"}
+			}
+		],
+		"warnings": [
+			{"code": "low_match_confidence", "message": "some spans were not matched by structural path"}
+		]
+	}`, string(got))
+}


### PR DESCRIPTION
**What this PR does**:

This PR proposes a new command to Tempo cli to iterate faster in how to present the differences between two traces.

The proposal is a purely mechanical diff trace format. More closer to a JSON patch than a semantic diff summary. This approach is extremelly efficient since it only encodes the changes, not the sum of trace A and B. 

On a 161-span benchmark pair, the compact trace-patch-v0 output was 5.6 KB versus 274 KB for the two raw trace JSON files. **That is a 97.9% reduction.**

The new command is set as **experimental** that means that it doesn't need to be promoted to a real command yet and its more intended for experimentation.

Example:

 ```json
   {
     "version": "trace-patch-v0",
     "stats": {
       "matchedSpans": 3,
       "modifiedSpans": 1,
       "addedSpans": 1,
       "removedSpans": 0
     },
     "modified": [
       {
         "span": {
           "path": [0, 1], // This identifies the span in the trace tree
           "service": "inventory",
           "name": "reserve",
           "kind": "client"
         },
         "changes": [
           {
             "op": "modify",
             "target": { "type": "field", "name": "duration_ms" }, // Intrinsic changes
             "before": 50,
             "after": 80
           },
           {
             "op": "add",
             "target": { "type": "attribute", "scope": "span", "key": "error.type" },
             "before": null,
             "after": "timeout"
           }
         ]
       }
     ],
     "added": [
       {
         "target": { "type": "span", "parentPath": [0], "index": 0 },
         "span": {
           "path": [0, 0],
           "service": "cache",
           "name": "warm",
           "kind": "client"
         }
       }
     ],
     "removed": []
   }
 ```



**The algorithm is the following:**

1. Both traces are normalized
2. From both normalized traces we build a map from their **match key**
3. It iterates the map classifying the spans as: added, removed or matched
4. For matched spans (meaning that are in both sets) it computes the differences if any in the intrinsics and span attributes


**How the normalization process works:**

1. Spans are flattered
2. Path is calculated from the root span 
3. A match key is computed as a logical ancestry path. Each path segment is:
      `service + name + kind + ordinal-among-identical-siblings`


The path is metadata for reconstruct the traces in a future UI or other derived format. Its not used for matching spans, ie: 

```text
   [0] checkout POST /checkout
   ├── [0,0] auth authorize
   ├── [0,1] inventory reserve inventory
   │   └── [0,1,0] inventory reserve
   └── [0,2] payment charge
 ```


**What has not been added**:

- Any kind of DRAIN normalization for high cardinality span names
- Differences in scope, events, links attributes


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)