### PR TITLE
ci: sign and attest tempo-vulture container images

### DIFF
--- a/.chloggen/sign-tempo-vulture-images.yaml
+++ b/.chloggen/sign-tempo-vulture-images.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: security
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: tempo-vulture
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: keyless-sign published images with cosign and attach SLSA build provenance.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7493]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mattdurham

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,8 @@ jobs:
   get-tag:
     if: github.repository == 'grafana/tempo'  # skip in forks
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.get-tag.outputs.tag }}
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -137,6 +137,56 @@ jobs:
           	--amend "$IMAGE_NAME:$TAG-arm64"
           docker manifest push "$IMAGE_NAME:$TAG"
 
+  # Resolve the digest of the pushed tempo-vulture multi-arch manifest so it can
+  # be signed by digest (not by tag). Scoped to tempo-vulture for now; extend
+  # the matrix to the other components once this is proven out.
+  resolve-vulture-digest:
+    if: github.repository == 'grafana/tempo'
+    needs: ['get-tag', 'manifest']
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+    env:
+      TAG: ${{ needs.get-tag.outputs.tag }}
+    steps:
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
+        with:
+          registry: us-docker.pkg.dev
+
+      - name: Resolve digest
+        id: resolve
+        run: |
+          # IMAGE_NAME is derived from the workflow-level DOCKERHUB_MIRROR_REPOSITORY
+          # (exported into the step env) so it can't drift from the build/manifest
+          # jobs when this is extended to the other components.
+          IMAGE_NAME="${DOCKERHUB_MIRROR_REPOSITORY}/tempo-vulture"
+          DIGEST="$(docker buildx imagetools inspect "$IMAGE_NAME:$TAG" --format '{{.Manifest.Digest}}')"
+          if [[ "$DIGEST" != sha256:* ]]; then
+            echo "::error::failed to resolve digest for $IMAGE_NAME:$TAG, got: $DIGEST"
+            exit 1
+          fi
+          echo "image=$IMAGE_NAME@$DIGEST" >> "$GITHUB_OUTPUT"
+
+  # Signing/attestation runs after publish and is intentionally NOT a gate on
+  # the release or on cd-to-dev-env: the image is immutable once pushed and
+  # can't be re-signed, so we sign best-effort and rely on this job's own
+  # verify steps (plus alerting on failures) to catch a bad signature. A
+  # failure here surfaces as a failed check on the run without blocking deploy.
+  sign-vulture:
+    needs: resolve-vulture-digest
+    if: needs.resolve-vulture-digest.outputs.image != ''
+    uses: ./.github/workflows/sign-and-attest.yml
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    with:
+      image: ${{ needs.resolve-vulture-digest.outputs.image }}
+
   cd-to-dev-env:
     # This job deploys the latest main commit to the dev environment
     if: github.repository == 'grafana/tempo' && github.ref == 'refs/heads/main'

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -13,6 +13,11 @@ It is keyless throughout: there are **no signing keys or stored secrets**. Trust
 comes from the workflow's GitHub Actions OIDC identity plus public transparency
 logs.
 
+> We use keyless cosign + SLSA provenance (Sigstore) because it is the
+> foundation-backed, widely adopted standard — used by Kubernetes, npm, PyPI,
+> and GitHub's own attestations — and it matches the approach already adopted by
+> Grafana Alloy.
+
 ## Why
 
 Image verification used to be manual (cross-referencing tag SHAs against the git

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -52,7 +52,7 @@ attestations store.
 | Input | Required | Default | Description |
 | --- | --- | --- | --- |
 | `image` | yes | — | Digest-pinned image ref, e.g. `us-docker.pkg.dev/.../tempo-vulture@sha256:...`. The workflow fails fast if it is not digest-pinned. |
-| `registry` | no | `us-docker.pkg.dev` | Registry to authenticate against when writing the signature and attestation. |
+| `registry` | no | `us-docker.pkg.dev` | GAR (Artifact Registry) hostname to authenticate against when writing the signature and attestation. |
 
 ## Step flow
 

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -156,3 +156,46 @@ gh attestation verify \
 > **Compatibility note:** the cosign verification identity
 > (`.../sign-and-attest.yml@<ref>` + the OIDC issuer) is a public contract.
 > Renaming or moving this workflow is a **breaking change** for anyone verifying.
+
+## Why this approach is solid
+
+The keyless flow relies on **Sigstore** (Fulcio + Rekor). It is a well-established,
+foundation-governed standard rather than a single-vendor tool:
+
+- **Governance & backing.** Sigstore is an open-source project under the
+  [OpenSSF](https://openssf.org/) / Linux Foundation, founded and maintained by
+  Google, Red Hat, and Purdue University with a broad community of maintainers.
+  The public Fulcio/Rekor instances are operated as a community good and the
+  project has undergone independent third-party security audits.
+- **Generally available & stable.** Sigstore has been GA since 2022 with a public
+  API stability guarantee, and `cosign` is the de-facto standard for container
+  signing.
+- **Load-bearing for major ecosystems.** The exact Fulcio + Rekor flow used here
+  underpins:
+  - **Kubernetes** — signs all release images and artifacts.
+  - **npm** and **PyPI** — package provenance / attestations.
+  - **GitHub** — `actions/attest-build-provenance` (used by this workflow) is
+    built on Sigstore.
+  - **OpenTelemetry Collector**, **Chainguard**, distroless images, and many
+    CNCF projects.
+- **Consistent with Grafana.** Mirrors the keyless cosign approach already adopted
+  by Grafana Alloy.
+
+### Trust trade-offs to be aware of
+
+- Signing has a **runtime dependency on the public Sigstore instances**
+  (`fulcio.sigstore.dev` / `rekor.sigstore.dev`). An outage breaks *signing*, not
+  verification of already-logged signatures. ([status page](https://status.sigstore.dev))
+- **Rekor is a public log** — everything written is world-readable forever. That
+  is fine for image digests and workflow identities, which are not secret.
+- Verification strength depends on **pinning the exact identity** (the
+  `--certificate-identity-regexp` + `--certificate-oidc-issuer` above). A loose
+  identity match weakens the guarantee.
+
+### References
+
+- Sigstore overview — https://docs.sigstore.dev/about/overview/
+- Fulcio (the CA) — https://docs.sigstore.dev/certificate_authority/overview/
+- Rekor (the transparency log) — https://docs.sigstore.dev/logging/overview/
+- cosign verifying — https://docs.sigstore.dev/cosign/verifying/verify/
+- SLSA provenance — https://slsa.dev/

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -32,33 +32,16 @@ These are distinct and answer different questions:
 
 ## How keyless signing works
 
-There is no private key. At signing time:
-
-1. **OIDC token** — the workflow gets a short-lived GitHub Actions OIDC identity
-   token (`https://github.com/grafana/tempo/.github/workflows/sign-and-attest.yml@<ref>`).
-2. **Fulcio** (Sigstore's CA) exchanges that OIDC token for a **short-lived
-   signing certificate** (~10 min) binding a freshly generated ephemeral key to
-   that workflow identity. The key is discarded after signing.
-3. **cosign** signs the image *index digest* with the ephemeral key.
-4. **Rekor** (Sigstore's public, append-only transparency log) records a
-   timestamped entry for the signature.
-
-The Rekor timestamp is what makes a signature from a short-lived cert verifiable
-forever: a verifier checks "was this signed while the cert was valid?" (proved by
-the log entry) rather than "is the cert valid right now?" (it expired minutes
-after signing).
-
-```
-GitHub OIDC identity ──▶ Fulcio short-lived cert ──▶ ephemeral key signs digest
-                                                              │
-                                                  logged + timestamped in Rekor
-                                                              │
-                                    verifiable forever — no key/cert to store or rotate
-```
-
-The SLSA provenance attestation is signed the same keyless way and is both
-pushed to the registry (as an OCI referrer next to the image) and recorded in the
-GitHub attestations store.
+There is no private key. The workflow gets a short-lived GitHub Actions OIDC
+identity token; **Fulcio** (Sigstore's CA) exchanges it for a short-lived
+certificate bound to that workflow identity; cosign signs the image *index
+digest* with a freshly generated ephemeral key (discarded after); and **Rekor**
+(Sigstore's public transparency log) records a timestamped entry. The Rekor
+timestamp is what keeps the signature verifiable after the short-lived cert
+expires — a verifier checks that it was signed *while* the cert was valid, not
+that the cert is valid now. The SLSA provenance attestation is signed the same
+keyless way and is pushed to the registry (as an OCI referrer) and the GitHub
+attestations store.
 
 ## Inputs
 
@@ -66,16 +49,6 @@ GitHub attestations store.
 | --- | --- | --- | --- |
 | `image` | yes | — | Digest-pinned image ref, e.g. `us-docker.pkg.dev/.../tempo-vulture@sha256:...`. The workflow fails fast if it is not digest-pinned. |
 | `registry` | no | `us-docker.pkg.dev` | Registry to authenticate against when writing the signature and attestation. |
-
-## Permissions
-
-| Permission | Why |
-| --- | --- |
-| `contents: read` | Checkout / repo context. |
-| `id-token: write` | Mints the OIDC token for keyless cosign, provenance signing, and GAR workload-identity login. |
-| `attestations: write` | Writes the SLSA provenance attestation to the GitHub attestations store. |
-
-No `secrets: inherit` — everything is OIDC.
 
 ## Step flow
 
@@ -100,40 +73,6 @@ Steps 6–7 run in CI so a broken signature or attestation fails the run before
 anyone relies on it. They check the **GAR** copy; the mirror to Docker Hub is
 async and is not verified here.
 
-## How it's wired into the docker build (`docker.yml`)
-
-The `docker` and `manifest` jobs build per-arch images and push a multi-arch
-manifest under
-`us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/<component>`.
-Two jobs then drive signing for `tempo-vulture`:
-
-1. `resolve-vulture-digest` — resolves the pushed `:$TAG` manifest to its
-   immutable **index digest** (`docker buildx imagetools inspect`) and outputs a
-   digest-pinned ref. Signing by digest, not by mutable tag, binds the signature
-   to exact bytes.
-2. `sign-vulture` — calls this reusable workflow with that digest-pinned ref.
-
-```
-docker (per-arch build+push) ─▶ manifest (multi-arch push)
-                                      │
-                                      ▼
-                         resolve-vulture-digest  (tag ─▶ @sha256 digest)
-                                      │
-                                      ▼
-                               sign-vulture  ─uses─▶ sign-and-attest.yml
-```
-
-Signing/attestation runs **after** publish and is intentionally **not a gate** on
-the release or `cd-to-dev-env`: a pushed image is immutable and can't be
-re-signed, so it is signed best-effort. A failure surfaces as a failed check on
-the run; alerting on `sign-vulture` failures is recommended.
-
-## Scope
-
-Currently scoped to **`tempo-vulture`** to prove out the flow. The other
-components (`tempo`, `tempo-query`, `tempo-cli`) can be added by widening the
-resolve step into the existing matrix and calling this workflow per component.
-
 ## Verifying an image (for consumers)
 
 Signature:
@@ -156,46 +95,3 @@ gh attestation verify \
 > **Compatibility note:** the cosign verification identity
 > (`.../sign-and-attest.yml@<ref>` + the OIDC issuer) is a public contract.
 > Renaming or moving this workflow is a **breaking change** for anyone verifying.
-
-## Why this approach is solid
-
-The keyless flow relies on **Sigstore** (Fulcio + Rekor). It is a well-established,
-foundation-governed standard rather than a single-vendor tool:
-
-- **Governance & backing.** Sigstore is an open-source project under the
-  [OpenSSF](https://openssf.org/) / Linux Foundation, founded and maintained by
-  Google, Red Hat, and Purdue University with a broad community of maintainers.
-  The public Fulcio/Rekor instances are operated as a community good and the
-  project has undergone independent third-party security audits.
-- **Generally available & stable.** Sigstore has been GA since 2022 with a public
-  API stability guarantee, and `cosign` is the de-facto standard for container
-  signing.
-- **Load-bearing for major ecosystems.** The exact Fulcio + Rekor flow used here
-  underpins:
-  - **Kubernetes** — signs all release images and artifacts.
-  - **npm** and **PyPI** — package provenance / attestations.
-  - **GitHub** — `actions/attest-build-provenance` (used by this workflow) is
-    built on Sigstore.
-  - **OpenTelemetry Collector**, **Chainguard**, distroless images, and many
-    CNCF projects.
-- **Consistent with Grafana.** Mirrors the keyless cosign approach already adopted
-  by Grafana Alloy.
-
-### Trust trade-offs to be aware of
-
-- Signing has a **runtime dependency on the public Sigstore instances**
-  (`fulcio.sigstore.dev` / `rekor.sigstore.dev`). An outage breaks *signing*, not
-  verification of already-logged signatures. ([status page](https://status.sigstore.dev))
-- **Rekor is a public log** — everything written is world-readable forever. That
-  is fine for image digests and workflow identities, which are not secret.
-- Verification strength depends on **pinning the exact identity** (the
-  `--certificate-identity-regexp` + `--certificate-oidc-issuer` above). A loose
-  identity match weakens the guarantee.
-
-### References
-
-- Sigstore overview — https://docs.sigstore.dev/about/overview/
-- Fulcio (the CA) — https://docs.sigstore.dev/certificate_authority/overview/
-- Rekor (the transparency log) — https://docs.sigstore.dev/logging/overview/
-- cosign verifying — https://docs.sigstore.dev/cosign/verifying/verify/
-- SLSA provenance — https://slsa.dev/

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -13,10 +13,9 @@ It is keyless throughout: there are **no signing keys or stored secrets**. Trust
 comes from the workflow's GitHub Actions OIDC identity plus public transparency
 logs.
 
-> We use keyless cosign + SLSA provenance (Sigstore) because it is the
-> foundation-backed, widely adopted standard — used by Kubernetes, npm, PyPI,
-> and GitHub's own attestations — and it matches the approach already adopted by
-> Grafana Alloy.
+> We use keyless cosign + SLSA provenance ([Sigstore](https://www.sigstore.dev/),
+> [docs](https://docs.sigstore.dev/)) because it is the foundation-backed, widely
+> adopted standard — used by Kubernetes, npm, PyPI, and GitHub's own attestations.
 
 ## Why
 

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -1,0 +1,158 @@
+# `sign-and-attest.yml`
+
+Reusable workflow that adds cryptographic supply-chain guarantees to a published
+container image. Given a **digest-pinned** image reference it produces, attaches,
+and verifies two artifacts:
+
+1. A **keyless cosign signature** — proves the image was produced by *this
+   workflow's identity* and hasn't been tampered with.
+2. A **SLSA build provenance attestation** — proves *how* and *from what* the
+   image was built (image digest → source commit → workflow → run).
+
+It is keyless throughout: there are **no signing keys or stored secrets**. Trust
+comes from the workflow's GitHub Actions OIDC identity plus public transparency
+logs.
+
+## Why
+
+Image verification used to be manual (cross-referencing tag SHAs against the git
+API), with no cryptographic chain from a CI run to a published image. This
+workflow establishes that chain so anyone can verify an image is authentic and
+trace it back to the exact commit and workflow run that built it.
+
+## The three supply-chain artifacts
+
+These are distinct and answer different questions:
+
+| Artifact | Question it answers | Produced here? |
+| --- | --- | --- |
+| **Signature** (`cosign sign`) | Was this image produced by a trusted identity, untampered? | ✅ |
+| **Provenance** (SLSA attestation) | How / from what was it built — which commit, workflow, run? | ✅ |
+| **SBOM** | What packages/versions are inside it? | ❌ (possible follow-up) |
+
+## How keyless signing works
+
+There is no private key. At signing time:
+
+1. **OIDC token** — the workflow gets a short-lived GitHub Actions OIDC identity
+   token (`https://github.com/grafana/tempo/.github/workflows/sign-and-attest.yml@<ref>`).
+2. **Fulcio** (Sigstore's CA) exchanges that OIDC token for a **short-lived
+   signing certificate** (~10 min) binding a freshly generated ephemeral key to
+   that workflow identity. The key is discarded after signing.
+3. **cosign** signs the image *index digest* with the ephemeral key.
+4. **Rekor** (Sigstore's public, append-only transparency log) records a
+   timestamped entry for the signature.
+
+The Rekor timestamp is what makes a signature from a short-lived cert verifiable
+forever: a verifier checks "was this signed while the cert was valid?" (proved by
+the log entry) rather than "is the cert valid right now?" (it expired minutes
+after signing).
+
+```
+GitHub OIDC identity ──▶ Fulcio short-lived cert ──▶ ephemeral key signs digest
+                                                              │
+                                                  logged + timestamped in Rekor
+                                                              │
+                                    verifiable forever — no key/cert to store or rotate
+```
+
+The SLSA provenance attestation is signed the same keyless way and is both
+pushed to the registry (as an OCI referrer next to the image) and recorded in the
+GitHub attestations store.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `image` | yes | — | Digest-pinned image ref, e.g. `us-docker.pkg.dev/.../tempo-vulture@sha256:...`. The workflow fails fast if it is not digest-pinned. |
+| `registry` | no | `us-docker.pkg.dev` | Registry to authenticate against when writing the signature and attestation. |
+
+## Permissions
+
+| Permission | Why |
+| --- | --- |
+| `contents: read` | Checkout / repo context. |
+| `id-token: write` | Mints the OIDC token for keyless cosign, provenance signing, and GAR workload-identity login. |
+| `attestations: write` | Writes the SLSA provenance attestation to the GitHub attestations store. |
+
+No `secrets: inherit` — everything is OIDC.
+
+## Step flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ sign-and-attest job                                          │
+├─────────────────────────────────────────────────────────────┤
+│ 1. Parse & validate image                                    │
+│    - require "@sha256:" (digest-pinned)                      │
+│    - split into subject-name (repo) + subject-digest         │
+│ 2. Login to GAR (OIDC workload identity)                     │
+│ 3. Install cosign                                            │
+│ 4. cosign sign      ──▶ keyless signature, logged to Rekor   │
+│ 5. attest-build-provenance ──▶ signed SLSA provenance,       │
+│                                pushed to registry + GH store │
+│ 6. cosign verify    ──▶ confirm signature against identity   │
+│ 7. gh attestation verify ──▶ confirm provenance vs repo      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Steps 6–7 run in CI so a broken signature or attestation fails the run before
+anyone relies on it. They check the **GAR** copy; the mirror to Docker Hub is
+async and is not verified here.
+
+## How it's wired into the docker build (`docker.yml`)
+
+The `docker` and `manifest` jobs build per-arch images and push a multi-arch
+manifest under
+`us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/<component>`.
+Two jobs then drive signing for `tempo-vulture`:
+
+1. `resolve-vulture-digest` — resolves the pushed `:$TAG` manifest to its
+   immutable **index digest** (`docker buildx imagetools inspect`) and outputs a
+   digest-pinned ref. Signing by digest, not by mutable tag, binds the signature
+   to exact bytes.
+2. `sign-vulture` — calls this reusable workflow with that digest-pinned ref.
+
+```
+docker (per-arch build+push) ─▶ manifest (multi-arch push)
+                                      │
+                                      ▼
+                         resolve-vulture-digest  (tag ─▶ @sha256 digest)
+                                      │
+                                      ▼
+                               sign-vulture  ─uses─▶ sign-and-attest.yml
+```
+
+Signing/attestation runs **after** publish and is intentionally **not a gate** on
+the release or `cd-to-dev-env`: a pushed image is immutable and can't be
+re-signed, so it is signed best-effort. A failure surfaces as a failed check on
+the run; alerting on `sign-vulture` failures is recommended.
+
+## Scope
+
+Currently scoped to **`tempo-vulture`** to prove out the flow. The other
+components (`tempo`, `tempo-query`, `tempo-cli`) can be added by widening the
+resolve step into the existing matrix and calling this workflow per component.
+
+## Verifying an image (for consumers)
+
+Signature:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/grafana/tempo/\.github/workflows/sign-and-attest\.yml@' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/tempo-vulture@sha256:...
+```
+
+Provenance:
+
+```bash
+gh attestation verify \
+  oci://us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/tempo-vulture@sha256:... \
+  --repo grafana/tempo
+```
+
+> **Compatibility note:** the cosign verification identity
+> (`.../sign-and-attest.yml@<ref>` + the OIDC issuer) is a public contract.
+> Renaming or moving this workflow is a **breaking change** for anyone verifying.

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -37,6 +37,10 @@ jobs:
     name: Sign and attest image
     if: github.repository == 'grafana/tempo'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write     # keyless cosign OIDC, provenance signing, login-to-gar workload identity
+      attestations: write # write the SLSA provenance attestation to the GitHub attestations store
     steps:
       - name: Parse and validate image
         id: image

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -22,7 +22,7 @@ on:
         required: true
         type: string
       registry:
-        description: 'Registry to authenticate against when writing the signature and attestation.'
+        description: 'GAR (Artifact Registry) hostname to authenticate against when writing the signature and attestation.'
         required: false
         type: string
         default: us-docker.pkg.dev

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -1,0 +1,106 @@
+name: Sign and attest container image
+
+# For a pushed, digest-pinned container image this workflow:
+#   1. Keyless-signs it with cosign via GitHub Actions OIDC (proves the image
+#      was produced by this workflow's identity).
+#   2. Generates and attaches a SLSA build provenance attestation that ties the
+#      image digest to the source commit, workflow, and run (proves *how* and
+#      *from what* the image was built).
+#
+# Signature verification identity:
+#   https://github.com/grafana/tempo/.github/workflows/sign-and-attest.yml@<ref>
+#   issuer https://token.actions.githubusercontent.com
+#
+# NOTE: this OIDC identity becomes part of the verification contract. Changing
+# the workflow path/name later is a breaking change for anyone verifying.
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Digest-pinned image reference, e.g. us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/tempo-vulture@sha256:...'
+        required: true
+        type: string
+      registry:
+        description: 'Registry to authenticate against when writing the signature and attestation.'
+        required: false
+        type: string
+        default: us-docker.pkg.dev
+
+permissions:
+  contents: read
+  id-token: write     # keyless cosign OIDC, provenance signing, login-to-gar workload identity
+  attestations: write # write the SLSA provenance attestation to the GitHub attestations store
+
+jobs:
+  sign-and-attest:
+    name: Sign and attest image
+    if: github.repository == 'grafana/tempo'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Parse and validate image
+        id: image
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          if [[ "${IMAGE}" != *"@sha256:"* ]]; then
+            echo "::error::image must be digest-pinned (contain @sha256:), got: ${IMAGE}"
+            exit 1
+          fi
+          # Split "<name>@sha256:<hex>" into the registry path and the digest,
+          # which the attestation action needs as separate inputs.
+          echo "name=${IMAGE%@*}" >> "$GITHUB_OUTPUT"
+          echo "digest=${IMAGE##*@}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
+        with:
+          registry: ${{ inputs.registry }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
+
+      - name: Sign image
+        # Signs the image index by digest. Uploads to the public Rekor
+        # transparency log by default, which is what makes the short-lived
+        # Fulcio cert verifiable after it expires.
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          cosign sign --yes "${IMAGE}"
+
+      - name: Attest SLSA build provenance
+        # Generates a signed SLSA provenance statement binding the image digest
+        # to this workflow, the source commit, and the run, and pushes it to the
+        # registry as an OCI referrer (in addition to the GitHub attestations
+        # store). This is the "tied to a commit / has provenance" requirement.
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Verify signature
+        # Catch a broken signature in CI before anyone relies on it. This checks
+        # the GAR copy; the mirror to Docker Hub is async, so it isn't verified
+        # here.
+        env:
+          IMAGE: ${{ inputs.image }}
+          REPO: ${{ github.repository }}
+        run: |
+          cosign verify \
+            --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/sign-and-attest\.yml@" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${IMAGE}"
+
+      - name: Verify provenance attestation
+        # Confirms the provenance attestation we just pushed verifies against
+        # this repository before anyone relies on it.
+        env:
+          IMAGE: ${{ inputs.image }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify "oci://${IMAGE}" --repo "${REPO}"


### PR DESCRIPTION
## What

Adds cryptographic provenance to the published `tempo-vulture` image as the first step of rolling out artifact signing/attestation across our images. Approach mirrors [grafana/alloy#6369](https://github.com/grafana/alloy/pull/6369), extended with real SLSA provenance.

A new reusable workflow `sign-and-attest.yml` takes a **digest-pinned** image ref and:

1. **Signs** it keyless with cosign via GitHub Actions OIDC (proves the image was produced by this workflow's identity).
2. **Attests** a signed **SLSA build provenance** statement binding the image digest → source commit → workflow → run, via `actions/attest-build-provenance`, pushed to the registry as an OCI referrer and to the GitHub attestations store.
3. **Verifies** both the signature (`cosign verify`) and the provenance (`gh attestation verify`) before the run completes.

`docker.yml` resolves the pushed multi-arch manifest digest for `tempo-vulture` and calls the reusable workflow.

## Scope

Intentionally scoped to **`tempo-vulture` only** to prove out the flow. `tempo`, `tempo-query`, and `tempo-cli` can be folded in afterwards by widening the resolve step into the existing matrix.

## Notes

- Keyless throughout — no signing keys or stored secrets; identity is the workflow's OIDC token.
- All actions are SHA-pinned; `actionlint` passes.
- Signing/attestation runs **after** publish and is **not a gate** on the release or `cd-to-dev-env` (pushed images are immutable and can't be re-signed). A failure surfaces as a failed check on the run. Recommend adding alerting on `sign-vulture` failures as a follow-up.
- `--provenance false` on `docker build` is left as-is; out-of-band provenance via `attest-build-provenance` supersedes BuildKit's inline attestation.

## Verification (for consumers)

\`\`\`
# signature
cosign verify \
  --certificate-identity-regexp '^https://github\.com/grafana/tempo/\.github/workflows/sign-and-attest\.yml@' \
  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
  us-docker.pkg.dev/grafanalabs-global/dockerhub-tempo-prod-mirror/tempo-vulture@sha256:...

# provenance
gh attestation verify oci://us-docker.pkg.dev/.../tempo-vulture@sha256:... --repo grafana/tempo
\`\`\`