### PR TITLE
[backendscheduler]: close redaction/compaction registration race with an atomic claim

### DIFF
--- a/.chloggen/redaction-atomic-claim.yaml
+++ b/.chloggen/redaction-atomic-claim.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: close a redaction/compaction registration race where a compaction registered concurrently with a redaction submission could leave its output block without a redaction job; the busy-block snapshot and batch barrier install are now atomic via ClaimRedactionBatch/TryRegisterJob.
+issues: [7482]
+subtext:
+user: zalegrala

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -67,6 +67,11 @@ func (s *BackendScheduler) RegisterJob(job *work.Job) {
 	s.work.RegisterJob(job)
 }
 
+// TryRegisterJob delegates to work.Work, satisfying the provider.Scheduler interface.
+func (s *BackendScheduler) TryRegisterJob(job *work.Job) bool {
+	return s.work.TryRegisterJob(job)
+}
+
 // New creates a new BackendScheduler
 func New(cfg Config, store storage.Store, overrides overrides.Interface, reader backend.RawReader, writer backend.RawWriter) (*BackendScheduler, error) {
 	err := ValidateConfig(&cfg)
@@ -451,10 +456,6 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 		return nil, status.Error(codes.FailedPrecondition, "compaction is disabled for this tenant")
 	}
 
-	if s.work.TenantPending(tenant) {
-		return nil, status.Error(codes.AlreadyExists, "a redaction is already in progress for this tenant")
-	}
-
 	batchID := uuid.New().String()
 	span.SetAttributes(
 		attribute.String("tenant", tenant),
@@ -468,49 +469,9 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 	if len(metas) == 0 {
 		return nil, status.Error(codes.NotFound, "no blocks found for tenant")
 	}
-
-	// Build a map of block ID -> job ID for all blocks currently referenced by
-	// any job. Blocks in active compaction may disappear before a redaction worker
-	// can process them — their contents will be merged into a new output block not
-	// yet covered by any pending redaction job. We record the job IDs so the
-	// maintenance loop can look up output blocks once compaction finishes.
-	// Since TenantPending returned false above, there are no active redaction jobs
-	// for this tenant, so busy blocks are exclusively from other providers.
-	busyBlocks := s.work.BusyBlocksForTenant(tenant)
-
-	skippedJobSet := make(map[string]struct{})
-	filtered := metas[:0:0]
-	for _, meta := range metas {
-		if jobID, busy := busyBlocks[meta.BlockID.String()]; busy {
-			skippedJobSet[jobID] = struct{}{}
-			continue
-		}
-		filtered = append(filtered, meta)
-	}
-	skippedBlocks := len(metas) - len(filtered)
-	if skippedBlocks > 0 {
-		level.Warn(log.Logger).Log("msg", "skipping blocks in active compaction jobs during redaction submission",
-			"tenant", tenant,
-			"skipped_blocks", skippedBlocks,
-			"skipped_compaction_jobs", len(skippedJobSet),
-			"total_blocks", len(metas))
-	}
-	metas = filtered
-
-	jobs := make([]*work.Job, 0, len(metas))
-	for _, meta := range metas {
-		jobs = append(jobs, &work.Job{
-			ID:   uuid.New().String(),
-			Type: tempopb.JobType_JOB_TYPE_REDACTION,
-			JobDetail: tempopb.JobDetail{
-				Tenant:  tenant,
-				BatchId: batchID,
-				Redaction: &tempopb.RedactionDetail{
-					BlockId: meta.BlockID.String(),
-					// TraceIds intentionally empty here — populated from batch in Next().
-				},
-			},
-		})
+	candidateBlockIDs := make([]string, len(metas))
+	for i, meta := range metas {
+		candidateBlockIDs[i] = meta.BlockID.String()
 	}
 
 	batch := &tempopb.RedactionBatch{
@@ -519,20 +480,47 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 		TraceIds:          req.TraceIds,
 		CreatedAtUnixNano: time.Now().UnixNano(),
 	}
-	if len(skippedJobSet) > 0 {
-		skippedJobIDs := make([]string, 0, len(skippedJobSet))
-		for id := range skippedJobSet {
-			skippedJobIDs = append(skippedJobIDs, id)
-		}
-		batch.SkippedCompactionJobIds = skippedJobIDs
-		batch.RescanAfterUnixNano = time.Now().Add(s.cfg.ProviderConfig.Redaction.RescanDelay).UnixNano()
+
+	// Atomically install the batch barrier and classify the candidate blocks against the
+	// tenant's busy blocks in a single critical section. Blocks under active compaction
+	// are recorded as skipped — their compaction job IDs feed the rescan, which follows
+	// the output blocks once compaction finishes — and the rest are free to redact
+	// directly. Because the busy snapshot and the barrier install are atomic, no
+	// compaction can register a block for this tenant in between and slip its output past
+	// the skip set (the prior split TenantPending-check / snapshot / AddBatch left that gap).
+	rescanAfter := time.Now().Add(s.cfg.ProviderConfig.Redaction.RescanDelay).UnixNano()
+	free, skipped, ok := s.work.ClaimRedactionBatch(batch, candidateBlockIDs, rescanAfter)
+	if !ok {
+		return nil, status.Error(codes.AlreadyExists, "a redaction is already in progress for this tenant")
 	}
 
-	// Store batch first, then jobs. On job failure, roll back the batch so the
-	// tenant is not permanently locked out of future submissions.
-	if err := s.work.AddBatch(batch); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+	skippedBlocks := len(candidateBlockIDs) - len(free)
+	if skippedBlocks > 0 {
+		level.Warn(log.Logger).Log("msg", "skipping blocks in active compaction jobs during redaction submission",
+			"tenant", tenant,
+			"skipped_blocks", skippedBlocks,
+			"skipped_compaction_jobs", len(skipped),
+			"total_blocks", len(candidateBlockIDs))
 	}
+
+	jobs := make([]*work.Job, 0, len(free))
+	for _, blockID := range free {
+		jobs = append(jobs, &work.Job{
+			ID:   uuid.New().String(),
+			Type: tempopb.JobType_JOB_TYPE_REDACTION,
+			JobDetail: tempopb.JobDetail{
+				Tenant:  tenant,
+				BatchId: batchID,
+				Redaction: &tempopb.RedactionDetail{
+					BlockId: blockID,
+					// TraceIds intentionally empty here — populated from batch in Next().
+				},
+			},
+		})
+	}
+
+	// The batch is already installed by ClaimRedactionBatch; on job-creation failure roll
+	// it back so the tenant is not permanently locked out of future submissions.
 	if err := s.work.AddPendingJobs(jobs); err != nil {
 		s.work.RemoveBatch(tenant)
 		return nil, status.Error(codes.Internal, err.Error())

--- a/modules/backendscheduler/provider/compaction.go
+++ b/modules/backendscheduler/provider/compaction.go
@@ -163,21 +163,20 @@ func (p *CompactionProvider) Start(ctx context.Context) <-chan *work.Job {
 				continue
 			}
 
-			// Re-check after job creation: a batch may have been submitted while we were
-			// draining the selector that was built before the submission. Discard the job
-			// before it enters the recent-jobs cache or the channel.
-			// TenantPending is true for the full batch lifetime (submission → cleanup),
-			// which subsumes the HasJobsForTenant(REDACTION) condition.
-			if p.sched.TenantPending(p.curTenant.Value()) {
-				level.Info(p.logger).Log("msg", "redaction batch submitted for tenant since selector was built; abandoning remaining compaction jobs", "tenant", p.curTenant.Value())
+			// Atomically register the job only if no redaction batch is active for the
+			// tenant. A batch may have been submitted while we were draining the selector
+			// that was built before the submission. TryRegisterJob and ClaimRedactionBatch
+			// are serialized by the batch RWMutex, so this either registers the job before
+			// the claim's busy snapshot (input blocks recorded for rescan) or is refused
+			// because the barrier is already installed (blocks stay put, redacted directly).
+			// This closes the check-then-act gap between a separate TenantPending check and
+			// RegisterJob.
+			if !p.sched.TryRegisterJob(job) {
+				level.Info(p.logger).Log("msg", "redaction batch active for tenant; abandoning remaining compaction jobs", "tenant", p.curTenant.Value())
 				span.AddEvent("tenant has active redaction batch")
 				reset()
 				continue
 			}
-
-			// Register the job so SubmitRedaction can see its input blocks
-			// before the job is promoted to active via AddJob.
-			p.sched.RegisterJob(job)
 
 			select {
 			case <-ctx.Done():

--- a/modules/backendscheduler/provider/types.go
+++ b/modules/backendscheduler/provider/types.go
@@ -22,6 +22,11 @@ type Scheduler interface {
 	// promoted to the active map via AddJob.
 	RegisterJob(job *work.Job)
 
+	// TryRegisterJob registers a job only if no redaction batch is active for its
+	// tenant, atomically with respect to batch installation. Returns false (without
+	// registering) when a batch is active.
+	TryRegisterJob(job *work.Job) bool
+
 	// HasJobsForTenant returns true if there are any jobs of the given type in
 	// any state (pending, in-flight, or active) for the tenant.
 	HasJobsForTenant(tenantID string, jobType tempopb.JobType) bool

--- a/modules/backendscheduler/work/batch.go
+++ b/modules/backendscheduler/work/batch.go
@@ -155,7 +155,7 @@ func (w *Work) ClaimRedactionBatch(batch *tempopb.RedactionBatch, candidateBlock
 	busy := w.busyBlocksForTenantLocked(batch.TenantId)
 	w.pendingMtx.Unlock()
 
-	skippedSet := make(map[string]struct{})
+	skippedSet := make(map[string]struct{}, len(busy))
 	free = make([]string, 0, len(candidateBlockIDs))
 	for _, blockID := range candidateBlockIDs {
 		if jobID, isBusy := busy[blockID]; isBusy {

--- a/modules/backendscheduler/work/batch.go
+++ b/modules/backendscheduler/work/batch.go
@@ -133,6 +133,52 @@ func (w *Work) AddBatch(batch *tempopb.RedactionBatch) error {
 	return w.batches.add(batch)
 }
 
+// ClaimRedactionBatch atomically installs batch for its tenant and classifies the
+// candidate block IDs against the tenant's busy blocks under one critical section, so no
+// provider can register a block for the tenant between the snapshot and the barrier
+// becoming active (see TryRegisterJob). Returns the block IDs that are free to redact and
+// the busy compaction job IDs to rescan; ok=false (nothing installed) if a batch already
+// exists for the tenant. When any block is skipped, the batch's rescan fields are set to
+// rescanAfter before the batch becomes observable, so a maintenance tick never sees a
+// half-initialized batch.
+//
+// Lock order: batch store (write) OUTER, pendingMtx INNER.
+func (w *Work) ClaimRedactionBatch(batch *tempopb.RedactionBatch, candidateBlockIDs []string, rescanAfter int64) (free []string, skipped []string, ok bool) {
+	w.batches.mu.Lock()
+	defer w.batches.mu.Unlock()
+
+	if _, exists := w.batches.byTenant[batch.TenantId]; exists {
+		return nil, nil, false
+	}
+
+	w.pendingMtx.Lock()
+	busy := w.busyBlocksForTenantLocked(batch.TenantId)
+	w.pendingMtx.Unlock()
+
+	skippedSet := make(map[string]struct{})
+	free = make([]string, 0, len(candidateBlockIDs))
+	for _, blockID := range candidateBlockIDs {
+		if jobID, isBusy := busy[blockID]; isBusy {
+			if _, seen := skippedSet[jobID]; !seen {
+				skippedSet[jobID] = struct{}{}
+				skipped = append(skipped, jobID)
+			}
+			continue
+		}
+		free = append(free, blockID)
+	}
+
+	if len(skipped) > 0 {
+		batch.SkippedCompactionJobIds = skipped
+		batch.RescanAfterUnixNano = rescanAfter
+	}
+
+	// Install last, with rescan fields already populated, so the batch is never
+	// observable in a half-initialized state.
+	w.batches.byTenant[batch.TenantId] = batch
+	return free, skipped, true
+}
+
 // GetBatch returns a live pointer into batchStore. Callers must treat the returned
 // value as read-only; use SetBatchRescan to mutate rescan fields under the write lock.
 // TODO: return a copy or add narrower accessor methods so the read-only contract is

--- a/modules/backendscheduler/work/claim_test.go
+++ b/modules/backendscheduler/work/claim_test.go
@@ -29,8 +29,8 @@ func compactionJob(tenant string, inputs ...string) *Job {
 	}
 }
 
-func redactionBatch(tenant, id string) *tempopb.RedactionBatch {
-	return &tempopb.RedactionBatch{BatchId: id, TenantId: tenant, TraceIds: [][]byte{[]byte("trace")}}
+func redactionBatch(id string) *tempopb.RedactionBatch {
+	return &tempopb.RedactionBatch{BatchId: id, TenantId: "t1", TraceIds: [][]byte{[]byte("trace")}}
 }
 
 func toSet(s []string) map[string]struct{} {
@@ -50,7 +50,7 @@ func TestClaimRedactionBatch_RegisterThenClaim(t *testing.T) {
 	require.True(t, w.TryRegisterJob(j), "no batch active yet → job registers")
 	require.True(t, w.IsBlockBusy("t1", "B"))
 
-	free, skipped, ok := w.ClaimRedactionBatch(redactionBatch("t1", "batch"), []string{"B", "C"}, int64(12345))
+	free, skipped, ok := w.ClaimRedactionBatch(redactionBatch("batch"), []string{"B", "C"}, int64(12345))
 	require.True(t, ok)
 	require.Equal(t, []string{j.ID}, skipped, "block under active compaction recorded for rescan")
 	require.Equal(t, []string{"C"}, free, "only the free block is redacted directly")
@@ -61,7 +61,7 @@ func TestClaimRedactionBatch_RegisterThenClaim(t *testing.T) {
 // covers it.
 func TestClaimRedactionBatch_ClaimThenRegisterRefused(t *testing.T) {
 	w := newTestWork(t)
-	free, skipped, ok := w.ClaimRedactionBatch(redactionBatch("t1", "batch"), []string{"B"}, int64(12345))
+	free, skipped, ok := w.ClaimRedactionBatch(redactionBatch("batch"), []string{"B"}, int64(12345))
 	require.True(t, ok)
 	require.Equal(t, []string{"B"}, free)
 	require.Empty(t, skipped)
@@ -73,10 +73,10 @@ func TestClaimRedactionBatch_ClaimThenRegisterRefused(t *testing.T) {
 
 func TestClaimRedactionBatch_RejectsConcurrentBatch(t *testing.T) {
 	w := newTestWork(t)
-	_, _, ok := w.ClaimRedactionBatch(redactionBatch("t1", "b1"), []string{"B"}, 0)
+	_, _, ok := w.ClaimRedactionBatch(redactionBatch("b1"), []string{"B"}, 0)
 	require.True(t, ok)
 
-	free, skipped, ok2 := w.ClaimRedactionBatch(redactionBatch("t1", "b2"), []string{"C"}, 0)
+	free, skipped, ok2 := w.ClaimRedactionBatch(redactionBatch("b2"), []string{"C"}, 0)
 	require.False(t, ok2, "second batch for the same tenant must be rejected")
 	require.Nil(t, free)
 	require.Nil(t, skipped)
@@ -104,7 +104,7 @@ func TestClaimRedactionBatch_RegisterRaceInvariant(t *testing.T) {
 	wg.Add(N + 1)
 	go func() {
 		defer wg.Done()
-		free, skipped, _ = w.ClaimRedactionBatch(redactionBatch("t1", "b"), blockIDs, int64(1))
+		free, skipped, _ = w.ClaimRedactionBatch(redactionBatch("b"), blockIDs, int64(1))
 	}()
 	for i := range jobs {
 		go func() {

--- a/modules/backendscheduler/work/claim_test.go
+++ b/modules/backendscheduler/work/claim_test.go
@@ -1,0 +1,130 @@
+package work
+
+import (
+	"flag"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestWork(t *testing.T) *Work {
+	t.Helper()
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	return New(cfg).(*Work)
+}
+
+func compactionJob(tenant string, inputs ...string) *Job {
+	return &Job{
+		ID:   uuid.New().String(),
+		Type: tempopb.JobType_JOB_TYPE_COMPACTION,
+		JobDetail: tempopb.JobDetail{
+			Tenant:     tenant,
+			Compaction: &tempopb.CompactionDetail{Input: inputs},
+		},
+	}
+}
+
+func redactionBatch(tenant, id string) *tempopb.RedactionBatch {
+	return &tempopb.RedactionBatch{BatchId: id, TenantId: tenant, TraceIds: [][]byte{[]byte("trace")}}
+}
+
+func toSet(s []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(s))
+	for _, v := range s {
+		m[v] = struct{}{}
+	}
+	return m
+}
+
+// Ordering A: a compaction job registered BEFORE the claim is seen by the claim's
+// busy snapshot, so its input block is recorded for rescan (skipped), never redacted
+// directly.
+func TestClaimRedactionBatch_RegisterThenClaim(t *testing.T) {
+	w := newTestWork(t)
+	j := compactionJob("t1", "B")
+	require.True(t, w.TryRegisterJob(j), "no batch active yet → job registers")
+	require.True(t, w.IsBlockBusy("t1", "B"))
+
+	free, skipped, ok := w.ClaimRedactionBatch(redactionBatch("t1", "batch"), []string{"B", "C"}, int64(12345))
+	require.True(t, ok)
+	require.Equal(t, []string{j.ID}, skipped, "block under active compaction recorded for rescan")
+	require.Equal(t, []string{"C"}, free, "only the free block is redacted directly")
+}
+
+// Ordering B: once the claim has installed the barrier, a compaction job for the same
+// tenant is refused — so the block stays put and the redaction job (built from `free`)
+// covers it.
+func TestClaimRedactionBatch_ClaimThenRegisterRefused(t *testing.T) {
+	w := newTestWork(t)
+	free, skipped, ok := w.ClaimRedactionBatch(redactionBatch("t1", "batch"), []string{"B"}, int64(12345))
+	require.True(t, ok)
+	require.Equal(t, []string{"B"}, free)
+	require.Empty(t, skipped)
+
+	j := compactionJob("t1", "B")
+	require.False(t, w.TryRegisterJob(j), "compaction must be refused while a batch is active")
+	require.False(t, w.IsBlockBusy("t1", "B"), "refused job must not be registered")
+}
+
+func TestClaimRedactionBatch_RejectsConcurrentBatch(t *testing.T) {
+	w := newTestWork(t)
+	_, _, ok := w.ClaimRedactionBatch(redactionBatch("t1", "b1"), []string{"B"}, 0)
+	require.True(t, ok)
+
+	free, skipped, ok2 := w.ClaimRedactionBatch(redactionBatch("t1", "b2"), []string{"C"}, 0)
+	require.False(t, ok2, "second batch for the same tenant must be rejected")
+	require.Nil(t, free)
+	require.Nil(t, skipped)
+}
+
+// The core safety property under concurrency: for every compaction job racing the
+// claim, EITHER it registered (and the claim recorded it for rescan) OR it was refused
+// (and the claim left its block free to redact). Never registered-AND-free, which would
+// leave a compaction output uncovered → trace survives redaction. Run with -race.
+func TestClaimRedactionBatch_RegisterRaceInvariant(t *testing.T) {
+	const N = 64
+	w := newTestWork(t)
+
+	jobs := make([]*Job, N)
+	blockIDs := make([]string, N)
+	for i := range jobs {
+		blockIDs[i] = fmt.Sprintf("B%d", i)
+		jobs[i] = compactionJob("t1", blockIDs[i])
+	}
+
+	registered := make([]bool, N)
+	var free, skipped []string
+
+	var wg sync.WaitGroup
+	wg.Add(N + 1)
+	go func() {
+		defer wg.Done()
+		free, skipped, _ = w.ClaimRedactionBatch(redactionBatch("t1", "b"), blockIDs, int64(1))
+	}()
+	for i := range jobs {
+		go func() {
+			defer wg.Done()
+			registered[i] = w.TryRegisterJob(jobs[i])
+		}()
+	}
+	wg.Wait()
+
+	freeSet := toSet(free)
+	skippedSet := toSet(skipped)
+	for i, j := range jobs {
+		if registered[i] {
+			require.Contains(t, skippedSet, j.ID,
+				"job %d (block %s) registered before the claim must be recorded for rescan", i, blockIDs[i])
+			require.NotContains(t, freeSet, blockIDs[i],
+				"block %s under compaction must not also be redacted directly", blockIDs[i])
+		} else {
+			require.Contains(t, freeSet, blockIDs[i],
+				"block %s whose compaction was refused must be redacted directly", blockIDs[i])
+		}
+	}
+}

--- a/modules/backendscheduler/work/interface.go
+++ b/modules/backendscheduler/work/interface.go
@@ -30,6 +30,11 @@ type Interface interface {
 	// visible to other components. Cleared automatically by AddJob when promoted to active.
 	RegisterJob(job *Job)
 
+	// TryRegisterJob registers job (like RegisterJob) only if no redaction batch is
+	// active for its tenant, atomically with respect to ClaimRedactionBatch. Returns
+	// false without registering when a batch is active.
+	TryRegisterJob(job *Job) bool
+
 	// HasJobsForTenant returns true if there are any jobs of the given type in any
 	// state (pending queue, in-flight channel, or active map) for the tenant.
 	HasJobsForTenant(tenantID string, jobType tempopb.JobType) bool
@@ -52,6 +57,13 @@ type Interface interface {
 
 	// Batch management -- shared trace ID list for redaction jobs to avoid per-job copies.
 	AddBatch(batch *tempopb.RedactionBatch) error
+
+	// ClaimRedactionBatch atomically installs batch for its tenant and classifies the
+	// candidate block IDs against the tenant's busy blocks under one critical section,
+	// so no provider can register a block for the tenant between the snapshot and the
+	// barrier becoming active. Returns the block IDs free to redact and the busy
+	// compaction job IDs to rescan; ok=false (nothing installed) if a batch exists.
+	ClaimRedactionBatch(batch *tempopb.RedactionBatch, candidateBlockIDs []string, rescanAfter int64) (free []string, skipped []string, ok bool)
 	GetBatch(tenantID string) *tempopb.RedactionBatch
 	RemoveBatch(tenantID string)
 	ListBatches() []*tempopb.RedactionBatch

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -174,12 +174,38 @@ func (w *Work) AddJob(j *Job) error {
 // The registration is cleared automatically when AddJob promotes the job to active.
 func (w *Work) RegisterJob(job *Job) {
 	w.pendingMtx.Lock()
+	w.registerJobLocked(job)
+	w.pendingMtx.Unlock()
+}
+
+// registerJobLocked indexes job's blocks as registered/running. Caller must hold pendingMtx.
+func (w *Work) registerJobLocked(job *Job) {
 	w.registeredJobs[job.ID] = job
 	for _, key := range runningBlockKeys(job) {
 		w.runningBlocks[key] = job
 	}
 	w.addRunningBlocksByTenant(job)
+}
+
+// TryRegisterJob registers job (like RegisterJob) only if no redaction batch is active
+// for its tenant, atomically with respect to ClaimRedactionBatch. Returns false without
+// registering when a batch is active.
+//
+// Lock order: batch store (read) OUTER, pendingMtx INNER — the same direction
+// ClaimRedactionBatch takes the batch write lock, so the two are serialized by the batch
+// RWMutex and never partially interleave. A compaction therefore either registers fully
+// before the claim's snapshot (its block lands in the snapshot → recorded for rescan) or
+// observes the installed barrier and is refused (the block stays put for direct redaction).
+func (w *Work) TryRegisterJob(job *Job) bool {
+	w.batches.mu.RLock()
+	defer w.batches.mu.RUnlock()
+	if _, active := w.batches.byTenant[job.Tenant()]; active {
+		return false
+	}
+	w.pendingMtx.Lock()
+	w.registerJobLocked(job)
 	w.pendingMtx.Unlock()
+	return true
 }
 
 // FlushToLocal writes the work cache to local storage using sharding optimizations
@@ -901,15 +927,21 @@ func (w *Work) IsBlockBusy(tenantID, blockID string) bool {
 // currently referenced by a pending, registered, or active job for the tenant.
 // Acquires pendingMtx exactly once and returns a snapshot.
 func (w *Work) BusyBlocksForTenant(tenantID string) map[string]string {
-	result := make(map[string]string)
 	w.pendingMtx.Lock()
+	defer w.pendingMtx.Unlock()
+	return w.busyBlocksForTenantLocked(tenantID)
+}
+
+// busyBlocksForTenantLocked returns blockID -> jobID for the tenant's pending and
+// running blocks. Caller must hold pendingMtx.
+func (w *Work) busyBlocksForTenantLocked(tenantID string) map[string]string {
+	result := make(map[string]string)
 	for blockID, jobID := range w.pendingBlocksByTenant[tenantID] {
 		result[blockID] = jobID
 	}
 	for blockID, jobID := range w.runningBlocksByTenant[tenantID] {
 		result[blockID] = jobID
 	}
-	w.pendingMtx.Unlock()
 	return result
 }
 

--- a/modules/backendworker/backendworker.go
+++ b/modules/backendworker/backendworker.go
@@ -382,9 +382,12 @@ func (w *BackendWorker) processRedactionJob(ctx context.Context, resp *tempopb.N
 	}
 	if meta == nil {
 		// Block absent from the live blocklist (e.g. compacted or retained away).
-		// Completing as a no-op is correct only because the scheduler re-targets a
-		// moved trace via the batch's coverage logic; surface it so a genuine
-		// coverage gap is visible rather than a silent "successful" redaction.
+		// Redaction coverage is the scheduler's responsibility: blocks under active
+		// compaction at submission are recorded for rescan against their output, and
+		// ClaimRedactionBatch blocks new compaction for the duration of a batch. This
+		// no-op only finalizes this one job — it does not itself guarantee the trace was
+		// redacted — so count it to make a genuine coverage gap observable rather than a
+		// silent "successful" redaction.
 		metricRedactionBlockMissing.WithLabelValues(tenantID).Inc()
 		level.Warn(log.Logger).Log("msg", "redaction block not found in live blocklist, completing as no-op",
 			"job_id", resp.JobId, "block_id", blockIDStr, "tenant", tenantID)


### PR DESCRIPTION
**What this PR does**:

Closes a correctness gap in the backend scheduler's redaction path where a compaction job registered concurrently with a redaction submission could leave its output block without a redaction job.

`SubmitRedaction` took the tenant's busy-block snapshot and installed the redaction batch barrier in **separate** critical sections, and the compaction provider re-checked `TenantPending` and then called `RegisterJob` in separate sections. A compaction that registered in the gap was invisible to the redaction skip set, so its output block received no redaction job — the target trace could survive redaction.

This adds two atomic `work` methods that share a single canonical lock order (batch store **outer**, `pendingMtx` **inner**):

- **`ClaimRedactionBatch`** — installs the batch and classifies the candidate blocks against the tenant's busy blocks in one critical section, returning the blocks free to redact and the busy compaction job IDs to rescan.
- **`TryRegisterJob`** — registers a job only if no redaction batch is active for its tenant.

Because the batch `RWMutex` serializes the two, a compaction either registers **before** the claim's snapshot (its input blocks are recorded for rescan) or is **refused** after the barrier is installed (the blocks stay put and are redacted directly) — never uncovered. `SubmitRedaction` and the compaction provider are swapped onto these methods. A backend-worker comment that described re-targeting logic which does not exist is also corrected.

Tests: deterministic coverage of both orderings, a rejection test, and a `-race` concurrency invariant (every racing compaction is either recorded for rescan or refused, never left uncovered). Existing scheduler/provider suites pass; `-race` is clean.

**Which issue(s) this PR fixes**:

Tracked internally.
