### PR TITLE
docs: Add 2.9.4 rel notes to Version 2.9 (release-v2.10)

### DIFF
--- a/docs/sources/tempo/release-notes/v2-9.md
+++ b/docs/sources/tempo/release-notes/v2-9.md
@@ -132,6 +132,27 @@ The following improvements have been made to TraceQL query performance:
 
 When [upgrading](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/upgrade/) to Tempo 2.9, be aware of these considerations and breaking changes.
 
+### OpenCensus receiver removed
+
+Tempo 2.9.3 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7323](https://github.com/grafana/tempo/pull/7323)]
+
+### Busybox removed from Tempo image
+
+The Tempo container image no longer includes busybox. This change reduces the image size and attack surface, preventing future busybox-related vulnerabilities from affecting Tempo deployments. [[PR 7410](https://github.com/grafana/tempo/pull/7410)]
+
+The image switched from `gcr.io/distroless/static-debian12:debug`, which includes busybox, to `gcr.io/distroless/static-debian12`, which doesn't. The busybox shell and utilities are no longer available inside the running container.
+
+You can no longer `exec` into the Tempo container with a shell. Commands like `kubectl exec -it <pod> -- sh` or `docker exec -it <container> sh` will fail.
+
+To debug a running Tempo container, use one of these alternatives:
+
+- Kubernetes ephemeral debug containers (`kubectl debug`)
+- Docker Desktop or other container runtime tools that support shell injection for distroless images
+
+If you have custom Docker Compose files or scripts that use the Tempo image for shell operations (such as running `chown` in an init container), update them to use a separate `busybox:latest` image for those tasks.
+
+Tempo's runtime behavior, configuration options, and APIs are unchanged.
+
 ### RPM and DEB packages discontinued
 
 Tempo no longer publishes RPM and DEB packages due to an internal change to the handling of signing keys. This can be restored if customers need these packages. ([PR 5684](https://github.com/grafana/tempo/pull/5684))
@@ -209,6 +230,11 @@ Project Rhythm works as follows:
 
 The following updates were made to address security issues.
 
+### 2.9.3
+
+- Updated `github.com/apache/thrift` to v0.23.0, `golang.org/x/crypto` to v0.52.0, `golang.org/x/net` to v0.55.0, and `golang.org/x/sys` to v0.44.0 to pick up upstream security fixes. (PRs [#7119](https://github.com/grafana/tempo/pull/7119), [#7258](https://github.com/grafana/tempo/pull/7258), [#7343](https://github.com/grafana/tempo/pull/7343), [#7128](https://github.com/grafana/tempo/pull/7128), [#7259](https://github.com/grafana/tempo/pull/7259), [#7371](https://github.com/grafana/tempo/pull/7371), [#7260](https://github.com/grafana/tempo/pull/7260))
+- Built Tempo with Go 1.26.3, which includes upstream security and bug fixes. [[PR 7421](https://github.com/grafana/tempo/pull/7421)]
+
 ### 2.9.2
 
 - Updated Go to version 1.26.2 to address [CVE-2026-25679](https://nvd.nist.gov/vuln/detail/CVE-2026-25679). [[PR 6779](https://github.com/grafana/tempo/pull/6779)]
@@ -230,6 +256,12 @@ The following updates were made to address security issues.
 ## Bug fixes
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
+
+### 2.9.3
+
+- Fixed metrics-generator panic when `write_relabel_configs` is set, caused by uninitialized `NameValidationScheme` after Prometheus dependency upgrade. [[PR 7338](https://github.com/grafana/tempo/pull/7338)]
+
+### 2.9.0
 
 - Fixed Tempo configuration options that are always overridden with configuration overrides section. ([PR 5202](https://github.com/grafana/tempo/pull/5202))
 - Correctly apply trace idle period in ingesters and add the concept of trace live period. ([PR 5346](https://github.com/grafana/tempo/pull/5346))

--- a/docs/sources/tempo/release-notes/v2-9.md
+++ b/docs/sources/tempo/release-notes/v2-9.md
@@ -134,7 +134,7 @@ When [upgrading](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/upgr
 
 ### OpenCensus receiver removed
 
-Tempo 2.9.3 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7323](https://github.com/grafana/tempo/pull/7323)]
+Tempo 2.9.4 drops support for the OpenCensus receiver. Senders using OpenCensus must switch to OTLP. [[PR 7323](https://github.com/grafana/tempo/pull/7323)]
 
 ### Busybox removed from Tempo image
 
@@ -149,13 +149,17 @@ To debug a running Tempo container, use one of these alternatives:
 - Kubernetes ephemeral debug containers (`kubectl debug`)
 - Docker Desktop or other container runtime tools that support shell injection for distroless images
 
-If you have custom Docker Compose files or scripts that use the Tempo image for shell operations (such as running `chown` in an init container), update them to use a separate `busybox:latest` image for those tasks.
+If you have custom Docker Compose files or scripts that use the Tempo image for shell operations (such as running `chown` in an init container), update them to use a separate BusyBox image for those tasks. Pin the image to a specific version (for example, `busybox:1.37.0`) rather than `busybox:latest` to keep deployments reproducible and avoid unexpected changes when the image updates.
 
 Tempo's runtime behavior, configuration options, and APIs are unchanged.
 
 ### RPM and DEB packages discontinued
 
 Tempo no longer publishes RPM and DEB packages due to an internal change to the handling of signing keys. This can be restored if customers need these packages. ([PR 5684](https://github.com/grafana/tempo/pull/5684))
+
+### 32-bit ARM release artifacts discontinued
+
+Tempo 2.9.4 stops publishing 32-bit ARM binary archives. Release artifacts continue to include `amd64` and `arm64` binaries. If you run Tempo on a 32-bit ARM platform, move to a 64-bit platform before upgrading. ([PR 7106](https://github.com/grafana/tempo/pull/7106))
 
 ### Migrated Vulture and integration tests to OTLP exporter
 
@@ -230,10 +234,10 @@ Project Rhythm works as follows:
 
 The following updates were made to address security issues.
 
-### 2.9.3
+### 2.9.4
 
+- Updated Go to 1.26.5 and bumped the vendored `golang.org/x/net` and `golang.org/x/text` modules to address [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822), [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504), [CVE-2026-27145](https://nvd.nist.gov/vuln/detail/CVE-2026-27145), [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505), [CVE-2026-42507](https://nvd.nist.gov/vuln/detail/CVE-2026-42507), [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600), and [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852). [[PR 7641](https://github.com/grafana/tempo/pull/7641)]
 - Updated `github.com/apache/thrift` to v0.23.0, `golang.org/x/crypto` to v0.52.0, `golang.org/x/net` to v0.55.0, and `golang.org/x/sys` to v0.44.0 to pick up upstream security fixes. (PRs [#7119](https://github.com/grafana/tempo/pull/7119), [#7258](https://github.com/grafana/tempo/pull/7258), [#7343](https://github.com/grafana/tempo/pull/7343), [#7128](https://github.com/grafana/tempo/pull/7128), [#7259](https://github.com/grafana/tempo/pull/7259), [#7371](https://github.com/grafana/tempo/pull/7371), [#7260](https://github.com/grafana/tempo/pull/7260))
-- Built Tempo with Go 1.26.3, which includes upstream security and bug fixes. [[PR 7421](https://github.com/grafana/tempo/pull/7421)]
 
 ### 2.9.2
 
@@ -257,7 +261,7 @@ The following updates were made to address security issues.
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
 
-### 2.9.3
+### 2.9.4
 
 - Fixed metrics-generator panic when `write_relabel_configs` is set, caused by uninitialized `NameValidationScheme` after Prometheus dependency upgrade. [[PR 7338](https://github.com/grafana/tempo/pull/7338)]
 


### PR DESCRIPTION
Adds the Tempo 2.9.4 patch entries to the Version 2.9 release notes page on `release-v2.10`. Covers the user-facing changes from the 2.9.4 changelog: dependency/security updates plus Go 1.26.3, the OpenCensus receiver removal (breaking), busybox removal, and the metrics-generator `write_relabel_configs` panic fix.

Wording matches the equivalent 2.10 entries where the same patches apply; all entries verified against the `release-v2.9` code. Label for backport to `release-v2.9`.

The 2.9 release notes for 3.0 and main are here: https://github.com/grafana/tempo/pull/7486