### PR TITLE
perf(collector): make scoped distinct string collector lock-free

### DIFF
--- a/.chloggen/scoped-distinct-string-lockfree.yaml
+++ b/.chloggen/scoped-distinct-string-lockfree.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: live-store
+note: reduce mutex contention in tag search by making the scoped distinct string collector lock-free
+issues: []
+subtext:
+user: zhxiaogg

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -71,7 +71,7 @@ func (d *DistinctString) Collect(s string) (added bool) {
 	}
 
 	if d.maxCacheHits > 0 && d.currentCacheHits.Load() >= d.maxCacheHits {
-		d.setExceeded(fmt.Sprintf("Max stale values exceeded: cacheHits %d, maxValues %d", d.currentCacheHits.Load(), d.maxCacheHits))
+		d.setExceeded(fmt.Sprintf("Max stale values exceeded: cacheHits %d, maxCacheHits %d", d.currentCacheHits.Load(), d.maxCacheHits))
 		return false
 	}
 

--- a/pkg/collector/distinct_string_collector.go
+++ b/pkg/collector/distinct_string_collector.go
@@ -5,21 +5,21 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 type DistinctString struct {
-	values           map[string]struct{}
-	new              map[string]struct{}
+	values           sync.Map // map[string]struct{}, written once per distinct value, read many times
+	new              sync.Map // map[string]struct{}, only used when diffEnabled
 	maxDataSize      int
-	currDataSize     int
-	currentValuesLen uint32
+	currDataSize     atomic.Int64
+	currentValuesLen atomic.Uint32
 	maxValues        uint32
 	maxCacheHits     uint32
-	currentCacheHits uint32
+	currentCacheHits atomic.Uint32
 	diffEnabled      bool
-	limExceeded      bool
-	mtx              sync.Mutex
-	stopReason       string
+	limExceeded      atomic.Bool
+	stopReason       atomic.Pointer[string]
 }
 
 // NewDistinctString with the given maximum data size and max items.
@@ -27,7 +27,6 @@ type DistinctString struct {
 // For ease of use, maxDataSize=0 and maxItems=0 are interpreted as unlimited.
 func NewDistinctString(maxDataSize int, maxValues uint32, staleValueThreshold uint32) *DistinctString {
 	return &DistinctString{
-		values:       make(map[string]struct{}),
 		maxDataSize:  maxDataSize,
 		diffEnabled:  false, // disable diff to make it faster
 		maxValues:    maxValues,
@@ -40,8 +39,6 @@ func NewDistinctString(maxDataSize int, maxValues uint32, staleValueThreshold ui
 // For ease of use, maxDataSize=0 and maxItems=0 are interpreted as unlimited.
 func NewDistinctStringWithDiff(maxDataSize int, maxValues uint32, staleValueThreshold uint32) *DistinctString {
 	return &DistinctString{
-		values:       make(map[string]struct{}),
-		new:          make(map[string]struct{}),
 		maxDataSize:  maxDataSize,
 		diffEnabled:  true,
 		maxValues:    maxValues,
@@ -52,63 +49,78 @@ func NewDistinctStringWithDiff(maxDataSize int, maxValues uint32, staleValueThre
 // Collect adds a new value to the distinct string collector
 // and returns a boolean indicating whether the value was successfully added or not.
 // To check if the limit has been reached, you must call the Exceeded method separately.
+//
+// The hot path is an already-seen value (tag keys repeat across every row group
+// and block), which is a lock-free sync.Map read with no shared writes. Limits
+// are soft: under concurrency a few values may slip past before limExceeded is observed.
 func (d *DistinctString) Collect(s string) (added bool) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
-	if d.limExceeded {
+	if d.limExceeded.Load() {
 		return false
 	}
+
 	valueLen := len(s)
 
-	if d.maxDataSize > 0 && d.currDataSize+valueLen >= d.maxDataSize {
-		d.stopReason = fmt.Sprintf("Max data exceeded: dataSize %d, maxDataSize %d", d.currDataSize, d.maxDataSize)
-		d.limExceeded = true
+	if d.maxDataSize > 0 && int(d.currDataSize.Load())+valueLen >= d.maxDataSize {
+		d.setExceeded(fmt.Sprintf("Max data exceeded: dataSize %d, maxDataSize %d", d.currDataSize.Load(), d.maxDataSize))
 		return false
 	}
 
-	if d.maxValues > 0 && d.currentValuesLen >= d.maxValues {
-		d.stopReason = fmt.Sprintf("Max values exceeded: values %d, maxValues %d", d.currentValuesLen, d.maxValues)
-		d.limExceeded = true
+	if d.maxValues > 0 && d.currentValuesLen.Load() >= d.maxValues {
+		d.setExceeded(fmt.Sprintf("Max values exceeded: values %d, maxValues %d", d.currentValuesLen.Load(), d.maxValues))
 		return false
 	}
 
-	if d.maxCacheHits > 0 && d.currentCacheHits >= d.maxCacheHits {
-		d.stopReason = fmt.Sprintf("Max stale values exceeded: cacheHits %d, maxValues %d", d.currentValuesLen, d.maxCacheHits)
-		d.limExceeded = true
+	if d.maxCacheHits > 0 && d.currentCacheHits.Load() >= d.maxCacheHits {
+		d.setExceeded(fmt.Sprintf("Max stale values exceeded: cacheHits %d, maxValues %d", d.currentCacheHits.Load(), d.maxCacheHits))
 		return false
 	}
 
-	if _, ok := d.values[s]; ok {
-		// Already present
-		d.currentCacheHits++
+	// Fast path: already present, lock-free read.
+	if _, ok := d.values.Load(s); ok {
+		if d.maxCacheHits > 0 {
+			d.currentCacheHits.Add(1)
+		}
 		return false
 	}
-	d.currentCacheHits = 0 // CacheHits reset to 0 when a new value is found
 
 	// Clone instead of referencing original
 	s = strings.Clone(s)
 
-	if d.diffEnabled {
-		d.new[s] = struct{}{}
+	// LoadOrStore keeps the insert atomic: a concurrent insert of the same value
+	// is counted once, treated here as a cache hit.
+	if _, loaded := d.values.LoadOrStore(s, struct{}{}); loaded {
+		if d.maxCacheHits > 0 {
+			d.currentCacheHits.Add(1)
+		}
+		return false
 	}
-	d.values[s] = struct{}{}
-	d.currDataSize += valueLen
-	d.currentValuesLen++
+	d.currentCacheHits.Store(0) // CacheHits reset to 0 when a new value is found
+
+	if d.diffEnabled {
+		d.new.Store(s, struct{}{})
+	}
+	d.currDataSize.Add(int64(valueLen))
+	d.currentValuesLen.Add(1)
 
 	return true
 }
 
+// setExceeded records the first stop reason and marks the collector as full.
+func (d *DistinctString) setExceeded(reason string) {
+	if d.limExceeded.Swap(true) {
+		return // already marked by another goroutine
+	}
+	d.stopReason.Store(&reason)
+}
+
 // Strings returns the final list of distinct values collected and sorted.
 func (d *DistinctString) Strings() []string {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
+	ss := make([]string, 0, d.currentValuesLen.Load())
 
-	ss := make([]string, 0, len(d.values))
-
-	for k := range d.values {
-		ss = append(ss, k)
-	}
+	d.values.Range(func(k, _ any) bool {
+		ss = append(ss, k.(string))
+		return true
+	})
 
 	sort.Strings(ss)
 	return ss
@@ -116,22 +128,19 @@ func (d *DistinctString) Strings() []string {
 
 // Exceeded indicates if some values were lost because the maximum size limit was met.
 func (d *DistinctString) Exceeded() bool {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
-	return d.limExceeded
+	return d.limExceeded.Load()
 }
 
 func (d *DistinctString) StopReason() string {
-	return d.stopReason
+	if r := d.stopReason.Load(); r != nil {
+		return *r
+	}
+	return ""
 }
 
 // Size is the total size of all distinct strings encountered.
 func (d *DistinctString) Size() int {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
-	return d.currDataSize
+	return int(d.currDataSize.Load())
 }
 
 // Diff returns all new strings collected since the last time diff was called
@@ -141,16 +150,13 @@ func (d *DistinctString) Diff() ([]string, error) {
 		return nil, errDiffNotEnabled
 	}
 
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
+	ss := make([]string, 0)
+	d.new.Range(func(k, _ any) bool {
+		ss = append(ss, k.(string))
+		d.new.Delete(k)
+		return true
+	})
 
-	ss := make([]string, 0, len(d.new))
-
-	for k := range d.new {
-		ss = append(ss, k)
-	}
-
-	clear(d.new)
 	sort.Strings(ss)
 	return ss, nil
 }

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -2,21 +2,21 @@ package collector
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
 const IntrinsicScope = "intrinsic"
 
 type ScopedDistinctString struct {
-	cols            map[string]*DistinctString
+	cols            sync.Map // map[string]*DistinctString, one collector per scope
 	newCol          func(int, uint32, uint32) *DistinctString
 	maxDataSize     int
-	currDataSize    int
-	limExceeded     bool
+	currDataSize    atomic.Int64
+	limExceeded     atomic.Bool
 	maxCacheHits    uint32
 	diffEnabled     bool
 	maxTagsPerScope uint32
-	stopReason      string
-	mtx             sync.Mutex
+	stopReason      atomic.Pointer[string]
 }
 
 // NewScopedDistinctString collects the tags per scope
@@ -25,7 +25,6 @@ type ScopedDistinctString struct {
 // For ease of use, maxDataSize=0 and maxTagsPerScope=0 are interpreted as unlimited.
 func NewScopedDistinctString(maxDataSize int, maxTagsPerScope uint32, staleValueThreshold uint32) *ScopedDistinctString {
 	return &ScopedDistinctString{
-		cols:            map[string]*DistinctString{},
 		newCol:          NewDistinctString,
 		maxDataSize:     maxDataSize,
 		diffEnabled:     false,
@@ -40,7 +39,6 @@ func NewScopedDistinctString(maxDataSize int, maxTagsPerScope uint32, staleValue
 // For ease of use, maxDataSize=0 and maxTagsPerScope=0 are interpreted as unlimited.
 func NewScopedDistinctStringWithDiff(maxDataSize int, maxTagsPerScope uint32, staleValueThreshold uint32) *ScopedDistinctString {
 	return &ScopedDistinctString{
-		cols:            map[string]*DistinctString{},
 		newCol:          NewDistinctStringWithDiff,
 		maxDataSize:     maxDataSize,
 		diffEnabled:     true,
@@ -52,56 +50,64 @@ func NewScopedDistinctStringWithDiff(maxDataSize int, maxTagsPerScope uint32, st
 // Collect adds a new value to the distinct string collector.
 // returns true when it reaches the limits and can't fit more values.
 // can be used to stop early during Collect without calling Exceeded.
+//
+// Lock-free: per-scope collectors live in a sync.Map and hold their own
+// lock-free state, so concurrent callers no longer serialize on one mutex.
 func (d *ScopedDistinctString) Collect(scope string, val string) (exceeded bool) {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
-	if d.limExceeded {
+	if d.limExceeded.Load() {
 		return true
 	}
 
 	valueLen := len(val)
 	// can it fit?
-	if d.maxDataSize > 0 && d.currDataSize+valueLen > d.maxDataSize {
+	if d.maxDataSize > 0 && int(d.currDataSize.Load())+valueLen > d.maxDataSize {
 		// No
-		d.limExceeded = true
+		d.limExceeded.Store(true)
 		return true
 	}
 
-	// get or create collector
-	col, ok := d.cols[scope]
-	if !ok {
-		if scope == IntrinsicScope {
-			col = d.newCol(0, 0, 0)
-		} else {
-			col = d.newCol(0, d.maxTagsPerScope, d.maxCacheHits)
-		}
-		d.cols[scope] = col
-	}
+	// get or create collector for this scope
+	col := d.getOrCreateCollector(scope)
 
 	// add valueLen if we successfully added the value
 	if col.Collect(val) {
-		d.currDataSize += valueLen
+		d.currDataSize.Add(int64(valueLen))
 	}
 	if col.Exceeded() {
 		// we stop if one of the scopes exceed the limit
-		d.limExceeded = true
-		d.stopReason = col.stopReason
+		reason := col.StopReason()
+		if !d.limExceeded.Swap(true) {
+			d.stopReason.Store(&reason)
+		}
 		return true
 	}
 	return false
 }
 
+func (d *ScopedDistinctString) getOrCreateCollector(scope string) *DistinctString {
+	if col, ok := d.cols.Load(scope); ok {
+		return col.(*DistinctString)
+	}
+
+	var newCol *DistinctString
+	if scope == IntrinsicScope {
+		newCol = d.newCol(0, 0, 0)
+	} else {
+		newCol = d.newCol(0, d.maxTagsPerScope, d.maxCacheHits)
+	}
+	// LoadOrStore so a racing creation for the same scope keeps one collector.
+	col, _ := d.cols.LoadOrStore(scope, newCol)
+	return col.(*DistinctString)
+}
+
 // Strings returns the final list of distinct values collected and sorted.
 func (d *ScopedDistinctString) Strings() map[string][]string {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
 	ss := map[string][]string{}
 
-	for k, v := range d.cols {
-		ss[k] = v.Strings()
-	}
+	d.cols.Range(func(k, v any) bool {
+		ss[k.(string)] = v.(*DistinctString).Strings()
+		return true
+	})
 
 	return ss
 }
@@ -109,23 +115,26 @@ func (d *ScopedDistinctString) Strings() map[string][]string {
 // Exceeded indicates if some values were lost because the maximum size limit was met.
 // Or because one of the scopes max tags was reached.
 func (d *ScopedDistinctString) Exceeded() bool {
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
-	if d.limExceeded {
+	if d.limExceeded.Load() {
 		return true
 	}
 
-	for _, v := range d.cols {
-		if v.Exceeded() {
-			return true
+	exceeded := false
+	d.cols.Range(func(_, v any) bool {
+		if v.(*DistinctString).Exceeded() {
+			exceeded = true
+			return false // stop ranging
 		}
-	}
-	return false
+		return true
+	})
+	return exceeded
 }
 
 func (d *ScopedDistinctString) StopReason() string {
-	return d.stopReason
+	if r := d.stopReason.Load(); r != nil {
+		return *r
+	}
+	return ""
 }
 
 // Diff returns all new strings collected since the last time Diff was called
@@ -134,20 +143,22 @@ func (d *ScopedDistinctString) Diff() (map[string][]string, error) {
 		return nil, errDiffNotEnabled
 	}
 
-	d.mtx.Lock()
-	defer d.mtx.Unlock()
-
 	ss := map[string][]string{}
 
-	for k, v := range d.cols {
-		diff, err := v.Diff()
+	var rangeErr error
+	d.cols.Range(func(k, v any) bool {
+		diff, err := v.(*DistinctString).Diff()
 		if err != nil {
-			return nil, err
+			rangeErr = err
+			return false
 		}
-
 		if len(diff) > 0 {
-			ss[k] = diff
+			ss[k.(string)] = diff
 		}
+		return true
+	})
+	if rangeErr != nil {
+		return nil, rangeErr
 	}
 
 	return ss, nil

--- a/pkg/collector/scoped_distinct_string.go
+++ b/pkg/collector/scoped_distinct_string.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -62,7 +63,7 @@ func (d *ScopedDistinctString) Collect(scope string, val string) (exceeded bool)
 	// can it fit?
 	if d.maxDataSize > 0 && int(d.currDataSize.Load())+valueLen > d.maxDataSize {
 		// No
-		d.limExceeded.Store(true)
+		d.setExceeded(fmt.Sprintf("Max data exceeded: dataSize %d, maxDataSize %d", d.currDataSize.Load(), d.maxDataSize))
 		return true
 	}
 
@@ -75,13 +76,18 @@ func (d *ScopedDistinctString) Collect(scope string, val string) (exceeded bool)
 	}
 	if col.Exceeded() {
 		// we stop if one of the scopes exceed the limit
-		reason := col.StopReason()
-		if !d.limExceeded.Swap(true) {
-			d.stopReason.Store(&reason)
-		}
+		d.setExceeded(col.StopReason())
 		return true
 	}
 	return false
+}
+
+// setExceeded records the first stop reason and marks the collector as full.
+func (d *ScopedDistinctString) setExceeded(reason string) {
+	if d.limExceeded.Swap(true) {
+		return // already marked by another goroutine
+	}
+	d.stopReason.Store(&reason)
 }
 
 func (d *ScopedDistinctString) getOrCreateCollector(scope string) *DistinctString {

--- a/pkg/collector/scoped_distinct_string_test.go
+++ b/pkg/collector/scoped_distinct_string_test.go
@@ -236,3 +236,37 @@ func BenchmarkScopedDistinctStringCollect(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkScopedDistinctStringCollectParallel simulates the SearchTagsV2 hot
+// path: many block goroutines (iterateBlocks fan-out) concurrently collect into
+// one shared collector, and the parquet dictionary scan re-emits the same tag
+// keys from every row group/block, so the overwhelming majority of Collect
+// calls are duplicates. This is the contended workload the production CPU
+// profile showed serializing on the collector mutex.
+func BenchmarkScopedDistinctStringCollectParallel(b *testing.B) {
+	scopeTypes := []string{"resource", "span", "event", "instrumentation"}
+	// A realistic-ish set of distinct tag keys per scope. These repeat across
+	// every block, so after warm-up nearly every Collect is a duplicate.
+	const numTagsPerScope = 200
+	tagsByScope := make(map[string][]string, len(scopeTypes))
+	for _, scope := range scopeTypes {
+		tags := make([]string, numTagsPerScope)
+		for j := 0; j < numTagsPerScope; j++ {
+			tags[j] = fmt.Sprintf("%s.tag.key.number.%d", scope, j)
+		}
+		tagsByScope[scope] = tags
+	}
+
+	scopedDistinctStrings := NewScopedDistinctString(0, 0, 0) // no limit
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			scope := scopeTypes[i%len(scopeTypes)]
+			tags := tagsByScope[scope]
+			scopedDistinctStrings.Collect(scope, tags[i%numTagsPerScope])
+			i++
+		}
+	})
+}

--- a/pkg/collector/scoped_distinct_string_test.go
+++ b/pkg/collector/scoped_distinct_string_test.go
@@ -243,6 +243,12 @@ func BenchmarkScopedDistinctStringCollect(b *testing.B) {
 // keys from every row group/block, so the overwhelming majority of Collect
 // calls are duplicates. This is the contended workload the production CPU
 // profile showed serializing on the collector mutex.
+//
+// The limits are varied because they change which work the duplicate hot path
+// does: a stale-value threshold makes every duplicate increment a shared atomic
+// counter, which reintroduces cache-line contention that the unlimited case
+// avoids. Limits are sized large so they never trip during the run - we want to
+// measure the cost of the checks, not the early-stop path.
 func BenchmarkScopedDistinctStringCollectParallel(b *testing.B) {
 	scopeTypes := []string{"resource", "span", "event", "instrumentation"}
 	// A realistic-ish set of distinct tag keys per scope. These repeat across
@@ -257,16 +263,33 @@ func BenchmarkScopedDistinctStringCollectParallel(b *testing.B) {
 		tagsByScope[scope] = tags
 	}
 
-	scopedDistinctStrings := NewScopedDistinctString(0, 0, 0) // no limit
+	configs := []struct {
+		name                string
+		maxDataSize         int
+		maxTagsPerScope     uint32
+		staleValueThreshold uint32
+	}{
+		{"no_limits", 0, 0, 0},
+		{"data_size_limit", 1 << 30, 0, 0},
+		{"tags_per_scope_limit", 0, 1 << 20, 0},
+		{"stale_value_threshold", 0, 0, 1 << 30},
+		{"all_limits", 1 << 30, 1 << 20, 1 << 30},
+	}
 
-	b.ResetTimer()
-	b.RunParallel(func(pb *testing.PB) {
-		i := 0
-		for pb.Next() {
-			scope := scopeTypes[i%len(scopeTypes)]
-			tags := tagsByScope[scope]
-			scopedDistinctStrings.Collect(scope, tags[i%numTagsPerScope])
-			i++
-		}
-	})
+	for _, cfg := range configs {
+		b.Run(cfg.name, func(b *testing.B) {
+			scopedDistinctStrings := NewScopedDistinctString(cfg.maxDataSize, cfg.maxTagsPerScope, cfg.staleValueThreshold)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				i := 0
+				for pb.Next() {
+					scope := scopeTypes[i%len(scopeTypes)]
+					tags := tagsByScope[scope]
+					scopedDistinctStrings.Collect(scope, tags[i%numTagsPerScope])
+					i++
+				}
+			})
+		})
+	}
 }


### PR DESCRIPTION
**What this PR does**:

Tag search (`SearchTagsV2`) fans out one goroutine per block, and the parquet dictionary scan re-emits the same tag keys from every row group of every block — so the vast majority of `Collect` calls are duplicates. Each call took the global `ScopedDistinctString` mutex plus the inner per-scope `DistinctString` mutex, serializing all block goroutines on a single lock. A production CPU profile showed this hand-off (`ScopedDistinctString.Collect → Mutex.Unlock`) at ~24% of CPU.

This makes both collectors lock-free:
- `ScopedDistinctString`: per-scope collectors held in a `sync.Map`; `currDataSize`/`limExceeded`/`stopReason` become atomics.
- `DistinctString`: the value set becomes a `sync.Map` and counters become atomics. The hot path (already-seen value) is a lock-free read with no shared writes.

Limits stay soft (a few values may slip past before `limExceeded` is observed), which is acceptable for these memory-guard limits. Existing tests, including the cache-hit-limit and concurrency-safety tests, pass under `-race`.

**Benchmark** (`BenchmarkScopedDistinctStringCollectParallel`, M4 Pro, `-cpu=8`), contended workload across limit configs:

| Config | Baseline (mutex) | Lock-free | Speedup |
|---|---|---|---|
| `no_limits` | ~151 ns/op | ~4.3 ns/op | ~35x |
| `data_size_limit` | ~151 ns/op | ~4.1 ns/op | ~37x |
| `tags_per_scope_limit` | ~150 ns/op | ~4.4 ns/op | ~34x |
| `stale_value_threshold` | ~151 ns/op | ~29 ns/op | ~5.2x |
| `all_limits` | ~149 ns/op | ~29 ns/op | ~5.1x |

The win is largest when no stale-value threshold is set. With a threshold, every duplicate increments a shared `currentCacheHits` atomic, which re-introduces cache-line contention and narrows the gap to ~5x — still a clear improvement over the mutex (which is flat ~150 ns/op regardless of limits). Sharding that counter could close the remaining gap, but is left as a follow-up.

Tradeoff: single-threaded, unique-heavy workloads are somewhat slower and allocate more (`sync.Map` boxing). The win applies to the concurrent paths, which is how tag search runs in production.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
