### PR TITLE
generator: zero-copy borrowed-label path in registry, adopted by spanmetrics

### DIFF
--- a/.chloggen/generator-spanmetrics-borrowed-labels.yaml
+++ b/.chloggen/generator-spanmetrics-borrowed-labels.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: metrics-generator
+note: The span-metrics processor builds series labels through the registry's borrowed-label buffers and updates metrics with a precomputed hash, building target_info once per resource instead of once per span. This reduces per-span CPU and allocations on the generator hot path with no change to metric names, labels, or values for valid configurations. Histogram buckets (classic and native) are now normalized (sorted) when the histogram is built, which only affects misconfigured non-monotonic histogram_buckets — correcting classic exemplar bucket placement and avoiding a panic when native histograms are enabled. Label-builder pools are now owned per-tenant.
+issues: [7124]
+subtext:
+user: carles-grafana

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -2,7 +2,6 @@ package spanmetrics
 
 import (
 	"context"
-	"slices"
 	"time"
 
 	"github.com/grafana/tempo/modules/generator/validation"
@@ -25,6 +24,10 @@ const (
 	metricDurationSeconds = "traces_spanmetrics_latency"
 	metricSizeTotal       = "traces_spanmetrics_size_total"
 	targetInfo            = "traces_target_info"
+
+	serviceNameKey       = "service.name"
+	serviceNamespaceKey  = "service.namespace"
+	serviceInstanceIDKey = "service.instance.id"
 )
 
 type Processor struct {
@@ -37,10 +40,14 @@ type Processor struct {
 	spanMetricsSizeTotal       registry.Counter
 	spanMetricsTargetInfo      registry.Gauge
 
-	filter               *spanfilter.SpanFilter
-	filteredSpansCounter prometheus.Counter
-	invalidUTF8Counter   prometheus.Counter
-	sanitizeCache        reclaimable.Cache[string, string]
+	filter                 *spanfilter.SpanFilter
+	filteredSpansCounter   prometheus.Counter
+	invalidUTF8Counter     prometheus.Counter
+	sanitizeCache          reclaimable.Cache[string, string]
+	targetInfoExcluded     map[string]struct{}
+	dimensionLabels        []string
+	dimensionMappingLabels []string
+	usesSpanMultiplier     bool
 
 	// for testing
 	now func() time.Time
@@ -72,14 +79,28 @@ func New(cfg Config, reg registry.Registry, filteredSpansCounter, invalidUTF8Cou
 		return nil, err
 	}
 
+	dimensionLabels := make([]string, len(cfg.Dimensions))
+	for i, d := range cfg.Dimensions {
+		dimensionLabels[i] = validation.SanitizeLabelNameWithCollisions(d, validation.SupportedIntrinsicDimensionsSet, c.Get)
+	}
+
+	dimensionMappingLabels := make([]string, len(cfg.DimensionMappings))
+	for i, m := range cfg.DimensionMappings {
+		dimensionMappingLabels[i] = validation.SanitizeLabelNameWithCollisions(m.Name, validation.SupportedIntrinsicDimensionsSet, c.Get)
+	}
+
 	p := &Processor{
-		Cfg:                   cfg,
-		registry:              reg,
-		spanMetricsTargetInfo: reg.NewGauge(targetInfo),
-		now:                   time.Now,
-		filteredSpansCounter:  filteredSpansCounter,
-		invalidUTF8Counter:    invalidUTF8Counter,
-		sanitizeCache:         c,
+		Cfg:                    cfg,
+		registry:               reg,
+		spanMetricsTargetInfo:  reg.NewGauge(targetInfo),
+		now:                    time.Now,
+		filteredSpansCounter:   filteredSpansCounter,
+		invalidUTF8Counter:     invalidUTF8Counter,
+		sanitizeCache:          c,
+		targetInfoExcluded:     excludedDimensionsSet(cfg.TargetInfoExcludedDimensions),
+		dimensionLabels:        dimensionLabels,
+		dimensionMappingLabels: dimensionMappingLabels,
+		usesSpanMultiplier:     cfg.SpanMultiplierKey != "" || cfg.EnableTraceStateSpanMultiplier,
 	}
 
 	if cfg.Subprocessors[Latency] {
@@ -113,40 +134,52 @@ func (p *Processor) Shutdown(_ context.Context) {
 }
 
 func (p *Processor) aggregateMetrics(resourceSpans []*v1_trace.ResourceSpans) {
-	resourceLabels := make([]string, 0)
-	resourceValues := make([]string, 0)
+	// One timestamp per push keeps time.Now off the per-span path; lastUpdated
+	// feeds staleness checks on the order of minutes, so per-batch granularity
+	// is more than enough.
+	updateTimeMs := p.now().UnixMilli()
 	for _, rs := range resourceSpans {
 		// already extract job name & instance id, so we only have to do it once per batch of spans
-		svcName, _ := processor_util.FindServiceName(rs.Resource.Attributes)
-		jobName := processor_util.GetJobValue(rs.Resource.Attributes)
-		instanceID, _ := processor_util.FindInstanceID(rs.Resource.Attributes)
-		if p.Cfg.EnableTargetInfo {
-			getTargetInfoAttributesValues(&resourceLabels, &resourceValues, rs.Resource.Attributes, p.Cfg.TargetInfoExcludedDimensions, p.sanitizeCache.Get)
-		}
+		svcName, jobName, instanceID := processor_util.FindServiceLabels(rs.Resource.Attributes)
+		targetInfoLabelsValid := true
+		targetInfoLabelsBuilt := false
 		for _, ils := range rs.ScopeSpans {
 			for _, span := range ils.Spans {
-				if p.filter.ApplyFilterPolicy(rs.Resource, span) {
-					p.aggregateMetricsForSpan(svcName, jobName, instanceID, rs.Resource, span, resourceLabels, resourceValues)
+				if !p.filter.ApplyFilterPolicy(rs.Resource, span) {
+					p.filteredSpansCounter.Inc()
 					continue
 				}
-				p.filteredSpansCounter.Inc()
+				if !p.aggregateMetricsForSpan(svcName, jobName, instanceID, rs.Resource, span, updateTimeMs) {
+					continue
+				}
+				if p.Cfg.EnableTargetInfo {
+					// Register target_info only after a span's primary labels have been
+					// validated and its series updated. This preserves the pre-optimization
+					// ordering: span metrics claim active-series/entity limiter capacity
+					// before target_info, and a resource whose accepted spans all carry
+					// invalid UTF-8 labels emits no target_info at all. The labels are
+					// still built and registered at most once per resource batch.
+					if !targetInfoLabelsBuilt {
+						targetInfoLabelsValid = p.buildAndSetTargetInfoLabels(rs.Resource.Attributes, jobName, instanceID, updateTimeMs)
+						targetInfoLabelsBuilt = true
+					}
+					if !targetInfoLabelsValid {
+						// Pre-optimization behavior: every span that reached the target_info
+						// step with invalid target_info labels counted one discarded update.
+						p.invalidUTF8Counter.Inc()
+					}
+				}
 			}
 		}
 	}
 }
 
-func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, resourceLabels []string, resourceValues []string) {
-	// Spans with negative latency are treated as zero.
-	latencySeconds := 0.0
-	if start, end := span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano(); start < end {
-		latencySeconds = float64(end-start) / float64(time.Second.Nanoseconds())
-	}
-
+// aggregateMetricsForSpan updates the enabled span metric series for a single
+// span. It reports whether the span's primary label set was valid UTF-8;
+// callers gate target_info registration on this, independent of which
+// subprocessors are enabled.
+func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, instanceID string, rs *v1.Resource, span *v1_trace.Span, updateTimeMs int64) bool {
 	builder := p.registry.NewLabelBuilder()
-	targetInfoBuilder := p.registry.NewInfoMetricLabelBuilder()
-	for i := range resourceLabels {
-		targetInfoBuilder.Add(resourceLabels[i], resourceValues[i])
-	}
 
 	if p.Cfg.IntrinsicDimensions.Service {
 		builder.Add(gen.DimService, svcName)
@@ -155,117 +188,175 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 		builder.Add(gen.DimSpanName, span.GetName())
 	}
 	if p.Cfg.IntrinsicDimensions.SpanKind {
-		builder.Add(gen.DimSpanKind, span.GetKind().String())
+		builder.Add(gen.DimSpanKind, spanKindString(span.GetKind()))
 	}
 	if p.Cfg.IntrinsicDimensions.StatusCode {
-		builder.Add(gen.DimStatusCode, span.GetStatus().GetCode().String())
+		builder.Add(gen.DimStatusCode, statusCodeString(span.GetStatus().GetCode()))
 	}
 	if p.Cfg.IntrinsicDimensions.StatusMessage {
 		builder.Add(gen.DimStatusMessage, span.GetStatus().GetMessage())
 	}
 
-	for _, d := range p.Cfg.Dimensions {
+	for i, d := range p.Cfg.Dimensions {
 		value, _ := processor_util.FindAttributeValue(d, rs.Attributes, span.Attributes)
-		label := validation.SanitizeLabelNameWithCollisions(d, validation.SupportedIntrinsicDimensionsSet, p.sanitizeCache.Get)
 		// if there is a collision, for example deployment.environment and deployment_environment,
 		// both sanitized to deployment_environment, we just take the last one configured.
-		builder.Add(label, value)
+		builder.Add(p.dimensionLabels[i], value)
 	}
 
-	for _, m := range p.Cfg.DimensionMappings {
+	for i, m := range p.Cfg.DimensionMappings {
+		// Plain concatenation: source lists are short (1-3 entries), where
+		// strings.Builder allocates more than simple concatenation.
 		values := ""
 		for _, s := range m.SourceLabel {
 			if value, _ := processor_util.FindAttributeValue(s, rs.Attributes, span.Attributes); value != "" {
 				if values == "" {
-					values += value
+					values = value
 				} else {
 					values = values + m.Join + value
 				}
 			}
 		}
-		label := validation.SanitizeLabelNameWithCollisions(m.Name, validation.SupportedIntrinsicDimensionsSet, p.sanitizeCache.Get)
-		builder.Add(label, values)
+		builder.Add(p.dimensionMappingLabels[i], values)
 	}
 
 	// add job label only if job is not blank and target_info is enabled
-	identifyingLabels := 0
 	if jobName != "" && p.Cfg.EnableTargetInfo {
 		builder.Add(gen.DimJob, jobName)
-		identifyingLabels++
 	}
 	// add instance label only if instance is not blank and enabled and target_info is enabled
 	if instanceID != "" && p.Cfg.EnableTargetInfo && p.Cfg.EnableInstanceLabel {
 		builder.Add(gen.DimInstance, instanceID)
-		identifyingLabels++
 	}
 
-	spanMultiplier := processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs, p.Cfg.EnableTraceStateSpanMultiplier)
+	spanMultiplier := 1.0
+	if p.usesSpanMultiplier {
+		spanMultiplier = processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs, p.Cfg.EnableTraceStateSpanMultiplier)
+	}
 
-	registryLabelValues, validUTF8 := builder.CloseAndBuildLabels()
+	registryLabelValues, validUTF8 := builder.CloseAndBorrowLabels()
 	if !validUTF8 {
 		p.invalidUTF8Counter.Inc()
-		return
+		return false
 	}
+	defer registryLabelValues.Release()
 
 	if p.Cfg.Subprocessors[Count] {
-		p.spanMetricsCallsTotal.Inc(registryLabelValues, 1*spanMultiplier)
+		p.spanMetricsCallsTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, 1*spanMultiplier, updateTimeMs)
 	}
 
 	if p.Cfg.Subprocessors[Latency] {
-		p.spanMetricsDurationSeconds.ObserveWithExemplar(registryLabelValues, latencySeconds, tempo_util.TraceIDToHexString(span.TraceId), spanMultiplier)
+		// Spans with negative latency are treated as zero.
+		latencySeconds := 0.0
+		if start, end := span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano(); start < end {
+			latencySeconds = float64(end-start) / float64(time.Second.Nanoseconds())
+		}
+		p.spanMetricsDurationSeconds.ObserveWithExemplarTraceIDBytesWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, latencySeconds, span.TraceId, spanMultiplier, updateTimeMs)
 	}
 
 	if p.Cfg.Subprocessors[Size] {
-		p.spanMetricsSizeTotal.Inc(registryLabelValues, float64(span.Size()))
+		p.spanMetricsSizeTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, float64(span.Size()), updateTimeMs)
 	}
 
-	// update target_info label values
-	if p.Cfg.EnableTargetInfo {
-		// TODO - The resource labels only need to be sanitized once
-		// TODO - attribute names are stable across applications
-		//        so let's cache the result of previous sanitizations
-
-		// add job label to target info only if job is not blank
-		if jobName != "" {
-			targetInfoBuilder.Add(gen.DimJob, jobName)
-		}
-		// add instance label to target info only if instance is not blank and enabled
-		if instanceID != "" && p.Cfg.EnableInstanceLabel {
-			targetInfoBuilder.Add(gen.DimInstance, instanceID)
-		}
-
-		targetInfoRegistryLabelValues, validUTF8 := targetInfoBuilder.CloseAndBuildLabels()
-		if !validUTF8 {
-			p.invalidUTF8Counter.Inc()
-			return
-		}
-
-		// Only register target_info if it has at least (job or instance) AND one other
-		// resource attribute in the built label set. We count from the built set because
-		// the Prometheus label builder drops empty-valued labels (Set("x","") calls Del("x")).
-		if identifyingLabels > 0 && targetInfoRegistryLabelValues.Len() > identifyingLabels {
-			p.spanMetricsTargetInfo.SetForTargetInfo(targetInfoRegistryLabelValues, 1)
-		}
-	}
+	return true
 }
 
-func getTargetInfoAttributesValues(keys, values *[]string, attributes []*v1_common.KeyValue, exclude []string, sanitizeFn validation.SanitizeFn) {
-	// TODO allocate with known length, or take new params for existing buffers
-	*keys = (*keys)[:0]
-	*values = (*values)[:0]
-	for _, attrs := range attributes {
-		// ignoring job and instance
-		key := attrs.Key
-		// Skip empty string keys, which are out of spec but
-		// technically possible in the proto. These will cause
-		// issues downstream for metrics datasources
+func (p *Processor) buildAndSetTargetInfoLabels(attributes []*v1_common.KeyValue, jobName string, instanceID string, updateTimeMs int64) bool {
+	targetInfoBuilder := p.registry.NewInfoMetricLabelBuilder()
+	for _, attr := range attributes {
+		key := attr.Key
+		// Skip empty string keys, which are out of spec but technically
+		// possible in the proto, and keys starting with a digit. These will
+		// cause issues downstream for metrics datasources.
 		if key == "" || (key[0] >= '0' && key[0] <= '9') {
 			continue
 		}
-		if key != "service.name" && key != "service.namespace" && key != "service.instance.id" && !slices.Contains(exclude, key) {
-			*keys = append(*keys, validation.SanitizeLabelNameWithCollisions(key, targetInfoIntrinsicLabelsSet, sanitizeFn))
-			value := tempo_util.StringifyAnyValue(attrs.Value)
-			*values = append(*values, value)
+		// The service.* attributes are represented by the job and instance
+		// labels instead.
+		if key == serviceNameKey || key == serviceNamespaceKey || key == serviceInstanceIDKey {
+			continue
 		}
+		if _, excluded := p.targetInfoExcluded[key]; excluded {
+			continue
+		}
+		targetInfoBuilder.Add(
+			validation.SanitizeLabelNameWithCollisions(key, targetInfoIntrinsicLabelsSet, p.sanitizeCache.Get),
+			tempo_util.StringifyAnyValue(attr.Value),
+		)
+	}
+
+	identifyingLabels := 0
+	// add job label to target info only if job is not blank
+	if jobName != "" {
+		targetInfoBuilder.Add(gen.DimJob, jobName)
+		identifyingLabels++
+	}
+	// add instance label to target info only if instance is not blank and enabled
+	if instanceID != "" && p.Cfg.EnableInstanceLabel {
+		targetInfoBuilder.Add(gen.DimInstance, instanceID)
+		identifyingLabels++
+	}
+
+	targetInfoLabels, validUTF8 := targetInfoBuilder.CloseAndBorrowLabels()
+	if !validUTF8 {
+		return false
+	}
+	defer targetInfoLabels.Release()
+	// Only register target_info if it has at least (job or instance) AND one other
+	// resource attribute in the built label set. We count from the built set because
+	// the registry label builder drops empty-valued labels (Add(name, "") deletes name).
+	if identifyingLabels > 0 && targetInfoLabels.Labels.Len() > identifyingLabels {
+		p.spanMetricsTargetInfo.SetForTargetInfoWithHashAt(targetInfoLabels.Labels, targetInfoLabels.Hash, 1, updateTimeMs)
+	}
+	return true
+}
+
+func excludedDimensionsSet(exclude []string) map[string]struct{} {
+	if len(exclude) == 0 {
+		return nil
+	}
+	m := make(map[string]struct{}, len(exclude))
+	for _, dim := range exclude {
+		m[dim] = struct{}{}
+	}
+	return m
+}
+
+// spanKindString avoids the proto enum-name map lookup that Span_SpanKind.String
+// performs on the per-span hot path. The cases must mirror the
+// v1_trace.Span_SpanKind enum; unknown values fall back to the generated String.
+func spanKindString(kind v1_trace.Span_SpanKind) string {
+	switch kind {
+	case v1_trace.Span_SPAN_KIND_UNSPECIFIED:
+		return "SPAN_KIND_UNSPECIFIED"
+	case v1_trace.Span_SPAN_KIND_INTERNAL:
+		return "SPAN_KIND_INTERNAL"
+	case v1_trace.Span_SPAN_KIND_SERVER:
+		return "SPAN_KIND_SERVER"
+	case v1_trace.Span_SPAN_KIND_CLIENT:
+		return "SPAN_KIND_CLIENT"
+	case v1_trace.Span_SPAN_KIND_PRODUCER:
+		return "SPAN_KIND_PRODUCER"
+	case v1_trace.Span_SPAN_KIND_CONSUMER:
+		return "SPAN_KIND_CONSUMER"
+	default:
+		return kind.String()
+	}
+}
+
+// statusCodeString avoids the proto enum-name map lookup that
+// Status_StatusCode.String performs on the per-span hot path. The cases must
+// mirror the v1_trace.Status_StatusCode enum; unknown values fall back to the
+// generated String.
+func statusCodeString(code v1_trace.Status_StatusCode) string {
+	switch code {
+	case v1_trace.Status_STATUS_CODE_UNSET:
+		return "STATUS_CODE_UNSET"
+	case v1_trace.Status_STATUS_CODE_OK:
+		return "STATUS_CODE_OK"
+	case v1_trace.Status_STATUS_CODE_ERROR:
+		return "STATUS_CODE_ERROR"
+	default:
+		return code.String()
 	}
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
@@ -1,0 +1,188 @@
+package spanmetrics
+
+import (
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+
+	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/pkg/sharedconfig"
+	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// BenchmarkSpanMetricsPushSpans measures the processor end to end against
+// registry.TestRegistry, which stringifies labels into a map and discards the
+// precomputed hash, so absolute numbers include test-registry scaffolding that
+// production does not pay. Treat results as before/after comparisons of
+// processor-side changes only; the production label-building path is measured
+// by BenchmarkManagedRegistryBorrowPath in the registry package.
+func BenchmarkSpanMetricsPushSpans(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		tune    func(*Config)
+		request *tempopb.PushSpansRequest
+	}{
+		{
+			name:    "default",
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "target_info",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = true
+				cfg.TargetInfoExcludedDimensions = []string{"excluded"}
+			},
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "target_info_all_filtered",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = true
+				cfg.TargetInfoExcludedDimensions = []string{"excluded"}
+				cfg.FilterPolicies = []filterconfig.FilterPolicy{{
+					Exclude: &filterconfig.PolicyMatch{
+						MatchType: filterconfig.Strict,
+						Attributes: []filterconfig.MatchPolicyAttribute{{
+							Key:   "span.http.method",
+							Value: "GET",
+						}},
+					},
+				}}
+			},
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "dimensions_and_mappings",
+			tune: func(cfg *Config) {
+				cfg.EnableTargetInfo = false
+				cfg.Dimensions = []string{
+					"k8s.cluster.name",
+					"k8s.namespace.name",
+					"http.method",
+					"http.status_code",
+					"span.attr.1",
+					"span.attr.2",
+				}
+				cfg.DimensionMappings = []sharedconfig.DimensionMappings{
+					{Name: "route_key", SourceLabel: []string{"http.method", "http.route", "http.status_code"}, Join: ":"},
+					{Name: "pod_key", SourceLabel: []string{"k8s.namespace.name", "k8s.pod.name"}, Join: "/"},
+				}
+			},
+			request: benchmarkSpanMetricsRequest(true),
+		},
+		{
+			name: "count_only",
+			tune: func(cfg *Config) {
+				cfg.Subprocessors[Latency] = false
+				cfg.Subprocessors[Size] = false
+			},
+			request: benchmarkSpanMetricsRequest(false),
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			if tc.tune != nil {
+				tc.tune(&cfg)
+			}
+
+			p, err := New(
+				cfg,
+				registry.NewTestRegistry(),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer p.Shutdown(context.Background())
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				p.PushSpans(context.Background(), tc.request)
+			}
+		})
+	}
+}
+
+func benchmarkSpanMetricsRequest(sameTracePerResource bool) *tempopb.PushSpansRequest {
+	const (
+		resources        = 4
+		spansPerResource = 100
+	)
+
+	req := &tempopb.PushSpansRequest{
+		Batches: make([]*trace_v1.ResourceSpans, 0, resources),
+	}
+	for r := 0; r < resources; r++ {
+		rs := &trace_v1.ResourceSpans{
+			Resource: &resource_v1.Resource{
+				Attributes: []*common_v1.KeyValue{
+					benchmarkStringAttr("service.name", "svc-"+strconv.Itoa(r)),
+					benchmarkStringAttr("service.namespace", "ns-"+strconv.Itoa(r%2)),
+					benchmarkStringAttr("service.instance.id", "instance-"+strconv.Itoa(r)),
+					benchmarkStringAttr("k8s.cluster.name", "cluster-a"),
+					benchmarkStringAttr("k8s.namespace.name", "namespace-"+strconv.Itoa(r%4)),
+					benchmarkStringAttr("k8s.pod.name", "pod-"+strconv.Itoa(r)),
+					benchmarkStringAttr("k8s.node.name", "node-"+strconv.Itoa(r%8)),
+					benchmarkStringAttr("telemetry.sdk.language", "go"),
+					benchmarkStringAttr("telemetry.sdk.version", "1.0.0"),
+					benchmarkStringAttr("excluded", "drop-me"),
+				},
+			},
+			ScopeSpans: []*trace_v1.ScopeSpans{{}},
+		}
+		for s := 0; s < spansPerResource; s++ {
+			traceID := benchmarkTraceID(r)
+			if !sameTracePerResource {
+				traceID = benchmarkTraceID(r*spansPerResource + s)
+			}
+			rs.ScopeSpans[0].Spans = append(rs.ScopeSpans[0].Spans, &trace_v1.Span{
+				TraceId:           traceID,
+				SpanId:            benchmarkSpanID(r*spansPerResource + s + 1),
+				Name:              "GET /api/:id",
+				Kind:              trace_v1.Span_SPAN_KIND_SERVER,
+				StartTimeUnixNano: uint64(1_700_000_000_000_000_000 + s),
+				EndTimeUnixNano:   uint64(1_700_000_000_100_000_000 + s),
+				Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+				Attributes: []*common_v1.KeyValue{
+					benchmarkStringAttr("http.method", "GET"),
+					benchmarkStringAttr("http.route", "/api/:id"),
+					benchmarkStringAttr("http.status_code", "200"),
+					benchmarkStringAttr("span.attr.1", "one"),
+					benchmarkStringAttr("span.attr.2", "two"),
+				},
+			})
+		}
+		req.Batches = append(req.Batches, rs)
+	}
+	return req
+}
+
+func benchmarkTraceID(i int) []byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[8:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSpanID(i int) []byte {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkStringAttr(key, value string) *common_v1.KeyValue {
+	return &common_v1.KeyValue{
+		Key: key,
+		Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{
+			StringValue: value,
+		}},
+	}
+}

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -12,10 +12,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	gen "github.com/grafana/tempo/modules/generator/processor"
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/pkg/sharedconfig"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
@@ -1872,4 +1874,253 @@ func TestSpanMetricsTraceStateMultiplier(t *testing.T) {
 
 	// With 50% sampling (th:8), span multiplier is 2, so 1 span → count of 2
 	assert.Equal(t, 2.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
+}
+
+// recordingRegistry wraps a TestRegistry and records the order of every metric
+// series update. The production registry limiter grants active-series and
+// entity capacity in call order, so tests use this to pin the relative
+// ordering of span metric and target_info updates.
+type recordingRegistry struct {
+	*registry.TestRegistry
+	calls []string
+}
+
+func newRecordingRegistry() *recordingRegistry {
+	return &recordingRegistry{TestRegistry: registry.NewTestRegistry()}
+}
+
+func (r *recordingRegistry) NewCounter(name string) registry.Counter {
+	return &recordingCounter{Counter: r.TestRegistry.NewCounter(name), name: name, calls: &r.calls}
+}
+
+func (r *recordingRegistry) NewGauge(name string) registry.Gauge {
+	return &recordingGauge{Gauge: r.TestRegistry.NewGauge(name), name: name, calls: &r.calls}
+}
+
+func (r *recordingRegistry) NewHistogram(name string, buckets []float64, mode registry.HistogramMode) registry.Histogram {
+	return &recordingHistogram{Histogram: r.TestRegistry.NewHistogram(name, buckets, mode), name: name, calls: &r.calls}
+}
+
+type recordingCounter struct {
+	registry.Counter
+	name  string
+	calls *[]string
+}
+
+func (c *recordingCounter) Inc(lbls labels.Labels, value float64) {
+	*c.calls = append(*c.calls, c.name)
+	c.Counter.Inc(lbls, value)
+}
+
+func (c *recordingCounter) IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+	*c.calls = append(*c.calls, c.name)
+	c.Counter.IncWithHashAt(lbls, hash, value, timeMs)
+}
+
+type recordingGauge struct {
+	registry.Gauge
+	name  string
+	calls *[]string
+}
+
+func (g *recordingGauge) Set(lbls labels.Labels, value float64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.Set(lbls, value)
+}
+
+func (g *recordingGauge) Inc(lbls labels.Labels, value float64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.Inc(lbls, value)
+}
+
+func (g *recordingGauge) SetForTargetInfo(lbls labels.Labels, value float64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.SetForTargetInfo(lbls, value)
+}
+
+func (g *recordingGauge) SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.SetForTargetInfoWithHashAt(lbls, hash, value, timeMs)
+}
+
+type recordingHistogram struct {
+	registry.Histogram
+	name  string
+	calls *[]string
+}
+
+func (h *recordingHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64) {
+	*h.calls = append(*h.calls, h.name)
+	h.Histogram.ObserveWithExemplar(lbls, value, traceID, multiplier)
+}
+
+func (h *recordingHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	*h.calls = append(*h.calls, h.name)
+	h.Histogram.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, value, traceID, multiplier, timeMs)
+}
+
+// TestSpanMetricsTargetInfoRegisteredAfterSpanMetrics pins the order in which
+// series are updated when target_info is enabled. The registry limiter grants
+// active-series and entity capacity in call order, so near the limit the span
+// metrics must claim the remaining capacity before target_info — not the
+// other way around. It also pins that target_info is registered exactly once
+// per resource batch.
+func TestSpanMetricsTargetInfoRegisteredAfterSpanMetrics(t *testing.T) {
+	recReg := newRecordingRegistry()
+	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered", "span-metrics")
+	invalidUTF8SpanLabelsCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "invalid_utf8", "span-metrics")
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.HistogramBuckets = []float64{0.5, 1}
+	cfg.EnableTargetInfo = true
+
+	p, err := New(cfg, recReg, filteredSpansCounter, invalidUTF8SpanLabelsCounter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	batch := test.MakeBatch(2, nil)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+	expected := []string{
+		// First accepted span updates its own series before target_info.
+		"traces_spanmetrics_calls_total",
+		"traces_spanmetrics_latency",
+		"traces_spanmetrics_size_total",
+		"traces_target_info",
+		// Subsequent spans of the same resource do not re-register target_info.
+		"traces_spanmetrics_calls_total",
+		"traces_spanmetrics_latency",
+		"traces_spanmetrics_size_total",
+	}
+	assert.Equal(t, expected, recReg.calls)
+}
+
+// TestSpanMetricsTargetInfoInvalidUTF8Spans verifies that target_info follows
+// the pre-optimization contract: it is registered only once a span's primary
+// labels validate, so a resource whose accepted spans all carry invalid UTF-8
+// labels emits no target_info at all.
+func TestSpanMetricsTargetInfoInvalidUTF8Spans(t *testing.T) {
+	newProcessor := func(t *testing.T) (*registry.TestRegistry, prometheus.Counter, gen.Processor) {
+		t.Helper()
+		testRegistry := registry.NewTestRegistry()
+		filteredSpansCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_filtered_spans_total"})
+		invalidUTF8Counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_invalid_utf8_spans_total"})
+
+		cfg := Config{}
+		cfg.RegisterFlagsAndApplyDefaults("", nil)
+		cfg.HistogramBuckets = []float64{0.5, 1}
+		cfg.EnableTargetInfo = true
+
+		p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8Counter)
+		require.NoError(t, err)
+		return testRegistry, invalidUTF8Counter, p
+	}
+
+	t.Run("all spans invalid emits no target_info", func(t *testing.T) {
+		testRegistry, invalidUTF8Counter, p := newProcessor(t)
+		defer p.Shutdown(context.Background())
+
+		batch := test.MakeBatch(2, nil)
+		for _, ss := range batch.ScopeSpans {
+			for _, span := range ss.Spans {
+				span.Name = "invalid-\xff-utf8"
+			}
+		}
+
+		p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+		assert.NotContains(t, testRegistry.String(), "traces_target_info")
+		assert.NotContains(t, testRegistry.String(), "traces_spanmetrics_calls_total")
+		assert.Equal(t, 2.0, testutil.ToFloat64(invalidUTF8Counter))
+	})
+
+	t.Run("target_info registered after first valid span", func(t *testing.T) {
+		testRegistry, invalidUTF8Counter, p := newProcessor(t)
+		defer p.Shutdown(context.Background())
+
+		batch := test.MakeBatch(2, nil)
+		batch.ScopeSpans[0].Spans[0].Name = "invalid-\xff-utf8"
+
+		p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+		assert.Contains(t, testRegistry.String(), "traces_target_info")
+		lbls := labels.FromMap(map[string]string{
+			"service":     "test-service",
+			"span_name":   "test",
+			"span_kind":   "SPAN_KIND_CLIENT",
+			"status_code": "STATUS_CODE_OK",
+			"job":         "test-service",
+		})
+		assert.Equal(t, 1.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
+		assert.Equal(t, 1.0, testutil.ToFloat64(invalidUTF8Counter))
+	})
+
+	t.Run("invalid target_info labels still emit span metrics", func(t *testing.T) {
+		testRegistry, invalidUTF8Counter, p := newProcessor(t)
+		defer p.Shutdown(context.Background())
+
+		// Valid spans, but a resource attribute with an invalid UTF-8 value
+		// poisons the target_info label set only.
+		batch := test.MakeBatchWithAttributes(2, nil, []*common_v1.KeyValue{
+			{
+				Key: "res.attr",
+				Value: &common_v1.AnyValue{
+					Value: &common_v1.AnyValue_StringValue{StringValue: "invalid-\xff-utf8"},
+				},
+			},
+		})
+
+		p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+		// Span metrics still emit for both spans; target_info is rejected and
+		// counted once per accepted span (pre-optimization contract).
+		lbls := labels.FromMap(map[string]string{
+			"service":     "test-service",
+			"span_name":   "test",
+			"span_kind":   "SPAN_KIND_CLIENT",
+			"status_code": "STATUS_CODE_OK",
+			"job":         "test-service",
+		})
+		assert.Equal(t, 2.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
+		assert.NotContains(t, testRegistry.String(), "traces_target_info")
+		assert.Equal(t, 2.0, testutil.ToFloat64(invalidUTF8Counter))
+	})
+}
+
+// TestSpanMetricsTargetInfoWithDisabledSubprocessors pins that target_info
+// registration only depends on the span's primary labels being valid UTF-8,
+// not on any span metric series actually being updated.
+func TestSpanMetricsTargetInfoWithDisabledSubprocessors(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+	filteredSpansCounter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_filtered_spans_total"})
+	invalidUTF8Counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_invalid_utf8_spans_total"})
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.EnableTargetInfo = true
+	cfg.Subprocessors[Count] = false
+	cfg.Subprocessors[Latency] = false
+	cfg.Subprocessors[Size] = false
+
+	p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8Counter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	batch := test.MakeBatch(1, nil)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+	var resAttr string
+	for _, kv := range batch.Resource.Attributes {
+		if kv.Key == "random.res.attr" {
+			resAttr = kv.Value.GetStringValue()
+		}
+	}
+	targetInfoLabels := labels.FromMap(map[string]string{
+		"job":             "test-service",
+		"random_res_attr": resAttr,
+	})
+	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", targetInfoLabels))
+	assert.NotContains(t, testRegistry.String(), "traces_spanmetrics_calls_total")
+	assert.Equal(t, 0.0, testutil.ToFloat64(invalidUTF8Counter))
 }

--- a/modules/generator/processor/util/util.go
+++ b/modules/generator/processor/util/util.go
@@ -16,12 +16,46 @@ func FindServiceName(attributes []*v1_common.KeyValue) (string, bool) {
 	return FindAttributeValue(string(semconv.ServiceNameKey), attributes)
 }
 
-func FindServiceNamespace(attributes []*v1_common.KeyValue) (string, bool) {
-	return FindAttributeValue(string(semconv.ServiceNamespaceKey), attributes)
-}
+// FindServiceLabels extracts the service.name, job, and service.instance.id
+// label values from resource attributes in a single pass. The job value is
+// "<service.namespace>/<service.name>" when the namespace is present and just
+// the service name otherwise; it is empty when service.name is absent. The
+// first occurrence of each attribute wins.
+func FindServiceLabels(attributes []*v1_common.KeyValue) (svcName, jobName, instanceID string) {
+	var (
+		namespace       string
+		foundSvcName    bool
+		foundNamespace  bool
+		foundInstanceID bool
+	)
 
-func FindInstanceID(attributes []*v1_common.KeyValue) (string, bool) {
-	return FindAttributeValue(string(semconv.ServiceInstanceIDKey), attributes)
+	for _, kv := range attributes {
+		switch kv.Key {
+		case string(semconv.ServiceNameKey):
+			if !foundSvcName {
+				svcName = tempo_util.StringifyAnyValue(kv.Value)
+				foundSvcName = true
+			}
+		case string(semconv.ServiceNamespaceKey):
+			if !foundNamespace {
+				namespace = tempo_util.StringifyAnyValue(kv.Value)
+				foundNamespace = true
+			}
+		case string(semconv.ServiceInstanceIDKey):
+			if !foundInstanceID {
+				instanceID = tempo_util.StringifyAnyValue(kv.Value)
+				foundInstanceID = true
+			}
+		}
+	}
+
+	if svcName == "" {
+		return svcName, "", instanceID
+	}
+	if namespace == "" {
+		return svcName, svcName, instanceID
+	}
+	return svcName, namespace + "/" + svcName, instanceID
 }
 
 func FindAttributeValue(key string, attributes ...[]*v1_common.KeyValue) (string, bool) {
@@ -105,17 +139,4 @@ func extractOpenTelemetryTraceState(traceState string) string {
 		}
 		traceState = strings.TrimSpace(traceState[nextComma+1:])
 	}
-}
-
-func GetJobValue(attributes []*v1_common.KeyValue) string {
-	svName, _ := FindServiceName(attributes)
-	// if service name is not present, consider job value empty
-	if svName == "" {
-		return ""
-	}
-	namespace, _ := FindServiceNamespace(attributes)
-	if namespace == "" {
-		return svName
-	}
-	return namespace + "/" + svName
 }

--- a/modules/generator/processor/util/util_test.go
+++ b/modules/generator/processor/util/util_test.go
@@ -103,6 +103,92 @@ func TestFindServiceName(t *testing.T) {
 	}
 }
 
+func TestFindServiceLabels(t *testing.T) {
+	strAttr := func(key, value string) *v1_common.KeyValue {
+		return &v1_common.KeyValue{
+			Key: key,
+			Value: &v1_common.AnyValue{
+				Value: &v1_common.AnyValue_StringValue{StringValue: value},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name               string
+		attributes         []*v1_common.KeyValue
+		expectedSvcName    string
+		expectedJobName    string
+		expectedInstanceID string
+	}{
+		{
+			name: "empty attributes",
+		},
+		{
+			name:            "service name only",
+			attributes:      []*v1_common.KeyValue{strAttr("service.name", "my-service")},
+			expectedSvcName: "my-service",
+			expectedJobName: "my-service",
+		},
+		{
+			name: "service name and namespace",
+			attributes: []*v1_common.KeyValue{
+				strAttr("service.namespace", "my-namespace"),
+				strAttr("service.name", "my-service"),
+			},
+			expectedSvcName: "my-service",
+			expectedJobName: "my-namespace/my-service",
+		},
+		{
+			name:       "namespace without service name yields empty job",
+			attributes: []*v1_common.KeyValue{strAttr("service.namespace", "my-namespace")},
+		},
+		{
+			name: "instance id",
+			attributes: []*v1_common.KeyValue{
+				strAttr("service.name", "my-service"),
+				strAttr("service.instance.id", "instance-1"),
+			},
+			expectedSvcName:    "my-service",
+			expectedJobName:    "my-service",
+			expectedInstanceID: "instance-1",
+		},
+		{
+			name: "first occurrence wins",
+			attributes: []*v1_common.KeyValue{
+				strAttr("service.name", "first"),
+				strAttr("service.name", "second"),
+				strAttr("service.instance.id", "instance-1"),
+				strAttr("service.instance.id", "instance-2"),
+			},
+			expectedSvcName:    "first",
+			expectedJobName:    "first",
+			expectedInstanceID: "instance-1",
+		},
+		{
+			name: "non-string values are stringified",
+			attributes: []*v1_common.KeyValue{
+				{
+					Key: "service.name",
+					Value: &v1_common.AnyValue{
+						Value: &v1_common.AnyValue_BoolValue{BoolValue: false},
+					},
+				},
+			},
+			expectedSvcName: "false",
+			expectedJobName: "false",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			svcName, jobName, instanceID := FindServiceLabels(tc.attributes)
+
+			assert.Equal(t, tc.expectedSvcName, svcName)
+			assert.Equal(t, tc.expectedJobName, jobName)
+			assert.Equal(t, tc.expectedInstanceID, instanceID)
+		})
+	}
+}
+
 func TestGetSpanMultiplierFromTraceState(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/modules/generator/registry/builder.go
+++ b/modules/generator/registry/builder.go
@@ -1,84 +1,227 @@
 package registry
 
 import (
+	"slices"
+	"strings"
 	"sync"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-type safeBuilderPool struct {
-	pool sync.Pool
-}
-
-func newSafeBuilderPool() *safeBuilderPool {
-	return &safeBuilderPool{
-		pool: sync.Pool{
-			New: func() interface{} {
-				return labels.NewBuilder(labels.New())
-			},
-		},
-	}
-}
-
-func (p *safeBuilderPool) Get() *labels.Builder {
-	return p.pool.Get().(*labels.Builder)
-}
-
-func (p *safeBuilderPool) Put(builder *labels.Builder) {
-	builder.Reset(labels.New())
-	p.pool.Put(builder)
-}
-
-var builderPool = newSafeBuilderPool()
-
 type labelBuilder struct {
-	builder         *labels.Builder
 	sanitizer       Sanitizer
 	perLabelLimiter LabelLimiter
+	labels          []labels.Label
+	pools           *labelBuilderPools
 
 	maxLabelNameLength  int
 	maxLabelValueLength int
+	closed              bool
 }
 
 var _ LabelBuilder = (*labelBuilder)(nil)
 
-func NewLabelBuilder(maxLabelNameLength int, maxLabelValueLength int, sanitizer Sanitizer, perLabelLimiter LabelLimiter) LabelBuilder {
-	builder := builderPool.Get()
-	return &labelBuilder{
-		builder:             builder,
-		sanitizer:           sanitizer,
-		perLabelLimiter:     perLabelLimiter,
-		maxLabelNameLength:  maxLabelNameLength,
-		maxLabelValueLength: maxLabelValueLength,
+// labelBuilderPools holds the object pools used while building a label set.
+// Each ManagedRegistry owns one set (see registry.New), so pooled scratch
+// memory is never shared across tenants: a retention bug then degrades from a
+// cross-tenant disclosure to same-tenant corruption.
+type labelBuilderPools struct {
+	labelBuilderPool   sync.Pool
+	scratchBuilderPool sync.Pool
+}
+
+func newLabelBuilderPools() *labelBuilderPools {
+	p := &labelBuilderPools{}
+	p.labelBuilderPool.New = func() interface{} {
+		return &labelBuilder{
+			labels: make([]labels.Label, 0, 16),
+		}
 	}
+	p.scratchBuilderPool.New = func() interface{} {
+		b := labels.NewScratchBuilder(16)
+		return &b
+	}
+	return p
+}
+
+// defaultLabelBuilderPools backs the exported NewLabelBuilder, which is used by
+// tests. Production code builds labels via (*ManagedRegistry).NewLabelBuilder /
+// NewInfoMetricLabelBuilder, which use the registry's own per-tenant pools.
+var defaultLabelBuilderPools = newLabelBuilderPools()
+
+// NewLabelBuilder returns a LabelBuilder backed by the package-default pools.
+// Intended for tests; production code uses the per-tenant pools owned by a
+// ManagedRegistry.
+func NewLabelBuilder(maxLabelNameLength int, maxLabelValueLength int, sanitizer Sanitizer, perLabelLimiter LabelLimiter) LabelBuilder {
+	return defaultLabelBuilderPools.newLabelBuilder(maxLabelNameLength, maxLabelValueLength, sanitizer, perLabelLimiter)
+}
+
+func (p *labelBuilderPools) newLabelBuilder(maxLabelNameLength int, maxLabelValueLength int, sanitizer Sanitizer, perLabelLimiter LabelLimiter) LabelBuilder {
+	b := p.labelBuilderPool.Get().(*labelBuilder)
+	b.sanitizer = sanitizer
+	b.perLabelLimiter = perLabelLimiter
+	b.labels = b.labels[:0]
+	b.maxLabelNameLength = maxLabelNameLength
+	b.maxLabelValueLength = maxLabelValueLength
+	b.closed = false
+	b.pools = p
+	return b
 }
 
 func (b *labelBuilder) Add(name, value string) {
+	if b.closed {
+		panic("label builder used after Close")
+	}
 	if b.maxLabelNameLength > 0 && len(name) > b.maxLabelNameLength {
 		name = name[:b.maxLabelNameLength]
 	}
 	if b.maxLabelValueLength > 0 && len(value) > b.maxLabelValueLength {
 		value = value[:b.maxLabelValueLength]
 	}
-	b.builder.Set(name, value)
+	// Empty values are appended as-is and dropped by compactLabels when the
+	// set is built: last-write-wins dedupe means an empty value deletes any
+	// prior label with this name (mirrors the prometheus.Builder.Set("x","")
+	// -> Del("x") semantics that callers depend on for sanitization-collision
+	// handling).
+	b.labels = append(b.labels, labels.Label{Name: name, Value: value})
 }
 
 func (b *labelBuilder) CloseAndBuildLabels() (labels.Labels, bool) {
+	if b.closed {
+		// This method pools the builder before returning, so a second call would
+		// double-Put it (handing one builder to two future callers concurrently)
+		// and operate on a builder another caller may already hold. Mirror Add's
+		// use-after-close guard.
+		panic("label builder used after Close")
+	}
+	b.closed = true
+	scratch := b.pools.scratchBuilderPool.Get().(*labels.ScratchBuilder)
+	b.prepareScratch(scratch)
+	lbls := scratch.Labels()
+
 	// We always run sanitizer first and then run per label limiter to ensure that
 	// per label limits are always applied after sanitizer.
 	// Pipeline: sanitize labels --> per-label cardinality limit --> entity/series limit
-	lbls := b.sanitizer.Sanitize(b.builder.Labels())
+	lbls = b.sanitizer.Sanitize(lbls)
 	lbls = b.perLabelLimiter.Limit(lbls)
-	// it's no longer safe to use the builder after this point, so we drop our
-	// reference to it. this may cause a nil panic if the builder is used after
-	// this point, but it's better than memory corruption.
-	builderPool.Put(b.builder)
-	b.builder = nil
+	// scratch.Labels() copied the label data out of the scratch, so both the
+	// builder and the scratch can be pooled before returning.
+	b.releaseBorrowedLabels(scratch)
 
+	return lbls, lbls.IsValid(model.UTF8Validation)
+}
+
+func (b *labelBuilder) CloseAndBorrowLabels() (BorrowedLabels, bool) {
+	if b.closed {
+		// Closing twice would borrow a second value backed by this same builder
+		// and scratch, and releasing both double-Puts them into the pools
+		// (handing one to two future callers concurrently). Mirror Add's guard.
+		panic("label builder used after Close")
+	}
+	b.closed = true
+	scratch := b.pools.scratchBuilderPool.Get().(*labels.ScratchBuilder)
+	b.prepareScratch(scratch)
+	var lbls labels.Labels
+	scratch.Overwrite(&lbls)
+
+	// We always run sanitizer first and then run per label limiter to ensure that
+	// per label limits are always applied after sanitizer.
+	// Pipeline: sanitize labels --> per-label cardinality limit --> entity/series limit
+	lbls = b.sanitizer.Sanitize(lbls)
+	lbls = b.perLabelLimiter.Limit(lbls)
 	if !lbls.IsValid(model.UTF8Validation) {
-		return lbls, false
+		b.releaseBorrowedLabels(scratch)
+		return BorrowedLabels{}, false
 	}
 
-	return lbls, true
+	return BorrowedLabels{
+		Labels:  lbls,
+		Hash:    lbls.Hash(),
+		builder: b,
+		scratch: scratch,
+	}, true
+}
+
+// releaseBorrowedLabels resets the builder and returns it and the scratch
+// buffer to their pools. It is no longer safe to use the builder after this
+// point, so we drop our references: a stale use nil-panics rather than
+// corrupting memory. The closed flag is best-effort — it catches misuse
+// against the same builder reference, but once the builder is recycled to the
+// pool and re-issued, a stale reference would corrupt another caller's labels.
+func (b *labelBuilder) releaseBorrowedLabels(scratch *labels.ScratchBuilder) {
+	b.sanitizer = nil
+	b.perLabelLimiter = nil
+	b.labels = b.labels[:0]
+	b.maxLabelNameLength = 0
+	b.maxLabelValueLength = 0
+	pools := b.pools
+	pools.scratchBuilderPool.Put(scratch)
+	pools.labelBuilderPool.Put(b)
+}
+
+func (b *labelBuilder) prepareScratch(scratch *labels.ScratchBuilder) {
+	scratch.Reset()
+	sortLabels(b.labels)
+	b.labels = compactLabels(b.labels)
+	for _, l := range b.labels {
+		scratch.Add(l.Name, l.Value)
+	}
+}
+
+// insertionSortThreshold is the label count above which sortLabels falls back
+// to the standard library sort. Span metric label sets are almost always small
+// and nearly sorted, where insertion sort is faster and allocation-free, but it
+// is O(n²) so large label sets (e.g. target_info on resources with many
+// attributes) use O(n log n) instead. Both paths are stable: compactLabels
+// relies on the last-added duplicate name winning.
+const insertionSortThreshold = 16
+
+func sortLabels(lbls []labels.Label) {
+	if len(lbls) > insertionSortThreshold {
+		slices.SortStableFunc(lbls, func(a, b labels.Label) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		return
+	}
+	for i := 1; i < len(lbls); i++ {
+		for j := i; j > 0 && strings.Compare(lbls[j-1].Name, lbls[j].Name) > 0; j-- {
+			lbls[j-1], lbls[j] = lbls[j], lbls[j-1]
+		}
+	}
+}
+
+// compactLabels owns duplicate-name and empty-value handling for sorted label
+// slices: the last-added entry per name wins, and an empty value deletes the
+// name entirely (Add appends empty values as-is). The common case — no
+// duplicates, no empty values — returns the slice unchanged.
+func compactLabels(lbls []labels.Label) []labels.Label {
+	if len(lbls) == 0 {
+		return lbls
+	}
+
+	for i, l := range lbls {
+		if l.Value == "" || (i > 0 && l.Name == lbls[i-1].Name) {
+			return compactLabelsSlow(lbls)
+		}
+	}
+	return lbls
+}
+
+func compactLabelsSlow(lbls []labels.Label) []labels.Label {
+	write := 0
+	for read := 0; read < len(lbls); {
+		next := read + 1
+		for next < len(lbls) && lbls[next].Name == lbls[read].Name {
+			next++
+		}
+
+		last := lbls[next-1]
+		if last.Value != "" {
+			lbls[write] = last
+			write++
+		}
+		read = next
+	}
+	return lbls[:write]
 }

--- a/modules/generator/registry/builder_test.go
+++ b/modules/generator/registry/builder_test.go
@@ -1,10 +1,13 @@
 package registry
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLabelBuilder(t *testing.T) {
@@ -42,28 +45,104 @@ func TestLabelBuilder_InvalidUTF8(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestSafeBuilderPool(t *testing.T) {
-	pool := newSafeBuilderPool()
-	builder := pool.Get()
-	builder.Set("name", "value")
-	lbls := builder.Labels()
-
-	assert.Equal(t, labels.FromStrings("name", "value"), lbls)
-
-	// Putting the builder back into the pool should reset it.
-	pool.Put(builder)
-
-	reusedBuilder := pool.Get()
-	assert.Equal(t, builder, reusedBuilder)
-	assert.Equal(t, labels.EmptyLabels(), reusedBuilder.Labels())
-}
-
 type sanitizerFunc func(lbls labels.Labels) labels.Labels
 
 var _ Sanitizer = (*sanitizerFunc)(nil)
 
 func (s sanitizerFunc) Sanitize(lbls labels.Labels) labels.Labels {
 	return s(lbls)
+}
+
+func TestLabelBuilder_DuplicateNamesLastWriteWins(t *testing.T) {
+	// Two non-empty Adds with the same name must yield the last value, matching
+	// prometheus.Builder.Set semantics. compactLabels' fast path detects the
+	// duplicate and routes to compactLabelsSlow, which keeps the last entry of
+	// each contiguous group of equal names after stable sorting.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+	builder.Add("dup", "first")
+	builder.Add("other", "v")
+	builder.Add("dup", "second")
+
+	lbls, ok := builder.CloseAndBuildLabels()
+	assert.True(t, ok)
+	assert.Equal(t, labels.FromStrings("dup", "second", "other", "v"), lbls)
+}
+
+func TestLabelBuilder_AddEmptyValueRemovesAllMatches(t *testing.T) {
+	// Add(name, "") must mirror prometheus.Builder.Set("x","")->Del("x"), which
+	// removes every prior label with that name. Sanitization can collapse
+	// distinct input keys (foo.bar, foo_bar, foo-bar) onto the same name, and
+	// removing only the first match would leave a stale earlier value.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+	builder.Add("dup", "first")
+	builder.Add("other", "v")
+	builder.Add("dup", "second")
+	builder.Add("dup", "")
+
+	lbls, ok := builder.CloseAndBuildLabels()
+	assert.True(t, ok)
+	assert.Equal(t, labels.FromStrings("other", "v"), lbls)
+}
+
+func TestBorrowedLabels_AppliesSanitizerAndLimiter(t *testing.T) {
+	// CloseAndBorrowLabels runs sanitizer then per-label limiter, like
+	// CloseAndBuildLabels. Verify the same transformations apply through the
+	// borrow path so callers can use either entry point interchangeably.
+	builder := NewLabelBuilder(0, 0, sanitizerFunc(func(_ labels.Labels) labels.Labels {
+		return labels.FromStrings("name", "sanitized")
+	}), newTestLabelLimiter())
+	builder.Add("name", "raw")
+
+	borrowed, ok := builder.CloseAndBorrowLabels()
+	assert.True(t, ok)
+	assert.Equal(t, "sanitized", borrowed.Labels.Get("name"))
+	// Hash must be computed on the post-sanitize/post-limit labels — it is the
+	// documented precondition for every *WithHash* metric method. A regression
+	// that hashed the pre-transform labels would silently split or collide
+	// series.
+	assert.Equal(t, borrowed.Labels.Hash(), borrowed.Hash, "Hash must match the transformed labels")
+	borrowed.Release()
+}
+
+func TestBorrowedLabels_SequentialReuseDoesNotLeak(t *testing.T) {
+	// The scratch pool reissues the same buffer to the next caller after
+	// Release. Verify that a second borrow does not see labels from the first.
+	for range 5 {
+		builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+		builder.Add("first", "a")
+		first, ok := builder.CloseAndBorrowLabels()
+		assert.True(t, ok)
+		assert.Equal(t, "a", first.Labels.Get("first"))
+		first.Release()
+
+		builder = NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+		builder.Add("second", "b")
+		second, ok := builder.CloseAndBorrowLabels()
+		assert.True(t, ok)
+		assert.Equal(t, "", second.Labels.Get("first"))
+		assert.Equal(t, "b", second.Labels.Get("second"))
+		second.Release()
+	}
+}
+
+func TestBorrowedLabels_ReleaseIsIdempotent(t *testing.T) {
+	// Release must not double-Put the builder/scratch into their pools when
+	// called more than once on the same struct value. This only protects
+	// repeated Release on the same value — Release on a copy of BorrowedLabels
+	// is documented as forbidden because each copy retains independent
+	// non-nil builder/scratch pointers and the second Release on the copy
+	// would still double-Put.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+	builder.Add("name", "value")
+
+	borrowed, ok := builder.CloseAndBorrowLabels()
+	assert.True(t, ok)
+	assert.Equal(t, "value", borrowed.Labels.Get("name"))
+
+	borrowed.Release()
+	// second release is a no-op; would otherwise corrupt the sync.Pool.
+	borrowed.Release()
+	assert.Equal(t, labels.EmptyLabels(), borrowed.Labels)
 }
 
 func TestLabelBuilder_Sanitizer(t *testing.T) {
@@ -75,4 +154,80 @@ func TestLabelBuilder_Sanitizer(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.Equal(t, labels.FromStrings("name", "sanitized_value"), lbls)
+}
+
+func TestLabelBuilder_LargeLabelSetSortsAndDeduplicates(t *testing.T) {
+	// More than insertionSortThreshold labels routes sortLabels to the stdlib
+	// stable sort. Last-write-wins for duplicates must hold on that path too.
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+
+	want := make(map[string]string, insertionSortThreshold+2)
+	// Add every name once in reverse order, then again in reverse order with
+	// the final values: duplicates are interleaved across the whole set, so
+	// last-write-wins only holds if the fallback sort is stable.
+	for i := insertionSortThreshold + 1; i >= 0; i-- {
+		builder.Add(fmt.Sprintf("label_%03d", i), "first")
+	}
+	for i := insertionSortThreshold + 1; i >= 0; i-- {
+		name := fmt.Sprintf("label_%03d", i)
+		builder.Add(name, fmt.Sprintf("value_%03d", i))
+		want[name] = fmt.Sprintf("value_%03d", i)
+	}
+
+	lbls, ok := builder.CloseAndBuildLabels()
+	assert.True(t, ok)
+	assert.Equal(t, labels.FromMap(want), lbls)
+}
+
+// TestBorrowedLabels_CollapsedLabelsProduceSingleSeries is the behavioral
+// counterpart of the Hash==Labels.Hash() invariant: when the sanitizer collapses
+// two different raw inputs to the same final label set, they must map to a
+// single series. This only holds because BorrowedLabels.Hash is computed on the
+// post-transform labels; a regression that hashed pre-transform labels would
+// split them into two series (or collide unrelated ones).
+func TestBorrowedLabels_CollapsedLabelsProduceSingleSeries(t *testing.T) {
+	collapse := sanitizerFunc(func(_ labels.Labels) labels.Labels {
+		return labels.FromStrings("span_name", "collapsed")
+	})
+
+	c := newCounter("my_counter", noopLimiter, nil, 15*time.Minute)
+
+	for _, raw := range []string{"GET /a", "GET /b"} {
+		builder := NewLabelBuilder(0, 0, collapse, newTestLabelLimiter())
+		builder.Add("span_name", raw)
+		borrowed, ok := builder.CloseAndBorrowLabels()
+		require.True(t, ok)
+		require.Equal(t, borrowed.Labels.Hash(), borrowed.Hash)
+		c.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, time.Now().UnixMilli())
+		borrowed.Release()
+	}
+
+	require.Equal(t, 1, c.countActiveSeries(), "labels that collapse to the same set must share one series")
+}
+
+// TestLabelBuilder_DoubleClosePanics verifies both close methods reject a second
+// close on the same builder. Without the guard the second close would build a
+// value backed by the same pooled builder/scratch, and releasing both would
+// double-Put them into the pools, handing one instance to two future callers.
+func TestLabelBuilder_DoubleClosePanics(t *testing.T) {
+	t.Run("CloseAndBuildLabels", func(t *testing.T) {
+		b := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+		b.Add("name", "value")
+		_, ok := b.CloseAndBuildLabels()
+		require.True(t, ok)
+		require.PanicsWithValue(t, "label builder used after Close", func() {
+			_, _ = b.CloseAndBuildLabels()
+		})
+	})
+
+	t.Run("CloseAndBorrowLabels", func(t *testing.T) {
+		b := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+		b.Add("name", "value")
+		borrowed, ok := b.CloseAndBorrowLabels()
+		require.True(t, ok)
+		defer borrowed.Release()
+		require.PanicsWithValue(t, "label builder used after Close", func() {
+			_, _ = b.CloseAndBorrowLabels()
+		})
+	})
 }

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -59,19 +59,20 @@ func newCounter(name string, lifecycler Limiter, externalLabels map[string]strin
 }
 
 func (c *counter) Inc(lbls labels.Labels, value float64) {
+	c.IncWithHashAt(lbls, lbls.Hash(), value, time.Now().UnixMilli())
+}
+
+func (c *counter) IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
 	if value < 0 {
 		panic("counter can only increase")
 	}
-
-	hash := lbls.Hash()
-
 	c.seriesMtx.RLock()
 	s, ok := c.series[hash]
 	c.seriesMtx.RUnlock()
 
 	c.seriesDemand.Insert(hash)
 	if ok {
-		c.updateSeries(hash, s, value)
+		c.updateSeries(hash, s, value, timeMs)
 		return
 	}
 
@@ -80,11 +81,11 @@ func (c *counter) Inc(lbls labels.Labels, value float64) {
 
 	s, lbls, hash = resolveSeries(c.series, hash, lbls, c.lifecycler, 1)
 	if s != nil {
-		c.updateSeries(hash, s, value)
+		c.updateSeries(hash, s, value, timeMs)
 		return
 	}
 
-	c.series[hash] = c.newSeries(lbls, value)
+	c.series[hash] = c.newSeries(lbls, value, timeMs)
 }
 
 func resolveSeries[T any](series map[uint64]*T, hash uint64, lbls labels.Labels, lifecycler Limiter, count uint32) (*T, labels.Labels, uint64) {
@@ -105,18 +106,18 @@ func resolveSeries[T any](series map[uint64]*T, hash uint64, lbls labels.Labels,
 	return nil, lbls, hash
 }
 
-func (c *counter) newSeries(lbls labels.Labels, value float64) *counterSeries {
+func (c *counter) newSeries(lbls labels.Labels, value float64, timeMs int64) *counterSeries {
 	return &counterSeries{
 		labels:      getSeriesLabels(c.metricName, lbls, c.externalLabels),
 		value:       atomic.NewFloat64(value),
-		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
+		lastUpdated: atomic.NewInt64(timeMs),
 		firstSeries: atomic.NewBool(true),
 	}
 }
 
-func (c *counter) updateSeries(hash uint64, s *counterSeries, value float64) {
+func (c *counter) updateSeries(hash uint64, s *counterSeries, value float64, timeMs int64) {
 	s.value.Add(value)
-	s.lastUpdated.Store(time.Now().UnixMilli())
+	s.lastUpdated.Store(timeMs)
 	c.lifecycler.OnUpdate(hash, 1)
 }
 

--- a/modules/generator/registry/drain_sanitizer.go
+++ b/modules/generator/registry/drain_sanitizer.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -73,7 +74,11 @@ func (s *DrainSanitizer) Sanitize(lbls labels.Labels) labels.Labels {
 	defer s.mtx.Unlock()
 
 	spanName := lbls.Get(labelSpanName)
-	cluster := s.drain.Train(spanName)
+	// drain.Train retains substrings of spanName in long-lived cluster tokens
+	// (drain.newCluster clones the token slice headers, not the bytes). spanName
+	// may alias a pooled/borrowed scratch buffer (see CloseAndBorrowLabels) that
+	// the caller reuses after this call, so clone it before handing it to drain.
+	cluster := s.drain.Train(strings.Clone(spanName))
 	// drain has various limits to prevent excessive memory usage, etc. in these
 	// cases, we will just return the original labels.
 	if cluster == nil {

--- a/modules/generator/registry/drain_sanitizer_test.go
+++ b/modules/generator/registry/drain_sanitizer_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -248,4 +249,52 @@ func TestDrainSanitizer_FullSanitizedOutput(t *testing.T) {
 			require.Equal(t, tc.expectedOutput, result.Get("span_name"))
 		})
 	}
+}
+
+// TestDrainSanitizer_BorrowedSpanNameNotRetained verifies that Sanitize does not
+// let drain retain token substrings that alias a reusable scratch buffer. drain
+// clones the token slice headers when it creates a cluster, but the bytes those
+// headers point at belong to the span name; if the span name aliases a pooled
+// scratch buffer (as CloseAndBorrowLabels produces) a later borrow that reuses
+// the buffer would corrupt the retained cluster tokens.
+func TestDrainSanitizer_BorrowedSpanNameNotRetained(t *testing.T) {
+	s := newTestDrainSanitizer(SpanNameSanitizationEnabled)
+
+	// A single ScratchBuilder reuses one internal buffer across Overwrite calls,
+	// exactly like the pooled scratch handed out by CloseAndBorrowLabels.
+	scratch := labels.NewScratchBuilder(1)
+
+	// span_name aliases the scratch buffer; this Sanitize call creates the drain
+	// cluster, which is the only place drain retains substrings of the input.
+	scratch.Reset()
+	scratch.Add("span_name", "GET /alpha/bravo")
+	var borrowed labels.Labels
+	scratch.Overwrite(&borrowed)
+	s.Sanitize(borrowed)
+
+	// Snapshot (owning a copy of) every token drain retained from the borrowed
+	// span name, so the comparison below is against the original bytes.
+	var snapshot []string
+	for _, c := range s.drain.Clusters() {
+		for _, tok := range c.Tokens {
+			snapshot = append(snapshot, strings.Clone(tok))
+		}
+	}
+	require.NotEmpty(t, snapshot, "expected drain to create a cluster and retain tokens")
+
+	// Reuse the SAME scratch buffer with a different span name of identical
+	// length, overwriting the bytes the retained tokens alias.
+	scratch.Reset()
+	scratch.Add("span_name", "PUT /xray0/yanke")
+	var reused labels.Labels
+	scratch.Overwrite(&reused)
+	require.Equal(t, "PUT /xray0/yanke", reused.Get("span_name"))
+
+	// The tokens drain retained must be unchanged: they must have been cloned
+	// from owned memory rather than left aliasing the borrowed scratch buffer.
+	var after []string
+	for _, c := range s.drain.Clusters() {
+		after = append(after, c.Tokens...)
+	}
+	require.Equal(t, snapshot, after, "drain retained tokens were corrupted by scratch-buffer reuse")
 }

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -55,20 +55,22 @@ func newGauge(name string, lifecycler Limiter, externalLabels map[string]string,
 }
 
 func (g *gauge) Set(lbls labels.Labels, value float64) {
-	g.updateSeries(lbls, value, set, true)
+	g.updateSeries(lbls, lbls.Hash(), value, set, true, time.Now().UnixMilli())
 }
 
 func (g *gauge) Inc(lbls labels.Labels, value float64) {
-	g.updateSeries(lbls, value, add, true)
+	g.updateSeries(lbls, lbls.Hash(), value, add, true, time.Now().UnixMilli())
 }
 
 func (g *gauge) SetForTargetInfo(lbls labels.Labels, value float64) {
-	g.updateSeries(lbls, value, set, false)
+	g.SetForTargetInfoWithHashAt(lbls, lbls.Hash(), value, time.Now().UnixMilli())
 }
 
-func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string, updateIfAlreadyExist bool) {
-	hash := lbls.Hash()
+func (g *gauge) SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+	g.updateSeries(lbls, hash, value, set, false, timeMs)
+}
 
+func (g *gauge) updateSeries(lbls labels.Labels, hash uint64, value float64, operation string, updateIfAlreadyExist bool, timeMs int64) {
 	g.seriesMtx.RLock()
 	s, ok := g.series[hash]
 	g.seriesMtx.RUnlock()
@@ -80,7 +82,7 @@ func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string
 		if !updateIfAlreadyExist {
 			return
 		}
-		g.updateSeriesValue(hash, s, value, operation)
+		g.updateSeriesValue(hash, s, value, operation, timeMs)
 		return
 	}
 
@@ -92,28 +94,28 @@ func (g *gauge) updateSeries(lbls labels.Labels, value float64, operation string
 		if !updateIfAlreadyExist {
 			return
 		}
-		g.updateSeriesValue(hash, s, value, operation)
+		g.updateSeriesValue(hash, s, value, operation, timeMs)
 		return
 	}
 
-	g.series[hash] = g.newSeries(lbls, value)
+	g.series[hash] = g.newSeries(lbls, value, timeMs)
 }
 
-func (g *gauge) newSeries(lbls labels.Labels, value float64) *gaugeSeries {
+func (g *gauge) newSeries(lbls labels.Labels, value float64, timeMs int64) *gaugeSeries {
 	return &gaugeSeries{
 		labels:      getSeriesLabels(g.metricName, lbls, g.externalLabels),
 		value:       atomic.NewFloat64(value),
-		lastUpdated: atomic.NewInt64(time.Now().UnixMilli()),
+		lastUpdated: atomic.NewInt64(timeMs),
 	}
 }
 
-func (g *gauge) updateSeriesValue(hash uint64, s *gaugeSeries, value float64, operation string) {
+func (g *gauge) updateSeriesValue(hash uint64, s *gaugeSeries, value float64, operation string, timeMs int64) {
 	if operation == add {
 		s.value.Add(value)
 	} else {
 		s.value.Store(value)
 	}
-	s.lastUpdated.Store(time.Now().UnixMilli())
+	s.lastUpdated.Store(timeMs)
 	g.lifecycler.OnUpdate(hash, 1)
 }
 

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -12,6 +12,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
 	"go.uber.org/atomic"
+
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 var _ metric = (*histogram)(nil)
@@ -34,6 +36,8 @@ type histogram struct {
 	traceIDLabelName string
 }
 
+// histogramSeries state is serialized by histogram.seriesMtx: the observe,
+// collect, and stale-removal paths all take the full mutex.
 type histogramSeries struct {
 	countLabels  labels.Labels
 	sumLabels    labels.Labels
@@ -43,23 +47,54 @@ type histogramSeries struct {
 	sum   *atomic.Float64
 	// buckets includes the +Inf bucket
 	buckets []*atomic.Float64
-	// exemplar is stored as a single traceID
-	exemplars      []*atomic.String
-	exemplarValues []*atomic.Float64
+	// exemplars stores either a hex-encoded string traceID or a raw <=16 byte
+	// traceID per bucket.
+	exemplars      []histogramExemplar
+	exemplarValues []float64
 	lastUpdated    *atomic.Int64
 	// firstSeries is used to track if this series is new to the counter.  This
 	// is used to ensure that new counters being with 0, and then are incremented
 	// to the desired value.  This avoids Prometheus throwing away the first
 	// value in the series, due to the transition from null -> x.
-	firstSeries *atomic.Bool
+	firstSeries bool
+}
+
+type histogramExemplar struct {
+	traceID      string
+	traceIDBytes [16]byte
+	traceIDLen   int
+}
+
+func newHistogramStringExemplar(traceID string) histogramExemplar {
+	return histogramExemplar{traceID: traceID}
+}
+
+func newHistogramTraceIDBytesExemplar(traceID []byte) histogramExemplar {
+	if len(traceID) == 0 {
+		return histogramExemplar{}
+	}
+	if len(traceID) > 16 {
+		return histogramExemplar{traceID: tempo_util.TraceIDToHexString(traceID)}
+	}
+
+	ex := histogramExemplar{traceIDLen: len(traceID)}
+	copy(ex.traceIDBytes[:], traceID)
+	return ex
+}
+
+func (ex histogramExemplar) string() string {
+	if ex.traceIDLen == 0 {
+		return ex.traceID
+	}
+	return tempo_util.TraceIDToHexString(ex.traceIDBytes[:ex.traceIDLen])
 }
 
 func (hs *histogramSeries) isNew() bool {
-	return hs.firstSeries.Load()
+	return hs.firstSeries
 }
 
 func (hs *histogramSeries) registerSeenSeries() {
-	hs.firstSeries.Store(false)
+	hs.firstSeries = false
 }
 
 var (
@@ -72,8 +107,19 @@ func newHistogram(name string, buckets []float64, lifecycler Limiter, traceIDLab
 		traceIDLabelName = "traceID"
 	}
 
-	// add +Inf bucket
-	buckets = append(buckets, math.Inf(1))
+	// Defensively copy and sort the buckets in ascending order. updateSeries
+	// counts buckets with sort.SearchFloat64s, which requires sorted input, and
+	// classic histograms require monotonic le buckets anyway. The override paths
+	// validate this, but a static histogram_buckets in the generator config is
+	// not validated, so sorting here keeps bucket counts correct on every path.
+	// Copying avoids mutating the caller's slice.
+	sorted := make([]float64, len(buckets), len(buckets)+1)
+	copy(sorted, buckets)
+	sort.Float64s(sorted)
+
+	// add +Inf bucket (always the largest value, so it stays last after sorting)
+	sorted = append(sorted, math.Inf(1))
+	buckets = sorted
 
 	bucketLabels := make([]string, len(buckets))
 	for i, bucket := range buckets {
@@ -96,8 +142,14 @@ func newHistogram(name string, buckets []float64, lifecycler Limiter, traceIDLab
 }
 
 func (h *histogram) ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64) {
-	hash := lbls.Hash()
+	h.observeWithExemplarWithHashAt(lbls, lbls.Hash(), value, newHistogramStringExemplar(traceID), multiplier, time.Now().UnixMilli())
+}
 
+func (h *histogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls, hash, value, newHistogramTraceIDBytesExemplar(traceID), multiplier, timeMs)
+}
+
+func (h *histogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, ex histogramExemplar, multiplier float64, timeMs int64) {
 	h.seriesDemand.Insert(hash)
 
 	h.seriesMtx.Lock()
@@ -105,26 +157,24 @@ func (h *histogram) ObserveWithExemplar(lbls labels.Labels, value float64, trace
 
 	s, lbls, hash := resolveSeries(h.series, hash, lbls, h.lifecycler, h.activeSeriesPerHistogramSerie())
 	if s != nil {
-		h.updateSeries(hash, s, value, traceID, multiplier)
+		h.updateSeries(hash, s, value, ex, multiplier, timeMs)
 		return
 	}
-	h.series[hash] = h.newSeries(lbls, value, traceID, multiplier)
+	h.series[hash] = h.newSeries(lbls, hash, value, ex, multiplier, timeMs)
 }
 
-func (h *histogram) newSeries(lbls labels.Labels, value float64, traceID string, multiplier float64) *histogramSeries {
+func (h *histogram) newSeries(lbls labels.Labels, hash uint64, value float64, ex histogramExemplar, multiplier float64, timeMs int64) *histogramSeries {
 	newSeries := &histogramSeries{
 		count:          atomic.NewFloat64(0),
 		sum:            atomic.NewFloat64(0),
 		buckets:        make([]*atomic.Float64, 0, len(h.buckets)),
-		exemplars:      make([]*atomic.String, 0, len(h.buckets)),
-		exemplarValues: make([]*atomic.Float64, 0, len(h.buckets)),
+		exemplars:      make([]histogramExemplar, len(h.buckets)),
+		exemplarValues: make([]float64, len(h.buckets)),
 		lastUpdated:    atomic.NewInt64(0),
-		firstSeries:    atomic.NewBool(true),
+		firstSeries:    true,
 	}
 	for i := 0; i < len(h.buckets); i++ {
 		newSeries.buckets = append(newSeries.buckets, atomic.NewFloat64(0))
-		newSeries.exemplars = append(newSeries.exemplars, atomic.NewString(""))
-		newSeries.exemplarValues = append(newSeries.exemplarValues, atomic.NewFloat64(0))
 	}
 
 	// Precompute all labels for all sub-metrics upfront
@@ -147,26 +197,24 @@ func (h *histogram) newSeries(lbls labels.Labels, value float64, traceID string,
 		newSeries.bucketLabels = append(newSeries.bucketLabels, lb.Labels())
 	}
 
-	h.updateSeries(lbls.Hash(), newSeries, value, traceID, multiplier)
+	h.updateSeries(hash, newSeries, value, ex, multiplier, timeMs)
 
 	return newSeries
 }
 
-func (h *histogram) updateSeries(hash uint64, s *histogramSeries, value float64, traceID string, multiplier float64) {
-	s.count.Add(1 * multiplier)
+func (h *histogram) updateSeries(hash uint64, s *histogramSeries, value float64, ex histogramExemplar, multiplier float64, timeMs int64) {
+	s.count.Add(multiplier)
 	s.sum.Add(value * multiplier)
 
-	for i, bucket := range h.buckets {
-		if value <= bucket {
-			s.buckets[i].Add(1 * multiplier)
-		}
+	bucket := sort.SearchFloat64s(h.buckets, value)
+	for i := bucket; i < len(h.buckets); i++ {
+		s.buckets[i].Add(multiplier)
 	}
 
-	bucket := sort.SearchFloat64s(h.buckets, value)
-	s.exemplars[bucket].Store(traceID)
-	s.exemplarValues[bucket].Store(value)
+	s.exemplars[bucket] = ex
+	s.exemplarValues[bucket] = value
 
-	s.lastUpdated.Store(time.Now().UnixMilli())
+	s.lastUpdated.Store(timeMs)
 	h.lifecycler.OnUpdate(hash, h.activeSeriesPerHistogramSerie())
 }
 
@@ -217,17 +265,18 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) erro
 				return err
 			}
 
-			ex := s.exemplars[i].Load()
-			if ex != "" {
+			ex := s.exemplars[i]
+			traceID := ex.string()
+			if traceID != "" {
 
 				lbls := []labels.Label{{
 					Name:  h.traceIDLabelName,
-					Value: ex,
+					Value: traceID,
 				}}
 
 				_, err = appender.AppendExemplar(ref, s.bucketLabels[i], exemplar.Exemplar{
 					Labels: labels.New(lbls...),
-					Value:  s.exemplarValues[i].Load(),
+					Value:  s.exemplarValues[i],
 					Ts:     timeMs,
 				})
 				if err != nil {
@@ -235,7 +284,7 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) erro
 				}
 			}
 			// clear the exemplar so we don't emit it again
-			s.exemplars[i].Store("")
+			s.exemplars[i] = histogramExemplar{}
 		}
 
 		if s.isNew() {

--- a/modules/generator/registry/histogram_benchmark_test.go
+++ b/modules/generator/registry/histogram_benchmark_test.go
@@ -1,0 +1,68 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func BenchmarkRegistryHistogramObserve(b *testing.B) {
+	lbls := labels.FromStrings("service", "frontend", "span_name", "GET /api")
+
+	b.Run("classic_low_bucket", func(b *testing.B) {
+		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
+		h.ObserveWithExemplar(lbls, 0.001, "trace-1", 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplar(lbls, 0.001, "trace-1", 1)
+		}
+	})
+
+	// The path spanmetrics uses on the hot path: raw trace ID bytes plus a
+	// precomputed label hash.
+	b.Run("classic_trace_id_bytes_with_hash", func(b *testing.B) {
+		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
+		traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+		hash := lbls.Hash()
+		timeMs := time.Now().UnixMilli()
+		h.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, 0.001, traceID, 1, timeMs)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, 0.001, traceID, 1, timeMs)
+		}
+	})
+
+	b.Run("classic_high_bucket", func(b *testing.B) {
+		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
+		h.ObserveWithExemplar(lbls, 4, "trace-1", 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplar(lbls, 4, "trace-1", 1)
+		}
+	})
+
+	b.Run("native", func(b *testing.B) {
+		// A zero bucket factor would disable sparse (native) buckets and fall
+		// back to classic DefBuckets, so configure real native parameters.
+		overrides := &mockOverrides{
+			nativeHistogramBucketFactor:     1.5,
+			nativeHistogramMaxBucketNumber:  100,
+			nativeHistogramMinResetDuration: 15 * time.Minute,
+		}
+		h := newNativeHistogram("bench_native_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", HistogramModeNative, nil, testTenant, overrides, 15*time.Minute)
+		h.ObserveWithExemplar(lbls, 0.5, "trace-1", 1)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			h.ObserveWithExemplar(lbls, 0.5, "trace-1", 1)
+		}
+	})
+}

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"sync"
 	"testing"
@@ -517,4 +518,33 @@ func Test_histogram_demandVsActiveSeries(t *testing.T) {
 	expectedDemand := 20 * int(h.activeSeriesPerHistogramSerie())
 	assert.Greater(t, demand, expectedDemand-20, "demand should track all attempted series")
 	assert.Greater(t, demand, h.countActiveSeries(), "demand should exceed active series")
+}
+
+// TestNewHistogram_SortsUnsortedBuckets verifies newHistogram sorts the buckets
+// it is given. updateSeries counts buckets with sort.SearchFloat64s, which is
+// only correct on ascending buckets, and classic histograms require monotonic
+// le buckets. A static histogram_buckets config is not validated upstream, so
+// the registry must be robust to unsorted input.
+func TestNewHistogram_SortsUnsortedBuckets(t *testing.T) {
+	h := newHistogram("my_histogram", []float64{5, 0.5, 2, 1}, noopLimiter, "trace_id", nil, 15*time.Minute)
+
+	// Buckets are sorted ascending, with the synthetic +Inf bucket last, and
+	// bucketLabels stay aligned with them.
+	assert.Equal(t, []float64{0.5, 1, 2, 5, math.Inf(1)}, h.buckets)
+	assert.Equal(t, []string{"0.5", "1", "2", "5", "+Inf"}, h.bucketLabels)
+
+	// Observe a value in (0.5, 1]: every bucket whose le >= value is incremented
+	// cumulatively, so le=0.5 stays 0 and all higher buckets become 1.
+	lbls := buildTestLabels([]string{"label"}, []string{"value-1"})
+	h.ObserveWithExemplar(lbls, 0.75, "trace-1", 1.0)
+
+	s := h.series[lbls.Hash()]
+	if s == nil {
+		t.Fatalf("series not found for %s", lbls.String())
+	}
+	got := make([]float64, len(s.buckets))
+	for i := range s.buckets {
+		got[i] = s.buckets[i].Load()
+	}
+	assert.Equal(t, []float64{0, 1, 1, 1, 1}, got)
 }

--- a/modules/generator/registry/interface.go
+++ b/modules/generator/registry/interface.go
@@ -19,6 +19,55 @@ type Registry interface {
 type LabelBuilder interface {
 	Add(name, value string)
 	CloseAndBuildLabels() (labels.Labels, bool)
+	CloseAndBorrowLabels() (BorrowedLabels, bool)
+}
+
+// BorrowedLabels holds a label set whose backing memory is owned by a pooled
+// scratch builder. The Labels and Hash are only valid between
+// CloseAndBorrowLabels and Release. Callers MUST NOT retain Labels (or substrings
+// of any Label.Name or Label.Value — in the default stringlabels build both
+// alias the pooled buffer) past Release, store BorrowedLabels in a long-lived field,
+// copy the value across goroutines, or copy the value at all and call Release
+// on more than one copy — the underlying scratch and builder are returned to
+// pools by Release, and a second Release on a copy double-Puts them and lets
+// later callers receive the same instance concurrently. Metric methods that
+// accept BorrowedLabels.Labels copy what they need synchronously before
+// returning.
+type BorrowedLabels struct {
+	// noCopy makes `go vet` copylocks flag accidental copies of BorrowedLabels,
+	// which are unsafe: a copy retains independent non-nil builder/scratch
+	// pointers, so releasing both copies double-Puts them into the pools (see
+	// the Release/copy warning above).
+	noCopy noCopy
+
+	Labels labels.Labels
+	Hash   uint64
+
+	builder *labelBuilder
+	scratch *labels.ScratchBuilder
+}
+
+// noCopy may be added as a (named, non-embedded) field to structs which must not
+// be copied after first use. It has no fields and zero runtime cost; its only
+// purpose is the Lock/Unlock pair, which makes `go vet`'s copylocks analyzer
+// report copies. See https://golang.org/issues/8005.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
+
+// Release returns the underlying builder and scratch buffer to their pools.
+// It is safe to call multiple times: subsequent calls are no-ops.
+// After Release, Labels and Hash are no longer valid.
+func (b *BorrowedLabels) Release() {
+	if b.builder == nil {
+		return
+	}
+	b.builder.releaseBorrowedLabels(b.scratch)
+	b.builder = nil
+	b.scratch = nil
+	b.Labels = labels.EmptyLabels()
+	b.Hash = 0
 }
 
 // Counter
@@ -27,6 +76,11 @@ type Counter interface {
 	metric
 
 	Inc(lbls labels.Labels, value float64)
+	// IncWithHashAt is like Inc but uses the supplied hash as the series key
+	// and timeMs as the lastUpdated stamp. Precondition: hash MUST equal
+	// lbls.Hash(). Supplying any other value silently maps to a different
+	// series and corrupts metrics.
+	IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64)
 }
 
 // Histogram
@@ -36,6 +90,13 @@ type Histogram interface {
 
 	// ObserveWithExemplar observes a datapoint with the given values. traceID will be added as exemplar.
 	ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64)
+	// ObserveWithExemplarTraceIDBytesWithHashAt is like ObserveWithExemplar but
+	// accepts the traceID as raw bytes, uses the supplied hash as the series key,
+	// and uses timeMs as the lastUpdated stamp. The histogram copies the traceID
+	// bytes synchronously, so the slice may be reused after the call.
+	// Precondition: hash MUST equal lbls.Hash(). Supplying any other value
+	// silently maps to a different series and corrupts metrics.
+	ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64)
 }
 
 // Gauge
@@ -48,6 +109,11 @@ type Gauge interface {
 	Set(lbls labels.Labels, value float64)
 	Inc(lbls labels.Labels, value float64)
 	SetForTargetInfo(lbls labels.Labels, value float64)
+	// SetForTargetInfoWithHashAt is like SetForTargetInfo but uses the supplied
+	// hash as the series key and timeMs as the lastUpdated stamp.
+	// Precondition: hash MUST equal lbls.Hash(). Supplying any other value
+	// silently maps to a different series and corrupts metrics.
+	SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64)
 }
 
 type HistogramMode int

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math"
+	"sort"
 	"sync"
 	"time"
 
@@ -14,7 +15,8 @@ import (
 	promhistogram "github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
+
+	tempo_util "github.com/grafana/tempo/pkg/util"
 )
 
 type nativeHistogram struct {
@@ -36,6 +38,7 @@ type nativeHistogram struct {
 	buckets []float64
 
 	traceIDLabelName string
+	exemplarLabels   prometheus.Labels
 
 	// Can be "native", classic", "both" to determine which histograms to
 	// generate.  A diff in the configured value on the processors will cause a
@@ -66,7 +69,7 @@ type nativeHistogramSeries struct {
 	// This is used in classic histograms to ensure that new counters begin with 0.
 	// This avoids Prometheus throwing away the first value in the series,
 	// due to the transition from null -> x.
-	firstSeries *atomic.Bool
+	firstSeries bool
 
 	// classic
 	countLabels labels.Labels
@@ -78,11 +81,11 @@ type nativeHistogramSeries struct {
 }
 
 func (hs *nativeHistogramSeries) isNew() bool {
-	return hs.firstSeries.Load()
+	return hs.firstSeries
 }
 
 func (hs *nativeHistogramSeries) registerSeenSeries() {
-	hs.firstSeries.Store(false)
+	hs.firstSeries = false
 }
 
 var (
@@ -95,12 +98,23 @@ func newNativeHistogram(name string, buckets []float64, lifecycler Limiter, trac
 		traceIDLabelName = "traceID"
 	}
 
+	// Defensively copy and sort the classic buckets, matching newHistogram. In
+	// hybrid/both mode these reach prometheus.NewHistogram, which panics on
+	// non-monotonic buckets, and classic le buckets must be ascending anyway. A
+	// static histogram_buckets config is not validated upstream. Copying avoids
+	// mutating the caller's slice.
+	sorted := make([]float64, len(buckets))
+	copy(sorted, buckets)
+	sort.Float64s(sorted)
+	buckets = sorted
+
 	return &nativeHistogram{
 		metricName:        name,
 		series:            make(map[uint64]*nativeHistogramSeries),
 		seriesDemand:      NewCardinality(staleDuration, removeStaleSeriesInterval),
 		lifecycler:        lifecycler,
 		traceIDLabelName:  traceIDLabelName,
+		exemplarLabels:    make(prometheus.Labels, 1),
 		buckets:           buckets,
 		histogramOverride: histogramOverride,
 		externalLabels:    externalLabels,
@@ -115,8 +129,14 @@ func newNativeHistogram(name string, buckets []float64, lifecycler Limiter, trac
 }
 
 func (h *nativeHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64) {
-	hash := lbls.Hash()
+	h.observeWithExemplarWithHashAt(lbls, lbls.Hash(), value, traceID, multiplier, time.Now().UnixMilli())
+}
 
+func (h *nativeHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls, hash, value, tempo_util.TraceIDToHexString(traceID), multiplier, timeMs)
+}
+
+func (h *nativeHistogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) {
 	h.seriesDemand.Insert(hash)
 
 	h.seriesMtx.Lock()
@@ -124,13 +144,13 @@ func (h *nativeHistogram) ObserveWithExemplar(lbls labels.Labels, value float64,
 
 	s, lbls, hash := resolveSeries(h.series, hash, lbls, h.lifecycler, h.activeSeriesPerHistogramSerie())
 	if s != nil {
-		h.updateSeries(hash, s, value, traceID, multiplier)
+		h.updateSeries(hash, s, value, traceID, multiplier, timeMs)
 		return
 	}
-	h.series[hash] = h.newSeries(lbls, value, traceID, multiplier)
+	h.series[hash] = h.newSeries(lbls, hash, value, traceID, multiplier, timeMs)
 }
 
-func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID string, multiplier float64) *nativeHistogramSeries {
+func (h *nativeHistogram) newSeries(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) *nativeHistogramSeries {
 	// Configure histogram based on mode
 	//
 	// Native-only mode sets buckets to nil, and uses the histogram.Exemplars slice as the native exemplar format.
@@ -166,11 +186,11 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID s
 	newSeries := &nativeHistogramSeries{
 		promHistogram: prometheus.NewHistogram(nativeOpts),
 		lastUpdated:   0,
-		firstSeries:   atomic.NewBool(true),
+		firstSeries:   true,
 		overridesHash: hsh,
 	}
 
-	h.updateSeries(lbls.Hash(), newSeries, value, traceID, multiplier)
+	h.updateSeries(hash, newSeries, value, traceID, multiplier, timeMs)
 
 	lb := newSeriesLabelsBuilder(lbls, h.externalLabels)
 
@@ -187,21 +207,26 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, value float64, traceID s
 	lb.Set(labels.MetricName, h.nameSum)
 	newSeries.sumLabels = lb.Labels()
 
+	// Keep the reusable bucket-label builder based on owned labels. The input
+	// labels may be borrowed by the caller and released after this update.
+	lb.Reset(newSeries.labels)
 	return newSeries
 }
 
-func (h *nativeHistogram) updateSeries(hash uint64, s *nativeHistogramSeries, value float64, traceID string, multiplier float64) {
+func (h *nativeHistogram) updateSeries(hash uint64, s *nativeHistogramSeries, value float64, traceID string, multiplier float64, timeMs int64) {
 	// Use Prometheus native exemplar handling
 	exemplarObserver := s.promHistogram.(prometheus.ExemplarObserver)
 
-	labels := prometheus.Labels{h.traceIDLabelName: traceID}
+	// ObserveWithExemplar copies the labels synchronously; seriesMtx serializes reuse.
+	h.exemplarLabels[h.traceIDLabelName] = traceID
 
+	// multiplier is 1 on the common path, so this loop runs exactly once.
 	for i := 0.0; i < multiplier; i++ {
 		// Let Prometheus handle exemplars natively
-		exemplarObserver.ObserveWithExemplar(value, labels)
+		exemplarObserver.ObserveWithExemplar(value, h.exemplarLabels)
 	}
 
-	s.lastUpdated = time.Now().UnixMilli()
+	s.lastUpdated = timeMs
 	h.lifecycler.OnUpdate(hash, h.activeSeriesPerHistogramSerie())
 }
 

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -962,3 +962,20 @@ func Test_nativeHistogram_leadingZero(t *testing.T) {
 		}
 	})
 }
+
+// TestNewNativeHistogram_SortsUnsortedBuckets verifies newNativeHistogram
+// normalizes its classic buckets (matching newHistogram). In hybrid/both mode
+// the buckets reach prometheus.NewHistogram on first series creation, which
+// panics on non-monotonic input; a static histogram_buckets config is not
+// validated upstream.
+func TestNewNativeHistogram_SortsUnsortedBuckets(t *testing.T) {
+	require.NotPanics(t, func() {
+		h := newNativeHistogram("test_native_histogram", []float64{5, 0.5, 2, 1}, noopLimiter, "trace_id", HistogramModeBoth, nil, testTenant, &mockOverrides{}, 15*time.Minute)
+		assert.Equal(t, []float64{0.5, 1, 2, 5}, h.buckets)
+
+		// Observing builds the per-series prometheus.Histogram from the buckets;
+		// this is where unsorted buckets would have panicked.
+		lbls := buildTestLabels([]string{"label"}, []string{"value-1"})
+		h.ObserveWithExemplar(lbls, 1.5, "trace-1", 1.0)
+	})
+}

--- a/modules/generator/registry/per_label_limiter.go
+++ b/modules/generator/registry/per_label_limiter.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -38,6 +39,16 @@ type maxCardinalityFunc func(tenant string) uint64
 type labelCardinalityState struct {
 	sketch    *Cardinality
 	overLimit bool // cached flag, updated periodically in maintenance tick
+	// ownedName is the heap-owned (cloned) label name. The incoming label name
+	// may alias a pooled/borrowed scratch buffer (see CloseAndBorrowLabels), so
+	// we keep an owned copy to hand to metricLabelValuesLimited.WithLabelValues:
+	// that retains the string, and a borrowed alias would be overwritten by a
+	// later borrow, corrupting the exported metric and leaking child series.
+	ownedName string
+	// limitedCounter is the metricLabelValuesLimited child for ownedName,
+	// created lazily on the first overflow and cached so the overflow path
+	// stays allocation-free.
+	limitedCounter prometheus.Counter
 }
 
 // PerLabelLimiter caps the number of distinct values any single label can have.
@@ -121,7 +132,15 @@ func (s *PerLabelLimiter) Limit(lbls labels.Labels) labels.Labels {
 				builder = labels.NewBuilder(lbls)
 			}
 			builder.Set(l.Name, overflowValue)
-			metricLabelValuesLimited.WithLabelValues(s.tenant, l.Name).Inc()
+			// Use the owned label name, never the borrowed l.Name:
+			// WithLabelValues retains the string header, so a borrowed alias
+			// would be corrupted once the scratch buffer is reused (and each
+			// corrupted lookup would leak a new child series). Cache the child
+			// counter on first use to keep this path allocation-free.
+			if state.limitedCounter == nil {
+				state.limitedCounter = metricLabelValuesLimited.WithLabelValues(s.tenant, state.ownedName)
+			}
+			state.limitedCounter.Inc()
 		}
 	})
 
@@ -135,10 +154,19 @@ func (s *PerLabelLimiter) Limit(lbls labels.Labels) labels.Labels {
 func (s *PerLabelLimiter) getOrCreateState(labelName string) *labelCardinalityState {
 	state, ok := s.labelsState[labelName]
 	if !ok {
+		// labelName may alias a pooled/borrowed scratch buffer (see
+		// CloseAndBorrowLabels) that the caller reuses after this call returns.
+		// Clone it once and retain only the owned copy (as the map key and as
+		// state.ownedName); a retained alias would be overwritten by a later
+		// borrow and corrupt both. Only the insert path clones; lookups above
+		// compare by value, so the hot path (existing label name) stays
+		// allocation-free.
+		owned := strings.Clone(labelName)
 		state = &labelCardinalityState{
-			sketch: NewCardinality(s.staleDuration, removeStaleSeriesInterval),
+			sketch:    NewCardinality(s.staleDuration, removeStaleSeriesInterval),
+			ownedName: owned,
 		}
-		s.labelsState[labelName] = state
+		s.labelsState[owned] = state
 	}
 	return state
 }

--- a/modules/generator/registry/per_label_limiter_test.go
+++ b/modules/generator/registry/per_label_limiter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
@@ -447,4 +448,101 @@ func triggerPrune(s *PerLabelLimiter) {
 	s.pruneChan = ch
 	ch <- time.Now()
 	s.doPeriodicMaintenance()
+}
+
+// TestPerLabelLimiter_BorrowedLabelNameNotRetained verifies that Limit does not
+// retain a label-name string that aliases a reusable scratch buffer. Limit
+// stores each newly seen label name as a key in labelsState; if it kept the
+// aliased string, a later borrow that overwrites the same buffer (as the pooled
+// scratch in CloseAndBorrowLabels does) would mutate that key in place and
+// corrupt the per-label cardinality tracking.
+func TestPerLabelLimiter_BorrowedLabelNameNotRetained(t *testing.T) {
+	s := NewPerLabelLimiter("test", testMaxCardinality(1000), 15*time.Minute)
+
+	// A single ScratchBuilder reuses one internal buffer across Overwrite calls
+	// (in place when the encoded size fits its cap), exactly like the pooled
+	// scratch handed out by CloseAndBorrowLabels.
+	scratch := labels.NewScratchBuilder(1)
+
+	// First series: the label name aliases the scratch buffer.
+	scratch.Reset()
+	scratch.Add("name_aaaa", "v")
+	var first labels.Labels
+	scratch.Overwrite(&first)
+	s.Limit(first)
+
+	// Reuse the SAME scratch buffer with a different, same-length label name.
+	// This overwrites the bytes that "name_aaaa" pointed at with "name_bbbb".
+	scratch.Reset()
+	scratch.Add("name_bbbb", "v")
+	var second labels.Labels
+	scratch.Overwrite(&second)
+	s.Limit(second)
+
+	s.mtx.Lock()
+	keys := make([]string, 0, len(s.labelsState))
+	for k := range s.labelsState {
+		keys = append(keys, k)
+	}
+	_, hasFirst := s.labelsState["name_aaaa"]
+	_, hasSecond := s.labelsState["name_bbbb"]
+	s.mtx.Unlock()
+
+	// Both keys must survive as independent, owned strings. Before the fix the
+	// first key aliased the scratch buffer, so overwriting it to "name_bbbb"
+	// made both Limit calls collapse onto the same corrupted key and
+	// "name_aaaa" disappeared.
+	require.True(t, hasFirst, "label name from the first borrow was not retained as an owned key; got keys %v", keys)
+	require.True(t, hasSecond, "label name from the second borrow is missing; got keys %v", keys)
+	require.Len(t, keys, 2, "expected exactly two distinct label-name keys, got %v", keys)
+}
+
+// TestPerLabelLimiter_BorrowedLabelNameNotRetainedInOverflowMetric verifies the
+// overflow path does not hand a borrowed label name to
+// metricLabelValuesLimited.WithLabelValues, which retains the string. A borrowed
+// alias would be corrupted once the scratch buffer is reused, exporting a
+// garbage label_name and leaking a fresh child series on every later overflow.
+var overflowMetricTestSeq atomic.Uint64
+
+func TestPerLabelLimiter_BorrowedLabelNameNotRetainedInOverflowMetric(t *testing.T) {
+	// metricLabelValuesLimited is a process-global CounterVec, so use a unique
+	// tenant per invocation; otherwise the asserted value would accumulate
+	// across repeated runs (e.g. go test -count=2).
+	tenant := fmt.Sprintf("test-overflow-metric-retention-%d", overflowMetricTestSeq.Add(1))
+	const labelName = "name_aaaa"
+	s := NewPerLabelLimiter(tenant, testMaxCardinality(2), 15*time.Minute)
+
+	// Drive the label over its limit, then refresh overLimit via the demand tick.
+	for i := 0; i < 50; i++ {
+		s.Limit(labels.FromStrings(labelName, fmt.Sprintf("v-%d", i)))
+	}
+	triggerDemandUpdate(s)
+	s.mtx.Lock()
+	overLimit := s.labelsState[labelName].overLimit
+	s.mtx.Unlock()
+	require.True(t, overLimit, "label should be over its limit after the demand update")
+
+	// Drive an overflow through a BORROWED label set whose name aliases a
+	// reusable scratch buffer, exactly like CloseAndBorrowLabels.
+	scratch := labels.NewScratchBuilder(1)
+	scratch.Reset()
+	scratch.Add(labelName, "overflowing")
+	var borrowed labels.Labels
+	scratch.Overwrite(&borrowed)
+	require.Equal(t, overflowValue, s.Limit(borrowed).Get(labelName), "overflow branch should have replaced the value")
+
+	// Reuse the SAME scratch buffer with a different, same-length label name to
+	// overwrite the bytes the overflow metric could have aliased.
+	scratch.Reset()
+	scratch.Add("name_bbbb", "overflowing")
+	var reused labels.Labels
+	scratch.Overwrite(&reused)
+	require.Equal(t, "overflowing", reused.Get("name_bbbb"))
+
+	// The exported metric must still carry the intact, owned label_name with the
+	// single increment from the overflow above. Before the fix the retained
+	// alias was overwritten, so this child read garbage and the lookup here
+	// would create a fresh 0-valued child (the leak).
+	got := testutil.ToFloat64(metricLabelValuesLimited.WithLabelValues(tenant, labelName))
+	require.Equal(t, 1.0, got, "overflow counter for %q was corrupted by scratch-buffer reuse", labelName)
 }

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -55,6 +55,7 @@ type ManagedRegistry struct {
 	sanitizer       Sanitizer
 	perLabelLimiter LabelLimiter
 	limiter         Limiter
+	builderPools    *labelBuilderPools
 
 	appendable storage.Appendable
 
@@ -102,6 +103,13 @@ type Limiter interface {
 	// OnAdd is called when a new entity is created. It accepts the labels and returns
 	// the labels to use (either original or transformed to reduce cardinality) along with the hash.
 	// OnAdd never fails - it always returns valid labels. LabelHash is a hash of all non-constant labels.
+	//
+	// Precondition: lbls may be borrowed from a pooled scratch buffer (see
+	// BorrowedLabels) that the caller reuses after OnAdd returns. Implementations
+	// MUST NOT retain lbls or any of its label name/value strings past the call;
+	// copy (e.g. labels.Labels.Copy or strings.Clone) anything kept in long-lived
+	// state. The returned labels are either lbls passed through (the caller owns
+	// copying it onto a new series) or implementation-owned labels.
 	OnAdd(labelHash uint64, seriesCount uint32, lbls labels.Labels) (labels.Labels, uint64)
 	// OnUpdate is called when an entity is updated.
 	// LabelHash is a hash of all non-constant labels.
@@ -112,11 +120,23 @@ type Limiter interface {
 }
 
 // LabelLimiter caps label cardinality by replacing high-cardinality values.
+//
+// Precondition: lbls may be borrowed from a pooled scratch buffer (see
+// BorrowedLabels) that the caller reuses after Limit returns. Implementations
+// MUST NOT retain lbls or any of its label name/value strings past the call;
+// clone (e.g. strings.Clone) anything kept in long-lived state. The returned
+// labels are either lbls passed through or implementation-owned labels.
 type LabelLimiter interface {
 	Limit(lbls labels.Labels) labels.Labels
 }
 
 // Sanitizer applies a transformation to all non-constant labels.
+//
+// Precondition: lbls may be borrowed from a pooled scratch buffer (see
+// BorrowedLabels) that the caller reuses after Sanitize returns. Implementations
+// MUST NOT retain lbls or any of its label name/value strings past the call;
+// clone (e.g. strings.Clone) anything kept in long-lived state. The returned
+// labels are either lbls passed through or implementation-owned labels.
 type Sanitizer interface {
 	Sanitize(lbls labels.Labels) labels.Labels
 }
@@ -154,6 +174,7 @@ func New(cfg *Config, overrides Overrides, tenant string, appendable storage.App
 		sanitizer:       drainSanitizer,
 		perLabelLimiter: perLabelLimiter,
 		limiter:         limiter,
+		builderPools:    newLabelBuilderPools(),
 		entityDemand:    NewCardinality(cfg.StaleDuration, removeStaleSeriesInterval),
 
 		logger:                 logger,
@@ -170,11 +191,11 @@ func New(cfg *Config, overrides Overrides, tenant string, appendable storage.App
 }
 
 func (r *ManagedRegistry) NewLabelBuilder() LabelBuilder {
-	return NewLabelBuilder(r.cfg.MaxLabelNameLength, r.cfg.MaxLabelValueLength, r.sanitizer, r.perLabelLimiter)
+	return r.builderPools.newLabelBuilder(r.cfg.MaxLabelNameLength, r.cfg.MaxLabelValueLength, r.sanitizer, r.perLabelLimiter)
 }
 
 func (r *ManagedRegistry) NewInfoMetricLabelBuilder() LabelBuilder {
-	return NewLabelBuilder(r.cfg.MaxLabelNameLength, r.cfg.MaxLabelValueLength, noopSanitizer{}, noopLabelLimiter{})
+	return r.builderPools.newLabelBuilder(r.cfg.MaxLabelNameLength, r.cfg.MaxLabelValueLength, noopSanitizer{}, noopLabelLimiter{})
 }
 
 func (r *ManagedRegistry) OnAdd(labelHash uint64, seriesCount uint32, lbls labels.Labels) (labels.Labels, uint64) {

--- a/modules/generator/registry/registry_benchmark_test.go
+++ b/modules/generator/registry/registry_benchmark_test.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+)
+
+// BenchmarkManagedRegistryBorrowPath measures the production label-building hot
+// path end to end: NewLabelBuilder -> Add -> CloseAndBorrowLabels (sort +
+// sanitize + per-label limit + hash + utf8 check) -> hash-keyed metric update
+// -> Release, against a real ManagedRegistry with its per-tenant pools. This is
+// the path spanmetrics drives per span and the one the borrow API optimizes.
+// BenchmarkSpanMetricsPushSpans uses registry.TestRegistry, which discards the
+// precomputed hash and stringifies labels, so it does not exercise this path.
+//
+// The variants toggle the sanitizer and per-label limiter so their per-span
+// cost is visible: the sanitizer strings.Clone's the span name on every
+// Sanitize call, while the limiter only clones a label name the first time it
+// is seen. The label set is identical every iteration, so after the first
+// iteration this measures the steady-state existing-series path (map hit, no
+// new-series allocation).
+func BenchmarkManagedRegistryBorrowPath(b *testing.B) {
+	variants := []struct {
+		name      string
+		overrides *mockOverrides
+	}{
+		{"plain", &mockOverrides{}},
+		{"sanitizer", &mockOverrides{spanNameSanitization: SpanNameSanitizationEnabled}},
+		{"limiter", &mockOverrides{maxCardinalityPerLabel: 1_000_000}},
+		{"sanitizer_and_limiter", &mockOverrides{
+			spanNameSanitization:   SpanNameSanitizationEnabled,
+			maxCardinalityPerLabel: 1_000_000,
+		}},
+	}
+
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	for _, v := range variants {
+		b.Run(v.name, func(b *testing.B) {
+			// Apply production defaults (e.g. MaxLabelNameLength/ValueLength) so
+			// the measured path includes the label-length truncation checks.
+			cfg := &Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			reg := New(cfg, v.overrides, "test", &noopAppender{}, log.NewNopLogger(), noopLimiter)
+			defer reg.Close()
+
+			counter := reg.NewCounter("bench_counter")
+			histogram := reg.NewHistogram("bench_histogram", []float64{0.1, 0.5, 1, 5}, HistogramModeClassic)
+			ts := time.Now().UnixMilli()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				builder := reg.NewLabelBuilder()
+				builder.Add("service", "frontend")
+				builder.Add("span_name", "GET /api/users")
+				builder.Add("status_code", "200")
+				borrowed, ok := builder.CloseAndBorrowLabels()
+				if !ok {
+					b.Fatal("expected valid labels")
+				}
+				counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, ts)
+				histogram.ObserveWithExemplarTraceIDBytesWithHashAt(borrowed.Labels, borrowed.Hash, 0.42, traceID, 1, ts)
+				borrowed.Release()
+			}
+		})
+	}
+}

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -1046,3 +1046,272 @@ func collectDemandEstimateLabels(t *testing.T, tenant string) map[string]float64
 	}
 	return result
 }
+
+// TestManagedRegistry_borrowedLabelsSurviveScratchReuse verifies the
+// BorrowedLabels contract from the metric side: counter, histogram, and gauge
+// updates must copy everything they need synchronously, so that after Release
+// aggressive reuse of the pooled builder and scratch storage cannot corrupt
+// previously created series or exemplars.
+func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
+	appender := &capturingAppender{}
+
+	registry := New(&Config{}, &mockOverrides{}, "test", appender, log.NewNopLogger(), noopLimiter)
+	defer registry.Close()
+
+	counter := registry.NewCounter("my_counter")
+	histogram := registry.NewHistogram("my_histogram", []float64{1.0}, HistogramModeClassic)
+	gauge := registry.NewGauge("my_gauge")
+
+	builder := registry.NewLabelBuilder()
+	builder.Add("label", "value-1")
+	borrowed, valid := builder.CloseAndBorrowLabels()
+	require.True(t, valid)
+
+	timeMs := time.Now().UnixMilli()
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, timeMs)
+	histogram.ObserveWithExemplarTraceIDBytesWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, traceID, 1.0, timeMs)
+	gauge.SetForTargetInfoWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, timeMs)
+	borrowed.Release()
+
+	// Overwrite the caller-owned trace ID slice: the histogram must have
+	// copied the bytes synchronously.
+	for i := range traceID {
+		traceID[i] = 0xff
+	}
+
+	// Churn the pooled builders and scratch buffers to overwrite the storage
+	// the borrowed labels were built in. Use the same label name and a shorter
+	// value so each borrow overwrites the original scratch buffer in place (a
+	// longer value would reallocate and leave the original bytes intact,
+	// hiding a retention bug).
+	for i := 0; i < 100; i++ {
+		b := registry.NewLabelBuilder()
+		b.Add("label", "x")
+		bl, ok := b.CloseAndBorrowLabels()
+		require.True(t, ok)
+		bl.Release()
+	}
+
+	expectedSamples := []sample{
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
+		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 0),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "+Inf"}, 0, 0),
+		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "+Inf"}, 0, 1),
+		newSample(map[string]string{"__name__": "my_gauge", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+	}
+	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
+
+	// The exemplar's trace ID bytes must have been copied out of the borrowed
+	// slice, and the exemplar series labels must be intact. Note
+	// TraceIDToHexString strips leading zeros.
+	require.Len(t, appender.exemplars, 1)
+	assert.Equal(t, "102030405060708090a0b0c0d0e0f10", appender.exemplars[0].e.Labels.Get("traceID"))
+	assert.Equal(t, "value-1", appender.exemplars[0].l.Get("label"))
+}
+
+// TestManagedRegistry_borrowedLabelsSurviveSanitizerAndLimiter is the
+// integration counterpart of the per-label-limiter and drain-sanitizer
+// retention unit tests. With span-name sanitization and the per-label
+// cardinality limiter both enabled, pushing many distinct series through the
+// borrow path churns the pooled scratch buffers; neither component may retain
+// label strings that alias those buffers. The limiter keys its state by label
+// name, which must stay exactly the small, stable set of names used here — a
+// retention bug corrupts those keys and pollutes the map with garbage.
+func TestManagedRegistry_borrowedLabelsSurviveSanitizerAndLimiter(t *testing.T) {
+	overrides := &mockOverrides{
+		spanNameSanitization:   SpanNameSanitizationEnabled,
+		maxCardinalityPerLabel: 1_000_000, // enabled, but high enough to never overflow
+	}
+	registry := New(&Config{}, overrides, "test", &noopAppender{}, log.NewNopLogger(), noopLimiter)
+	defer registry.Close()
+
+	counter := registry.NewCounter("my_counter")
+
+	const iterations = 500
+	for i := 0; i < iterations; i++ {
+		builder := registry.NewLabelBuilder()
+		// Stable label NAMES (what the limiter keys on) with varying VALUES and
+		// span_name (what the sanitizer trains on). Varying value lengths force
+		// the pooled scratch buffer to be overwritten with different content
+		// between borrows.
+		builder.Add("service", "svc")
+		builder.Add("span_name", fmt.Sprintf("GET /api/users/%d/detail", i))
+		builder.Add("route", fmt.Sprintf("/u/%0*d", i%37, i))
+		borrowed, ok := builder.CloseAndBorrowLabels()
+		require.True(t, ok)
+		counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, time.Now().UnixMilli())
+		borrowed.Release()
+	}
+
+	// The per-label limiter must only know the stable, owned label names.
+	pll := registry.perLabelLimiter.(*PerLabelLimiter)
+	pll.mtx.Lock()
+	keys := make([]string, 0, len(pll.labelsState))
+	for k := range pll.labelsState {
+		keys = append(keys, k)
+	}
+	pll.mtx.Unlock()
+
+	sort.Strings(keys)
+	require.Equal(t, []string{"route", "service", "span_name"}, keys,
+		"per-label limiter retained corrupted or unexpected label-name keys: %v", keys)
+}
+
+// TestManagedRegistry_retainingLimiterDoesNotCorruptSeries documents the
+// Limiter.OnAdd no-retain precondition from the registry's side: even if a
+// Limiter implementation violates the contract and retains the borrowed labels
+// it is handed, the registry's own emitted series stay correct because the
+// registry copies labels onto every new series before the borrow is released.
+func TestManagedRegistry_retainingLimiterDoesNotCorruptSeries(t *testing.T) {
+	var retained []labels.Labels
+	retainingLimiter := &mockLimiter{
+		onAddFunc: func(hash uint64, _ uint32, lbls labels.Labels) (labels.Labels, uint64) {
+			// Deliberately (incorrectly) keep a reference to the borrowed labels.
+			retained = append(retained, lbls)
+			return lbls, hash
+		},
+	}
+
+	appender := &capturingAppender{}
+	registry := New(&Config{}, &mockOverrides{}, "test", appender, log.NewNopLogger(), retainingLimiter)
+	defer registry.Close()
+
+	counter := registry.NewCounter("my_counter")
+
+	builder := registry.NewLabelBuilder()
+	builder.Add("label", "value-1")
+	borrowed, ok := builder.CloseAndBorrowLabels()
+	require.True(t, ok)
+	counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, time.Now().UnixMilli())
+	borrowed.Release()
+
+	// Churn the pools so anything the limiter wrongly retained is overwritten.
+	// Use the same label name and a shorter value so each borrow overwrites the
+	// original scratch buffer in place (a longer value would reallocate and
+	// leave the original bytes intact, hiding a retention bug).
+	for i := 0; i < 100; i++ {
+		b := registry.NewLabelBuilder()
+		b.Add("label", "x")
+		bl, ok := b.CloseAndBorrowLabels()
+		require.True(t, ok)
+		bl.Release()
+	}
+
+	require.NotEmpty(t, retained)
+	expected := []sample{
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
+		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+	}
+	collectRegistryMetricsAndAssert(t, registry, appender, expected)
+}
+
+// TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse covers the native
+// and both-mode histogram borrow path, which is production-reachable
+// (HistogramOverride native/both) but exercised by no other borrow/scratch-reuse
+// test. The native series re-bases its reusable bucket-label builder onto owned
+// labels (native_histogram.go: lb.Reset(newSeries.labels)); a regression there
+// would corrupt the emitted series labels once the pooled scratch is reused.
+func TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode HistogramMode
+	}{
+		{"native", HistogramModeNative},
+		{"both", HistogramModeBoth},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			appender := &capturingAppender{}
+			overrides := &mockOverrides{
+				nativeHistogramBucketFactor:     1.5,
+				nativeHistogramMaxBucketNumber:  10,
+				nativeHistogramMinResetDuration: time.Minute,
+			}
+			registry := New(&Config{}, overrides, "test", appender, log.NewNopLogger(), noopLimiter)
+			defer registry.Close()
+
+			histogram := registry.NewHistogram("my_histogram", []float64{1.0}, tc.mode)
+
+			traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+			builder := registry.NewLabelBuilder()
+			builder.Add("label", "value-1")
+			borrowed, valid := builder.CloseAndBorrowLabels()
+			require.True(t, valid)
+			histogram.ObserveWithExemplarTraceIDBytesWithHashAt(borrowed.Labels, borrowed.Hash, 1.5, traceID, 1.0, time.Now().UnixMilli())
+			borrowed.Release()
+
+			// Churn the pooled builders/scratch so any retained borrowed label
+			// would now read overwritten bytes. Use the same label name and a
+			// shorter value so the next borrow overwrites the original scratch
+			// buffer in place (a longer value would reallocate and leave the
+			// original bytes intact, hiding a retention bug).
+			for i := 0; i < 100; i++ {
+				b := registry.NewLabelBuilder()
+				b.Add("label", "x")
+				bl, ok := b.CloseAndBorrowLabels()
+				require.True(t, ok)
+				bl.Release()
+			}
+
+			require.NoError(t, histogram.collectMetrics(appender, time.Now().UnixMilli()))
+
+			// Gather the labels of every emitted series. Native-only mode emits
+			// native histograms (AppendHistogram) plus exemplars; both-mode also
+			// emits classic float samples. Each must carry the intact owned
+			// label, never corrupted bytes from the churned scratch buffers.
+			var seriesLabels []labels.Labels
+			for _, s := range appender.samples {
+				seriesLabels = append(seriesLabels, s.l)
+			}
+			for _, h := range appender.histograms {
+				seriesLabels = append(seriesLabels, h.l)
+			}
+			for _, ex := range appender.exemplars {
+				seriesLabels = append(seriesLabels, ex.l)
+			}
+			require.NotEmpty(t, seriesLabels, "native histogram emitted no series")
+			for _, l := range seriesLabels {
+				assert.Equal(t, "value-1", l.Get("label"), "series labels corrupted after scratch reuse: %s", l.String())
+			}
+		})
+	}
+}
+
+// TestManagedRegistryPerTenantPools verifies that each ManagedRegistry owns its
+// own label-builder pools, so pooled scratch memory is never shared across
+// tenants. A regression to a shared/global pool would fail the NotSame check;
+// run under -race to catch cross-tenant aliasing in the borrow/release path.
+func TestManagedRegistryPerTenantPools(t *testing.T) {
+	regA := New(&Config{}, &mockOverrides{}, "tenant-a", &noopAppender{}, log.NewNopLogger(), noopLimiter)
+	defer regA.Close()
+	regB := New(&Config{}, &mockOverrides{}, "tenant-b", &noopAppender{}, log.NewNopLogger(), noopLimiter)
+	defer regB.Close()
+
+	require.NotNil(t, regA.builderPools)
+	require.NotNil(t, regB.builderPools)
+	assert.NotSame(t, regA.builderPools, regB.builderPools, "each tenant's registry must own a distinct pool set")
+
+	// Interleaved borrow/release against each registry's own pools. Uses the
+	// info-metric builder (noop sanitizer/limiter) so the borrowed labels are
+	// exactly what was added, isolating the test to pooling behaviour.
+	for i := 0; i < 100; i++ {
+		ba := regA.NewInfoMetricLabelBuilder()
+		ba.Add("k", "a")
+		la, ok := ba.CloseAndBorrowLabels()
+		require.True(t, ok)
+		assert.Equal(t, "a", la.Labels.Get("k"))
+		la.Release()
+
+		bb := regB.NewInfoMetricLabelBuilder()
+		bb.Add("k", "b")
+		lb, ok := bb.CloseAndBorrowLabels()
+		require.True(t, ok)
+		assert.Equal(t, "b", lb.Labels.Get("k"))
+		lb.Release()
+	}
+}

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -19,6 +19,13 @@ func newTestLabelLimiter() *PerLabelLimiter {
 type TestRegistry struct {
 	// "metric{labels}" -> value
 	metrics map[string]float64
+
+	// Lazily built passthrough sanitizer and per-label limiter shared by every
+	// builder from NewLabelBuilder. Both are disabled, so sharing is safe;
+	// building them per call would start tickers and allocate a drain tree per
+	// builder, drowning benchmarks that push spans through this registry.
+	sanitizer       Sanitizer
+	perLabelLimiter LabelLimiter
 }
 
 var _ Registry = (*TestRegistry)(nil)
@@ -44,9 +51,11 @@ func (t *TestRegistry) NewGauge(name string) Gauge {
 }
 
 func (t *TestRegistry) NewLabelBuilder() LabelBuilder {
-	nds := NewDrainSanitizer("test", func(string) string { return SpanNameSanitizationDisabled }, 0)
-
-	return NewLabelBuilder(0, 0, nds, newTestLabelLimiter())
+	if t.sanitizer == nil {
+		t.sanitizer = NewDrainSanitizer("test", func(string) string { return SpanNameSanitizationDisabled }, 0)
+		t.perLabelLimiter = newTestLabelLimiter()
+	}
+	return NewLabelBuilder(0, 0, t.sanitizer, t.perLabelLimiter)
 }
 
 func (t *TestRegistry) NewInfoMetricLabelBuilder() LabelBuilder {
@@ -112,6 +121,10 @@ func (t *testCounter) Inc(lbls labels.Labels, value float64) {
 	t.registry.addToMetric(t.n, lbls, value)
 }
 
+func (t *testCounter) IncWithHashAt(lbls labels.Labels, _ uint64, value float64, _ int64) {
+	t.Inc(lbls, value)
+}
+
 func (t *testCounter) name() string {
 	return t.n
 }
@@ -153,6 +166,10 @@ func (t *testGauge) Set(lbls labels.Labels, value float64) {
 
 func (t *testGauge) SetForTargetInfo(lbls labels.Labels, value float64) {
 	t.Set(lbls, value)
+}
+
+func (t *testGauge) SetForTargetInfoWithHashAt(lbls labels.Labels, _ uint64, value float64, _ int64) {
+	t.SetForTargetInfo(lbls, value)
 }
 
 func (t *testGauge) name() string {
@@ -199,6 +216,12 @@ func (t *testHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, _
 		}
 	}
 	t.registry.addToMetric(t.nameBucket, withLe(lbls, math.Inf(1)), 1*multiplier)
+}
+
+func (t *testHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, _ uint64, value float64, _ []byte, multiplier float64, _ int64) {
+	// testHistogram discards the trace ID (ObserveWithExemplar ignores it), so
+	// skip hex-encoding it — that allocation only inflated benchmark allocs.
+	t.ObserveWithExemplar(lbls, value, "", multiplier)
 }
 
 func (t *testHistogram) name() string {


### PR DESCRIPTION
## Summary

The metrics-generator's per-span hot path pays an allocation-and-hash tax it doesn't need to. For every observation, spanmetrics builds a label set, and the registry copies the strings and re-hashes the set — even when the series already exists, which at steady state is nearly always. At production cardinality that's thousands of short-lived allocations per push: CPU spent building/copying/hashing, then spent again collecting the garbage. #7498 adds a zero-copy borrowed-label path to the registry (build in pooled scratch, hash once, observe by hash, release) and adopts it in spanmetrics. Same metric names, labels, and series identity — materially less CPU and GC.

## What this PR does

Adds a zero-copy, hash-reuse label path to the metrics-generator registry and adopts it in the **span-metrics** processor. On the per-span hot path it stops **re-allocating** and **re-hashing** the label set per series, and builds `target_info` once per resource instead of once per span.

**No change to metric names, label names, label values, or series identity.**

Part of the #7124 split (registry + span-metrics here; the service-graphs adoption is a separate follow-up PR).

## Review it commit by commit

The three commits are the three sections — best reviewed in order: **capability → its ownership contract → consumer.**

### Commit 1 — registry: zero-copy borrowed-label path + per-tenant pools (the capability)
- `CloseAndBorrowLabels()` returns a `BorrowedLabels` whose `Labels` alias a pooled scratch buffer; `Release()` returns it to the pool. The labels are valid **only** between borrow and `Release`. A `noCopy` guard (`go vet`) and a double-close guard make misuse fail loudly instead of silently double-Putting a pooled builder/scratch.
- **Hash-keyed metric methods** — `IncWithHashAt`, `ObserveWithExemplarTraceIDBytesWithHashAt`, `SetForTargetInfoWithHashAt` — let callers pass the precomputed hash so the registry skips re-hashing. Precondition: `hash == lbls.Hash()`.
- The label-builder and scratch pools are owned **per-tenant** by each `ManagedRegistry`, so pooled scratch is never shared across tenants.
- `newHistogram` / `newNativeHistogram` defensively copy and sort their classic buckets (a static `histogram_buckets` config is not validated upstream; non-monotonic buckets would panic `NewHistogram` or miscount).
- `CloseAndBuildLabels` (copy-out) is unchanged for callers that need owned labels.

### Commit 2 — make the sanitizer and limiter own the label strings they retain (the borrow-path contract — review here)
The borrow path comes with a contract: `BorrowedLabels` strings are only valid until `Release`, because they alias pooled scratch that the next borrow reuses. The drain sanitizer and per-label limiter retain strings **across** calls — a map key, a `CounterVec` child via `WithLabelValues`, and drain's span-name tokens — so on the borrow path they must **own** (clone) what they keep.

This commit clones at those three retention points, on the **insert path only** so the steady-state hot path stays allocation-free, caches the per-label overflow counter on the owned name, and documents the no-retain precondition on `Sanitizer` / `LabelLimiter` / `Limiter.OnAdd`. It adds regression tests that deliberately reuse the scratch buffer to prove retained data survives.

> This contract is **new and self-contained to this PR**: `main` uses the copy-out `CloseAndBuildLabels` path and is unaffected. The borrow path (commit 1) has no caller until span-metrics in commit 3, and this commit lands the required ownership first — so no state in this PR (or on `main`) is ever exposed to it. It's listed separately because it's the subtle part worth a careful read, not because it fixes anything shipped.

### Commit 3 — spanmetrics adopts registry borrowed labels (the consumer)
span-metrics builds labels via `CloseAndBorrowLabels` + `defer Release()`, updates metrics with the precomputed hash (`IncWithHashAt` / `ObserveWithExemplarTraceIDBytesWithHashAt` / `SetForTargetInfoWithHashAt`), builds `target_info` directly from resource attributes once per resource, and takes a single update timestamp per push. Service/job/instance extraction moves to `processor/util` as `FindServiceLabels`, replacing the now-orphaned `FindServiceNamespace` / `FindInstanceID` / `GetJobValue` helpers.

## Safety

The borrow path trades a copy for a lifetime contract — "own what you keep past `Release`." It's contained three ways:
- **per-tenant pools** — any future contract violation is same-tenant, never cross-tenant;
- the contract is satisfied at every retention point (commit 2), with scratch-reuse / aliasing regression tests;
- `noCopy` + double-close guards on `BorrowedLabels` make misuse fail loudly.

`main` is unaffected — the contract applies only to the new borrow path, which ships fully satisfied here. All touched packages pass under `-race`.

## Testing

Per-tenant-pool isolation, borrow-path scratch-reuse / aliasing regressions (sanitizer, limiter, overflow metric), span-metrics behaviour + `target_info` ordering, and registry/span-metrics benchmarks.

## Validation

Being validated on dev-01 (the metrics-generator + sampler-metrics-generator run this build; the rest of the stack stays on the release image as a diff-in-diff control). Behaviour-preserving; the goal is reduced per-span CPU and allocations on the generator hot path.
