### PR TITLE
fix: add retryable errors on kafka writes timeout

### DIFF
--- a/.chloggen/fix-return-retryable-errors-on-kafka-timeouts.yaml
+++ b/.chloggen/fix-return-retryable-errors-on-kafka-timeouts.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: distributor
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Return a retryable status for transient errors writting into Kafka
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolinar

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -657,7 +657,7 @@ func (d *Distributor) sendToKafka(ctx context.Context, userID string, keys []uin
 
 		_ = level.Debug(d.logger).Log("msg", "kafka write success stats", "count", count, "size_bytes", sizeBytes, "partition", partitionLabel)
 
-		return produceResults.FirstErr()
+		return ingest.StatusFromProduceErr(produceResults.FirstErr())
 	}, ring.DoBatchOptions{})
 }
 

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/grafana/dskit/ring"
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
-	"github.com/grafana/tempo/modules/generator"
-	"github.com/grafana/tempo/pkg/ingest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,6 +31,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/grafana/tempo/modules/generator"
+	"github.com/grafana/tempo/pkg/ingest"
 
 	"github.com/grafana/tempo/modules/distributor/receiver"
 	"github.com/grafana/tempo/modules/overrides"
@@ -1610,6 +1611,49 @@ func TestPushTracesSkipMetricsGenerationIngestStorage(t *testing.T) {
 		// Expect that we've fetched at least one record.
 		require.True(t, recordProcessed)
 	})
+}
+
+func TestPushTracesKafkaWriteErrorReturnsRetryableStatus(t *testing.T) {
+	const topic = "test-topic"
+
+	kafka, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.AllowAutoTopicCreation())
+	require.NoError(t, err)
+	t.Cleanup(kafka.Close)
+
+	limitCfg := overrides.Config{}
+	limitCfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
+
+	distributorCfg, overridesSvc, loggingLevel, middleware := setupDependencies(t, limitCfg)
+
+	distributorCfg.PushSpansToKafka = true
+	distributorCfg.KafkaConfig = ingest.KafkaConfig{}
+	distributorCfg.KafkaConfig.RegisterFlags(&flag.FlagSet{})
+	distributorCfg.KafkaConfig.Address = kafka.ListenAddrs()[0]
+	distributorCfg.KafkaConfig.Topic = topic
+	distributorCfg.KafkaConfig.WriteTimeout = time.Second
+
+	d, err := New(
+		distributorCfg,
+		LocalPushTargets{},
+		singlePartitionRingReader{},
+		overridesSvc,
+		middleware,
+		kitlog.NewLogfmtLogger(os.Stdout),
+		loggingLevel,
+		prometheus.NewRegistry(),
+	)
+	require.NoError(t, err)
+
+	kafka.Close()
+
+	traces := batchesToTraces(t, []*v1.ResourceSpans{test.MakeBatch(10, nil)})
+
+	_, err = d.PushTraces(ctx, traces)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "kafka write error must carry a gRPC status, got %T: %v", err, err)
+	require.Equal(t, codes.Unavailable, st.Code())
 }
 
 func TestPushTracesToLocalLiveStore(t *testing.T) {

--- a/modules/distributor/receiver/shim_test.go
+++ b/modules/distributor/receiver/shim_test.go
@@ -1,8 +1,10 @@
 package receiver
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -22,12 +25,15 @@ import (
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/collector/pdata/testdata"
 	metricnoop "go.opentelemetry.io/otel/metric/noop"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -226,6 +232,95 @@ func (p *capturingPusher) PushTraces(ctx context.Context, t ptrace.Traces) (*tem
 
 func (p *capturingPusher) RetryInfoEnabled(_ context.Context) (bool, error) {
 	return p.retryInfoEnabled, nil
+}
+
+type erroringPusher struct {
+	err error
+}
+
+func (p *erroringPusher) PushTraces(context.Context, ptrace.Traces) (*tempopb.PushResponse, error) {
+	return nil, p.err
+}
+
+func (p *erroringPusher) RetryInfoEnabled(context.Context) (bool, error) {
+	return false, nil
+}
+
+func TestKafkaWriteTimeoutHTTPStatus(t *testing.T) {
+	receiverCfg := map[string]interface{}{
+		"otlp": map[string]interface{}{
+			"protocols": map[string]interface{}{
+				"http": nil,
+			},
+		},
+	}
+
+	pusher := &erroringPusher{err: kgo.ErrRecordTimeout}
+	reg := prometheus.NewPedanticRegistry()
+
+	stopShim := runReceiverShim(t, receiverCfg, pusher, reg)
+	defer stopShim()
+
+	req := ptraceotlp.NewExportRequestFromTraces(testdata.GenerateTraces(1))
+	body, err := req.MarshalProto()
+	require.NoError(t, err)
+
+	var resp *http.Response
+	require.Eventually(t, func() bool {
+		httpReq, reqErr := http.NewRequest(http.MethodPost, "http://127.0.0.1:4318/v1/traces", bytes.NewReader(body))
+		if reqErr != nil {
+			return false
+		}
+		httpReq.Header.Set("Content-Type", "application/x-protobuf")
+		resp, reqErr = http.DefaultClient.Do(httpReq)
+		return reqErr == nil
+	}, 5*time.Second, 50*time.Millisecond)
+	defer resp.Body.Close()
+
+	t.Logf("Kafka write timeout (kgo.ErrRecordTimeout) -> HTTP %d", resp.StatusCode)
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"expected a retryable 503 for a Kafka write timeout, got %d", resp.StatusCode)
+}
+
+func TestKafkaWriteTimeoutGRPCStatus(t *testing.T) {
+	receiverCfg := map[string]interface{}{
+		"otlp": map[string]interface{}{
+			"protocols": map[string]interface{}{
+				"grpc": nil,
+			},
+		},
+	}
+
+	pusher := &erroringPusher{err: kgo.ErrRecordTimeout}
+	reg := prometheus.NewPedanticRegistry()
+
+	stopShim := runReceiverShim(t, receiverCfg, pusher, reg)
+	defer stopShim()
+
+	conn, err := grpc.NewClient("127.0.0.1:4317", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := ptraceotlp.NewGRPCClient(conn)
+	req := ptraceotlp.NewExportRequestFromTraces(testdata.GenerateTraces(1))
+
+	var st *status.Status
+	require.Eventually(t, func() bool {
+		_, e := client.Export(context.Background(), req)
+		if e == nil {
+			return false
+		}
+		s, ok := status.FromError(e)
+		if !ok || !strings.Contains(s.Message(), "records have timed out") {
+			return false
+		}
+		st = s
+		return true
+	}, 5*time.Second, 50*time.Millisecond)
+
+	t.Logf("Kafka write timeout (kgo.ErrRecordTimeout) -> gRPC code %s", st.Code())
+	require.Equal(t, codes.Unavailable, st.Code(),
+		"expected retryable Unavailable, got %s (Unknown here would mean the raw error escaped without status conversion)", st.Code())
 }
 
 // TestWrapRetryableError confirms that errors are wrapped as expected

--- a/modules/distributor/receiver/shim_test.go
+++ b/modules/distributor/receiver/shim_test.go
@@ -265,6 +265,8 @@ func TestKafkaWriteTimeoutHTTPStatus(t *testing.T) {
 	body, err := req.MarshalProto()
 	require.NoError(t, err)
 
+	httpClient := &http.Client{Timeout: 1 * time.Second}
+
 	var resp *http.Response
 	require.Eventually(t, func() bool {
 		httpReq, reqErr := http.NewRequest(http.MethodPost, "http://127.0.0.1:4318/v1/traces", bytes.NewReader(body))
@@ -272,7 +274,7 @@ func TestKafkaWriteTimeoutHTTPStatus(t *testing.T) {
 			return false
 		}
 		httpReq.Header.Set("Content-Type", "application/x-protobuf")
-		resp, reqErr = http.DefaultClient.Do(httpReq)
+		resp, reqErr = httpClient.Do(httpReq)
 		return reqErr == nil
 	}, 5*time.Second, 50*time.Millisecond)
 	defer resp.Body.Close()

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -20,6 +20,8 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/atomic"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // NewWriterClient returns the kgo.Client that should be used by the Writer.
@@ -334,6 +336,18 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 		// Once we're done, it's guaranteed that no more results will be appended, so we can safely return it.
 		return res
 	}
+}
+
+// StatusFromProduceErr maps a Kafka produce error to a retryable gRPC status,
+// or codes.InvalidArgument for records that are too large.
+func StatusFromProduceErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, kerr.MessageTooLarge) {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	return status.Error(codes.Unavailable, err.Error())
 }
 
 func produceErrReason(err error) string {

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -338,11 +338,12 @@ func (c *Producer) ProduceSync(ctx context.Context, records []*kgo.Record) kgo.P
 	}
 }
 
-// StatusFromProduceErr maps a Kafka produce error to a retryable gRPC status,
-// or codes.InvalidArgument for records that are too large.
 func StatusFromProduceErr(err error) error {
 	if err == nil {
 		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, err.Error())
 	}
 	if errors.Is(err, kerr.MessageTooLarge) {
 		return status.Error(codes.InvalidArgument, err.Error())

--- a/pkg/ingest/writer_client_test.go
+++ b/pkg/ingest/writer_client_test.go
@@ -19,9 +19,11 @@ func TestStatusFromProduceErr(t *testing.T) {
 		err  error
 		want codes.Code
 	}{
+	{
 		{"nil", nil, codes.OK},
 		{"record timeout", kgo.ErrRecordTimeout, codes.Unavailable},
 		{"context deadline", context.DeadlineExceeded, codes.Unavailable},
+		{"context canceled", context.Canceled, codes.Canceled},
 		{"buffer full", kgo.ErrMaxBuffered, codes.Unavailable},
 		{"generic", errors.New("boom"), codes.Unavailable},
 		{"message too large", kerr.MessageTooLarge, codes.InvalidArgument},

--- a/pkg/ingest/writer_client_test.go
+++ b/pkg/ingest/writer_client_test.go
@@ -1,0 +1,41 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestStatusFromProduceErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{"nil", nil, codes.OK},
+		{"record timeout", kgo.ErrRecordTimeout, codes.Unavailable},
+		{"context deadline", context.DeadlineExceeded, codes.Unavailable},
+		{"buffer full", kgo.ErrMaxBuffered, codes.Unavailable},
+		{"generic", errors.New("boom"), codes.Unavailable},
+		{"message too large", kerr.MessageTooLarge, codes.InvalidArgument},
+		{"wrapped message too large", fmt.Errorf("failed to produce: %w", kerr.MessageTooLarge), codes.InvalidArgument},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StatusFromProduceErr(tt.err)
+			require.Equal(t, tt.want, status.Code(got))
+			if tt.err == nil {
+				require.NoError(t, got)
+				return
+			}
+			require.Contains(t, got.Error(), tt.err.Error())
+		})
+	}
+}

--- a/pkg/ingest/writer_client_test.go
+++ b/pkg/ingest/writer_client_test.go
@@ -19,7 +19,6 @@ func TestStatusFromProduceErr(t *testing.T) {
 		err  error
 		want codes.Code
 	}{
-	{
 		{"nil", nil, codes.OK},
 		{"record timeout", kgo.ErrRecordTimeout, codes.Unavailable},
 		{"context deadline", context.DeadlineExceeded, codes.Unavailable},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Makes the distributor return a retryable error when a Kafka write fails, so OTLP clients retry instead of dropping the data.


1. A Kafka write times out (default 10s `WriteTimeout` and returns a plain error with no gRPC status code.
2. `sendToKafka` returns that error as-is. It travels up through `PushTraces`
and `ConsumeTraces` unchanged 
3. The OTLP receiver decides the client's HTTP/gRPC status from the gRPC status
code on the error. This error has none, so it relies on the OTel collector's
fallback  503, unless it is marked permanent, in which case it becomes
`Internal` (HTTP 500, not retryable).

**Checklist**
- [X] Tests updated
- [ ] Documentation added
- [X] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)