### PR TITLE
ci: fix GAR auth for tempo-vulture attestation push and release-tag permissions

### DIFF
--- a/.chloggen/fix-tempo-vulture-signing-auth.yaml
+++ b/.chloggen/fix-tempo-vulture-signing-auth.yaml
@@ -1,4 +1,4 @@
-change_type: bug_fix
+change_type: enhancement
 component: operations
 note: Fix GAR authentication for tempo-vulture attestation push and add missing attestations permission in release-tag workflow.
 issues: [7499]

--- a/.chloggen/fix-tempo-vulture-signing-auth.yaml
+++ b/.chloggen/fix-tempo-vulture-signing-auth.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: operations
+note: Fix GAR authentication for tempo-vulture attestation push and add missing attestations permission in release-tag workflow.
+issues: [7499]
+user: mattdurham

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -99,6 +99,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write # nested sign-and-attest.yml writes a SLSA provenance attestation
     uses: ./.github/workflows/docker.yml
     with:
       tag: ${{ needs.guard-and-tag.outputs.tag }}

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -70,13 +70,14 @@ jobs:
           project_id: grafanalabs-workload-identity
           workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
           create_credentials_file: false # must never be set to true: keeps the WIF creds file out of the workspace
+          token_format: access_token # request a short-lived OAuth2 access token for Docker auth
 
       - name: Log in to GAR (static docker auth)
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.registry }}
           username: oauth2accesstoken
-          password: ${{ steps.gar_auth.outputs.auth_token }}
+          password: ${{ steps.gar_auth.outputs.access_token }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -76,7 +76,7 @@ jobs:
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.registry }}
-          username: oauth2accesstoken
+          username: oauth2accesstoken # literal magic string required by GAR; not a secret — tells GAR the password is an OAuth2 access token
           password: ${{ steps.gar_auth.outputs.access_token }}
 
       - name: Install cosign

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -29,7 +29,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write     # keyless cosign OIDC, provenance signing, login-to-gar workload identity
+  id-token: write     # keyless cosign OIDC, provenance signing, and WIF auth to GAR
   attestations: write # write the SLSA provenance attestation to the GitHub attestations store
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      id-token: write     # keyless cosign OIDC, provenance signing, login-to-gar workload identity
+      id-token: write     # keyless cosign OIDC, provenance signing, and WIF auth to GAR
       attestations: write # write the SLSA provenance attestation to the GitHub attestations store
     steps:
       - name: Parse and validate image
@@ -56,29 +56,27 @@ jobs:
           echo "name=${IMAGE%@*}" >> "$GITHUB_OUTPUT"
           echo "digest=${IMAGE##*@}" >> "$GITHUB_OUTPUT"
 
-      - name: Login to GAR
-        uses: grafana/shared-workflows/actions/login-to-gar@1f541877ceb22c7be7667d8a8df04984aeac9f9d # login-to-gar/v1.0.3
+      # We deliberately do NOT use grafana/shared-workflows/login-to-gar here:
+      # it configures a gcloud docker *credential helper*, and actions/attest
+      # (push-to-registry) reads only static `auths` from the docker config and
+      # does not invoke helpers — so it fails with "No credentials found for
+      # registry ...". Instead authenticate via WIF directly and write a static
+      # auth entry with docker/login-action (the same pattern as
+      # grafana/grafana-image-renderer). cosign works with static auths too.
+      - name: Authenticate to GAR (WIF)
+        id: gar_auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          project_id: grafanalabs-workload-identity
+          workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+          create_credentials_file: false # must never be set to true: keeps the WIF creds file out of the workspace
+
+      - name: Log in to GAR (static docker auth)
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ inputs.registry }}
-
-      - name: Add static registry credentials
-        # login-to-gar configures a gcloud docker *credential helper*. cosign
-        # understands credential helpers, but actions/attest (push-to-registry)
-        # only reads static `auths` from the docker config and does not invoke
-        # helpers — so without this it fails with "No credentials found for
-        # registry ...". Write a static auth entry (additive; cosign still works)
-        # using a short-lived GAR access token from the gcloud auth above.
-        env:
-          REGISTRY: ${{ inputs.registry }}
-        run: |
-          token="$(gcloud auth print-access-token)"
-          enc="$(printf 'oauth2accesstoken:%s' "$token" | base64 -w0)"
-          cfg="${HOME}/.docker/config.json"
-          mkdir -p "${HOME}/.docker"
-          [ -f "$cfg" ] || echo '{}' > "$cfg"
-          tmp="$(mktemp)"
-          jq --arg reg "$REGISTRY" --arg a "$enc" '.auths[$reg] = {auth: $a}' "$cfg" > "$tmp"
-          mv "$tmp" "$cfg"
+          username: oauth2accesstoken
+          password: ${{ steps.gar_auth.outputs.auth_token }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -61,6 +61,25 @@ jobs:
         with:
           registry: ${{ inputs.registry }}
 
+      - name: Add static registry credentials
+        # login-to-gar configures a gcloud docker *credential helper*. cosign
+        # understands credential helpers, but actions/attest (push-to-registry)
+        # only reads static `auths` from the docker config and does not invoke
+        # helpers — so without this it fails with "No credentials found for
+        # registry ...". Write a static auth entry (additive; cosign still works)
+        # using a short-lived GAR access token from the gcloud auth above.
+        env:
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          token="$(gcloud auth print-access-token)"
+          enc="$(printf 'oauth2accesstoken:%s' "$token" | base64 -w0)"
+          cfg="${HOME}/.docker/config.json"
+          mkdir -p "${HOME}/.docker"
+          [ -f "$cfg" ] || echo '{}' > "$cfg"
+          tmp="$(mktemp)"
+          jq --arg reg "$REGISTRY" --arg a "$enc" '.auths[$reg] = {auth: $a}' "$cfg" > "$tmp"
+          mv "$tmp" "$cfg"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:


### PR DESCRIPTION
Follow-up fixes to the tempo-vulture image signing/attestation that landed in #7493. Two independent bugs surfaced on `main` after merge.

## 1. `attest-build-provenance` can't authenticate to GAR (fails every `docker.yml` run)

The `sign-vulture` job fails at **Attest SLSA build provenance** with `No credentials found for registry us-docker.pkg.dev`.

Verified via step-level job data — `cosign sign` **succeeds**, only the attestation step fails:

```
3 success  Login to GAR
5 success  Sign image                    ← cosign
6 failure  Attest SLSA build provenance  ← actions/attest push-to-registry
```

Root cause: `login-to-gar` configures a gcloud docker **credential *helper***. `cosign` resolves auth via helpers, but `actions/attest` reads only **static `auths`** from the docker config and does not invoke helpers.

Fix: drop `login-to-gar` in this job and authenticate the way `grafana/grafana-image-renderer` does for the same GAR + attestation case — `google-github-actions/auth` (WIF, `create_credentials_file: false`) + `docker/login-action` with `oauth2accesstoken`, which writes a static `auths` entry. No credential helper is configured, so `cosign` (helper- and static-aware) and `actions/attest` (static only) both authenticate off the same credentials.

## 2. `release-tag.yml` nested permission ceiling -> `startup_failure`

`release-tag.yml`'s `build-docker` job calls `docker.yml` with a ceiling of `contents: read` + `id-token: write`, but the nested `sign-and-attest.yml` requests `attestations: write`. A nested reusable workflow requesting more than the caller granted is a static validation error (`startup_failure`), which broke the release path.

Fix: add `attestations: write` to the `build-docker` call.

## Notes
- `actionlint` passes.
- Both are unreleased CI changes; the feature changelog entry already merged with #7493.