### PR TITLE
docs: add v2.10.7 release notes

### DIFF
--- a/docs/sources/tempo/release-notes/v2-10.md
+++ b/docs/sources/tempo/release-notes/v2-10.md
@@ -280,6 +280,7 @@ Be aware of these breaking changes when upgrading to Tempo 2.10:
   - Tempo 2.10.1 upgrades to Go 1.25.7. (PR [#6449](https://github.com/grafana/tempo/pull/6449))
   - Tempo 2.10.5 upgrades to Go 1.26.2. [[PR 7040](https://github.com/grafana/tempo/pull/7040)]
 - OpenCensus receiver removed: Tempo 2.10.6 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7322](https://github.com/grafana/tempo/pull/7322)]
+- 32-bit ARM binaries removed: Tempo 2.10.7 stops publishing 32-bit ARM binary archives. Release artifacts continue to include amd64 and arm64 binaries. [[PR 7106](https://github.com/grafana/tempo/pull/7106)]
 
 ## Project Rhythm: New Tempo architecture
 
@@ -335,6 +336,10 @@ The following updates were made to address security issues.
 ## Bug fixes
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
+
+### 2.10.7
+
+- Fixed the version reported by `--version`, the build-info metric, and `/api/status/buildinfo`. The build version is now read from the top-level `VERSION` file instead of the most recently created git tag, which could belong to a different release. [[PR 7469](https://github.com/grafana/tempo/pull/7469)]
 
 ### 2.10.2
 


### PR DESCRIPTION
**What this PR does**:
Adds the v2.10.7 release-notes entries to `release-notes/v2-10.md` on `release-v2.10`, which is the branch the versioned docs publish from:

- A `### 2.10.7` bug-fixes entry for the build-version reporting fix ([#7469](https://github.com/grafana/tempo/pull/7469)).
- A 32-bit-ARM-binaries-removal note under breaking changes ([#7106](https://github.com/grafana/tempo/pull/7106)).

The same entries land on `main` (for `/next/` docs) via #7479.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` (N/A — docs-only release-notes update)