### PR TITLE
docs: backfill v2.10.7 changelog and release notes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,11 @@
 * [CHANGE] **BREAKING CHANGE** Clean up enterprise jsonnet [#6505](https://github.com/grafana/tempo/pull/6505) (@javiermolinar)
 * [CHANGE] Expose otlp http and grpc ports for Docker examples [#6296](https://github.com/grafana/tempo/pull/6296) (@javiermolinar)
 
+# v2.10.7
+
+* [CHANGE] Stop publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [#7106](https://github.com/grafana/tempo/pull/7106) (@javiermolinar)
+* [BUGFIX] Fix incorrect version reported by `--version`, the build-info metric, and `/api/status/buildinfo`. The build version is now read from the new top-level VERSION file instead of the most recently created git tag, which could belong to a different release. [#7469](https://github.com/grafana/tempo/pull/7469) (@zhxiaogg)
+
 # v2.10.6
 
 * [CHANGE] **BREAKING CHANGE** Remove Opencensus receiver [#7322](https://github.com/grafana/tempo/pull/7322) (@zhxiaogg)

--- a/docs/sources/tempo/release-notes/version-2/v2-10.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-10.md
@@ -281,6 +281,7 @@ Be aware of these breaking changes when upgrading to Tempo 2.10:
 - Go version upgrade: Tempo 2.10.1 upgrades to Go 1.25.7, which may affect custom builds or deployments with specific Go version requirements. (PR [#6449](https://github.com/grafana/tempo/pull/6449))
 - Go version upgrade: Tempo 2.10.5 upgrades to Go 1.26.2, which may affect custom builds or deployments with specific Go version requirements. [[PR 7040](https://github.com/grafana/tempo/pull/7040)]
 - OpenCensus receiver removed: Tempo 2.10.6 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7322](https://github.com/grafana/tempo/pull/7322)]
+- 32-bit ARM binaries removed: Tempo 2.10.7 stops publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [[PR 7106](https://github.com/grafana/tempo/pull/7106)]
 
 ## Project Rhythm: New Tempo architecture
 
@@ -336,6 +337,10 @@ The following updates were made to address security issues.
 ## Bug fixes
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
+
+### 2.10.7
+
+- Fixed the version reported by `--version`, the build-info metric, and `/api/status/buildinfo`. The build version is now read from the top-level `VERSION` file instead of the most recently created git tag, which could belong to a different release. [[PR 7469](https://github.com/grafana/tempo/pull/7469)]
 
 ### 2.10.2
 


### PR DESCRIPTION
**What this PR does**:
`main` was missing the `v2.10.7` section that already shipped on `release-v2.10`, so the released notes aren't reflected on `main` (per `RELEASES.md` Patch Releases step 8). This backfills:

- `CHANGELOG.md`: adds the `v2.10.7` section (build-version reporting fix, 32-bit ARM binary archives dropped), converted to main's entry style.
- `release-notes/version-2/v2-10.md`: adds a `### 2.10.7` bug-fixes entry for the version-reporting fix and a 32-bit-ARM-removal note under breaking changes.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` (N/A — backfills an already-released section onto `main`)