### PR TITLE
[traceql] Fix missing event and link intrinsic handling in new vp5 metrics fetch layer

### DIFF
--- a/.chloggen/vp5-spanonly-fetch-fix.yaml
+++ b/.chloggen/vp5-spanonly-fetch-fix.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: traceql
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Fixes a bug where TraceQL metrics queries on event and link intrinsics such as `{ } | rate() by (event:name) would return incorrect results when using vParquet5 and the new faster fetch layer.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mdisibio

--- a/.chloggen/vp5-spanonly-fetch-fix.yaml
+++ b/.chloggen/vp5-spanonly-fetch-fix.yaml
@@ -8,7 +8,7 @@ change_type: bug_fix
 component: traceql
 
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
-note: Fixes a bug where TraceQL metrics queries on event and link intrinsics such as `{ } | rate() by (event:name) would return incorrect results when using vParquet5 and the new faster fetch layer.
+note: Fixes a bug where TraceQL metrics queries on event and link intrinsics such as `{ } | rate() by (event:name)` would return incorrect results when using vParquet5 and the new faster fetch layer.
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -118,7 +118,7 @@ func (f *FetchSpansRequest) appendCondition(c ...Condition) {
 	f.Conditions = append(f.Conditions, c...)
 }
 
-func (_ FetchSpansRequest) match(cc, a Attribute) bool {
+func (FetchSpansRequest) match(cc, a Attribute) bool {
 	if cc == a {
 		return true
 	}

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -118,14 +118,28 @@ func (f *FetchSpansRequest) appendCondition(c ...Condition) {
 	f.Conditions = append(f.Conditions, c...)
 }
 
+func (_ FetchSpansRequest) match(cc, a Attribute) bool {
+	if cc == a {
+		return true
+	}
+
+	// An unscoped condition like .foo, can be matched by the
+	// more-restrictive span and resource conditions like resource.foo.
+	return cc.Scope == AttributeScopeNone &&
+		(a.Scope == AttributeScopeResource || a.Scope == AttributeScopeSpan) &&
+		cc.Parent == a.Parent &&
+		cc.Name == a.Name &&
+		cc.Intrinsic == a.Intrinsic
+}
+
 func (f *FetchSpansRequest) HasAttribute(a Attribute) bool {
 	for _, cc := range f.Conditions {
-		if cc.Attribute == a {
+		if f.match(cc.Attribute, a) {
 			return true
 		}
 	}
 	for _, cc := range f.SecondPassConditions {
-		if cc.Attribute == a {
+		if f.match(cc.Attribute, a) {
 			return true
 		}
 	}
@@ -135,7 +149,7 @@ func (f *FetchSpansRequest) HasAttribute(a Attribute) bool {
 
 func (f *FetchSpansRequest) SecondPassHasAttribute(a Attribute) bool {
 	for _, cc := range f.SecondPassConditions {
-		if cc.Attribute == a {
+		if f.match(cc.Attribute, a) {
 			return true
 		}
 	}
@@ -145,13 +159,13 @@ func (f *FetchSpansRequest) SecondPassHasAttribute(a Attribute) bool {
 
 func (f *FetchSpansRequest) HasAttributeWithOp(a Attribute, o Operator) bool {
 	for _, cc := range f.Conditions {
-		if cc.Attribute == a && cc.Op == o {
+		if f.match(cc.Attribute, a) && cc.Op == o {
 			return true
 		}
 	}
 
 	for _, cc := range f.SecondPassConditions {
-		if cc.Attribute == a && cc.Op == o {
+		if f.match(cc.Attribute, a) && cc.Op == o {
 			return true
 		}
 	}

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -181,10 +181,10 @@ func create(makeIter, makeNilIter makeIterFn,
 		options = append(options, parquetquery.WithIterator(DefinitionLevelResourceSpansILSSpan, iter, false, traceql.AttributeScopeSpan))
 	}
 	for _, iter := range eventIters {
-		options = append(options, parquetquery.WithIterator(DefinitionLevelResourceSpansILSSpan, iter, true, traceql.AttributeScopeEvent))
+		options = append(options, parquetquery.WithIterator(DefinitionLevelResourceSpansILSSpan, iter, false, traceql.AttributeScopeEvent))
 	}
 	for _, iter := range linkIters {
-		options = append(options, parquetquery.WithIterator(DefinitionLevelResourceSpansILSSpan, iter, true, traceql.AttributeScopeLink))
+		options = append(options, parquetquery.WithIterator(DefinitionLevelResourceSpansILSSpan, iter, false, traceql.AttributeScopeLink))
 	}
 
 	for _, iter := range traceOptional {
@@ -1296,6 +1296,8 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 				sp.addSpanAttr(newSpanAttr(e.Key), v)
 			case res.RowNumber[DefinitionLevelResourceSpans] >= 0:
 				sp.resourceAttrs = append(sp.resourceAttrs, attrVal{traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, e.Key), v})
+			default:
+				panic("unhandled static value: " + e.Key)
 			}
 		case *event:
 			sp.setEventAttrs(v.attrs)
@@ -1408,6 +1410,34 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 				traceql.NewScopedAttribute(traceql.AttributeScopeResource, false, "service.name"),
 				traceql.NewStaticString(unsafeToString(kv.Value.Bytes())),
 			})
+		// --------------------
+		// Event-level columns:
+		// --------------------
+		case ColumnPathEventName:
+			sp.eventAttrs = append(sp.eventAttrs, attrVal{
+				traceql.NewIntrinsic(traceql.IntrinsicEventName),
+				traceql.NewStaticString(unsafeToString(kv.Value.Bytes())),
+			})
+		case columnPathEventTimeSinceStart:
+			sp.eventAttrs = append(sp.eventAttrs, attrVal{
+				a: traceql.IntrinsicEventTimeSinceStartAttribute,
+				s: traceql.NewStaticDuration(time.Duration(kv.Value.Int64())),
+			})
+		// --------------------
+		// Link-level columns:
+		// --------------------
+		case columnPathLinkTraceID:
+			sp.linkAttrs = append(sp.linkAttrs, attrVal{
+				a: traceql.NewIntrinsic(traceql.IntrinsicLinkTraceID),
+				s: traceql.NewStaticString(util.TraceIDToHexString(kv.Value.Bytes())),
+			})
+		case columnPathLinkSpanID:
+			sp.linkAttrs = append(sp.linkAttrs, attrVal{
+				a: traceql.NewIntrinsic(traceql.IntrinsicLinkSpanID),
+				s: traceql.NewStaticString(util.SpanIDToHexString(kv.Value.Bytes())),
+			})
+		// --------------------
+		// --------------------
 		default:
 			// Decomposed attributes from dedicated columns.
 			scope := param.(traceql.AttributeScope)

--- a/tempodb/encoding/vparquet5/block_traceql_fetch_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch_test.go
@@ -46,6 +46,7 @@ func TestSearchFetchSpansOnly(t *testing.T) {
 
 			resp, err := b.FetchSpans(ctx, req, common.DefaultSearchOptions())
 			require.NoError(t, err, "search request:%v", req)
+			defer resp.Results.Close()
 
 			found := false
 			for {
@@ -86,6 +87,7 @@ func TestSearchFetchSpansOnly(t *testing.T) {
 
 			resp, err := b.FetchSpans(ctx, req, common.DefaultSearchOptions())
 			require.NoError(t, err, "search request:%v", req)
+			defer resp.Results.Close()
 
 			for {
 				span, err := resp.Results.Next(ctx)

--- a/tempodb/encoding/vparquet5/block_traceql_fetch_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch_test.go
@@ -54,12 +54,19 @@ func TestSearchFetchSpansOnly(t *testing.T) {
 				if span == nil {
 					break
 				}
+
+				// Ensure that every attribute returned is present in the list of conditions.
+				span.AllAttributesFunc(func(a traceql.Attribute, _ traceql.Static) {
+					if !req.HasAttribute(a) {
+						t.Errorf("attribute %v not found in conditions", a)
+					}
+				})
+
 				traceID, ok := span.AttributeFor(traceql.IntrinsicTraceIDAttribute)
 				if !ok {
 					continue
 				}
 				traceIDString := traceID.EncodeToString(false)
-				// fmt.Println("got:", traceIDString, "want:", traceIDText)
 				found = (traceIDString == traceIDText)
 				if found {
 					break


### PR DESCRIPTION
**What this PR does**:
A query like `{ } | rate() by (event:name)` would incorrectly return nils when using vp5 and the new span-only fetch layer.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)