### PR TITLE
chore: use large runner for release workflow

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,5 @@
 self-hosted-runner:
-  # Grafana org GitHub-hosted runner labels, unknown to actionlint by default.
+  # Grafana org runner labels, unknown to actionlint by default.
   labels:
     - github-hosted-ubuntu-arm64
-    - github-hosted-ubuntu-x64-large
+    - ubuntu-x64-large

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Grafana org GitHub-hosted runner labels, unknown to actionlint by default.
+  labels:
+    - github-hosted-ubuntu-arm64
+    - github-hosted-ubuntu-x64-large

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'grafana/tempo'  # skip in forks
     # Large runner: goreleaser cross-compiles ~20 binaries in parallel, making
     # this the longest job in the repo (~17 min) on standard 4-vCPU runners.
-    runs-on: github-hosted-ubuntu-x64-large
+    runs-on: ubuntu-x64-large
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ permissions: {}
 jobs:
   release:
     if: github.repository == 'grafana/tempo'  # skip in forks
-    runs-on: ubuntu-24.04
+    # Large runner: goreleaser cross-compiles ~20 binaries in parallel, making
+    # this the longest job in the repo (~17 min) on standard 4-vCPU runners.
+    runs-on: github-hosted-ubuntu-x64-large
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
**What this PR does**:

Moves the release workflow to a larger runner (`ubuntu-x64-large`). The release job is the longest single job in the repo (~17 min, e.g. [this run](https://github.com/grafana/tempo/actions/runs/27218376010)), almost entirely spent in `make release-snapshot` where goreleaser cross-compiles ~20 binaries. goreleaser parallelizes across CPUs, so the standard 4-vCPU runner is the bottleneck. It is also the critical path of the tag-release flow: `release-tag.yml` blocks `publish` on this build while docker images finish in ~6 min.

Also adds `.github/actionlint.yaml` (already watched by the actionlint workflow) to declare custom runner labels, which actionlint otherwise rejects.

Other workflows are left as-is: the longest CI jobs are e2e integration tests bound by test wall-time rather than compile CPU, and already run in parallel.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (not needed, CI-only `chore:` change)