### PR TITLE
tempo-cli: add experimental trace summary

### DIFF
--- a/.chloggen/trace-summary-v0.yaml
+++ b/.chloggen/trace-summary-v0.yaml
@@ -1,6 +1,6 @@
 change_type: feature
 component: tempo-cli
-note: Add an experimental trace-summary-v0-native format to tempo-cli trace diff. It provides a compact overview of latency, span work, errors, structural changes, affected services, and common change patterns.
+note: Add an experimental trace-summary-v0-native format to tempo-cli trace diff. It provides a compact overview of latency, summed span duration, errors, structural changes, and affected services.
 issues: [7510]
 subtext:
 user: carles-grafana

--- a/.chloggen/trace-summary-v0.yaml
+++ b/.chloggen/trace-summary-v0.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: tempo-cli
+note: Add an experimental trace-summary-v0-native format to tempo-cli trace diff. It provides a compact overview of latency, span work, errors, structural changes, affected services, and common change patterns.
+issues: [7510]
+subtext:
+user: carles-grafana

--- a/cmd/tempo-cli/cmd-experimental-trace-diff.go
+++ b/cmd/tempo-cli/cmd-experimental-trace-diff.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,22 +16,24 @@ import (
 type experimentalTraceDiffCmd struct {
 	TraceA string `name:"trace-a" type:"path" required:"" help:"Baseline trace JSON file"`
 	TraceB string `name:"trace-b" type:"path" required:"" help:"Comparison trace JSON file"`
-	Format string `help:"Output format" default:"trace-patch-v0" enum:"trace-patch-v0"`
+	Format string `help:"Output format" default:"trace-patch-v0" enum:"trace-patch-v0,trace-summary-v0-native"`
 	Out    string `short:"o" type:"path" help:"File to write output to, instead of stdout" default:""`
 	Pretty bool   `help:"Pretty-print JSON output"`
 }
 
 func (cmd *experimentalTraceDiffCmd) Run(_ *globalOptions) error {
-	base, err := readTraceJSONFile(cmd.TraceA)
+	base, warningsA, err := readTraceJSONFileWithWarnings(cmd.TraceA, "trace-a")
 	if err != nil {
 		return fmt.Errorf("read trace-a: %w", err)
 	}
-	compare, err := readTraceJSONFile(cmd.TraceB)
+	compare, warningsB, err := readTraceJSONFileWithWarnings(cmd.TraceB, "trace-b")
 	if err != nil {
 		return fmt.Errorf("read trace-b: %w", err)
 	}
+	warnings := warningsA
+	warnings = append(warnings, warningsB...)
 
-	result, err := tracediff.Diff(base, compare, tracediff.Format(cmd.Format))
+	result, err := buildTraceDiffOutput(base, compare, cmd.Format, warnings)
 	if err != nil {
 		return err
 	}
@@ -53,30 +56,68 @@ func (cmd *experimentalTraceDiffCmd) Run(_ *globalOptions) error {
 	return enc.Encode(result)
 }
 
-func readTraceJSONFile(path string) (*tempopb.Trace, error) {
+func buildTraceDiffOutput(base, compare *tempopb.Trace, format string, warnings []tracediff.Warning) (any, error) {
+	switch format {
+	case tracediff.VersionTracePatchV0:
+		result, err := tracediff.Diff(base, compare, tracediff.FormatTracePatchV0)
+		if err != nil {
+			return nil, err
+		}
+		result.Warnings = append(result.Warnings, warnings...)
+		return result, nil
+	case tracediff.VersionTraceSummaryV0Native:
+		result, err := tracediff.Summarize(base, compare)
+		if err != nil {
+			return nil, err
+		}
+		result.Warnings = append(result.Warnings, warnings...)
+		return result, nil
+	default:
+		return nil, fmt.Errorf("%q: %w", format, tracediff.ErrUnsupportedFormat)
+	}
+}
+
+func readTraceJSONFileWithWarnings(path string, label string) (*tempopb.Trace, []tracediff.Warning, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	if trace, ok := unmarshalTraceByIDResponse(bytes); ok {
-		return trace, nil
+	if resp, ok := unmarshalTraceByIDResponseFull(bytes); ok {
+		var warnings []tracediff.Warning
+		if resp.GetStatus() == tempopb.PartialStatus_PARTIAL {
+			warnings = append(warnings, partialTraceWarning(label, path, resp.GetMessage()))
+		}
+		return resp.Trace, warnings, nil
 	}
 
 	trace := &tempopb.Trace{}
 	if err := tempopb.UnmarshalFromJSONV1(bytes, trace); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return trace, nil
+	return trace, nil, nil
 }
 
-func unmarshalTraceByIDResponse(bytes []byte) (*tempopb.Trace, bool) {
+// unmarshalTraceByIDResponseFull parses a v2 TraceByIDResponse wrapper, returning
+// the full response so callers can inspect Status/Message. It reports false when
+// the bytes are not a wrapper with a populated Trace.
+func unmarshalTraceByIDResponseFull(data []byte) (*tempopb.TraceByIDResponse, bool) {
 	resp := &tempopb.TraceByIDResponse{}
-	if err := jsonpb.UnmarshalString(string(bytes), resp); err != nil {
+	if err := jsonpb.Unmarshal(bytes.NewReader(data), resp); err != nil {
 		return nil, false
 	}
 	if resp.Trace == nil {
 		return nil, false
 	}
-	return resp.Trace, true
+	return resp, true
+}
+
+// partialTraceWarning builds the warning for a partial trace. source is a trace
+// file path; detail is the optional server explanation.
+func partialTraceWarning(label, source, detail string) tracediff.Warning {
+	message := fmt.Sprintf("%s (%s) was returned as a partial trace and may be incomplete; the diff could be inaccurate", label, source)
+	if detail != "" {
+		message = fmt.Sprintf("%s: %s", message, detail)
+	}
+	return tracediff.Warning{Code: tracediff.WarningPartialTrace, Message: message}
 }

--- a/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
+++ b/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
@@ -96,9 +96,9 @@ func TestExperimentalTraceDiffWritesTraceSummary(t *testing.T) {
 	require.Equal(t, tracediff.VersionTraceSummaryV0Native, result.Version)
 	require.Equal(t, "increased", result.Signals.TraceLatency)
 	require.Equal(t, int64(50), result.Stats.TraceLatencyDeltaMs)
+	require.Equal(t, "increased", result.Signals.SumSpanDuration)
 	require.Equal(t, "checkout", result.Base.RootService)
 	require.Len(t, result.Services, 1)
-	require.Len(t, result.Patterns, 1)
 }
 
 func TestExperimentalTraceDiffSummaryWarnsOnPartialTraceFile(t *testing.T) {

--- a/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
+++ b/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
@@ -2,11 +2,18 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/grafana/tempo/pkg/model/tracediff"
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,4 +42,157 @@ func TestExperimentalTraceDiffWritesTracePatch(t *testing.T) {
 	require.Empty(t, result.Modified)
 	require.Empty(t, result.Added)
 	require.Empty(t, result.Removed)
+}
+
+func TestExperimentalTraceDiffPatchEncodesNonFiniteAttributes(t *testing.T) {
+	dir := t.TempDir()
+	traceA := filepath.Join(dir, "trace-a.json")
+	traceB := filepath.Join(dir, "trace-b.json")
+	out := filepath.Join(dir, "diff.json")
+
+	base := experimentalTraceDiffTrace(1, 100_000_000)
+	base.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes = append(base.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes, experimentalTraceDiffDoubleKV("score", 1.5))
+	compare := experimentalTraceDiffTrace(1, 100_000_000)
+	compare.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes = append(compare.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes, experimentalTraceDiffDoubleKV("score", math.NaN()))
+	writeExperimentalTraceDiffTraceFile(t, traceA, base)
+	writeExperimentalTraceDiffTraceFile(t, traceB, compare)
+
+	cmd := experimentalTraceDiffCmd{
+		TraceA: traceA,
+		TraceB: traceB,
+		Format: string(tracediff.FormatTracePatchV0),
+		Out:    out,
+	}
+	require.NoError(t, cmd.Run(nil))
+
+	bytes, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.Contains(t, string(bytes), `"before":1.5`)
+	assert.Contains(t, string(bytes), `"after":"NaN"`)
+}
+
+func TestExperimentalTraceDiffWritesTraceSummary(t *testing.T) {
+	dir := t.TempDir()
+	traceAFile := filepath.Join(dir, "trace-a.json")
+	traceBFile := filepath.Join(dir, "trace-b.json")
+	outFile := filepath.Join(dir, "summary.json")
+
+	writeExperimentalTraceDiffTraceFile(t, traceAFile, experimentalTraceDiffTrace(1, 100_000_000))
+	writeExperimentalTraceDiffTraceFile(t, traceBFile, experimentalTraceDiffTrace(2, 150_000_000))
+
+	cmd := experimentalTraceDiffCmd{
+		TraceA: traceAFile,
+		TraceB: traceBFile,
+		Format: tracediff.VersionTraceSummaryV0Native,
+		Out:    outFile,
+	}
+	require.NoError(t, cmd.Run(nil))
+
+	bytes, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+
+	var result tracediff.SummaryResult
+	require.NoError(t, json.Unmarshal(bytes, &result))
+	require.Equal(t, tracediff.VersionTraceSummaryV0Native, result.Version)
+	require.Equal(t, "increased", result.Signals.TraceLatency)
+	require.Equal(t, int64(50), result.Stats.TraceLatencyDeltaMs)
+	require.Equal(t, "checkout", result.Base.RootService)
+	require.Len(t, result.Services, 1)
+	require.Len(t, result.Patterns, 1)
+}
+
+func TestExperimentalTraceDiffSummaryWarnsOnPartialTraceFile(t *testing.T) {
+	dir := t.TempDir()
+	traceAFile := filepath.Join(dir, "trace-a.json")
+	traceBFile := filepath.Join(dir, "trace-b.json")
+	outFile := filepath.Join(dir, "summary.json")
+
+	writeExperimentalTraceDiffTraceFile(t, traceAFile, experimentalTraceDiffTrace(1, 100_000_000))
+	writeExperimentalTraceDiffResponseFile(t, traceBFile, &tempopb.TraceByIDResponse{
+		Trace:   experimentalTraceDiffTrace(2, 150_000_000),
+		Status:  tempopb.PartialStatus_PARTIAL,
+		Message: "deadline exceeded",
+	})
+
+	cmd := experimentalTraceDiffCmd{
+		TraceA: traceAFile,
+		TraceB: traceBFile,
+		Format: tracediff.VersionTraceSummaryV0Native,
+		Out:    outFile,
+	}
+	require.NoError(t, cmd.Run(nil))
+
+	bytes, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+
+	var result tracediff.SummaryResult
+	require.NoError(t, json.Unmarshal(bytes, &result))
+	require.Equal(t, tracediff.VersionTraceSummaryV0Native, result.Version)
+	require.Len(t, result.Warnings, 1)
+	assert.Equal(t, tracediff.WarningPartialTrace, result.Warnings[0].Code)
+	assert.Contains(t, result.Warnings[0].Message, "trace-b")
+	assert.Contains(t, result.Warnings[0].Message, "deadline exceeded")
+}
+
+func writeExperimentalTraceDiffTraceFile(t *testing.T, path string, trace *tempopb.Trace) {
+	t.Helper()
+	data, err := tempopb.MarshalToJSONV1(trace)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}
+
+func writeExperimentalTraceDiffResponseFile(t *testing.T, path string, resp *tempopb.TraceByIDResponse) {
+	t.Helper()
+	data, err := (&jsonpb.Marshaler{}).MarshalToString(resp)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
+}
+
+func experimentalTraceDiffTrace(traceID byte, durationNanos uint64) *tempopb.Trace {
+	const startNanos = uint64(1_700_000_000_000_000_000)
+	return &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{experimentalTraceDiffStringKV("service.name", "checkout")},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{
+					{Spans: []*tracev1.Span{
+						{
+							TraceId:           experimentalTraceDiffTraceID(traceID),
+							SpanId:            []byte{traceID},
+							Name:              "GET /checkout",
+							Kind:              tracev1.Span_SPAN_KIND_SERVER,
+							StartTimeUnixNano: startNanos,
+							EndTimeUnixNano:   startNanos + durationNanos,
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func experimentalTraceDiffTraceID(id byte) []byte {
+	traceID := make([]byte, 16)
+	traceID[15] = id
+	return traceID
+}
+
+func experimentalTraceDiffStringKV(key, value string) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key: key,
+		Value: &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_StringValue{StringValue: value},
+		},
+	}
+}
+
+func experimentalTraceDiffDoubleKV(key string, value float64) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key: key,
+		Value: &commonv1.AnyValue{
+			Value: &commonv1.AnyValue_DoubleValue{DoubleValue: value},
+		},
+	}
 }

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -94,7 +94,7 @@ var cli struct {
 	} `cmd:""`
 
 	Experimental struct {
-		TraceDiff experimentalTraceDiffCmd `cmd:"" help:"Compare two local trace JSON files and emit an experimental trace-aware patch"`
+		TraceDiff experimentalTraceDiffCmd `cmd:"" help:"Compare two local trace JSON files and emit an experimental trace-aware diff or summary"`
 	} `cmd:""`
 
 	Redact redactCmd `cmd:"" help:"Submit a redaction request to the backend scheduler"`

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -866,7 +866,9 @@ tempo-cli gen attr-index --add-intrinsics ./path/to/block
 This command is experimental. The output format and behavior may change in future releases.
 {{< /admonition >}}
 
-Compare two local trace JSON files and produce a structural diff in `trace-patch-v0` format. The diff output identifies spans that were added, removed, or modified between a baseline trace and a comparison trace.
+Compare two local trace JSON files. Use the default `trace-patch-v0` format for
+an exact mechanical change list, or `trace-summary-v0-native` for a compact
+triage and service-localization view.
 
 Use this command to compare traces captured at different times or from different environments, for example, to understand how a deployment changed trace structure.
 
@@ -881,7 +883,7 @@ Arguments:
 
 Options:
 
-- `--format <value>` Output format. Currently only `trace-patch-v0` is supported (default).
+- `--format <value>` Output format: `trace-patch-v0` (default) or `trace-summary-v0-native`.
 - `-o, --out <path>` File to write output to. If not specified, output is printed to `stdout`.
 - `--pretty` Pretty-print JSON output.
 
@@ -898,6 +900,28 @@ Example writing output to a file:
 ```bash
 tempo-cli experimental trace-diff --trace-a baseline.json --trace-b compare.json -o diff-output.json
 ```
+
+Example producing the native summary:
+
+```bash
+tempo-cli experimental trace-diff \
+  --trace-a baseline.json \
+  --trace-b compare.json \
+  --format trace-summary-v0-native \
+  --pretty
+```
+
+The native summary calculates latency, span-work, topology, and significant
+per-service drift from the normalized traces. It combines those values with
+matcher-derived change and error counts. `changedServices` and service rollups
+cover all matcher changes and significant work drift; `changedServices` also
+includes structure-only changes, which do not have service rollups. Repeated
+change patterns are ranked by frequency and capped at 20; `patternsTruncated`
+reports exact omitted pattern and span counts.
+
+Warnings report partial inputs, high-cardinality span names, duplicate span
+IDs, ambiguous duplicate-span matching, empty traces, and invalid durations.
+Invalid spans contribute zero to summary duration aggregates.
 
 ## Drop traces by ID
 

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -911,13 +911,12 @@ tempo-cli experimental trace-diff \
   --pretty
 ```
 
-The native summary calculates latency, span-work, topology, and significant
-per-service drift from the normalized traces. It combines those values with
-matcher-derived change and error counts. `changedServices` and service rollups
-cover all matcher changes and significant work drift; `changedServices` also
-includes structure-only changes, which do not have service rollups. Repeated
-change patterns are ranked by frequency and capped at 20; `patternsTruncated`
-reports exact omitted pattern and span counts.
+The native summary calculates latency, the sum of inclusive span durations,
+topology, and significant per-service duration drift from the normalized traces.
+It combines those values with matcher-derived change and error counts.
+`changedServices` and service rollups cover all matcher changes and significant
+duration drift; `changedServices` also includes structure-only changes, which do
+not have service rollups.
 
 Warnings report partial inputs, high-cardinality span names, duplicate span
 IDs, ambiguous duplicate-span matching, empty traces, and invalid durations.

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -35,12 +35,6 @@ func diffTraceInputs(base, compare *tempopb.Trace) (*Result, normalizedTrace, no
 	compareTrace, compareWarnings := normalizeTraceForSide(compare, "compare")
 	matched, modified, added, removed := computeDiff(baseTrace, compareTrace)
 	warnings := mergeWarnings(baseWarnings, compareWarnings)
-	if ambiguousGroups := ambiguousSpanGroupCount(baseTrace, compareTrace); ambiguousGroups > 0 {
-		warnings = append(warnings, Warning{
-			Code:    WarningAmbiguousSpanMatch,
-			Message: fmt.Sprintf("%d duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation", ambiguousGroups),
-		})
-	}
 
 	return &Result{
 		Version: VersionTracePatchV0,
@@ -102,74 +96,45 @@ func computeDiff(base, compare normalizedTrace) (int, []ModifiedSpan, []SpanChan
 // matchSpans decides which base span, if any, matches each compare span.
 func matchSpans(base, compare normalizedTrace) map[string]normalizedSpan {
 	baseSpanByCompareSpanID := make(map[string]normalizedSpan)
+	usedBaseSpanIDs := make(map[string]struct{})
 	baseByID := bucketByIdentity(base)
-	compareByID := bucketByIdentity(compare)
-	for identity, compareCandidates := range compareByID {
-		for compareSpanID, baseSpan := range matchSpanGroup(baseByID[identity], compareCandidates) {
-			baseSpanByCompareSpanID[compareSpanID] = baseSpan
+
+	for _, compareSpan := range compare.spans {
+		baseSpan, ok := findMatch(baseByID[compareSpan.identity()], compareSpan, usedBaseSpanIDs)
+		if !ok {
+			continue
 		}
+		baseSpanByCompareSpanID[compareSpan.spanID] = baseSpan
+		usedBaseSpanIDs[baseSpan.spanID] = struct{}{}
 	}
 	return baseSpanByCompareSpanID
 }
 
-// matchSpanGroup pairs a logical-identity bucket in phases. Matching all
-// unchanged spans before changed spans makes the result independent of sibling
-// order while parent-first phases preserve branch identity where it is known.
-func matchSpanGroup(baseCandidates, compareCandidates []normalizedSpan) map[string]normalizedSpan {
-	matchCount := min(len(baseCandidates), len(compareCandidates))
-	matches := make(map[string]normalizedSpan, matchCount)
-	usedBaseSpanIDs := make(map[string]struct{}, matchCount)
-
-	pair := func(eligible func(normalizedSpan, normalizedSpan) bool) {
-		for _, compareSpan := range compareCandidates {
-			if _, ok := matches[compareSpan.spanID]; ok {
-				continue
-			}
-			for _, baseSpan := range baseCandidates {
-				if _, ok := usedBaseSpanIDs[baseSpan.spanID]; ok || !eligible(baseSpan, compareSpan) {
-					continue
-				}
-				matches[compareSpan.spanID] = baseSpan
-				usedBaseSpanIDs[baseSpan.spanID] = struct{}{}
-				break
-			}
+// findMatch receives base spans with the same identity as compareSpan. Parent
+// identity is only a duplicate tie-breaker: if it cannot disambiguate, the first
+// unused candidate preserves the ancestor-insert behavior.
+func findMatch(baseCandidates []normalizedSpan, compareSpan normalizedSpan, usedBaseSpanIDs map[string]struct{}) (normalizedSpan, bool) {
+	var fallback normalizedSpan
+	fallbackSet := false
+	for _, baseSpan := range baseCandidates {
+		if _, ok := usedBaseSpanIDs[baseSpan.spanID]; ok {
+			continue
+		}
+		// Both spans share the same parent identity
+		if sameParentIdentity(baseSpan, compareSpan) {
+			return baseSpan, true
+		}
+		// If not we choose the first one as a fallback
+		if !fallbackSet {
+			fallback = baseSpan
+			fallbackSet = true
 		}
 	}
-
-	pair(func(base, compare normalizedSpan) bool {
-		return sameParentIdentity(base, compare) && spansEquivalentForMatching(base, compare)
-	})
-	pair(func(base, compare normalizedSpan) bool {
-		return sameParentIdentity(base, compare) && base.snapshot.Status == compare.snapshot.Status
-	})
-	pair(sameParentIdentity)
-	pair(spansEquivalentForMatching)
-	pair(func(base, compare normalizedSpan) bool {
-		return base.snapshot.Status == compare.snapshot.Status
-	})
-	pair(func(normalizedSpan, normalizedSpan) bool { return true })
-	return matches
+	return fallback, fallbackSet
 }
 
 func sameParentIdentity(a, b normalizedSpan) bool {
-	return a.hasParent == b.hasParent && (!a.hasParent || a.parentIdentity == b.parentIdentity)
-}
-
-func spansEquivalentForMatching(base, compare normalizedSpan) bool {
-	baseDuration, compareDuration := durationChangeValues(base, compare)
-	if durationChanged(baseDuration, compareDuration) || base.snapshot.Status != compare.snapshot.Status {
-		return false
-	}
-	if len(base.spanAttrs) != len(compare.spanAttrs) {
-		return false
-	}
-	for key, before := range base.spanAttrs {
-		after, ok := compare.spanAttrs[key]
-		if !ok || attributeChanged(key, before, after) {
-			return false
-		}
-	}
-	return true
+	return a.hasParent && b.hasParent && a.parentIdentity == b.parentIdentity
 }
 
 // bucketByIdentity groups spans by their flat identity.
@@ -180,72 +145,6 @@ func bucketByIdentity(trace normalizedTrace) map[spanLogicalKey][]normalizedSpan
 		out[id] = append(out[id], s)
 	}
 	return out
-}
-
-type spanParentIdentity struct {
-	identity  spanLogicalKey
-	hasParent bool
-}
-
-// ambiguousSpanGroupCount counts logical identities whose spans cannot be
-// paired uniquely using parent identity. Exact-content matching still avoids
-// spurious changes where possible, but consumers must not treat the remaining
-// pairings as certain instance-to-instance transitions.
-func ambiguousSpanGroupCount(base, compare normalizedTrace) int {
-	baseCounts := spanParentCounts(base)
-	compareCounts := spanParentCounts(compare)
-
-	identities := make(map[spanLogicalKey]struct{}, len(baseCounts)+len(compareCounts))
-	for identity := range baseCounts {
-		identities[identity] = struct{}{}
-	}
-	for identity := range compareCounts {
-		identities[identity] = struct{}{}
-	}
-
-	ambiguous := 0
-	for identity := range identities {
-		baseParents := baseCounts[identity]
-		compareParents := compareCounts[identity]
-		remainingBase := 0
-		remainingCompare := 0
-		isAmbiguous := false
-		for parent, baseCount := range baseParents {
-			compareCount := compareParents[parent]
-			paired := min(baseCount, compareCount)
-			if paired > 0 && (baseCount > 1 || compareCount > 1) {
-				isAmbiguous = true
-			}
-			remainingBase += baseCount - paired
-			remainingCompare += compareCount - paired
-		}
-		for parent, compareCount := range compareParents {
-			if _, ok := baseParents[parent]; !ok {
-				remainingCompare += compareCount
-			}
-		}
-		if remainingBase > 0 && remainingCompare > 0 && (remainingBase > 1 || remainingCompare > 1) {
-			isAmbiguous = true
-		}
-		if isAmbiguous {
-			ambiguous++
-		}
-	}
-	return ambiguous
-}
-
-func spanParentCounts(trace normalizedTrace) map[spanLogicalKey]map[spanParentIdentity]int {
-	counts := make(map[spanLogicalKey]map[spanParentIdentity]int)
-	for _, span := range trace.spans {
-		identity := span.identity()
-		parents := counts[identity]
-		if parents == nil {
-			parents = make(map[spanParentIdentity]int)
-			counts[identity] = parents
-		}
-		parents[spanParentIdentity{identity: span.parentIdentity, hasParent: span.hasParent}]++
-	}
-	return counts
 }
 
 func mergeWarnings(warningGroups ...[]Warning) []Warning {

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -3,6 +3,7 @@ package tracediff
 import (
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -15,20 +16,31 @@ var (
 
 // Diff compares base and compare and returns the requested diff format.
 func Diff(base, compare *tempopb.Trace, format Format) (*Result, error) {
-	if base == nil {
-		return nil, fmt.Errorf("base: %w", ErrNilTrace)
-	}
-	if compare == nil {
-		return nil, fmt.Errorf("compare: %w", ErrNilTrace)
-	}
 	if format != FormatTracePatchV0 {
 		return nil, fmt.Errorf("%q: %w", format, ErrUnsupportedFormat)
 	}
+	result, _, _, err := diffTraceInputs(base, compare)
+	return result, err
+}
 
-	baseTrace, baseWarnings := normalizeTrace(base)
-	compareTrace, compareWarnings := normalizeTrace(compare)
+func diffTraceInputs(base, compare *tempopb.Trace) (*Result, normalizedTrace, normalizedTrace, error) {
+	if base == nil {
+		return nil, normalizedTrace{}, normalizedTrace{}, fmt.Errorf("base: %w", ErrNilTrace)
+	}
+	if compare == nil {
+		return nil, normalizedTrace{}, normalizedTrace{}, fmt.Errorf("compare: %w", ErrNilTrace)
+	}
+
+	baseTrace, baseWarnings := normalizeTraceForSide(base, "base")
+	compareTrace, compareWarnings := normalizeTraceForSide(compare, "compare")
 	matched, modified, added, removed := computeDiff(baseTrace, compareTrace)
 	warnings := mergeWarnings(baseWarnings, compareWarnings)
+	if ambiguousGroups := ambiguousSpanGroupCount(baseTrace, compareTrace); ambiguousGroups > 0 {
+		warnings = append(warnings, Warning{
+			Code:    WarningAmbiguousSpanMatch,
+			Message: fmt.Sprintf("%d duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation", ambiguousGroups),
+		})
+	}
 
 	return &Result{
 		Version: VersionTracePatchV0,
@@ -48,7 +60,7 @@ func Diff(base, compare *tempopb.Trace, format Format) (*Result, error) {
 		Added:    added,
 		Removed:  removed,
 		Warnings: warnings,
-	}, nil
+	}, baseTrace, compareTrace, nil
 }
 
 func computeDiff(base, compare normalizedTrace) (int, []ModifiedSpan, []SpanChange, []SpanChange) {
@@ -90,45 +102,74 @@ func computeDiff(base, compare normalizedTrace) (int, []ModifiedSpan, []SpanChan
 // matchSpans decides which base span, if any, matches each compare span.
 func matchSpans(base, compare normalizedTrace) map[string]normalizedSpan {
 	baseSpanByCompareSpanID := make(map[string]normalizedSpan)
-	usedBaseSpanIDs := make(map[string]struct{})
 	baseByID := bucketByIdentity(base)
-
-	for _, compareSpan := range compare.spans {
-		baseSpan, ok := findMatch(baseByID[compareSpan.identity()], compareSpan, usedBaseSpanIDs)
-		if !ok {
-			continue
+	compareByID := bucketByIdentity(compare)
+	for identity, compareCandidates := range compareByID {
+		for compareSpanID, baseSpan := range matchSpanGroup(baseByID[identity], compareCandidates) {
+			baseSpanByCompareSpanID[compareSpanID] = baseSpan
 		}
-		baseSpanByCompareSpanID[compareSpan.spanID] = baseSpan
-		usedBaseSpanIDs[baseSpan.spanID] = struct{}{}
 	}
 	return baseSpanByCompareSpanID
 }
 
-// findMatch receives base spans with the same identity as compareSpan. Parent
-// identity is only a duplicate tie-breaker: if it cannot disambiguate, the first
-// unused candidate preserves the ancestor-insert behavior.
-func findMatch(baseCandidates []normalizedSpan, compareSpan normalizedSpan, usedBaseSpanIDs map[string]struct{}) (normalizedSpan, bool) {
-	var fallback normalizedSpan
-	fallbackSet := false
-	for _, baseSpan := range baseCandidates {
-		if _, ok := usedBaseSpanIDs[baseSpan.spanID]; ok {
-			continue
-		}
-		// Both spans share the same parent identity
-		if sameParentIdentity(baseSpan, compareSpan) {
-			return baseSpan, true
-		}
-		// If not we choose the first one as a fallback
-		if !fallbackSet {
-			fallback = baseSpan
-			fallbackSet = true
+// matchSpanGroup pairs a logical-identity bucket in phases. Matching all
+// unchanged spans before changed spans makes the result independent of sibling
+// order while parent-first phases preserve branch identity where it is known.
+func matchSpanGroup(baseCandidates, compareCandidates []normalizedSpan) map[string]normalizedSpan {
+	matchCount := min(len(baseCandidates), len(compareCandidates))
+	matches := make(map[string]normalizedSpan, matchCount)
+	usedBaseSpanIDs := make(map[string]struct{}, matchCount)
+
+	pair := func(eligible func(normalizedSpan, normalizedSpan) bool) {
+		for _, compareSpan := range compareCandidates {
+			if _, ok := matches[compareSpan.spanID]; ok {
+				continue
+			}
+			for _, baseSpan := range baseCandidates {
+				if _, ok := usedBaseSpanIDs[baseSpan.spanID]; ok || !eligible(baseSpan, compareSpan) {
+					continue
+				}
+				matches[compareSpan.spanID] = baseSpan
+				usedBaseSpanIDs[baseSpan.spanID] = struct{}{}
+				break
+			}
 		}
 	}
-	return fallback, fallbackSet
+
+	pair(func(base, compare normalizedSpan) bool {
+		return sameParentIdentity(base, compare) && spansEquivalentForMatching(base, compare)
+	})
+	pair(func(base, compare normalizedSpan) bool {
+		return sameParentIdentity(base, compare) && base.snapshot.Status == compare.snapshot.Status
+	})
+	pair(sameParentIdentity)
+	pair(spansEquivalentForMatching)
+	pair(func(base, compare normalizedSpan) bool {
+		return base.snapshot.Status == compare.snapshot.Status
+	})
+	pair(func(normalizedSpan, normalizedSpan) bool { return true })
+	return matches
 }
 
 func sameParentIdentity(a, b normalizedSpan) bool {
-	return a.hasParent && b.hasParent && a.parentIdentity == b.parentIdentity
+	return a.hasParent == b.hasParent && (!a.hasParent || a.parentIdentity == b.parentIdentity)
+}
+
+func spansEquivalentForMatching(base, compare normalizedSpan) bool {
+	baseDuration, compareDuration := durationChangeValues(base, compare)
+	if durationChanged(baseDuration, compareDuration) || base.snapshot.Status != compare.snapshot.Status {
+		return false
+	}
+	if len(base.spanAttrs) != len(compare.spanAttrs) {
+		return false
+	}
+	for key, before := range base.spanAttrs {
+		after, ok := compare.spanAttrs[key]
+		if !ok || attributeChanged(key, before, after) {
+			return false
+		}
+	}
+	return true
 }
 
 // bucketByIdentity groups spans by their flat identity.
@@ -141,29 +182,107 @@ func bucketByIdentity(trace normalizedTrace) map[spanLogicalKey][]normalizedSpan
 	return out
 }
 
+type spanParentIdentity struct {
+	identity  spanLogicalKey
+	hasParent bool
+}
+
+// ambiguousSpanGroupCount counts logical identities whose spans cannot be
+// paired uniquely using parent identity. Exact-content matching still avoids
+// spurious changes where possible, but consumers must not treat the remaining
+// pairings as certain instance-to-instance transitions.
+func ambiguousSpanGroupCount(base, compare normalizedTrace) int {
+	baseCounts := spanParentCounts(base)
+	compareCounts := spanParentCounts(compare)
+
+	identities := make(map[spanLogicalKey]struct{}, len(baseCounts)+len(compareCounts))
+	for identity := range baseCounts {
+		identities[identity] = struct{}{}
+	}
+	for identity := range compareCounts {
+		identities[identity] = struct{}{}
+	}
+
+	ambiguous := 0
+	for identity := range identities {
+		baseParents := baseCounts[identity]
+		compareParents := compareCounts[identity]
+		remainingBase := 0
+		remainingCompare := 0
+		isAmbiguous := false
+		for parent, baseCount := range baseParents {
+			compareCount := compareParents[parent]
+			paired := min(baseCount, compareCount)
+			if paired > 0 && (baseCount > 1 || compareCount > 1) {
+				isAmbiguous = true
+			}
+			remainingBase += baseCount - paired
+			remainingCompare += compareCount - paired
+		}
+		for parent, compareCount := range compareParents {
+			if _, ok := baseParents[parent]; !ok {
+				remainingCompare += compareCount
+			}
+		}
+		if remainingBase > 0 && remainingCompare > 0 && (remainingBase > 1 || remainingCompare > 1) {
+			isAmbiguous = true
+		}
+		if isAmbiguous {
+			ambiguous++
+		}
+	}
+	return ambiguous
+}
+
+func spanParentCounts(trace normalizedTrace) map[spanLogicalKey]map[spanParentIdentity]int {
+	counts := make(map[spanLogicalKey]map[spanParentIdentity]int)
+	for _, span := range trace.spans {
+		identity := span.identity()
+		parents := counts[identity]
+		if parents == nil {
+			parents = make(map[spanParentIdentity]int)
+			counts[identity] = parents
+		}
+		parents[spanParentIdentity{identity: span.parentIdentity, hasParent: span.hasParent}]++
+	}
+	return counts
+}
+
 func mergeWarnings(warningGroups ...[]Warning) []Warning {
 	out := make([]Warning, 0)
 	seen := make(map[string]struct{})
 	for _, group := range warningGroups {
 		for _, warning := range group {
-			if _, ok := seen[warning.Code]; ok {
+			key := warningDedupKey(warning)
+			if _, ok := seen[key]; ok {
 				continue
 			}
-			seen[warning.Code] = struct{}{}
+			seen[key] = struct{}{}
 			out = append(out, warning)
 		}
 	}
 	return out
 }
 
+func warningDedupKey(warning Warning) string {
+	switch warning.Code {
+	case WarningInvalidDuration, WarningZeroSpanTrace, WarningDuplicateSpanID:
+		// The message carries the side; keying on it keeps both sides visible.
+		return warning.Code + "\x00" + warning.Message
+	default:
+		return warning.Code
+	}
+}
+
 func fieldChanges(base, compare normalizedSpan) []Change {
 	changes := make([]Change, 0, 2)
-	if !numericClose(float64(base.snapshot.DurationNanos), float64(compare.snapshot.DurationNanos), durationRelTolerance, durationAbsTolerance) {
+	baseDuration, compareDuration := durationChangeValues(base, compare)
+	if durationChanged(baseDuration, compareDuration) {
 		changes = append(changes, Change{
 			Op:     OperationModify,
 			Target: Target{Type: TargetField, Name: FieldDurationNanos},
-			Before: base.snapshot.DurationNanos,
-			After:  compare.snapshot.DurationNanos,
+			Before: baseDuration,
+			After:  compareDuration,
 		})
 	}
 	if base.snapshot.Status != compare.snapshot.Status {
@@ -175,6 +294,30 @@ func fieldChanges(base, compare normalizedSpan) []Change {
 		})
 	}
 	return changes
+}
+
+func durationChangeValues(base, compare normalizedSpan) (any, any) {
+	if !base.durationValid && !compare.durationValid {
+		return nil, nil
+	}
+	var before any
+	if base.durationValid {
+		before = base.snapshot.DurationNanos
+	}
+	var after any
+	if compare.durationValid {
+		after = compare.snapshot.DurationNanos
+	}
+	return before, after
+}
+
+func durationChanged(before, after any) bool {
+	beforeNanos, beforeOK := before.(int64)
+	afterNanos, afterOK := after.(int64)
+	if beforeOK && afterOK {
+		return !numericClose(float64(beforeNanos), float64(afterNanos), durationRelTolerance, durationAbsTolerance)
+	}
+	return !valuesEqual(before, after)
 }
 
 func attributeChanges(base, compare normalizedSpan) []Change {
@@ -189,11 +332,11 @@ func attributeChanges(base, compare normalizedSpan) []Change {
 
 		switch {
 		case !inBase:
-			changes = append(changes, Change{Op: OperationAdd, Target: target, Before: nil, After: after})
+			changes = append(changes, Change{Op: OperationAdd, Target: target, Before: nil, After: sanitizeJSONValue(after)})
 		case !inCompare:
-			changes = append(changes, Change{Op: OperationRemove, Target: target, Before: before, After: nil})
+			changes = append(changes, Change{Op: OperationRemove, Target: target, Before: sanitizeJSONValue(before), After: nil})
 		case attributeChanged(key, before, after):
-			changes = append(changes, Change{Op: OperationModify, Target: target, Before: before, After: after})
+			changes = append(changes, Change{Op: OperationModify, Target: target, Before: sanitizeJSONValue(before), After: sanitizeJSONValue(after)})
 		}
 	}
 	return changes
@@ -230,9 +373,17 @@ func valuesEqual(a, b any) bool {
 				return ai == bi
 			}
 		}
-		af, _ := numericValue(a)
-		bf, ok := numericValue(b)
-		return ok && af == bf
+		af, aOK := numericValue(a)
+		bf, bOK := numericValue(b)
+		if !aOK || !bOK {
+			return false
+		}
+		// NaN != NaN under ==, but two attributes that are both NaN should be
+		// treated as unchanged rather than reported as a spurious modification.
+		if math.IsNaN(af) && math.IsNaN(bf) {
+			return true
+		}
+		return af == bf
 	case []byte:
 		bv, ok := b.([]byte)
 		if !ok || len(av) != len(bv) {

--- a/pkg/model/tracediff/diff_test.go
+++ b/pkg/model/tracediff/diff_test.go
@@ -275,55 +275,6 @@ func TestDiffMatchesDuplicateSpanIdentityByParent(t *testing.T) {
 	assert.Equal(t, []int64{10_000_000}, removedDBDurations)
 }
 
-func TestDiffWarnsAndAvoidsSpuriousDuplicateTransitions(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(first, second tracev1.Status_StatusCode) *tempopb.Trace {
-		return traceWithNamedSpans(
-			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "first", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 10, 20, first),
-			spanForNormalizeTest(traceID, "second", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 30, 40, second),
-		)
-	}
-
-	got, err := Diff(
-		makeTrace(tracev1.Status_STATUS_CODE_OK, tracev1.Status_STATUS_CODE_ERROR),
-		makeTrace(tracev1.Status_STATUS_CODE_ERROR, tracev1.Status_STATUS_CODE_OK),
-		FormatTracePatchV0,
-	)
-	require.NoError(t, err)
-	assert.Empty(t, got.Modified)
-	assert.Contains(t, got.Warnings, Warning{
-		Code:    WarningAmbiguousSpanMatch,
-		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
-	})
-}
-
-func TestDiffMatchesDuplicateMultisetBeforeReportingChanges(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	span := func(id, variant string, start uint64) *tracev1.Span {
-		span := spanForNormalizeTest(traceID, id, "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, start, start+10, tracev1.Status_STATUS_CODE_OK)
-		span.Attributes = append(span.Attributes, stringAttribute("variant", variant))
-		return span
-	}
-	base := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-		span("base-a", "a", 10),
-		span("base-b", "b", 30),
-	)
-	compare := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-		span("compare-c", "c", 10),
-		span("compare-a", "a", 30),
-	)
-
-	got, err := Diff(base, compare, FormatTracePatchV0)
-	require.NoError(t, err)
-	require.Len(t, got.Modified, 1)
-	require.Len(t, got.Modified[0].Changes, 1)
-	assert.Equal(t, "b", got.Modified[0].Changes[0].Before)
-	assert.Equal(t, "c", got.Modified[0].Changes[0].After)
-}
-
 func TestDiffWarnsAndUsesRawHighCardinalitySpanName(t *testing.T) {
 	// The span name embeds a per-request ID. That is an instrumentation problem:
 	// IDs belong in attributes, not span names. The diff should preserve raw-name

--- a/pkg/model/tracediff/diff_test.go
+++ b/pkg/model/tracediff/diff_test.go
@@ -1,7 +1,9 @@
 package tracediff
 
 import (
+	"encoding/json"
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -53,7 +55,10 @@ func TestDiffEmptyTracesReturnsEmptyResult(t *testing.T) {
 		Modified: []ModifiedSpan{},
 		Added:    []SpanChange{},
 		Removed:  []SpanChange{},
-		Warnings: []Warning{},
+		Warnings: []Warning{
+			{Code: WarningZeroSpanTrace, Message: "base trace contains no spans; comparison has no span matches"},
+			{Code: WarningZeroSpanTrace, Message: "compare trace contains no spans; comparison has no span matches"},
+		},
 	}, got)
 }
 
@@ -270,6 +275,55 @@ func TestDiffMatchesDuplicateSpanIdentityByParent(t *testing.T) {
 	assert.Equal(t, []int64{10_000_000}, removedDBDurations)
 }
 
+func TestDiffWarnsAndAvoidsSpuriousDuplicateTransitions(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(first, second tracev1.Status_StatusCode) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "first", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 10, 20, first),
+			spanForNormalizeTest(traceID, "second", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 30, 40, second),
+		)
+	}
+
+	got, err := Diff(
+		makeTrace(tracev1.Status_STATUS_CODE_OK, tracev1.Status_STATUS_CODE_ERROR),
+		makeTrace(tracev1.Status_STATUS_CODE_ERROR, tracev1.Status_STATUS_CODE_OK),
+		FormatTracePatchV0,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, got.Modified)
+	assert.Contains(t, got.Warnings, Warning{
+		Code:    WarningAmbiguousSpanMatch,
+		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
+	})
+}
+
+func TestDiffMatchesDuplicateMultisetBeforeReportingChanges(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	span := func(id, variant string, start uint64) *tracev1.Span {
+		span := spanForNormalizeTest(traceID, id, "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, start, start+10, tracev1.Status_STATUS_CODE_OK)
+		span.Attributes = append(span.Attributes, stringAttribute("variant", variant))
+		return span
+	}
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		span("base-a", "a", 10),
+		span("base-b", "b", 30),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		span("compare-c", "c", 10),
+		span("compare-a", "a", 30),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+	require.Len(t, got.Modified, 1)
+	require.Len(t, got.Modified[0].Changes, 1)
+	assert.Equal(t, "b", got.Modified[0].Changes[0].Before)
+	assert.Equal(t, "c", got.Modified[0].Changes[0].After)
+}
+
 func TestDiffWarnsAndUsesRawHighCardinalitySpanName(t *testing.T) {
 	// The span name embeds a per-request ID. That is an instrumentation problem:
 	// IDs belong in attributes, not span names. The diff should preserve raw-name
@@ -342,6 +396,61 @@ func TestDiffReportsModifiedSpanFields(t *testing.T) {
 			After:  "error",
 		},
 	}, got.Modified[0].Changes)
+}
+
+func TestDiffReportsInvalidDurationTransitionsWithNull(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(&tracev1.Span{
+		TraceId:           traceID,
+		SpanId:            []byte("root"),
+		Name:              "POST /checkout",
+		Kind:              tracev1.Span_SPAN_KIND_SERVER,
+		StartTimeUnixNano: 0,
+		EndTimeUnixNano:   (normalizeTestTimeOffsetMs + 250) * 1_000_000,
+		Attributes:        []*commonv1.KeyValue{stringAttribute("service.name", "checkout")},
+		Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+	})
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+
+	assert.Equal(t, Stats{
+		SpanCountA:    1,
+		SpanCountB:    1,
+		MatchedSpans:  1,
+		ModifiedSpans: 1,
+		FieldChanges:  1,
+	}, got.Stats)
+	require.Len(t, got.Modified, 1)
+	assert.Equal(t, []Change{
+		{
+			Op:     OperationModify,
+			Target: Target{Type: TargetField, Name: "duration_nanos"},
+			Before: int64(100_000_000),
+			After:  nil,
+		},
+	}, got.Modified[0].Changes)
+	require.Len(t, got.Warnings, 1)
+	assert.Equal(t, WarningInvalidDuration, got.Warnings[0].Code)
+	assert.Contains(t, got.Warnings[0].Message, "compare trace")
+}
+
+func TestDiffKeepsInvalidAddedSpanDurationCompatible(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	root := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	invalid := spanForNormalizeTest(traceID, "child", "root", "checkout", "invalid", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK)
+	invalid.StartTimeUnixNano = 0
+
+	got, err := Diff(traceWithNamedSpans(root), traceWithNamedSpans(root, invalid), FormatTracePatchV0)
+	require.NoError(t, err)
+	require.Len(t, got.Added, 1)
+	assert.Zero(t, got.Added[0].Span.DurationNanos)
+	data, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"duration_nanos":0`)
 }
 
 func TestDiffReportsSpanAttributeChanges(t *testing.T) {
@@ -420,6 +529,42 @@ func TestDiffReportsArraySpanAttributeChanges(t *testing.T) {
 			After:  []any{"a", "c"},
 		},
 	}, got.Modified[0].Changes)
+}
+
+func TestDiffTreatsIdenticalNaNAttributesAsUnchanged(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeSpan := func() *tracev1.Span {
+		span := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+		span.Attributes = append(span.Attributes, doubleAttribute("score", math.NaN()))
+		return span
+	}
+
+	got, err := Diff(traceWithNamedSpans(makeSpan()), traceWithNamedSpans(makeSpan()), FormatTracePatchV0)
+	require.NoError(t, err)
+	// NaN != NaN under ==, but two attributes that are both NaN must not be
+	// reported as a spurious modification.
+	assert.Equal(t, 0, got.Stats.AttributeChanges)
+	assert.Empty(t, got.Modified)
+}
+
+func TestDiffReportsNaNToValueAttributeChange(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	baseSpan := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	baseSpan.Attributes = append(baseSpan.Attributes, doubleAttribute("latency", math.NaN()))
+	compareSpan := spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	compareSpan.Attributes = append(compareSpan.Attributes, doubleAttribute("latency", 1.5))
+
+	got, err := Diff(traceWithNamedSpans(baseSpan), traceWithNamedSpans(compareSpan), FormatTracePatchV0)
+	require.NoError(t, err)
+	// A NaN that becomes a finite value is a real change and must be reported.
+	assert.Equal(t, 1, got.Stats.AttributeChanges)
+	require.Len(t, got.Modified, 1)
+	require.Len(t, got.Modified[0].Changes, 1)
+	assert.Equal(t, OperationModify, got.Modified[0].Changes[0].Op)
+	assert.Equal(t, "latency", got.Modified[0].Changes[0].Target.Key)
+	assert.Equal(t, "NaN", got.Modified[0].Changes[0].Before)
+	_, err = json.Marshal(got)
+	require.NoError(t, err)
 }
 
 func traceWithSpans(traceID []byte, spanIDs ...[]byte) *tempopb.Trace {

--- a/pkg/model/tracediff/normalize.go
+++ b/pkg/model/tracediff/normalize.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
+	"strings"
 
 	modeltrace "github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -26,6 +28,9 @@ type normalizedSpan struct {
 	hasParent      bool
 	ref            SpanRef
 	snapshot       SpanSnapshot
+	startUnixNano  uint64
+	endUnixNano    uint64
+	durationValid  bool
 	spanAttrs      map[string]any
 }
 
@@ -41,12 +46,23 @@ type spanWithResource struct {
 }
 
 func normalizeTrace(trace *tempopb.Trace) (normalizedTrace, []Warning) {
+	return normalizeTraceForSide(trace, "")
+}
+
+func normalizeTraceForSide(trace *tempopb.Trace, side string) (normalizedTrace, []Warning) {
 	if trace == nil {
 		return normalizedTrace{}, nil
 	}
 
 	spans, meta := flattenSpans(trace)
 	warnings := highCardinalitySpanNameWarnings(spans)
+	warnings = append(warnings, invalidDurationWarnings(spans, side)...)
+	if len(spans) == 0 {
+		warnings = append(warnings, Warning{
+			Code:    WarningZeroSpanTrace,
+			Message: fmt.Sprintf("%s contains no spans; comparison has no span matches", sideTraceLabel(side)),
+		})
+	}
 	byID := make(map[string]spanWithResource, len(spans))
 	children := map[string][]spanWithResource{}
 	for _, span := range spans {
@@ -70,8 +86,23 @@ func normalizeTrace(trace *tempopb.Trace) (normalizedTrace, []Warning) {
 	// First assign paths from normal roots and orphans.
 	rootIndex := assignPaths(&out, children, children[""], nil, spanLogicalKey{}, false, 0, visited)
 	// Then assign remaining cycle-only/disconnected spans as extra roots.
-	assignPaths(&out, children, spans, nil, spanLogicalKey{}, false, rootIndex, visited)
+	remaining := append([]spanWithResource(nil), spans...)
+	sortSpans(remaining)
+	assignPaths(&out, children, remaining, nil, spanLogicalKey{}, false, rootIndex, visited)
+	if dropped := meta.SpanCount - len(out.spans); dropped > 0 {
+		warnings = append(warnings, Warning{
+			Code:    WarningDuplicateSpanID,
+			Message: fmt.Sprintf("%s has %d span(s) with duplicate span IDs; duplicates are ignored by the diff and counts may disagree", sideTraceLabel(side), dropped),
+		})
+	}
 	return out, warnings
+}
+
+func sideTraceLabel(side string) string {
+	if side == "" {
+		return "trace"
+	}
+	return side + " trace"
 }
 
 func flattenSpans(trace *tempopb.Trace) ([]spanWithResource, TraceMeta) {
@@ -128,6 +159,9 @@ func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey,
 		parentIdentity: parentIdentity,
 		hasParent:      hasParent,
 		ref:            ref,
+		startUnixNano:  span.span.GetStartTimeUnixNano(),
+		endUnixNano:    span.span.GetEndTimeUnixNano(),
+		durationValid:  hasValidDuration(span.span),
 		spanAttrs:      attributesMap(span.span.GetAttributes()),
 		snapshot: SpanSnapshot{
 			Path:          path,
@@ -138,6 +172,52 @@ func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey,
 			Status:        statusToString(span.span.GetStatus()),
 		},
 	}
+}
+
+func invalidDurationWarnings(spans []spanWithResource, side string) []Warning {
+	invalid := make([]spanLogicalKey, 0)
+	for _, span := range spans {
+		if hasValidDuration(span.span) {
+			continue
+		}
+		invalid = append(invalid, logicalKey(span))
+	}
+	if len(invalid) == 0 {
+		return nil
+	}
+
+	examples := invalidDurationExamples(invalid, 3)
+	message := fmt.Sprintf(
+		"%s has %d span(s) with unset or invalid duration; matched duration changes use null on the invalid side; examples: %s",
+		sideTraceLabel(side),
+		len(invalid),
+		examples,
+	)
+	return []Warning{{Code: WarningInvalidDuration, Message: message}}
+}
+
+func invalidDurationExamples(invalid []spanLogicalKey, limit int) string {
+	invalid = append([]spanLogicalKey(nil), invalid...)
+	sort.Slice(invalid, func(i, j int) bool {
+		if invalid[i].service != invalid[j].service {
+			return invalid[i].service < invalid[j].service
+		}
+		if invalid[i].name != invalid[j].name {
+			return invalid[i].name < invalid[j].name
+		}
+		return invalid[i].kind < invalid[j].kind
+	})
+	if len(invalid) < limit {
+		limit = len(invalid)
+	}
+	examples := make([]string, 0, limit)
+	for _, key := range invalid[:limit] {
+		examples = append(examples, fmt.Sprintf("%q service %q kind %q", key.name, key.service, key.kind))
+	}
+	if len(invalid) > limit {
+		examples = append(examples, fmt.Sprintf("and %d more", len(invalid)-limit))
+	}
+	return fmt.Sprintf("[%s]", strings.Join(examples, "; "))
 }
 
 func logicalKey(span spanWithResource) spanLogicalKey {
@@ -243,10 +323,19 @@ func anyValue(value *commonv1.AnyValue) any {
 }
 
 func durationNanos(span *tracev1.Span) int64 {
-	if span.GetEndTimeUnixNano() < span.GetStartTimeUnixNano() {
+	if !hasValidDuration(span) {
 		return 0
 	}
 	return int64(span.GetEndTimeUnixNano() - span.GetStartTimeUnixNano())
+}
+
+func hasValidDuration(span *tracev1.Span) bool {
+	start := span.GetStartTimeUnixNano()
+	end := span.GetEndTimeUnixNano()
+	// A start of 0 is unset (OTLP starts are non-zero); treating it as the epoch
+	// would report a multi-decade duration against a real end. An end before the
+	// start or a duration that cannot fit in int64 is likewise unusable.
+	return start > 0 && end >= start && end-start <= math.MaxInt64
 }
 
 func statusToString(status *tracev1.Status) string {

--- a/pkg/model/tracediff/normalize_test.go
+++ b/pkg/model/tracediff/normalize_test.go
@@ -1,6 +1,7 @@
 package tracediff
 
 import (
+	"math"
 	"testing"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -113,6 +114,8 @@ func traceForNormalizeTest() *tempopb.Trace {
 	}
 }
 
+const normalizeTestTimeOffsetMs = uint64(1_700_000_000_000)
+
 func spanForNormalizeTest(traceID []byte, spanID, parentID, service, name string, kind tracev1.Span_SpanKind, start, end uint64, status tracev1.Status_StatusCode) *tracev1.Span {
 	return &tracev1.Span{
 		TraceId:           traceID,
@@ -120,8 +123,8 @@ func spanForNormalizeTest(traceID []byte, spanID, parentID, service, name string
 		ParentSpanId:      []byte(parentID),
 		Name:              name,
 		Kind:              kind,
-		StartTimeUnixNano: start * 1_000_000,
-		EndTimeUnixNano:   end * 1_000_000,
+		StartTimeUnixNano: (normalizeTestTimeOffsetMs + start) * 1_000_000,
+		EndTimeUnixNano:   (normalizeTestTimeOffsetMs + end) * 1_000_000,
 		Attributes: []*commonv1.KeyValue{
 			stringAttribute("service.name", service),
 		},
@@ -157,6 +160,48 @@ func TestSpanNameHasHighCardinalityToken(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, spanNameHasHighCardinalityToken(tc.in))
+		})
+	}
+}
+
+func TestInvalidDurationExamplesAreDeterministic(t *testing.T) {
+	invalid := []spanLogicalKey{
+		{service: "z", name: "beta", kind: "client"},
+		{service: "a", name: "zeta", kind: "server"},
+		{service: "a", name: "alpha", kind: "producer"},
+		{service: "a", name: "alpha", kind: "consumer"},
+	}
+
+	assert.Equal(
+		t,
+		`["alpha" service "a" kind "consumer"; "alpha" service "a" kind "producer"; "zeta" service "a" kind "server"; and 1 more]`,
+		invalidDurationExamples(invalid, 3),
+	)
+}
+
+func TestDurationNanos(t *testing.T) {
+	// A realistic (~2023) start in unix nanos; an unset (0) start against an end
+	// this large would report ~decades if not guarded.
+	const realisticStart = uint64(1_700_000_000_000_000_000)
+	tests := []struct {
+		name  string
+		start uint64
+		end   uint64
+		want  int64
+	}{
+		{name: "normal span", start: realisticStart, end: realisticStart + 100_000_000, want: 100_000_000},
+		{name: "zero-length span", start: realisticStart, end: realisticStart, want: 0},
+		{name: "unset start with realistic end", start: 0, end: realisticStart, want: 0},
+		{name: "unset start with small end", start: 0, end: 90_000_000, want: 0},
+		{name: "both unset", start: 0, end: 0, want: 0},
+		{name: "end before start", start: realisticStart + 100, end: realisticStart, want: 0},
+		{name: "maximum int64 duration", start: 1, end: uint64(math.MaxInt64) + 1, want: math.MaxInt64},
+		{name: "duration exceeds int64", start: 1, end: uint64(math.MaxInt64) + 2, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := &tracev1.Span{StartTimeUnixNano: tt.start, EndTimeUnixNano: tt.end}
+			assert.Equal(t, tt.want, durationNanos(span))
 		})
 	}
 }

--- a/pkg/model/tracediff/numeric.go
+++ b/pkg/model/tracediff/numeric.go
@@ -59,6 +59,12 @@ var numericFuzzyAttributes = map[string]struct{}{
 // numericClose reports whether a and b are equal within the given relative and
 // absolute tolerances: |a-b| <= absTol + relTol*max(|a|, |b|).
 func numericClose(a, b, relTol, absTol float64) bool {
+	if math.IsNaN(a) || math.IsNaN(b) {
+		return math.IsNaN(a) && math.IsNaN(b)
+	}
+	if math.IsInf(a, 0) || math.IsInf(b, 0) {
+		return a == b
+	}
 	return math.Abs(a-b) <= absTol+relTol*math.Max(math.Abs(a), math.Abs(b))
 }
 

--- a/pkg/model/tracediff/numeric_test.go
+++ b/pkg/model/tracediff/numeric_test.go
@@ -1,6 +1,7 @@
 package tracediff
 
 import (
+	"math"
 	"testing"
 
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
@@ -35,6 +36,11 @@ func TestNumericClose(t *testing.T) {
 		{name: "sign flip", a: -100, b: 100, relTol: 0.05, want: false},
 		{name: "zero tolerances reduce to exact equal", a: 5, b: 5, want: true},
 		{name: "zero tolerances reduce to exact unequal", a: 5, b: 6, want: false},
+		{name: "NaNs are equal", a: math.NaN(), b: math.NaN(), relTol: 0.05, want: true},
+		{name: "NaN differs from finite", a: math.NaN(), b: 1, relTol: 0.05, want: false},
+		{name: "same infinities are equal", a: math.Inf(1), b: math.Inf(1), relTol: 0.05, want: true},
+		{name: "opposite infinities differ", a: math.Inf(1), b: math.Inf(-1), relTol: 0.05, want: false},
+		{name: "infinity differs from finite", a: math.Inf(1), b: 1, relTol: 0.05, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -102,6 +108,8 @@ func TestAttributeChanged(t *testing.T) {
 		{name: "non-allow-listed numeric compared exactly", key: "custom.count", before: int64(1000), after: int64(1001), want: true},
 		{name: "non-allow-listed int vs float equal value", key: "custom.count", before: int64(80), after: 80.0, want: false},
 		{name: "status code compared exactly", key: "http.response.status_code", before: int64(200), after: int64(201), want: true},
+		{name: "allow-listed NaNs are unchanged", key: testAttrFileSize, before: math.NaN(), after: math.NaN(), want: false},
+		{name: "allow-listed infinity to finite changes", key: testAttrFileSize, before: math.Inf(1), after: 100.0, want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/model/tracediff/summary.go
+++ b/pkg/model/tracediff/summary.go
@@ -1,10 +1,6 @@
 package tracediff
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
-	"fmt"
-	"hash"
 	"maps"
 	"math"
 	"sort"
@@ -13,23 +9,12 @@ import (
 )
 
 const (
-	signalIncreased      = "increased"
-	signalDecreased      = "decreased"
-	signalUnchanged      = "unchanged"
-	patternStateAdded    = "added"
-	patternStateRemoved  = "removed"
-	patternStateModified = "modified"
-
-	// patternCap bounds the patterns section. Overflow is disclosed in
-	// patternsTruncated instead of silently dropped: a bounded section must
-	// never be the only carrier of a fact class, and truncation without
-	// disclosure lies by omission.
-	patternCap = 20
-	// patternSampleSpans bounds the sample span refs carried per pattern.
-	patternSampleSpans = 3
+	signalIncreased = "increased"
+	signalDecreased = "decreased"
+	signalUnchanged = "unchanged"
 	// Aggregate drift significance: a service counts as drifted when the
-	// absolute per-service span-work delta is at least
-	// max(driftMinNanos, 5% of base work). This is what lets the
+	// absolute per-service sum-of-span-durations delta is at least
+	// max(driftMinNanos, 5% of the base sum). This is what lets the
 	// summary attribute systemic sub-tolerance drift (every span slightly
 	// slower) that the per-span patch tolerance filters out entirely.
 	driftMinNanos      = int64(1_000_000)
@@ -38,7 +23,7 @@ const (
 
 // SummaryResult is the trace-summary-v0-native document: a compact
 // triage/localization summary of a trace diff. The envelope, signals, and
-// per-service work deltas are computed from the normalized traces — not from
+// per-service summed-duration deltas are computed from the normalized traces — not from
 // the patch — because whole-trace facts (the latency envelope, the topology
 // signature, sub-tolerance drift) are not derivable from the change list.
 // Matcher-derived counts complement them: net-zero churn on unambiguous spans
@@ -52,26 +37,22 @@ type SummaryResult struct {
 	Stats    SummaryStats `json:"stats"`
 	Warnings []Warning    `json:"warnings,omitempty"`
 	// ChangedServices contains all services with matcher changes, significant
-	// span-work drift, or structural changes.
+	// sum-of-span-durations drift, or structural changes.
 	ChangedServices []string `json:"changedServices"`
 	// Services contains rollups for services with matcher changes or significant
-	// span-work drift. Structure-only services remain in ChangedServices.
+	// sum-of-span-durations drift. Structure-only services remain in ChangedServices.
 	Services []ServiceRollup `json:"services"`
-	// Patterns groups identical span changes into exemplars, capped at
-	// patternCap with explicit truncation disclosure.
-	Patterns          []Pattern          `json:"patterns"`
-	PatternsTruncated *PatternsTruncated `json:"patternsTruncated,omitempty"`
 }
 
 // Signals are factual direction labels. They intentionally avoid declaring that
 // a change is good or bad; callers and LLMs can interpret the directions in
 // context.
 type Signals struct {
-	TraceLatency string `json:"traceLatency"`
-	SpanWork     string `json:"spanWork"`
-	Errors       string `json:"errors"`
-	SpanCount    string `json:"spanCount"`
-	Structure    string `json:"structure"`
+	TraceLatency    string `json:"traceLatency"`
+	SumSpanDuration string `json:"sumSpanDuration"`
+	Errors          string `json:"errors"`
+	SpanCount       string `json:"spanCount"`
+	Structure       string `json:"structure"`
 }
 
 // TraceSummary describes one side of the comparison.
@@ -86,9 +67,9 @@ type TraceSummary struct {
 	// end >= start). It is a proxy for end-to-end latency and is 0 when no span
 	// has a valid duration.
 	DurationMs int64 `json:"durationMs"`
-	// SpanWorkMs is the sum of every span's individual duration, which can exceed
+	// SumSpanDurationMs is the sum of every span's individual duration, which can exceed
 	// DurationMs when spans run concurrently. Invalid spans contribute zero.
-	SpanWorkMs int64 `json:"spanWorkMs"`
+	SumSpanDurationMs int64 `json:"sumSpanDurationMs"`
 }
 
 // TrustSummary reports span matching coverage. It does not measure whether
@@ -107,71 +88,30 @@ type TrustSummary struct {
 type SummaryStats struct {
 	// TraceLatencyDeltaMs is the difference in the wall-clock envelope (see
 	// TraceSummary.DurationMs), not the difference in any single root span.
-	TraceLatencyDeltaMs int64 `json:"traceLatencyDeltaMs"`
-	SpanWorkDeltaMs     int64 `json:"spanWorkDeltaMs"`
-	SpanCountDelta      int   `json:"spanCountDelta"`
-	ErrorSpanDelta      int   `json:"errorSpanDelta"`
-	MatchedSpans        int   `json:"matchedSpans"`
-	ModifiedSpans       int   `json:"modifiedSpans"`
-	AddedSpans          int   `json:"addedSpans"`
-	RemovedSpans        int   `json:"removedSpans"`
-	FieldChanges        int   `json:"fieldChanges"`
-	AttributeChanges    int   `json:"attributeChanges"`
+	TraceLatencyDeltaMs    int64 `json:"traceLatencyDeltaMs"`
+	SumSpanDurationDeltaMs int64 `json:"sumSpanDurationDeltaMs"`
+	SpanCountDelta         int   `json:"spanCountDelta"`
+	ErrorSpanDelta         int   `json:"errorSpanDelta"`
+	MatchedSpans           int   `json:"matchedSpans"`
+	ModifiedSpans          int   `json:"modifiedSpans"`
+	AddedSpans             int   `json:"addedSpans"`
+	RemovedSpans           int   `json:"removedSpans"`
+	FieldChanges           int   `json:"fieldChanges"`
+	AttributeChanges       int   `json:"attributeChanges"`
 }
 
-// ServiceRollup summarizes one changed service. SpanWorkDeltaMs is computed
+// ServiceRollup summarizes one changed service. SumSpanDurationDeltaMs is computed
 // from raw nanoseconds before final millisecond conversion; count columns come
 // from the matcher so unambiguous net-zero churn remains visible.
 type ServiceRollup struct {
-	Name            string `json:"name"`
-	SpanWorkDeltaMs int64  `json:"spanWorkDeltaMs"`
-	Modified        int    `json:"modified"`
-	Added           int    `json:"added"`
-	Removed         int    `json:"removed"`
-	NewErrors       int    `json:"newErrors"`
-	ResolvedErrors  int    `json:"resolvedErrors"`
+	Name                   string `json:"name"`
+	SumSpanDurationDeltaMs int64  `json:"sumSpanDurationDeltaMs"`
+	Modified               int    `json:"modified"`
+	Added                  int    `json:"added"`
+	Removed                int    `json:"removed"`
+	NewErrors              int    `json:"newErrors"`
+	ResolvedErrors         int    `json:"resolvedErrors"`
 }
-
-// PatternSpan is the logical identity a pattern groups by.
-type PatternSpan struct {
-	Service string `json:"service"`
-	Name    string `json:"name"`
-	Kind    string `json:"kind"`
-}
-
-// Pattern is an exemplar of one repeated change shape: identical changes on
-// spans with the same logical identity collapse into a single entry with a
-// count, a bounded set of sample refs, and the exemplar's rendered changes.
-// Duration changes group by direction, not exact values, so per-span jitter
-// does not defeat the compression.
-type Pattern struct {
-	State       string      `json:"state"`
-	Span        PatternSpan `json:"span"`
-	Count       int         `json:"count"`
-	SampleSpans []SpanRef   `json:"sampleSpans"`
-	// Changes is the exemplar span's rendered change list; durations are
-	// rendered in milliseconds for readability.
-	Changes         []Change            `json:"changes,omitempty"`
-	DurationDeltaMs *DurationDeltaStats `json:"durationDeltaMs,omitempty"`
-}
-
-// DurationDeltaStats summarizes the duration deltas across all spans grouped
-// into one pattern.
-type DurationDeltaStats struct {
-	Min   int64 `json:"min"`
-	Max   int64 `json:"max"`
-	Total int64 `json:"total"`
-}
-
-// PatternsTruncated discloses how much the pattern cap dropped.
-type PatternsTruncated struct {
-	Patterns int `json:"patterns"`
-	Spans    int `json:"spans"`
-}
-
-// fieldDurationMs is the rendered Target.Name for duration changes inside
-// patterns (the patch itself always uses FieldDurationNanos).
-const fieldDurationMs = "duration_ms"
 
 // Summarize compares base and compare and returns the trace-summary-v0-native
 // document built from the normalized traces plus the trace-patch-v0 diff.
@@ -205,22 +145,21 @@ func Summarize(base, compare *tempopb.Trace) (*SummaryResult, error) {
 		},
 	}
 	result.Stats.TraceLatencyDeltaMs = deltaUint64Millis(compareDurations.envelopeNanos, baseDurations.envelopeNanos)
-	result.Stats.SpanWorkDeltaMs = nanosToMillis(compareDurations.workNanos - baseDurations.workNanos)
+	result.Stats.SumSpanDurationDeltaMs = nanosToMillis(compareDurations.sumSpanDurationNanos - baseDurations.sumSpanDurationNanos)
 	result.Signals = summarySignals(result.Stats, len(structureChanged) > 0)
 	result.ChangedServices, result.Services = buildServiceSections(
 		patch,
-		serviceWorkNanos(baseTrace),
-		serviceWorkNanos(compareTrace),
+		serviceSumSpanDurationNanos(baseTrace),
+		serviceSumSpanDurationNanos(compareTrace),
 		structureChanged,
 	)
-	result.Patterns, result.PatternsTruncated = buildPatterns(patch)
 	result.Warnings = patch.Warnings
 	return result, nil
 }
 
 type traceDurationAggregate struct {
-	envelopeNanos uint64
-	workNanos     int64
+	envelopeNanos        uint64
+	sumSpanDurationNanos int64
 }
 
 // summarizeNormalizedTrace keeps nanoseconds until cross-trace deltas have been
@@ -246,7 +185,7 @@ func summarizeNormalizedTrace(trace normalizedTrace) (TraceSummary, traceDuratio
 		if span.durationValid && end > lastEnd {
 			lastEnd = end
 		}
-		durations.workNanos += span.snapshot.DurationNanos
+		durations.sumSpanDurationNanos += span.snapshot.DurationNanos
 		if isErrorStatus(span.snapshot.Status) {
 			summary.ErrorSpanCount++
 		}
@@ -254,7 +193,7 @@ func summarizeNormalizedTrace(trace normalizedTrace) (TraceSummary, traceDuratio
 	if haveStart && lastEnd >= firstStart {
 		durations.envelopeNanos = lastEnd - firstStart
 	}
-	summary.SpanWorkMs = nanosToMillis(durations.workNanos)
+	summary.SumSpanDurationMs = nanosToMillis(durations.sumSpanDurationNanos)
 	summary.DurationMs = int64(durations.envelopeNanos / 1_000_000)
 	if len(trace.spans) > 0 {
 		summary.RootService = trace.spans[0].ref.Service
@@ -318,11 +257,11 @@ func summarySignals(stats SummaryStats, structureChanged bool) Signals {
 		structure = "changed"
 	}
 	return Signals{
-		TraceLatency: signalFromDelta(stats.TraceLatencyDeltaMs),
-		SpanWork:     signalFromDelta(stats.SpanWorkDeltaMs),
-		Errors:       signalFromDelta(int64(stats.ErrorSpanDelta)),
-		SpanCount:    signalFromDelta(int64(stats.SpanCountDelta)),
-		Structure:    structure,
+		TraceLatency:    signalFromDelta(stats.TraceLatencyDeltaMs),
+		SumSpanDuration: signalFromDelta(stats.SumSpanDurationDeltaMs),
+		Errors:          signalFromDelta(int64(stats.ErrorSpanDelta)),
+		SpanCount:       signalFromDelta(int64(stats.SpanCountDelta)),
+		Structure:       structure,
 	}
 }
 
@@ -337,15 +276,15 @@ func signalFromDelta(delta int64) string {
 	}
 }
 
-// serviceWorkNanos sums span durations per service over a whole normalized
+// serviceSumSpanDurationNanos sums span durations per service over a whole normalized
 // trace. Unlike the patch, this sees every span, so systemic drift below the
 // per-span tolerance still accumulates here.
-func serviceWorkNanos(trace normalizedTrace) map[string]int64 {
-	work := make(map[string]int64)
+func serviceSumSpanDurationNanos(trace normalizedTrace) map[string]int64 {
+	sums := make(map[string]int64)
 	for _, span := range trace.spans {
-		work[serviceOrUnknown(span.ref.Service)] += span.snapshot.DurationNanos
+		sums[serviceOrUnknown(span.ref.Service)] += span.snapshot.DurationNanos
 	}
-	return work
+	return sums
 }
 
 type rankedServiceRollup struct {
@@ -355,14 +294,14 @@ type rankedServiceRollup struct {
 // buildServiceSections follows the native reference contract: changedServices
 // is complete, while service rollups contain matcher churn and significant
 // trace-derived drift. Structure-only changes remain in changedServices.
-func buildServiceSections(patch *Result, baseWork, compareWork map[string]int64, structureChanged map[string]struct{}) ([]string, []ServiceRollup) {
+func buildServiceSections(patch *Result, baseDurationSums, compareDurationSums map[string]int64, structureChanged map[string]struct{}) ([]string, []ServiceRollup) {
 	counts := matcherRollupCounts(patch)
 
-	services := make(map[string]struct{}, len(baseWork)+len(compareWork))
-	for service := range baseWork {
+	services := make(map[string]struct{}, len(baseDurationSums)+len(compareDurationSums))
+	for service := range baseDurationSums {
 		services[service] = struct{}{}
 	}
-	for service := range compareWork {
+	for service := range compareDurationSums {
 		services[service] = struct{}{}
 	}
 
@@ -376,16 +315,16 @@ func buildServiceSections(patch *Result, baseWork, compareWork map[string]int64,
 
 	rollups := make([]rankedServiceRollup, 0, len(services))
 	for service := range services {
-		deltaNanos := compareWork[service] - baseWork[service]
+		deltaNanos := compareDurationSums[service] - baseDurationSums[service]
 		count := counts[service]
-		drifted := driftSignificant(baseWork[service], deltaNanos)
+		drifted := driftSignificant(baseDurationSums[service], deltaNanos)
 		if drifted {
 			changed[service] = struct{}{}
 		} else if count == nil {
 			continue
 		}
 		rollup := ServiceRollup{Name: service}
-		rollup.SpanWorkDeltaMs = nanosToMillis(deltaNanos)
+		rollup.SumSpanDurationDeltaMs = nanosToMillis(deltaNanos)
 		if count != nil {
 			rollup.Modified = count.Modified
 			rollup.Added = count.Added
@@ -397,8 +336,8 @@ func buildServiceSections(patch *Result, baseWork, compareWork map[string]int64,
 	}
 	sort.SliceStable(rollups, func(i, j int) bool {
 		a, b := rollups[i].rollup, rollups[j].rollup
-		if absInt64(a.SpanWorkDeltaMs) != absInt64(b.SpanWorkDeltaMs) {
-			return absInt64(a.SpanWorkDeltaMs) > absInt64(b.SpanWorkDeltaMs)
+		if absInt64(a.SumSpanDurationDeltaMs) != absInt64(b.SumSpanDurationDeltaMs) {
+			return absInt64(a.SumSpanDurationDeltaMs) > absInt64(b.SumSpanDurationDeltaMs)
 		}
 		if a.NewErrors != b.NewErrors {
 			return a.NewErrors > b.NewErrors
@@ -481,266 +420,6 @@ func matcherRollupCounts(patch *Result) map[string]*ServiceRollup {
 	return counts
 }
 
-type patternInput struct {
-	state   string
-	ref     SpanRef
-	changes []Change
-}
-
-type patternAccumulator struct {
-	input           patternInput
-	count           int
-	samples         []SpanRef
-	durationSet     bool
-	durationMinMs   int64
-	durationMaxMs   int64
-	durationTotalNs int64
-}
-
-// buildPatterns follows the native reference: collect exact pattern counts,
-// rank by frequency, and cap only the rendered pattern section.
-func buildPatterns(patch *Result) ([]Pattern, *PatternsTruncated) {
-	accumulators := make(map[[sha256.Size]byte]*patternAccumulator)
-	order := make([][sha256.Size]byte, 0, len(patch.Modified)+len(patch.Added)+len(patch.Removed))
-	forEachPatternInput(patch, func(input patternInput) {
-		key := patternKey(input)
-		acc := accumulators[key]
-		if acc == nil {
-			acc = &patternAccumulator{input: input, samples: make([]SpanRef, 0, patternSampleSpans)}
-			accumulators[key] = acc
-			order = append(order, key)
-		}
-		acc.count++
-		if len(acc.samples) < patternSampleSpans {
-			acc.samples = append(acc.samples, input.ref)
-		}
-		if delta, ok := patternDurationDeltaNanos(input); ok {
-			deltaMs := nanosToMillis(delta)
-			if !acc.durationSet {
-				acc.durationSet = true
-				acc.durationMinMs = deltaMs
-				acc.durationMaxMs = deltaMs
-			}
-			acc.durationMinMs = min(acc.durationMinMs, deltaMs)
-			acc.durationMaxMs = max(acc.durationMaxMs, deltaMs)
-			acc.durationTotalNs += delta
-		}
-	})
-
-	ranked := make([]*patternAccumulator, 0, len(order))
-	for _, key := range order {
-		ranked = append(ranked, accumulators[key])
-	}
-	sort.SliceStable(ranked, func(i, j int) bool {
-		a, b := ranked[i], ranked[j]
-		if a.count != b.count {
-			return a.count > b.count
-		}
-		if a.input.state != b.input.state {
-			return a.input.state < b.input.state
-		}
-		if a.input.ref.Service != b.input.ref.Service {
-			return a.input.ref.Service < b.input.ref.Service
-		}
-		if a.input.ref.Name != b.input.ref.Name {
-			return a.input.ref.Name < b.input.ref.Name
-		}
-		return false
-	})
-
-	var patternTruncated *PatternsTruncated
-	if len(ranked) > patternCap {
-		patternTruncated = &PatternsTruncated{Patterns: len(ranked) - patternCap}
-		for _, acc := range ranked[patternCap:] {
-			patternTruncated.Spans += acc.count
-		}
-		ranked = ranked[:patternCap]
-	}
-
-	patterns := make([]Pattern, 0, len(ranked))
-	for _, acc := range ranked {
-		pattern := Pattern{
-			State: acc.input.state,
-			Span: PatternSpan{
-				Service: acc.input.ref.Service,
-				Name:    acc.input.ref.Name,
-				Kind:    acc.input.ref.Kind,
-			},
-			Count:       acc.count,
-			SampleSpans: append([]SpanRef(nil), acc.samples...),
-			Changes:     renderPatternChanges(acc.input.changes),
-		}
-		if acc.durationSet {
-			pattern.DurationDeltaMs = &DurationDeltaStats{
-				Min:   acc.durationMinMs,
-				Max:   acc.durationMaxMs,
-				Total: nanosToMillis(acc.durationTotalNs),
-			}
-		}
-		patterns = append(patterns, pattern)
-	}
-	return patterns, patternTruncated
-}
-
-func forEachPatternInput(patch *Result, visit func(patternInput)) {
-	for _, modified := range patch.Modified {
-		visit(patternInput{state: patternStateModified, ref: modified.Span, changes: modified.Changes})
-	}
-	for _, added := range patch.Added {
-		visit(patternInput{state: patternStateAdded, ref: spanRefFromSnapshot(added.Span)})
-	}
-	for _, removed := range patch.Removed {
-		visit(patternInput{state: patternStateRemoved, ref: spanRefFromSnapshot(removed.Span)})
-	}
-}
-
-// patternKey uses a length-prefixed typed hash, so legal control characters in
-// names or values cannot merge otherwise distinct patterns.
-func patternKey(input patternInput) [sha256.Size]byte {
-	hasher := sha256.New()
-	hashString(hasher, input.state)
-	hashString(hasher, input.ref.Service)
-	hashString(hasher, input.ref.Name)
-	hashString(hasher, input.ref.Kind)
-	hashUint64(hasher, uint64(len(input.changes)))
-	for _, change := range input.changes {
-		hashString(hasher, "change")
-		hashString(hasher, string(change.Op))
-		if isDurationChange(change) {
-			hashString(hasher, fieldDurationMs)
-			hashString(hasher, durationChangeDirection(change))
-			continue
-		}
-		hashString(hasher, string(change.Target.Type))
-		hashString(hasher, change.Target.Name)
-		hashString(hasher, change.Target.Scope)
-		hashString(hasher, change.Target.Key)
-		hashValue(hasher, change.Before)
-		hashValue(hasher, change.After)
-	}
-	var key [sha256.Size]byte
-	copy(key[:], hasher.Sum(nil))
-	return key
-}
-
-func hashString(hasher hash.Hash, value string) {
-	hashUint64(hasher, uint64(len(value)))
-	_, _ = hasher.Write([]byte(value))
-}
-
-func hashUint64(hasher hash.Hash, value uint64) {
-	var encoded [8]byte
-	binary.BigEndian.PutUint64(encoded[:], value)
-	_, _ = hasher.Write(encoded[:])
-}
-
-func hashValue(hasher hash.Hash, value any) {
-	switch typed := value.(type) {
-	case nil:
-		hashString(hasher, "nil")
-	case string:
-		hashString(hasher, "string")
-		hashString(hasher, typed)
-	case bool:
-		hashString(hasher, fmt.Sprintf("bool:%t", typed))
-	case int64:
-		hashString(hasher, "int64")
-		var encoded [8]byte
-		binary.BigEndian.PutUint64(encoded[:], uint64(typed))
-		_, _ = hasher.Write(encoded[:])
-	case float64:
-		hashString(hasher, "float64")
-		var encoded [8]byte
-		binary.BigEndian.PutUint64(encoded[:], math.Float64bits(typed))
-		_, _ = hasher.Write(encoded[:])
-	case []byte:
-		hashString(hasher, "bytes")
-		hashUint64(hasher, uint64(len(typed)))
-		_, _ = hasher.Write(typed)
-	case []any:
-		hashString(hasher, "array")
-		hashUint64(hasher, uint64(len(typed)))
-		for _, item := range typed {
-			hashValue(hasher, item)
-		}
-	case map[string]any:
-		hashString(hasher, "map")
-		hashUint64(hasher, uint64(len(typed)))
-		keys := make([]string, 0, len(typed))
-		for key := range typed {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			hashString(hasher, key)
-			hashValue(hasher, typed[key])
-		}
-	default:
-		hashString(hasher, fmt.Sprintf("%T:%v", value, value))
-	}
-}
-
-// renderPatternChanges converts duration values to milliseconds.
-func renderPatternChanges(changes []Change) []Change {
-	if len(changes) == 0 {
-		return nil
-	}
-	out := make([]Change, 0, len(changes))
-	for _, change := range changes {
-		rendered := change
-		if isDurationChange(change) {
-			rendered.Target.Name = fieldDurationMs
-			rendered.Before = renderDurationMs(change.Before)
-			rendered.After = renderDurationMs(change.After)
-		}
-		out = append(out, rendered)
-	}
-	return out
-}
-
-func renderDurationMs(value any) any {
-	if nanos, ok := value.(int64); ok {
-		return nanosToMillis(nanos)
-	}
-	return value
-}
-
-func isDurationChange(change Change) bool {
-	return change.Target.Type == TargetField && change.Target.Name == FieldDurationNanos
-}
-
-// durationChangeDeltaNanos returns the raw delta of a duration change. ok is
-// false when either side is not a valid duration.
-func durationChangeDeltaNanos(change Change) (int64, bool) {
-	if !isDurationChange(change) {
-		return 0, false
-	}
-	before, beforeOK := change.Before.(int64)
-	after, afterOK := change.After.(int64)
-	if !beforeOK || !afterOK {
-		return 0, false
-	}
-	return after - before, true
-}
-
-func durationChangeDirection(change Change) string {
-	before, beforeOK := change.Before.(int64)
-	after, afterOK := change.After.(int64)
-	if !beforeOK || !afterOK {
-		return "invalid"
-	}
-	return signalFromDelta(nanosToMillis(after - before))
-}
-
-func patternDurationDeltaNanos(input patternInput) (int64, bool) {
-	for _, change := range input.changes {
-		if delta, ok := durationChangeDeltaNanos(change); ok {
-			return delta, true
-		}
-	}
-	return 0, false
-}
-
 func serviceOrUnknown(service string) string {
 	if service == "" {
 		return unknownServiceName
@@ -749,10 +428,6 @@ func serviceOrUnknown(service string) string {
 }
 
 const unknownServiceName = "<unknown>"
-
-func spanRefFromSnapshot(snapshot SpanSnapshot) SpanRef {
-	return SpanRef{Path: snapshot.Path, Service: snapshot.Service, Name: snapshot.Name, Kind: snapshot.Kind}
-}
 
 // matchedSpanRatio divides matched spans by the larger span count, so it stays
 // low whenever either trace has many unmatched spans.

--- a/pkg/model/tracediff/summary.go
+++ b/pkg/model/tracediff/summary.go
@@ -1,0 +1,838 @@
+package tracediff
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"maps"
+	"math"
+	"sort"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+const (
+	signalIncreased      = "increased"
+	signalDecreased      = "decreased"
+	signalUnchanged      = "unchanged"
+	patternStateAdded    = "added"
+	patternStateRemoved  = "removed"
+	patternStateModified = "modified"
+
+	// patternCap bounds the patterns section. Overflow is disclosed in
+	// patternsTruncated instead of silently dropped: a bounded section must
+	// never be the only carrier of a fact class, and truncation without
+	// disclosure lies by omission.
+	patternCap = 20
+	// patternSampleSpans bounds the sample span refs carried per pattern.
+	patternSampleSpans = 3
+	// Aggregate drift significance: a service counts as drifted when the
+	// absolute per-service span-work delta is at least
+	// max(driftMinNanos, 5% of base work). This is what lets the
+	// summary attribute systemic sub-tolerance drift (every span slightly
+	// slower) that the per-span patch tolerance filters out entirely.
+	driftMinNanos      = int64(1_000_000)
+	driftRelativeScale = int64(20)
+)
+
+// SummaryResult is the trace-summary-v0-native document: a compact
+// triage/localization summary of a trace diff. The envelope, signals, and
+// per-service work deltas are computed from the normalized traces — not from
+// the patch — because whole-trace facts (the latency envelope, the topology
+// signature, sub-tolerance drift) are not derivable from the change list.
+// Matcher-derived counts complement them: net-zero churn on unambiguous spans
+// cancels out of aggregates but stays visible in counts.
+type SummaryResult struct {
+	Version  string       `json:"version"`
+	Base     TraceSummary `json:"base"`
+	Compare  TraceSummary `json:"compare"`
+	Signals  Signals      `json:"signals"`
+	Trust    TrustSummary `json:"trust"`
+	Stats    SummaryStats `json:"stats"`
+	Warnings []Warning    `json:"warnings,omitempty"`
+	// ChangedServices contains all services with matcher changes, significant
+	// span-work drift, or structural changes.
+	ChangedServices []string `json:"changedServices"`
+	// Services contains rollups for services with matcher changes or significant
+	// span-work drift. Structure-only services remain in ChangedServices.
+	Services []ServiceRollup `json:"services"`
+	// Patterns groups identical span changes into exemplars, capped at
+	// patternCap with explicit truncation disclosure.
+	Patterns          []Pattern          `json:"patterns"`
+	PatternsTruncated *PatternsTruncated `json:"patternsTruncated,omitempty"`
+}
+
+// Signals are factual direction labels. They intentionally avoid declaring that
+// a change is good or bad; callers and LLMs can interpret the directions in
+// context.
+type Signals struct {
+	TraceLatency string `json:"traceLatency"`
+	SpanWork     string `json:"spanWork"`
+	Errors       string `json:"errors"`
+	SpanCount    string `json:"spanCount"`
+	Structure    string `json:"structure"`
+}
+
+// TraceSummary describes one side of the comparison.
+type TraceSummary struct {
+	TraceID        string `json:"traceId"`
+	RootService    string `json:"rootService,omitempty"`
+	RootName       string `json:"rootName,omitempty"`
+	SpanCount      int    `json:"spanCount"`
+	ErrorSpanCount int    `json:"errorSpanCount"`
+	// DurationMs is the trace wall-clock envelope: the latest span end minus
+	// the earliest span start across spans with valid durations (start > 0 and
+	// end >= start). It is a proxy for end-to-end latency and is 0 when no span
+	// has a valid duration.
+	DurationMs int64 `json:"durationMs"`
+	// SpanWorkMs is the sum of every span's individual duration, which can exceed
+	// DurationMs when spans run concurrently. Invalid spans contribute zero.
+	SpanWorkMs int64 `json:"spanWorkMs"`
+}
+
+// TrustSummary reports span matching coverage. It does not measure whether
+// duplicate logical spans were paired unambiguously.
+type TrustSummary struct {
+	// MatchedSpanRatio is matched spans over the larger trace's span count, so it
+	// falls when either side has many unmatched spans.
+	MatchedSpanRatio float64 `json:"matchedSpanRatio"`
+	// StructureOverlap is matched spans over the smaller trace's span count. It is
+	// a containment ratio (1.0 when the smaller trace is fully contained in the
+	// larger), not a symmetric overlap, so read it together with MatchedSpanRatio.
+	StructureOverlap float64 `json:"structureOverlap"`
+}
+
+// SummaryStats holds aggregate deltas between the two traces.
+type SummaryStats struct {
+	// TraceLatencyDeltaMs is the difference in the wall-clock envelope (see
+	// TraceSummary.DurationMs), not the difference in any single root span.
+	TraceLatencyDeltaMs int64 `json:"traceLatencyDeltaMs"`
+	SpanWorkDeltaMs     int64 `json:"spanWorkDeltaMs"`
+	SpanCountDelta      int   `json:"spanCountDelta"`
+	ErrorSpanDelta      int   `json:"errorSpanDelta"`
+	MatchedSpans        int   `json:"matchedSpans"`
+	ModifiedSpans       int   `json:"modifiedSpans"`
+	AddedSpans          int   `json:"addedSpans"`
+	RemovedSpans        int   `json:"removedSpans"`
+	FieldChanges        int   `json:"fieldChanges"`
+	AttributeChanges    int   `json:"attributeChanges"`
+}
+
+// ServiceRollup summarizes one changed service. SpanWorkDeltaMs is computed
+// from raw nanoseconds before final millisecond conversion; count columns come
+// from the matcher so unambiguous net-zero churn remains visible.
+type ServiceRollup struct {
+	Name            string `json:"name"`
+	SpanWorkDeltaMs int64  `json:"spanWorkDeltaMs"`
+	Modified        int    `json:"modified"`
+	Added           int    `json:"added"`
+	Removed         int    `json:"removed"`
+	NewErrors       int    `json:"newErrors"`
+	ResolvedErrors  int    `json:"resolvedErrors"`
+}
+
+// PatternSpan is the logical identity a pattern groups by.
+type PatternSpan struct {
+	Service string `json:"service"`
+	Name    string `json:"name"`
+	Kind    string `json:"kind"`
+}
+
+// Pattern is an exemplar of one repeated change shape: identical changes on
+// spans with the same logical identity collapse into a single entry with a
+// count, a bounded set of sample refs, and the exemplar's rendered changes.
+// Duration changes group by direction, not exact values, so per-span jitter
+// does not defeat the compression.
+type Pattern struct {
+	State       string      `json:"state"`
+	Span        PatternSpan `json:"span"`
+	Count       int         `json:"count"`
+	SampleSpans []SpanRef   `json:"sampleSpans"`
+	// Changes is the exemplar span's rendered change list; durations are
+	// rendered in milliseconds for readability.
+	Changes         []Change            `json:"changes,omitempty"`
+	DurationDeltaMs *DurationDeltaStats `json:"durationDeltaMs,omitempty"`
+}
+
+// DurationDeltaStats summarizes the duration deltas across all spans grouped
+// into one pattern.
+type DurationDeltaStats struct {
+	Min   int64 `json:"min"`
+	Max   int64 `json:"max"`
+	Total int64 `json:"total"`
+}
+
+// PatternsTruncated discloses how much the pattern cap dropped.
+type PatternsTruncated struct {
+	Patterns int `json:"patterns"`
+	Spans    int `json:"spans"`
+}
+
+// fieldDurationMs is the rendered Target.Name for duration changes inside
+// patterns (the patch itself always uses FieldDurationNanos).
+const fieldDurationMs = "duration_ms"
+
+// Summarize compares base and compare and returns the trace-summary-v0-native
+// document built from the normalized traces plus the trace-patch-v0 diff.
+func Summarize(base, compare *tempopb.Trace) (*SummaryResult, error) {
+	patch, baseTrace, compareTrace, err := diffTraceInputs(base, compare)
+	if err != nil {
+		return nil, err
+	}
+
+	baseSummary, baseDurations := summarizeNormalizedTrace(baseTrace)
+	compareSummary, compareDurations := summarizeNormalizedTrace(compareTrace)
+	structureChanged := structureChangedServices(structureSignature(baseTrace), structureSignature(compareTrace))
+
+	result := &SummaryResult{
+		Version: VersionTraceSummaryV0Native,
+		Base:    baseSummary,
+		Compare: compareSummary,
+		Trust: TrustSummary{
+			MatchedSpanRatio: matchedSpanRatio(patch.Stats.SpanCountA, patch.Stats.SpanCountB, patch.Stats.MatchedSpans),
+			StructureOverlap: structureOverlap(patch.Stats.SpanCountA, patch.Stats.SpanCountB, patch.Stats.MatchedSpans),
+		},
+		Stats: SummaryStats{
+			SpanCountDelta:   patch.Stats.SpanCountB - patch.Stats.SpanCountA,
+			ErrorSpanDelta:   compareSummary.ErrorSpanCount - baseSummary.ErrorSpanCount,
+			MatchedSpans:     patch.Stats.MatchedSpans,
+			ModifiedSpans:    patch.Stats.ModifiedSpans,
+			AddedSpans:       patch.Stats.AddedSpans,
+			RemovedSpans:     patch.Stats.RemovedSpans,
+			FieldChanges:     patch.Stats.FieldChanges,
+			AttributeChanges: patch.Stats.AttributeChanges,
+		},
+	}
+	result.Stats.TraceLatencyDeltaMs = deltaUint64Millis(compareDurations.envelopeNanos, baseDurations.envelopeNanos)
+	result.Stats.SpanWorkDeltaMs = nanosToMillis(compareDurations.workNanos - baseDurations.workNanos)
+	result.Signals = summarySignals(result.Stats, len(structureChanged) > 0)
+	result.ChangedServices, result.Services = buildServiceSections(
+		patch,
+		serviceWorkNanos(baseTrace),
+		serviceWorkNanos(compareTrace),
+		structureChanged,
+	)
+	result.Patterns, result.PatternsTruncated = buildPatterns(patch)
+	result.Warnings = patch.Warnings
+	return result, nil
+}
+
+type traceDurationAggregate struct {
+	envelopeNanos uint64
+	workNanos     int64
+}
+
+// summarizeNormalizedTrace keeps nanoseconds until cross-trace deltas have been
+// calculated. Invalid spans contribute zero duration, matching the native
+// reference policy.
+func summarizeNormalizedTrace(trace normalizedTrace) (TraceSummary, traceDurationAggregate) {
+	summary := TraceSummary{TraceID: trace.meta.TraceID, SpanCount: trace.meta.SpanCount}
+	var durations traceDurationAggregate
+	var firstStart uint64
+	var lastEnd uint64
+	var haveStart bool
+	for _, span := range trace.spans {
+		// A start time of 0 is unset (OTLP start times are required and non-zero);
+		// including it would collapse firstStart to the epoch and report a trace
+		// duration of tens of thousands of years. Skip unset starts so a single
+		// span with buggy instrumentation cannot poison the whole envelope.
+		start := span.startUnixNano
+		end := span.endUnixNano
+		if span.durationValid && (!haveStart || start < firstStart) {
+			firstStart = start
+			haveStart = true
+		}
+		if span.durationValid && end > lastEnd {
+			lastEnd = end
+		}
+		durations.workNanos += span.snapshot.DurationNanos
+		if isErrorStatus(span.snapshot.Status) {
+			summary.ErrorSpanCount++
+		}
+	}
+	if haveStart && lastEnd >= firstStart {
+		durations.envelopeNanos = lastEnd - firstStart
+	}
+	summary.SpanWorkMs = nanosToMillis(durations.workNanos)
+	summary.DurationMs = int64(durations.envelopeNanos / 1_000_000)
+	if len(trace.spans) > 0 {
+		summary.RootService = trace.spans[0].ref.Service
+		summary.RootName = trace.spans[0].ref.Name
+	}
+	return summary, durations
+}
+
+// structureSigEntry is one row of a structure signature: a span's logical
+// identity plus its parent linkage.
+type structureSigEntry struct {
+	identity       spanLogicalKey
+	parentIdentity spanLogicalKey
+	hasParent      bool
+}
+
+// structureSignature builds each service's multiset of signature rows from the
+// normalized spans. Sibling order never enters a row, so the signature is
+// order-insensitive by construction, while any reparenting rewrites the moved
+// span's row.
+func structureSignature(trace normalizedTrace) map[string]map[structureSigEntry]int {
+	sig := make(map[string]map[structureSigEntry]int)
+	for _, span := range trace.spans {
+		service := serviceOrUnknown(span.ref.Service)
+		rows := sig[service]
+		if rows == nil {
+			rows = make(map[structureSigEntry]int)
+			sig[service] = rows
+		}
+		rows[structureSigEntry{
+			identity:       span.identity(),
+			parentIdentity: span.parentIdentity,
+			hasParent:      span.hasParent,
+		}]++
+	}
+	return sig
+}
+
+// structureChangedServices returns the services whose signature multiset
+// differs between base and compare. The signature partitions the whole trace
+// by service, so a non-empty result is also the whole-trace structure-changed
+// signal, and a matched span's parent change always rewrites its row.
+func structureChangedServices(base, compare map[string]map[structureSigEntry]int) map[string]struct{} {
+	changed := make(map[string]struct{})
+	for service, baseRows := range base {
+		if !maps.Equal(baseRows, compare[service]) {
+			changed[service] = struct{}{}
+		}
+	}
+	for service := range compare {
+		if _, ok := base[service]; !ok {
+			changed[service] = struct{}{}
+		}
+	}
+	return changed
+}
+
+func summarySignals(stats SummaryStats, structureChanged bool) Signals {
+	structure := signalUnchanged
+	if stats.AddedSpans > 0 || stats.RemovedSpans > 0 || structureChanged {
+		structure = "changed"
+	}
+	return Signals{
+		TraceLatency: signalFromDelta(stats.TraceLatencyDeltaMs),
+		SpanWork:     signalFromDelta(stats.SpanWorkDeltaMs),
+		Errors:       signalFromDelta(int64(stats.ErrorSpanDelta)),
+		SpanCount:    signalFromDelta(int64(stats.SpanCountDelta)),
+		Structure:    structure,
+	}
+}
+
+func signalFromDelta(delta int64) string {
+	switch {
+	case delta > 0:
+		return signalIncreased
+	case delta < 0:
+		return signalDecreased
+	default:
+		return signalUnchanged
+	}
+}
+
+// serviceWorkNanos sums span durations per service over a whole normalized
+// trace. Unlike the patch, this sees every span, so systemic drift below the
+// per-span tolerance still accumulates here.
+func serviceWorkNanos(trace normalizedTrace) map[string]int64 {
+	work := make(map[string]int64)
+	for _, span := range trace.spans {
+		work[serviceOrUnknown(span.ref.Service)] += span.snapshot.DurationNanos
+	}
+	return work
+}
+
+type rankedServiceRollup struct {
+	rollup ServiceRollup
+}
+
+// buildServiceSections follows the native reference contract: changedServices
+// is complete, while service rollups contain matcher churn and significant
+// trace-derived drift. Structure-only changes remain in changedServices.
+func buildServiceSections(patch *Result, baseWork, compareWork map[string]int64, structureChanged map[string]struct{}) ([]string, []ServiceRollup) {
+	counts := matcherRollupCounts(patch)
+
+	services := make(map[string]struct{}, len(baseWork)+len(compareWork))
+	for service := range baseWork {
+		services[service] = struct{}{}
+	}
+	for service := range compareWork {
+		services[service] = struct{}{}
+	}
+
+	changed := make(map[string]struct{}, len(counts)+len(structureChanged))
+	for service := range counts {
+		changed[service] = struct{}{}
+	}
+	for service := range structureChanged {
+		changed[service] = struct{}{}
+	}
+
+	rollups := make([]rankedServiceRollup, 0, len(services))
+	for service := range services {
+		deltaNanos := compareWork[service] - baseWork[service]
+		count := counts[service]
+		drifted := driftSignificant(baseWork[service], deltaNanos)
+		if drifted {
+			changed[service] = struct{}{}
+		} else if count == nil {
+			continue
+		}
+		rollup := ServiceRollup{Name: service}
+		rollup.SpanWorkDeltaMs = nanosToMillis(deltaNanos)
+		if count != nil {
+			rollup.Modified = count.Modified
+			rollup.Added = count.Added
+			rollup.Removed = count.Removed
+			rollup.NewErrors = count.NewErrors
+			rollup.ResolvedErrors = count.ResolvedErrors
+		}
+		rollups = append(rollups, rankedServiceRollup{rollup: rollup})
+	}
+	sort.SliceStable(rollups, func(i, j int) bool {
+		a, b := rollups[i].rollup, rollups[j].rollup
+		if absInt64(a.SpanWorkDeltaMs) != absInt64(b.SpanWorkDeltaMs) {
+			return absInt64(a.SpanWorkDeltaMs) > absInt64(b.SpanWorkDeltaMs)
+		}
+		if a.NewErrors != b.NewErrors {
+			return a.NewErrors > b.NewErrors
+		}
+		return a.Name < b.Name
+	})
+
+	outputRollups := make([]ServiceRollup, 0, len(rollups))
+	for _, ranked := range rollups {
+		outputRollups = append(outputRollups, ranked.rollup)
+	}
+	changedServices := make([]string, 0, len(changed))
+	for service := range changed {
+		changedServices = append(changedServices, service)
+	}
+	sort.Strings(changedServices)
+	return changedServices, outputRollups
+}
+
+// driftSignificant applies the aggregate drift threshold in nanoseconds, so a
+// sub-millisecond jitter can never round up past the absolute floor.
+func driftSignificant(baseNanos, deltaNanos int64) bool {
+	absDelta := absInt64(deltaNanos)
+	if absDelta < driftMinNanos {
+		return false
+	}
+	relativeThreshold := baseNanos / driftRelativeScale
+	if baseNanos%driftRelativeScale != 0 {
+		relativeThreshold++
+	}
+	return absDelta >= relativeThreshold
+}
+
+// matcherRollupCounts extracts the per-service count columns from the patch.
+// Status changes are never tolerance-filtered, so matcher-derived error
+// transitions on unambiguous spans preserve simultaneous churn even when the
+// net error delta is 0. Ambiguous duplicate groups use minimum-change multiset
+// matching and carry a warning instead of inventing instance identity.
+func matcherRollupCounts(patch *Result) map[string]*ServiceRollup {
+	counts := map[string]*ServiceRollup{}
+	get := func(service string) *ServiceRollup {
+		service = serviceOrUnknown(service)
+		count := counts[service]
+		if count == nil {
+			count = &ServiceRollup{Name: service}
+			counts[service] = count
+		}
+		return count
+	}
+	for _, modified := range patch.Modified {
+		count := get(modified.Span.Service)
+		count.Modified++
+		for _, change := range modified.Changes {
+			if change.Target.Type != TargetField || change.Target.Name != FieldStatus {
+				continue
+			}
+			before, _ := change.Before.(string)
+			after, _ := change.After.(string)
+			if isErrorStatus(after) && !isErrorStatus(before) {
+				count.NewErrors++
+			} else if isErrorStatus(before) && !isErrorStatus(after) {
+				count.ResolvedErrors++
+			}
+		}
+	}
+	for _, added := range patch.Added {
+		count := get(added.Span.Service)
+		count.Added++
+		if isErrorStatus(added.Span.Status) {
+			count.NewErrors++
+		}
+	}
+	for _, removed := range patch.Removed {
+		count := get(removed.Span.Service)
+		count.Removed++
+		if isErrorStatus(removed.Span.Status) {
+			count.ResolvedErrors++
+		}
+	}
+	return counts
+}
+
+type patternInput struct {
+	state   string
+	ref     SpanRef
+	changes []Change
+}
+
+type patternAccumulator struct {
+	input           patternInput
+	count           int
+	samples         []SpanRef
+	durationSet     bool
+	durationMinMs   int64
+	durationMaxMs   int64
+	durationTotalNs int64
+}
+
+// buildPatterns follows the native reference: collect exact pattern counts,
+// rank by frequency, and cap only the rendered pattern section.
+func buildPatterns(patch *Result) ([]Pattern, *PatternsTruncated) {
+	accumulators := make(map[[sha256.Size]byte]*patternAccumulator)
+	order := make([][sha256.Size]byte, 0, len(patch.Modified)+len(patch.Added)+len(patch.Removed))
+	forEachPatternInput(patch, func(input patternInput) {
+		key := patternKey(input)
+		acc := accumulators[key]
+		if acc == nil {
+			acc = &patternAccumulator{input: input, samples: make([]SpanRef, 0, patternSampleSpans)}
+			accumulators[key] = acc
+			order = append(order, key)
+		}
+		acc.count++
+		if len(acc.samples) < patternSampleSpans {
+			acc.samples = append(acc.samples, input.ref)
+		}
+		if delta, ok := patternDurationDeltaNanos(input); ok {
+			deltaMs := nanosToMillis(delta)
+			if !acc.durationSet {
+				acc.durationSet = true
+				acc.durationMinMs = deltaMs
+				acc.durationMaxMs = deltaMs
+			}
+			acc.durationMinMs = min(acc.durationMinMs, deltaMs)
+			acc.durationMaxMs = max(acc.durationMaxMs, deltaMs)
+			acc.durationTotalNs += delta
+		}
+	})
+
+	ranked := make([]*patternAccumulator, 0, len(order))
+	for _, key := range order {
+		ranked = append(ranked, accumulators[key])
+	}
+	sort.SliceStable(ranked, func(i, j int) bool {
+		a, b := ranked[i], ranked[j]
+		if a.count != b.count {
+			return a.count > b.count
+		}
+		if a.input.state != b.input.state {
+			return a.input.state < b.input.state
+		}
+		if a.input.ref.Service != b.input.ref.Service {
+			return a.input.ref.Service < b.input.ref.Service
+		}
+		if a.input.ref.Name != b.input.ref.Name {
+			return a.input.ref.Name < b.input.ref.Name
+		}
+		return false
+	})
+
+	var patternTruncated *PatternsTruncated
+	if len(ranked) > patternCap {
+		patternTruncated = &PatternsTruncated{Patterns: len(ranked) - patternCap}
+		for _, acc := range ranked[patternCap:] {
+			patternTruncated.Spans += acc.count
+		}
+		ranked = ranked[:patternCap]
+	}
+
+	patterns := make([]Pattern, 0, len(ranked))
+	for _, acc := range ranked {
+		pattern := Pattern{
+			State: acc.input.state,
+			Span: PatternSpan{
+				Service: acc.input.ref.Service,
+				Name:    acc.input.ref.Name,
+				Kind:    acc.input.ref.Kind,
+			},
+			Count:       acc.count,
+			SampleSpans: append([]SpanRef(nil), acc.samples...),
+			Changes:     renderPatternChanges(acc.input.changes),
+		}
+		if acc.durationSet {
+			pattern.DurationDeltaMs = &DurationDeltaStats{
+				Min:   acc.durationMinMs,
+				Max:   acc.durationMaxMs,
+				Total: nanosToMillis(acc.durationTotalNs),
+			}
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns, patternTruncated
+}
+
+func forEachPatternInput(patch *Result, visit func(patternInput)) {
+	for _, modified := range patch.Modified {
+		visit(patternInput{state: patternStateModified, ref: modified.Span, changes: modified.Changes})
+	}
+	for _, added := range patch.Added {
+		visit(patternInput{state: patternStateAdded, ref: spanRefFromSnapshot(added.Span)})
+	}
+	for _, removed := range patch.Removed {
+		visit(patternInput{state: patternStateRemoved, ref: spanRefFromSnapshot(removed.Span)})
+	}
+}
+
+// patternKey uses a length-prefixed typed hash, so legal control characters in
+// names or values cannot merge otherwise distinct patterns.
+func patternKey(input patternInput) [sha256.Size]byte {
+	hasher := sha256.New()
+	hashString(hasher, input.state)
+	hashString(hasher, input.ref.Service)
+	hashString(hasher, input.ref.Name)
+	hashString(hasher, input.ref.Kind)
+	hashUint64(hasher, uint64(len(input.changes)))
+	for _, change := range input.changes {
+		hashString(hasher, "change")
+		hashString(hasher, string(change.Op))
+		if isDurationChange(change) {
+			hashString(hasher, fieldDurationMs)
+			hashString(hasher, durationChangeDirection(change))
+			continue
+		}
+		hashString(hasher, string(change.Target.Type))
+		hashString(hasher, change.Target.Name)
+		hashString(hasher, change.Target.Scope)
+		hashString(hasher, change.Target.Key)
+		hashValue(hasher, change.Before)
+		hashValue(hasher, change.After)
+	}
+	var key [sha256.Size]byte
+	copy(key[:], hasher.Sum(nil))
+	return key
+}
+
+func hashString(hasher hash.Hash, value string) {
+	hashUint64(hasher, uint64(len(value)))
+	_, _ = hasher.Write([]byte(value))
+}
+
+func hashUint64(hasher hash.Hash, value uint64) {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], value)
+	_, _ = hasher.Write(encoded[:])
+}
+
+func hashValue(hasher hash.Hash, value any) {
+	switch typed := value.(type) {
+	case nil:
+		hashString(hasher, "nil")
+	case string:
+		hashString(hasher, "string")
+		hashString(hasher, typed)
+	case bool:
+		hashString(hasher, fmt.Sprintf("bool:%t", typed))
+	case int64:
+		hashString(hasher, "int64")
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], uint64(typed))
+		_, _ = hasher.Write(encoded[:])
+	case float64:
+		hashString(hasher, "float64")
+		var encoded [8]byte
+		binary.BigEndian.PutUint64(encoded[:], math.Float64bits(typed))
+		_, _ = hasher.Write(encoded[:])
+	case []byte:
+		hashString(hasher, "bytes")
+		hashUint64(hasher, uint64(len(typed)))
+		_, _ = hasher.Write(typed)
+	case []any:
+		hashString(hasher, "array")
+		hashUint64(hasher, uint64(len(typed)))
+		for _, item := range typed {
+			hashValue(hasher, item)
+		}
+	case map[string]any:
+		hashString(hasher, "map")
+		hashUint64(hasher, uint64(len(typed)))
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			hashString(hasher, key)
+			hashValue(hasher, typed[key])
+		}
+	default:
+		hashString(hasher, fmt.Sprintf("%T:%v", value, value))
+	}
+}
+
+// renderPatternChanges converts duration values to milliseconds.
+func renderPatternChanges(changes []Change) []Change {
+	if len(changes) == 0 {
+		return nil
+	}
+	out := make([]Change, 0, len(changes))
+	for _, change := range changes {
+		rendered := change
+		if isDurationChange(change) {
+			rendered.Target.Name = fieldDurationMs
+			rendered.Before = renderDurationMs(change.Before)
+			rendered.After = renderDurationMs(change.After)
+		}
+		out = append(out, rendered)
+	}
+	return out
+}
+
+func renderDurationMs(value any) any {
+	if nanos, ok := value.(int64); ok {
+		return nanosToMillis(nanos)
+	}
+	return value
+}
+
+func isDurationChange(change Change) bool {
+	return change.Target.Type == TargetField && change.Target.Name == FieldDurationNanos
+}
+
+// durationChangeDeltaNanos returns the raw delta of a duration change. ok is
+// false when either side is not a valid duration.
+func durationChangeDeltaNanos(change Change) (int64, bool) {
+	if !isDurationChange(change) {
+		return 0, false
+	}
+	before, beforeOK := change.Before.(int64)
+	after, afterOK := change.After.(int64)
+	if !beforeOK || !afterOK {
+		return 0, false
+	}
+	return after - before, true
+}
+
+func durationChangeDirection(change Change) string {
+	before, beforeOK := change.Before.(int64)
+	after, afterOK := change.After.(int64)
+	if !beforeOK || !afterOK {
+		return "invalid"
+	}
+	return signalFromDelta(nanosToMillis(after - before))
+}
+
+func patternDurationDeltaNanos(input patternInput) (int64, bool) {
+	for _, change := range input.changes {
+		if delta, ok := durationChangeDeltaNanos(change); ok {
+			return delta, true
+		}
+	}
+	return 0, false
+}
+
+func serviceOrUnknown(service string) string {
+	if service == "" {
+		return unknownServiceName
+	}
+	return service
+}
+
+const unknownServiceName = "<unknown>"
+
+func spanRefFromSnapshot(snapshot SpanSnapshot) SpanRef {
+	return SpanRef{Path: snapshot.Path, Service: snapshot.Service, Name: snapshot.Name, Kind: snapshot.Kind}
+}
+
+// matchedSpanRatio divides matched spans by the larger span count, so it stays
+// low whenever either trace has many unmatched spans.
+func matchedSpanRatio(a, b, matched int) float64 {
+	if a == 0 && b == 0 {
+		return 1
+	}
+	denominator := max(a, b)
+	if denominator == 0 {
+		return 0
+	}
+	return float64(matched) / float64(denominator)
+}
+
+// structureOverlap divides matched spans by the smaller span count. This is a
+// containment ratio: it reaches 1.0 when the smaller trace is fully contained in
+// the larger one even if the larger trace has many extra spans. Pair it with
+// matchedSpanRatio (which uses the larger count) to detect that asymmetry.
+func structureOverlap(a, b, matched int) float64 {
+	if a == 0 && b == 0 {
+		return 1
+	}
+	denominator := min(a, b)
+	if denominator == 0 {
+		return 0
+	}
+	return float64(matched) / float64(denominator)
+}
+
+func isErrorStatus(status string) bool {
+	return status == "error"
+}
+
+// sanitizeJSONValue replaces non-finite float64 values (NaN, +Inf, -Inf) with
+// string placeholders so diff outputs remain JSON-encodable. Arrays and maps
+// are sanitized recursively.
+func sanitizeJSONValue(value any) any {
+	switch v := value.(type) {
+	case float64:
+		switch {
+		case math.IsNaN(v):
+			return "NaN"
+		case math.IsInf(v, 1):
+			return "+Inf"
+		case math.IsInf(v, -1):
+			return "-Inf"
+		default:
+			return v
+		}
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = sanitizeJSONValue(item)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, item := range v {
+			out[key] = sanitizeJSONValue(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func absInt64(value int64) int64 {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+func nanosToMillis(value int64) int64 {
+	return value / 1_000_000
+}
+
+func deltaUint64Millis(compare, base uint64) int64 {
+	if compare >= base {
+		return int64((compare - base) / 1_000_000)
+	}
+	return -int64((base - compare) / 1_000_000)
+}

--- a/pkg/model/tracediff/summary.go
+++ b/pkg/model/tracediff/summary.go
@@ -26,8 +26,8 @@ const (
 // per-service summed-duration deltas are computed from the normalized traces — not from
 // the patch — because whole-trace facts (the latency envelope, the topology
 // signature, sub-tolerance drift) are not derivable from the change list.
-// Matcher-derived counts complement them: net-zero churn on unambiguous spans
-// cancels out of aggregates but stays visible in counts.
+// Matcher-derived counts complement them: net-zero churn that cancels out of
+// aggregates stays visible in counts.
 type SummaryResult struct {
 	Version  string       `json:"version"`
 	Base     TraceSummary `json:"base"`
@@ -373,9 +373,7 @@ func driftSignificant(baseNanos, deltaNanos int64) bool {
 
 // matcherRollupCounts extracts the per-service count columns from the patch.
 // Status changes are never tolerance-filtered, so matcher-derived error
-// transitions on unambiguous spans preserve simultaneous churn even when the
-// net error delta is 0. Ambiguous duplicate groups use minimum-change multiset
-// matching and carry a warning instead of inventing instance identity.
+// transitions preserve simultaneous churn even when the net error delta is 0.
 func matcherRollupCounts(patch *Result) map[string]*ServiceRollup {
 	counts := map[string]*ServiceRollup{}
 	get := func(service string) *ServiceRollup {

--- a/pkg/model/tracediff/summary_test.go
+++ b/pkg/model/tracediff/summary_test.go
@@ -21,31 +21,29 @@ func TestSummarize(t *testing.T) {
 
 	assert.Equal(t, VersionTraceSummaryV0Native, got.Version)
 	assert.Equal(t, Signals{
-		TraceLatency: "increased",
-		SpanWork:     "increased",
-		Errors:       "increased",
-		SpanCount:    "unchanged",
-		Structure:    "unchanged",
+		TraceLatency:    "increased",
+		SumSpanDuration: "increased",
+		Errors:          "increased",
+		SpanCount:       "unchanged",
+		Structure:       "unchanged",
 	}, got.Signals)
 	assert.Equal(t, 1.0, got.Trust.MatchedSpanRatio)
 	assert.Equal(t, 1.0, got.Trust.StructureOverlap)
 	assert.Equal(t, SummaryStats{
-		TraceLatencyDeltaMs: 10,
-		SpanWorkDeltaMs:     12,
-		SpanCountDelta:      0,
-		ErrorSpanDelta:      1,
-		MatchedSpans:        3,
-		ModifiedSpans:       2,
-		FieldChanges:        1,
-		AttributeChanges:    1,
+		TraceLatencyDeltaMs:    10,
+		SumSpanDurationDeltaMs: 12,
+		SpanCountDelta:         0,
+		ErrorSpanDelta:         1,
+		MatchedSpans:           3,
+		ModifiedSpans:          2,
+		FieldChanges:           1,
+		AttributeChanges:       1,
 	}, got.Stats)
 
 	assert.Equal(t, []string{"checkout"}, got.ChangedServices)
 	assert.Equal(t, []ServiceRollup{
-		{Name: "checkout", SpanWorkDeltaMs: 12, Modified: 2, NewErrors: 1},
+		{Name: "checkout", SumSpanDurationDeltaMs: 12, Modified: 2, NewErrors: 1},
 	}, got.Services)
-	assert.Len(t, got.Patterns, 2)
-	assert.Nil(t, got.PatternsTruncated)
 }
 
 func TestSummarizeNativeJSONShape(t *testing.T) {
@@ -65,7 +63,7 @@ func TestSummarizeNativeJSONShape(t *testing.T) {
     "spanCount": 3,
     "errorSpanCount": 0,
     "durationMs": 100,
-    "spanWorkMs": 140
+    "sumSpanDurationMs": 140
   },
   "compare": {
     "traceId": "74726163652d69642d30303030303031",
@@ -74,11 +72,11 @@ func TestSummarizeNativeJSONShape(t *testing.T) {
     "spanCount": 3,
     "errorSpanCount": 1,
     "durationMs": 110,
-    "spanWorkMs": 152
+    "sumSpanDurationMs": 152
   },
   "signals": {
     "traceLatency": "increased",
-    "spanWork": "increased",
+    "sumSpanDuration": "increased",
     "errors": "increased",
     "spanCount": "unchanged",
     "structure": "unchanged"
@@ -89,7 +87,7 @@ func TestSummarizeNativeJSONShape(t *testing.T) {
   },
   "stats": {
     "traceLatencyDeltaMs": 10,
-    "spanWorkDeltaMs": 12,
+    "sumSpanDurationDeltaMs": 12,
     "spanCountDelta": 0,
     "errorSpanDelta": 1,
     "matchedSpans": 3,
@@ -105,76 +103,12 @@ func TestSummarizeNativeJSONShape(t *testing.T) {
   "services": [
     {
       "name": "checkout",
-      "spanWorkDeltaMs": 12,
+      "sumSpanDurationDeltaMs": 12,
       "modified": 2,
       "added": 0,
       "removed": 0,
       "newErrors": 1,
       "resolvedErrors": 0
-    }
-  ],
-  "patterns": [
-    {
-      "state": "modified",
-      "span": {
-        "service": "checkout",
-        "name": "GET /checkout",
-        "kind": "server"
-      },
-      "count": 1,
-      "sampleSpans": [
-        {
-          "path": [
-            0
-          ],
-          "service": "checkout",
-          "name": "GET /checkout",
-          "kind": "server"
-        }
-      ],
-      "changes": [
-        {
-          "op": "modify",
-          "target": {
-            "type": "attribute",
-            "scope": "span",
-            "key": "service.version"
-          },
-          "before": "v1",
-          "after": "v2"
-        }
-      ]
-    },
-    {
-      "state": "modified",
-      "span": {
-        "service": "checkout",
-        "name": "cache lookup",
-        "kind": "client"
-      },
-      "count": 1,
-      "sampleSpans": [
-        {
-          "path": [
-            0,
-            0
-          ],
-          "service": "checkout",
-          "name": "cache lookup",
-          "kind": "client"
-        }
-      ],
-      "changes": [
-        {
-          "op": "modify",
-          "target": {
-            "type": "field",
-            "name": "status"
-          },
-          "before": "ok",
-          "after": "error"
-        }
-      ]
     }
   ]
 }`, string(data))
@@ -221,7 +155,6 @@ func TestSummarizePureReparentJoinsChangedServicesOnly(t *testing.T) {
 	assert.Equal(t, 0, got.Stats.ModifiedSpans)
 	assert.Equal(t, []string{"db"}, got.ChangedServices)
 	assert.Empty(t, got.Services)
-	assert.Empty(t, got.Patterns)
 }
 
 func TestSummarizeWarnsOnReparentBetweenDuplicateLogicalParents(t *testing.T) {
@@ -274,29 +207,6 @@ func TestSummarizeMatchingCoverageRatiosDoNotRoundNearPerfectToOne(t *testing.T)
 	assert.Equal(t, 1.0, matchedSpanRatio(10_000, 10_000, 10_000))
 }
 
-func TestSummarizeNativeEncodesNonFiniteAttributes(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	baseRoot := spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
-	baseRoot.Attributes = append(baseRoot.Attributes, doubleAttribute("score", 1.5))
-	compareRoot := spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
-	compareRoot.Attributes = append(compareRoot.Attributes, doubleAttribute("score", math.NaN()))
-
-	got, err := Summarize(traceWithNamedSpans(baseRoot), traceWithNamedSpans(compareRoot))
-	require.NoError(t, err)
-	require.Len(t, got.Patterns, 1)
-	require.Len(t, got.Patterns[0].Changes, 1)
-	change := got.Patterns[0].Changes[0]
-	assert.Equal(t, "score", change.Target.Key)
-	assert.Equal(t, 1.5, change.Before)
-	assert.Equal(t, "NaN", change.After)
-
-	// The default encoder rejects non-finite floats; the sanitized result must
-	// still encode successfully.
-	data, err := json.Marshal(got)
-	require.NoError(t, err)
-	assert.Contains(t, string(data), `"after":"NaN"`)
-}
-
 func TestSummarizeTreatsIdenticalNonFiniteAttributesAsUnchanged(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
 	makeTrace := func() *tempopb.Trace {
@@ -308,11 +218,10 @@ func TestSummarizeTreatsIdenticalNonFiniteAttributesAsUnchanged(t *testing.T) {
 	got, err := Summarize(makeTrace(), makeTrace())
 	require.NoError(t, err)
 	assert.Equal(t, "unchanged", got.Signals.TraceLatency)
-	assert.Equal(t, "unchanged", got.Signals.SpanWork)
+	assert.Equal(t, "unchanged", got.Signals.SumSpanDuration)
 	assert.Equal(t, "unchanged", got.Signals.Errors)
 	assert.Equal(t, 0, got.Stats.AttributeChanges)
 	assert.Empty(t, got.Services)
-	assert.Empty(t, got.Patterns)
 }
 
 func TestSummarizeSignalsReportIndependentDirections(t *testing.T) {
@@ -358,14 +267,14 @@ func TestSummarizeIgnoresUnsetSpanStartInDuration(t *testing.T) {
 	assert.Equal(t, int64(100), got.Base.DurationMs)
 	assert.Equal(t, int64(100), got.Compare.DurationMs)
 	assert.Zero(t, got.Stats.TraceLatencyDeltaMs)
-	assert.Equal(t, int64(100), got.Base.SpanWorkMs)
-	assert.Equal(t, int64(100), got.Compare.SpanWorkMs)
-	assert.Zero(t, got.Stats.SpanWorkDeltaMs)
+	assert.Equal(t, int64(100), got.Base.SumSpanDurationMs)
+	assert.Equal(t, int64(100), got.Compare.SumSpanDurationMs)
+	assert.Zero(t, got.Stats.SumSpanDurationDeltaMs)
 	assert.Equal(t, "unchanged", got.Signals.TraceLatency)
-	assert.Equal(t, "unchanged", got.Signals.SpanWork)
+	assert.Equal(t, "unchanged", got.Signals.SumSpanDuration)
 }
 
-func TestSummarizeUnsetSpanStartDoesNotInflateSpanWork(t *testing.T) {
+func TestSummarizeUnsetSpanStartDoesNotInflateSumSpanDuration(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
 	// Baseline: a root and a child, both with usable start times.
 	base := traceWithNamedSpans(
@@ -391,18 +300,10 @@ func TestSummarizeUnsetSpanStartDoesNotInflateSpanWork(t *testing.T) {
 
 	got, err := Summarize(base, compare)
 	require.NoError(t, err)
-	assert.Equal(t, int64(150), got.Base.SpanWorkMs)
-	assert.Equal(t, int64(100), got.Compare.SpanWorkMs)
-	assert.Equal(t, int64(-50), got.Stats.SpanWorkDeltaMs)
-	assert.Equal(t, "decreased", got.Signals.SpanWork)
-	// The duration change with an invalid side renders null and must not
-	// fabricate delta stats.
-	require.Len(t, got.Patterns, 1)
-	require.Len(t, got.Patterns[0].Changes, 1)
-	assert.Equal(t, "duration_ms", got.Patterns[0].Changes[0].Target.Name)
-	assert.Equal(t, int64(50), got.Patterns[0].Changes[0].Before)
-	assert.Nil(t, got.Patterns[0].Changes[0].After)
-	assert.Nil(t, got.Patterns[0].DurationDeltaMs)
+	assert.Equal(t, int64(150), got.Base.SumSpanDurationMs)
+	assert.Equal(t, int64(100), got.Compare.SumSpanDurationMs)
+	assert.Equal(t, int64(-50), got.Stats.SumSpanDurationDeltaMs)
+	assert.Equal(t, "decreased", got.Signals.SumSpanDuration)
 }
 
 func TestSummarizeStructuralSurfacesAddedAndRemovedErrors(t *testing.T) {
@@ -421,23 +322,13 @@ func TestSummarizeStructuralSurfacesAddedAndRemovedErrors(t *testing.T) {
 
 	require.Len(t, got.Services, 1)
 	assert.Equal(t, ServiceRollup{
-		Name:            "checkout",
-		SpanWorkDeltaMs: 0,
-		Added:           1,
-		Removed:         1,
-		NewErrors:       1,
-		ResolvedErrors:  1,
+		Name:                   "checkout",
+		SumSpanDurationDeltaMs: 0,
+		Added:                  1,
+		Removed:                1,
+		NewErrors:              1,
+		ResolvedErrors:         1,
 	}, got.Services[0])
-
-	require.Len(t, got.Patterns, 2)
-	added := got.Patterns[0]
-	assert.Equal(t, "added", added.State)
-	assert.Equal(t, "new call", added.Span.Name)
-	assert.Empty(t, added.Changes)
-	removed := got.Patterns[1]
-	assert.Equal(t, "removed", removed.State)
-	assert.Equal(t, "dropped call", removed.Span.Name)
-	assert.Empty(t, removed.Changes)
 }
 
 func TestSummarizeInvalidDurationWarnsAndDoesNotInflateEnvelope(t *testing.T) {
@@ -505,11 +396,11 @@ func TestSummarizeZeroSpanTracesWarnAndStayUnchanged(t *testing.T) {
 	assert.Equal(t, 1.0, got.Trust.MatchedSpanRatio)
 	assert.Equal(t, 1.0, got.Trust.StructureOverlap)
 	assert.Equal(t, Signals{
-		TraceLatency: "unchanged",
-		SpanWork:     "unchanged",
-		Errors:       "unchanged",
-		SpanCount:    "unchanged",
-		Structure:    "unchanged",
+		TraceLatency:    "unchanged",
+		SumSpanDuration: "unchanged",
+		Errors:          "unchanged",
+		SpanCount:       "unchanged",
+		Structure:       "unchanged",
 	}, got.Signals)
 }
 
@@ -547,7 +438,7 @@ func TestSummarizeDuplicateSpanIDsWarn(t *testing.T) {
 	assert.Contains(t, got.Warnings[1].Message, "compare trace has 1 span(s) with duplicate span IDs")
 }
 
-func TestSummarizeEmptySectionsEncodeAsEmptyArrays(t *testing.T) {
+func TestSummarizeEmptyServicesEncodeAsEmptyArray(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
 	makeTrace := func() *tempopb.Trace {
 		return traceWithNamedSpans(
@@ -560,7 +451,6 @@ func TestSummarizeEmptySectionsEncodeAsEmptyArrays(t *testing.T) {
 	data, err := json.Marshal(got)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"services":[]`)
-	assert.Contains(t, string(data), `"patterns":[]`)
 }
 
 func TestSummarizeNilTrace(t *testing.T) {
@@ -609,11 +499,10 @@ func TestSummarizeSystemicDriftAttribution(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, got.Stats.ModifiedSpans)
 	assert.Equal(t, 0, got.Stats.FieldChanges)
-	assert.Empty(t, got.Patterns)
 	assert.Equal(t, []ServiceRollup{
-		{Name: "backend", SpanWorkDeltaMs: 13},
-		{Name: "database", SpanWorkDeltaMs: 13},
-		{Name: "frontend", SpanWorkDeltaMs: 13},
+		{Name: "backend", SumSpanDurationDeltaMs: 13},
+		{Name: "database", SumSpanDurationDeltaMs: 13},
+		{Name: "frontend", SumSpanDurationDeltaMs: 13},
 	}, got.Services)
 }
 
@@ -643,9 +532,8 @@ func TestSummarizeNanosecondJitterNotFlagged(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, 0, got.Stats.ModifiedSpans)
 			assert.Empty(t, got.Services)
-			assert.Empty(t, got.Patterns)
-			assert.Zero(t, got.Stats.SpanWorkDeltaMs)
-			assert.Equal(t, "unchanged", got.Signals.SpanWork)
+			assert.Zero(t, got.Stats.SumSpanDurationDeltaMs)
+			assert.Equal(t, "unchanged", got.Signals.SumSpanDuration)
 		})
 	}
 }
@@ -670,12 +558,12 @@ func TestSummarizeSubMillisecondDriftAccumulatesInNanoseconds(t *testing.T) {
 	got, err := Summarize(makeTrace(), compare)
 	require.NoError(t, err)
 	assert.Equal(t, 0, got.Stats.ModifiedSpans)
-	assert.Equal(t, int64(15), got.Base.SpanWorkMs)
-	assert.Equal(t, int64(16), got.Compare.SpanWorkMs)
-	assert.Equal(t, int64(1), got.Stats.SpanWorkDeltaMs)
-	assert.Equal(t, "increased", got.Signals.SpanWork)
+	assert.Equal(t, int64(15), got.Base.SumSpanDurationMs)
+	assert.Equal(t, int64(16), got.Compare.SumSpanDurationMs)
+	assert.Equal(t, int64(1), got.Stats.SumSpanDurationDeltaMs)
+	assert.Equal(t, "increased", got.Signals.SumSpanDuration)
 	require.Len(t, got.Services, 1)
-	assert.Equal(t, int64(1), got.Services[0].SpanWorkDeltaMs)
+	assert.Equal(t, int64(1), got.Services[0].SumSpanDurationDeltaMs)
 }
 
 func TestSummarizeErrorChurnFromMatcherCounts(t *testing.T) {
@@ -718,14 +606,13 @@ func TestSummarizeWarnsOnAmbiguousDuplicateErrorChurn(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, got.Stats.ModifiedSpans)
 	assert.Empty(t, got.Services)
-	assert.Empty(t, got.Patterns)
 	assert.Contains(t, got.Warnings, Warning{
 		Code:    WarningAmbiguousSpanMatch,
 		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
 	})
 }
 
-func TestSummarizeUsesCanonicalAmbiguousPatterns(t *testing.T) {
+func TestSummarizeUsesCanonicalAmbiguousMatcherCounts(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
 	span := func(id, variant string, start uint64) *tracev1.Span {
 		span := spanForNormalizeTest(traceID, id, "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, start, start+10, tracev1.Status_STATUS_CODE_OK)
@@ -747,10 +634,6 @@ func TestSummarizeUsesCanonicalAmbiguousPatterns(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, got.Stats.ModifiedSpans)
 	assert.Equal(t, []ServiceRollup{{Name: "backend", Modified: 1}}, got.Services)
-	require.Len(t, got.Patterns, 1)
-	require.Len(t, got.Patterns[0].Changes, 1)
-	assert.Equal(t, "b", got.Patterns[0].Changes[0].Before)
-	assert.Equal(t, "c", got.Patterns[0].Changes[0].After)
 }
 
 func TestSummarizeWarnsWhenDuplicateParentsAllChange(t *testing.T) {
@@ -796,64 +679,6 @@ func TestSummarizeKeepsOpposingTransitionsUnderDistinctParents(t *testing.T) {
 	for _, warning := range got.Warnings {
 		assert.NotEqual(t, WarningAmbiguousSpanMatch, warning.Code)
 	}
-}
-
-func TestSummarizePatternsCompressRepeatedChanges(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(childDurationMs func(i uint64) uint64) *tempopb.Trace {
-		spans := []*tracev1.Span{
-			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 300, tracev1.Status_STATUS_CODE_OK),
-		}
-		for i := uint64(0); i < 30; i++ {
-			start := 10 + i
-			spans = append(spans, spanForNormalizeTest(traceID, fmt.Sprintf("child-%02d", i), "root", "backend", "repeated op", tracev1.Span_SPAN_KIND_CLIENT, start, start+childDurationMs(i), tracev1.Status_STATUS_CODE_OK))
-		}
-		return traceWithNamedSpans(spans...)
-	}
-
-	base := makeTrace(func(uint64) uint64 { return 100 })
-	// Every span slows in the same direction but by different amounts (+50..+79ms,
-	// all above tolerance), so direction-based grouping must still compress them.
-	compare := makeTrace(func(i uint64) uint64 { return 150 + i })
-
-	got, err := Summarize(base, compare)
-	require.NoError(t, err)
-	require.Len(t, got.Patterns, 1)
-	pattern := got.Patterns[0]
-	assert.Equal(t, "modified", pattern.State)
-	assert.Equal(t, PatternSpan{Service: "backend", Name: "repeated op", Kind: "client"}, pattern.Span)
-	assert.Equal(t, 30, pattern.Count)
-	assert.Len(t, pattern.SampleSpans, patternSampleSpans)
-	require.NotNil(t, pattern.DurationDeltaMs)
-	assert.Equal(t, DurationDeltaStats{Min: 50, Max: 79, Total: 1935}, *pattern.DurationDeltaMs)
-	require.Len(t, pattern.Changes, 1)
-	assert.Equal(t, "duration_ms", pattern.Changes[0].Target.Name)
-	assert.Equal(t, int64(100), pattern.Changes[0].Before)
-	assert.Equal(t, int64(150), pattern.Changes[0].After)
-	assert.Nil(t, got.PatternsTruncated)
-}
-
-func TestSummarizePatternsCapWithDisclosure(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(childDurationMs uint64) *tempopb.Trace {
-		spans := []*tracev1.Span{
-			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 300, tracev1.Status_STATUS_CODE_OK),
-		}
-		for i := uint64(0); i < 25; i++ {
-			start := 10 + i
-			spans = append(spans, spanForNormalizeTest(traceID, fmt.Sprintf("span-%02d", i), "root", "backend", fmt.Sprintf("op-%02d", i), tracev1.Span_SPAN_KIND_CLIENT, start, start+childDurationMs, tracev1.Status_STATUS_CODE_OK))
-		}
-		return traceWithNamedSpans(spans...)
-	}
-
-	// 25 distinct span names, each slowed above tolerance: 25 distinct patterns.
-	got, err := Summarize(makeTrace(100), makeTrace(150))
-	require.NoError(t, err)
-	require.Len(t, got.Patterns, patternCap)
-	assert.Equal(t, "op-00", got.Patterns[0].Span.Name)
-	assert.Equal(t, "op-19", got.Patterns[patternCap-1].Span.Name)
-	require.NotNil(t, got.PatternsTruncated)
-	assert.Equal(t, PatternsTruncated{Patterns: 5, Spans: 5}, *got.PatternsTruncated)
 }
 
 func TestSummarizeRootFallsBackForCycleOnlyTrace(t *testing.T) {
@@ -909,59 +734,6 @@ func TestSummarizeTraceLatencyDeltaUsesRawNanoseconds(t *testing.T) {
 	assert.Equal(t, "unchanged", got.Signals.TraceLatency)
 }
 
-func TestSummarizePatternDurationTotalSumsBeforeTruncating(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(childDurationNanos uint64) *tempopb.Trace {
-		children := []*tracev1.Span{
-			spanForNormalizeTest(traceID, "a", "root", "backend", "op", tracev1.Span_SPAN_KIND_CLIENT, 10, 10, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "b", "root", "backend", "op", tracev1.Span_SPAN_KIND_CLIENT, 20, 20, tracev1.Status_STATUS_CODE_OK),
-		}
-		for _, child := range children {
-			child.EndTimeUnixNano = child.StartTimeUnixNano + childDurationNanos
-		}
-		return traceWithNamedSpans(
-			spanForNormalizeTest(traceID, "root", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-			children[0],
-			children[1],
-		)
-	}
-
-	got, err := Summarize(makeTrace(0), makeTrace(1_500_000))
-	require.NoError(t, err)
-	require.Len(t, got.Patterns, 1)
-	require.NotNil(t, got.Patterns[0].DurationDeltaMs)
-	assert.Equal(t, DurationDeltaStats{Min: 1, Max: 1, Total: 3}, *got.Patterns[0].DurationDeltaMs)
-}
-
-func TestSummarizeGroupsInvalidDurationTransitions(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	invalid := func(span *tracev1.Span) *tracev1.Span {
-		span.StartTimeUnixNano = 0
-		return span
-	}
-	base := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-		spanForNormalizeTest(traceID, "parent-a", "root", "a", "parent a", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
-		spanForNormalizeTest(traceID, "child-a", "parent-a", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 15, 25, tracev1.Status_STATUS_CODE_OK),
-		spanForNormalizeTest(traceID, "parent-b", "root", "b", "parent b", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
-		invalid(spanForNormalizeTest(traceID, "child-b", "parent-b", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 55, 65, tracev1.Status_STATUS_CODE_OK)),
-	)
-	compare := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root-2", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-		spanForNormalizeTest(traceID, "parent-a-2", "root-2", "a", "parent a", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
-		invalid(spanForNormalizeTest(traceID, "child-a-2", "parent-a-2", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 15, 25, tracev1.Status_STATUS_CODE_OK)),
-		spanForNormalizeTest(traceID, "parent-b-2", "root-2", "b", "parent b", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
-		spanForNormalizeTest(traceID, "child-b-2", "parent-b-2", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 55, 65, tracev1.Status_STATUS_CODE_OK),
-	)
-
-	got, err := Summarize(base, compare)
-	require.NoError(t, err)
-	require.Len(t, got.Patterns, 1)
-	assert.Equal(t, 2, got.Patterns[0].Count)
-	require.Len(t, got.Patterns[0].Changes, 1)
-	assert.Nil(t, got.Patterns[0].Changes[0].After)
-}
-
 func TestSummarizeMissingServiceUsesReferenceUnknownFallback(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
 	makeTrace := func(status tracev1.Status_StatusCode) *tempopb.Trace {
@@ -981,67 +753,6 @@ func TestSummarizeMissingServiceUsesReferenceUnknownFallback(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, string(data), `"rootService"`)
 	assert.Contains(t, string(data), `"name":"\u003cunknown\u003e"`)
-	assert.Contains(t, string(data), `"service":""`)
-	assert.Contains(t, string(data), `"service":"\u003cunknown\u003e"`)
-}
-
-func TestSummarizeAddedPatternsFollowReferenceCompression(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	root := func() *tracev1.Span {
-		return spanForNormalizeTest(traceID, "root", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
-	}
-	base := traceWithNamedSpans(root())
-	compare := traceWithNamedSpans(
-		root(),
-		spanForNormalizeTest(traceID, "ok", "root", "backend", "call", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
-		spanForNormalizeTest(traceID, "error", "root", "backend", "call", tracev1.Span_SPAN_KIND_CLIENT, 30, 40, tracev1.Status_STATUS_CODE_ERROR),
-	)
-
-	got, err := Summarize(base, compare)
-	require.NoError(t, err)
-	require.Len(t, got.Patterns, 1)
-	assert.Equal(t, 2, got.Patterns[0].Count)
-	assert.Empty(t, got.Patterns[0].Changes)
-	assert.Nil(t, got.Patterns[0].DurationDeltaMs)
-}
-
-func TestPatternKeySeparatesNestedCollectionShapes(t *testing.T) {
-	target := Target{Type: TargetAttribute, Scope: ScopeSpan, Key: "value"}
-	a := patternInput{state: patternStateModified, ref: SpanRef{Name: "op"}, changes: []Change{{
-		Op: OperationModify, Target: target, Before: []any{[]any{}, "x"}, After: nil,
-	}}}
-	b := patternInput{state: patternStateModified, ref: SpanRef{Name: "op"}, changes: []Change{{
-		Op: OperationModify, Target: target, Before: []any{[]any{"x"}}, After: nil,
-	}}}
-
-	assert.NotEqual(t, patternKey(a), patternKey(b))
-}
-
-func TestBuildPatternsTieOrderingIsDeterministic(t *testing.T) {
-	patch := &Result{}
-	for i := 0; i < patternCap+5; i++ {
-		patch.Modified = append(patch.Modified, ModifiedSpan{
-			Span: SpanRef{Service: "backend", Name: "op", Kind: fmt.Sprintf("kind-%02d", i)},
-			Changes: []Change{{
-				Op:     OperationModify,
-				Target: Target{Type: TargetAttribute, Scope: ScopeSpan, Key: "value"},
-				Before: int64(i),
-				After:  int64(i + 1),
-			}},
-		})
-	}
-
-	var expected []byte
-	for i := 0; i < 20; i++ {
-		patterns, _ := buildPatterns(patch)
-		data, err := json.Marshal(patterns)
-		require.NoError(t, err)
-		if i == 0 {
-			expected = data
-			continue
-		}
-		assert.Equal(t, string(expected), string(data))
-	}
 }
 
 func TestSummarizeKeepsCompleteServiceSections(t *testing.T) {
@@ -1071,15 +782,15 @@ func TestSummarizeKeepsCompleteServiceSections(t *testing.T) {
 	assert.Len(t, got.Services, serviceCount)
 }
 
-func TestBuildServiceSectionsRetainsLargestWorkChange(t *testing.T) {
+func TestBuildServiceSectionsRetainsLargestDurationSumChange(t *testing.T) {
 	const serviceCount = 50
-	baseWork := make(map[string]int64, serviceCount+1)
-	compareWork := make(map[string]int64, serviceCount+1)
+	baseDurationSums := make(map[string]int64, serviceCount+1)
+	compareDurationSums := make(map[string]int64, serviceCount+1)
 	patch := &Result{}
 	for i := 0; i < serviceCount; i++ {
 		service := fmt.Sprintf("error-%02d", i)
-		baseWork[service] = 10_000_000
-		compareWork[service] = 10_000_000
+		baseDurationSums[service] = 10_000_000
+		compareDurationSums[service] = 10_000_000
 		patch.Modified = append(patch.Modified, ModifiedSpan{
 			Span: SpanRef{Service: service},
 			Changes: []Change{{
@@ -1090,23 +801,23 @@ func TestBuildServiceSectionsRetainsLargestWorkChange(t *testing.T) {
 			}},
 		})
 	}
-	baseWork["regressor"] = 10_000_000
-	compareWork["regressor"] = 1_010_000_000
+	baseDurationSums["regressor"] = 10_000_000
+	compareDurationSums["regressor"] = 1_010_000_000
 
-	_, services := buildServiceSections(patch, baseWork, compareWork, nil)
+	_, services := buildServiceSections(patch, baseDurationSums, compareDurationSums, nil)
 	require.Len(t, services, serviceCount+1)
 	assert.Equal(t, "regressor", services[0].Name)
 }
 
 func TestBuildServiceSectionsDoesNotLetJitterDisplaceErrors(t *testing.T) {
 	const serviceCount = 50
-	baseWork := make(map[string]int64, serviceCount*2)
-	compareWork := make(map[string]int64, serviceCount*2)
+	baseDurationSums := make(map[string]int64, serviceCount*2)
+	compareDurationSums := make(map[string]int64, serviceCount*2)
 	patch := &Result{}
 	for i := 0; i < serviceCount; i++ {
 		service := fmt.Sprintf("error-%02d", i)
-		baseWork[service] = 10_000_000
-		compareWork[service] = 10_000_000
+		baseDurationSums[service] = 10_000_000
+		compareDurationSums[service] = 10_000_000
 		patch.Modified = append(patch.Modified, ModifiedSpan{
 			Span: SpanRef{Service: service},
 			Changes: []Change{{
@@ -1119,38 +830,15 @@ func TestBuildServiceSectionsDoesNotLetJitterDisplaceErrors(t *testing.T) {
 	}
 	for i := 0; i < serviceCount; i++ {
 		service := fmt.Sprintf("jitter-%02d", i)
-		baseWork[service] = 10_000_000
-		compareWork[service] = 10_000_001
+		baseDurationSums[service] = 10_000_000
+		compareDurationSums[service] = 10_000_001
 	}
 
-	_, services := buildServiceSections(patch, baseWork, compareWork, nil)
+	_, services := buildServiceSections(patch, baseDurationSums, compareDurationSums, nil)
 	require.Len(t, services, serviceCount)
 	for _, service := range services {
 		assert.Equal(t, 1, service.NewErrors)
 	}
-}
-
-func TestBuildPatternsRetainsFullExemplarData(t *testing.T) {
-	changes := make([]Change, 25)
-	for i := range changes {
-		changes[i] = Change{
-			Op:     OperationModify,
-			Target: Target{Type: TargetAttribute, Scope: ScopeSpan, Key: fmt.Sprintf("attribute-%02d", i)},
-			Before: []any{"before", int64(i)},
-			After:  []any{"after", int64(i)},
-		}
-	}
-	path := make([]int, 70)
-	patch := &Result{Modified: []ModifiedSpan{{
-		Span:    SpanRef{Path: path, Service: "service", Name: "operation", Kind: "client"},
-		Changes: changes,
-	}}}
-
-	patterns, _ := buildPatterns(patch)
-	require.Len(t, patterns, 1)
-	assert.Equal(t, changes, patterns[0].Changes)
-	require.Len(t, patterns[0].SampleSpans, 1)
-	assert.Equal(t, path, patterns[0].SampleSpans[0].Path)
 }
 
 func doubleAttribute(key string, value float64) *commonv1.KeyValue {

--- a/pkg/model/tracediff/summary_test.go
+++ b/pkg/model/tracediff/summary_test.go
@@ -157,50 +157,6 @@ func TestSummarizePureReparentJoinsChangedServicesOnly(t *testing.T) {
 	assert.Empty(t, got.Services)
 }
 
-func TestSummarizeWarnsOnReparentBetweenDuplicateLogicalParents(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(childParent string) *tempopb.Trace {
-		return traceWithNamedSpans(
-			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "parent-a", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "parent-b", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "child", childParent, "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
-		)
-	}
-
-	got, err := Summarize(makeTrace("parent-a"), makeTrace("parent-b"))
-	require.NoError(t, err)
-	assert.Zero(t, got.Stats.ModifiedSpans)
-	assert.Zero(t, got.Stats.AddedSpans)
-	assert.Zero(t, got.Stats.RemovedSpans)
-	assert.Equal(t, "unchanged", got.Signals.Structure)
-	assert.Contains(t, got.Warnings, Warning{
-		Code:    WarningAmbiguousSpanMatch,
-		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
-	})
-}
-
-func TestSummarizeDuplicateLogicalParentReorderIsStable(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(parentAStart, parentBStart uint64) *tempopb.Trace {
-		return traceWithNamedSpans(
-			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "parent-a", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, parentAStart, parentAStart+30, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "parent-b", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, parentBStart, parentBStart+30, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "child-a", "parent-a", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, parentAStart+10, parentAStart+20, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "child-b", "parent-b", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, parentBStart+10, parentBStart+20, tracev1.Status_STATUS_CODE_OK),
-		)
-	}
-
-	got, err := Summarize(makeTrace(10, 50), makeTrace(50, 10))
-	require.NoError(t, err)
-	assert.Equal(t, "unchanged", got.Signals.Structure)
-	assert.Contains(t, got.Warnings, Warning{
-		Code:    WarningAmbiguousSpanMatch,
-		Message: "2 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
-	})
-}
-
 func TestSummarizeMatchingCoverageRatiosDoNotRoundNearPerfectToOne(t *testing.T) {
 	assert.NotEqual(t, 1.0, matchedSpanRatio(10_000, 10_000, 9_999))
 	assert.Equal(t, float64(9_999)/float64(10_000), matchedSpanRatio(10_000, 10_000, 9_999))
@@ -589,73 +545,6 @@ func TestSummarizeErrorChurnFromMatcherCounts(t *testing.T) {
 	assert.Equal(t, 1, got.Services[0].ResolvedErrors)
 }
 
-func TestSummarizeWarnsOnAmbiguousDuplicateErrorChurn(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(first, second tracev1.Status_StatusCode) *tempopb.Trace {
-		return traceWithNamedSpans(
-			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "first", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 10, 20, first),
-			spanForNormalizeTest(traceID, "second", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 30, 40, second),
-		)
-	}
-
-	got, err := Summarize(
-		makeTrace(tracev1.Status_STATUS_CODE_OK, tracev1.Status_STATUS_CODE_ERROR),
-		makeTrace(tracev1.Status_STATUS_CODE_ERROR, tracev1.Status_STATUS_CODE_OK),
-	)
-	require.NoError(t, err)
-	assert.Zero(t, got.Stats.ModifiedSpans)
-	assert.Empty(t, got.Services)
-	assert.Contains(t, got.Warnings, Warning{
-		Code:    WarningAmbiguousSpanMatch,
-		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
-	})
-}
-
-func TestSummarizeUsesCanonicalAmbiguousMatcherCounts(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	span := func(id, variant string, start uint64) *tracev1.Span {
-		span := spanForNormalizeTest(traceID, id, "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, start, start+10, tracev1.Status_STATUS_CODE_OK)
-		span.Attributes = append(span.Attributes, stringAttribute("variant", variant))
-		return span
-	}
-	base := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-		span("base-a", "a", 10),
-		span("base-b", "b", 30),
-	)
-	compare := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-		span("compare-c", "c", 10),
-		span("compare-a", "a", 30),
-	)
-
-	got, err := Summarize(base, compare)
-	require.NoError(t, err)
-	assert.Equal(t, 1, got.Stats.ModifiedSpans)
-	assert.Equal(t, []ServiceRollup{{Name: "backend", Modified: 1}}, got.Services)
-}
-
-func TestSummarizeWarnsWhenDuplicateParentsAllChange(t *testing.T) {
-	traceID := []byte("trace-id-0000001")
-	makeTrace := func(parentAService, parentBService string) *tempopb.Trace {
-		return traceWithNamedSpans(
-			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "parent-a", "root", parentAService, "parent", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "parent-b", "root", parentBService, "parent", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "first", "parent-a", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 20, 30, tracev1.Status_STATUS_CODE_OK),
-			spanForNormalizeTest(traceID, "second", "parent-b", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 60, 70, tracev1.Status_STATUS_CODE_ERROR),
-		)
-	}
-
-	got, err := Summarize(makeTrace("a", "b"), makeTrace("c", "d"))
-	require.NoError(t, err)
-	assert.Contains(t, got.Warnings, Warning{
-		Code:    WarningAmbiguousSpanMatch,
-		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
-	})
-}
-
 func TestSummarizeKeepsOpposingTransitionsUnderDistinctParents(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
 	makeTrace := func(first, second tracev1.Status_StatusCode) *tempopb.Trace {
@@ -676,9 +565,6 @@ func TestSummarizeKeepsOpposingTransitionsUnderDistinctParents(t *testing.T) {
 	require.Len(t, got.Services, 1)
 	assert.Equal(t, 1, got.Services[0].NewErrors)
 	assert.Equal(t, 1, got.Services[0].ResolvedErrors)
-	for _, warning := range got.Warnings {
-		assert.NotEqual(t, WarningAmbiguousSpanMatch, warning.Code)
-	}
 }
 
 func TestSummarizeRootFallsBackForCycleOnlyTrace(t *testing.T) {

--- a/pkg/model/tracediff/summary_test.go
+++ b/pkg/model/tracediff/summary_test.go
@@ -1,0 +1,1179 @@
+package tracediff
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummarize(t *testing.T) {
+	base, compare := summaryFixtureTraces()
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+
+	assert.Equal(t, VersionTraceSummaryV0Native, got.Version)
+	assert.Equal(t, Signals{
+		TraceLatency: "increased",
+		SpanWork:     "increased",
+		Errors:       "increased",
+		SpanCount:    "unchanged",
+		Structure:    "unchanged",
+	}, got.Signals)
+	assert.Equal(t, 1.0, got.Trust.MatchedSpanRatio)
+	assert.Equal(t, 1.0, got.Trust.StructureOverlap)
+	assert.Equal(t, SummaryStats{
+		TraceLatencyDeltaMs: 10,
+		SpanWorkDeltaMs:     12,
+		SpanCountDelta:      0,
+		ErrorSpanDelta:      1,
+		MatchedSpans:        3,
+		ModifiedSpans:       2,
+		FieldChanges:        1,
+		AttributeChanges:    1,
+	}, got.Stats)
+
+	assert.Equal(t, []string{"checkout"}, got.ChangedServices)
+	assert.Equal(t, []ServiceRollup{
+		{Name: "checkout", SpanWorkDeltaMs: 12, Modified: 2, NewErrors: 1},
+	}, got.Services)
+	assert.Len(t, got.Patterns, 2)
+	assert.Nil(t, got.PatternsTruncated)
+}
+
+func TestSummarizeNativeJSONShape(t *testing.T) {
+	base, compare := summaryFixtureTraces()
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	data, err := json.MarshalIndent(got, "", "  ")
+	require.NoError(t, err)
+
+	assert.Equal(t, `{
+  "version": "trace-summary-v0-native",
+  "base": {
+    "traceId": "74726163652d69642d30303030303031",
+    "rootService": "checkout",
+    "rootName": "GET /checkout",
+    "spanCount": 3,
+    "errorSpanCount": 0,
+    "durationMs": 100,
+    "spanWorkMs": 140
+  },
+  "compare": {
+    "traceId": "74726163652d69642d30303030303031",
+    "rootService": "checkout",
+    "rootName": "GET /checkout",
+    "spanCount": 3,
+    "errorSpanCount": 1,
+    "durationMs": 110,
+    "spanWorkMs": 152
+  },
+  "signals": {
+    "traceLatency": "increased",
+    "spanWork": "increased",
+    "errors": "increased",
+    "spanCount": "unchanged",
+    "structure": "unchanged"
+  },
+  "trust": {
+    "matchedSpanRatio": 1,
+    "structureOverlap": 1
+  },
+  "stats": {
+    "traceLatencyDeltaMs": 10,
+    "spanWorkDeltaMs": 12,
+    "spanCountDelta": 0,
+    "errorSpanDelta": 1,
+    "matchedSpans": 3,
+    "modifiedSpans": 2,
+    "addedSpans": 0,
+    "removedSpans": 0,
+    "fieldChanges": 1,
+    "attributeChanges": 1
+  },
+  "changedServices": [
+    "checkout"
+  ],
+  "services": [
+    {
+      "name": "checkout",
+      "spanWorkDeltaMs": 12,
+      "modified": 2,
+      "added": 0,
+      "removed": 0,
+      "newErrors": 1,
+      "resolvedErrors": 0
+    }
+  ],
+  "patterns": [
+    {
+      "state": "modified",
+      "span": {
+        "service": "checkout",
+        "name": "GET /checkout",
+        "kind": "server"
+      },
+      "count": 1,
+      "sampleSpans": [
+        {
+          "path": [
+            0
+          ],
+          "service": "checkout",
+          "name": "GET /checkout",
+          "kind": "server"
+        }
+      ],
+      "changes": [
+        {
+          "op": "modify",
+          "target": {
+            "type": "attribute",
+            "scope": "span",
+            "key": "service.version"
+          },
+          "before": "v1",
+          "after": "v2"
+        }
+      ]
+    },
+    {
+      "state": "modified",
+      "span": {
+        "service": "checkout",
+        "name": "cache lookup",
+        "kind": "client"
+      },
+      "count": 1,
+      "sampleSpans": [
+        {
+          "path": [
+            0,
+            0
+          ],
+          "service": "checkout",
+          "name": "cache lookup",
+          "kind": "client"
+        }
+      ],
+      "changes": [
+        {
+          "op": "modify",
+          "target": {
+            "type": "field",
+            "name": "status"
+          },
+          "before": "ok",
+          "after": "error"
+        }
+      ]
+    }
+  ]
+}`, string(data))
+}
+
+func TestSummarizeStructureSignalDetectsTopologyChange(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "auth", "root", "auth", "authorize", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "db", "root", "db", "SELECT user", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "auth", "root", "auth", "authorize", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "db", "auth", "db", "SELECT user", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Stats.AddedSpans)
+	assert.Equal(t, 0, got.Stats.RemovedSpans)
+	assert.Equal(t, "changed", got.Signals.Structure)
+	assert.Equal(t, []string{"db"}, got.ChangedServices)
+	assert.Empty(t, got.Services)
+}
+
+func TestSummarizePureReparentJoinsChangedServicesOnly(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "auth", "root", "auth", "authorize", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "db", "auth", "db", "SELECT user", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "auth", "root", "auth", "authorize", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "db", "root", "db", "SELECT user", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	assert.Equal(t, "changed", got.Signals.Structure)
+	assert.Equal(t, 0, got.Stats.ModifiedSpans)
+	assert.Equal(t, []string{"db"}, got.ChangedServices)
+	assert.Empty(t, got.Services)
+	assert.Empty(t, got.Patterns)
+}
+
+func TestSummarizeWarnsOnReparentBetweenDuplicateLogicalParents(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(childParent string) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-a", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-b", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "child", childParent, "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 20, 30, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	got, err := Summarize(makeTrace("parent-a"), makeTrace("parent-b"))
+	require.NoError(t, err)
+	assert.Zero(t, got.Stats.ModifiedSpans)
+	assert.Zero(t, got.Stats.AddedSpans)
+	assert.Zero(t, got.Stats.RemovedSpans)
+	assert.Equal(t, "unchanged", got.Signals.Structure)
+	assert.Contains(t, got.Warnings, Warning{
+		Code:    WarningAmbiguousSpanMatch,
+		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
+	})
+}
+
+func TestSummarizeDuplicateLogicalParentReorderIsStable(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(parentAStart, parentBStart uint64) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-a", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, parentAStart, parentAStart+30, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-b", "root", "worker", "process", tracev1.Span_SPAN_KIND_INTERNAL, parentBStart, parentBStart+30, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "child-a", "parent-a", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, parentAStart+10, parentAStart+20, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "child-b", "parent-b", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, parentBStart+10, parentBStart+20, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	got, err := Summarize(makeTrace(10, 50), makeTrace(50, 10))
+	require.NoError(t, err)
+	assert.Equal(t, "unchanged", got.Signals.Structure)
+	assert.Contains(t, got.Warnings, Warning{
+		Code:    WarningAmbiguousSpanMatch,
+		Message: "2 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
+	})
+}
+
+func TestSummarizeMatchingCoverageRatiosDoNotRoundNearPerfectToOne(t *testing.T) {
+	assert.NotEqual(t, 1.0, matchedSpanRatio(10_000, 10_000, 9_999))
+	assert.Equal(t, float64(9_999)/float64(10_000), matchedSpanRatio(10_000, 10_000, 9_999))
+	assert.Equal(t, 1.0, matchedSpanRatio(10_000, 10_000, 10_000))
+}
+
+func TestSummarizeNativeEncodesNonFiniteAttributes(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	baseRoot := spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	baseRoot.Attributes = append(baseRoot.Attributes, doubleAttribute("score", 1.5))
+	compareRoot := spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	compareRoot.Attributes = append(compareRoot.Attributes, doubleAttribute("score", math.NaN()))
+
+	got, err := Summarize(traceWithNamedSpans(baseRoot), traceWithNamedSpans(compareRoot))
+	require.NoError(t, err)
+	require.Len(t, got.Patterns, 1)
+	require.Len(t, got.Patterns[0].Changes, 1)
+	change := got.Patterns[0].Changes[0]
+	assert.Equal(t, "score", change.Target.Key)
+	assert.Equal(t, 1.5, change.Before)
+	assert.Equal(t, "NaN", change.After)
+
+	// The default encoder rejects non-finite floats; the sanitized result must
+	// still encode successfully.
+	data, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"after":"NaN"`)
+}
+
+func TestSummarizeTreatsIdenticalNonFiniteAttributesAsUnchanged(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func() *tempopb.Trace {
+		root := spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+		root.Attributes = append(root.Attributes, doubleAttribute("score", math.NaN()))
+		return traceWithNamedSpans(root)
+	}
+
+	got, err := Summarize(makeTrace(), makeTrace())
+	require.NoError(t, err)
+	assert.Equal(t, "unchanged", got.Signals.TraceLatency)
+	assert.Equal(t, "unchanged", got.Signals.SpanWork)
+	assert.Equal(t, "unchanged", got.Signals.Errors)
+	assert.Equal(t, 0, got.Stats.AttributeChanges)
+	assert.Empty(t, got.Services)
+	assert.Empty(t, got.Patterns)
+}
+
+func TestSummarizeSignalsReportIndependentDirections(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	// Fewer errors but higher latency: report both facts without declaring whether
+	// the overall change is good or bad.
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_ERROR),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 150, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	assert.Equal(t, "increased", got.Signals.TraceLatency)
+	assert.Equal(t, "decreased", got.Signals.Errors)
+}
+
+func TestSummarizeIgnoresUnsetSpanStartInDuration(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	// A child span has an unset (zero) start. It contributes zero while the valid
+	// root still determines the trace envelope and work.
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			&tracev1.Span{
+				TraceId:           traceID,
+				SpanId:            []byte("child"),
+				ParentSpanId:      []byte("root"),
+				Name:              "cache lookup",
+				Kind:              tracev1.Span_SPAN_KIND_CLIENT,
+				StartTimeUnixNano: 0, // unset
+				EndTimeUnixNano:   (normalizeTestTimeOffsetMs + 50) * 1_000_000,
+				Attributes:        []*commonv1.KeyValue{stringAttribute("service.name", "checkout")},
+				Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+			},
+		)
+	}
+
+	got, err := Summarize(makeTrace(), makeTrace())
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), got.Base.DurationMs)
+	assert.Equal(t, int64(100), got.Compare.DurationMs)
+	assert.Zero(t, got.Stats.TraceLatencyDeltaMs)
+	assert.Equal(t, int64(100), got.Base.SpanWorkMs)
+	assert.Equal(t, int64(100), got.Compare.SpanWorkMs)
+	assert.Zero(t, got.Stats.SpanWorkDeltaMs)
+	assert.Equal(t, "unchanged", got.Signals.TraceLatency)
+	assert.Equal(t, "unchanged", got.Signals.SpanWork)
+}
+
+func TestSummarizeUnsetSpanStartDoesNotInflateSpanWork(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	// Baseline: a root and a child, both with usable start times.
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "child", "root", "checkout", "cache lookup", tracev1.Span_SPAN_KIND_CLIENT, 10, 60, tracev1.Status_STATUS_CODE_OK),
+	)
+	// Comparison: the child keeps a realistic end but loses its start and
+	// contributes zero work.
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		&tracev1.Span{
+			TraceId:           traceID,
+			SpanId:            []byte("child"),
+			ParentSpanId:      []byte("root"),
+			Name:              "cache lookup",
+			Kind:              tracev1.Span_SPAN_KIND_CLIENT,
+			StartTimeUnixNano: 0, // unset
+			EndTimeUnixNano:   (normalizeTestTimeOffsetMs + 60) * 1_000_000,
+			Attributes:        []*commonv1.KeyValue{stringAttribute("service.name", "checkout")},
+			Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+		},
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	assert.Equal(t, int64(150), got.Base.SpanWorkMs)
+	assert.Equal(t, int64(100), got.Compare.SpanWorkMs)
+	assert.Equal(t, int64(-50), got.Stats.SpanWorkDeltaMs)
+	assert.Equal(t, "decreased", got.Signals.SpanWork)
+	// The duration change with an invalid side renders null and must not
+	// fabricate delta stats.
+	require.Len(t, got.Patterns, 1)
+	require.Len(t, got.Patterns[0].Changes, 1)
+	assert.Equal(t, "duration_ms", got.Patterns[0].Changes[0].Target.Name)
+	assert.Equal(t, int64(50), got.Patterns[0].Changes[0].Before)
+	assert.Nil(t, got.Patterns[0].Changes[0].After)
+	assert.Nil(t, got.Patterns[0].DurationDeltaMs)
+}
+
+func TestSummarizeStructuralSurfacesAddedAndRemovedErrors(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "gone", "root", "checkout", "dropped call", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_ERROR),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "new", "root", "checkout", "new call", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_ERROR),
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+
+	require.Len(t, got.Services, 1)
+	assert.Equal(t, ServiceRollup{
+		Name:            "checkout",
+		SpanWorkDeltaMs: 0,
+		Added:           1,
+		Removed:         1,
+		NewErrors:       1,
+		ResolvedErrors:  1,
+	}, got.Services[0])
+
+	require.Len(t, got.Patterns, 2)
+	added := got.Patterns[0]
+	assert.Equal(t, "added", added.State)
+	assert.Equal(t, "new call", added.Span.Name)
+	assert.Empty(t, added.Changes)
+	removed := got.Patterns[1]
+	assert.Equal(t, "removed", removed.State)
+	assert.Equal(t, "dropped call", removed.Span.Name)
+	assert.Empty(t, removed.Changes)
+}
+
+func TestSummarizeInvalidDurationWarnsAndDoesNotInflateEnvelope(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			&tracev1.Span{
+				TraceId:           traceID,
+				SpanId:            []byte("bad-child"),
+				ParentSpanId:      []byte("root"),
+				Name:              "bad duration",
+				Kind:              tracev1.Span_SPAN_KIND_CLIENT,
+				StartTimeUnixNano: 0,
+				EndTimeUnixNano:   (normalizeTestTimeOffsetMs + 1000) * 1_000_000,
+				Attributes:        []*commonv1.KeyValue{stringAttribute("service.name", "checkout")},
+				Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+			},
+		)
+	}
+
+	got, err := Summarize(makeTrace(), makeTrace())
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), got.Base.DurationMs)
+	assert.Equal(t, int64(100), got.Compare.DurationMs)
+	require.Len(t, got.Warnings, 2)
+	assert.Equal(t, WarningInvalidDuration, got.Warnings[0].Code)
+	assert.Contains(t, got.Warnings[0].Message, "base trace")
+	assert.Equal(t, WarningInvalidDuration, got.Warnings[1].Code)
+	assert.Contains(t, got.Warnings[1].Message, "compare trace")
+}
+
+func TestSummarizeInvalidDurationOnlyServiceKeepsRollupCounts(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(status tracev1.Status_StatusCode) *tempopb.Trace {
+		return traceWithNamedSpans(&tracev1.Span{
+			TraceId:           traceID,
+			SpanId:            []byte("invalid"),
+			Name:              "invalid operation",
+			Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
+			StartTimeUnixNano: 0,
+			EndTimeUnixNano:   100_000_000,
+			Attributes:        []*commonv1.KeyValue{stringAttribute("service.name", "broken")},
+			Status:            &tracev1.Status{Code: status},
+		})
+	}
+
+	got, err := Summarize(makeTrace(tracev1.Status_STATUS_CODE_OK), makeTrace(tracev1.Status_STATUS_CODE_ERROR))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"broken"}, got.ChangedServices)
+	assert.Equal(t, []ServiceRollup{{Name: "broken", Modified: 1, NewErrors: 1}}, got.Services)
+}
+
+func TestSummarizeZeroSpanTracesWarnAndStayUnchanged(t *testing.T) {
+	got, err := Summarize(&tempopb.Trace{}, &tempopb.Trace{})
+	require.NoError(t, err)
+
+	require.Len(t, got.Warnings, 2)
+	assert.Equal(t, WarningZeroSpanTrace, got.Warnings[0].Code)
+	assert.Contains(t, got.Warnings[0].Message, "base trace")
+	assert.Equal(t, WarningZeroSpanTrace, got.Warnings[1].Code)
+	assert.Contains(t, got.Warnings[1].Message, "compare trace")
+	// The (0,0) branch pins both coverage ratios at 1; the warning explains that
+	// the vacuous ratios carry no matching evidence.
+	assert.Equal(t, 1.0, got.Trust.MatchedSpanRatio)
+	assert.Equal(t, 1.0, got.Trust.StructureOverlap)
+	assert.Equal(t, Signals{
+		TraceLatency: "unchanged",
+		SpanWork:     "unchanged",
+		Errors:       "unchanged",
+		SpanCount:    "unchanged",
+		Structure:    "unchanged",
+	}, got.Signals)
+}
+
+func TestSummarizeOneSideEmptyTraceZeroesMatchingCoverageRatios(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Summarize(&tempopb.Trace{}, compare)
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, got.Trust.MatchedSpanRatio)
+	assert.Equal(t, 0.0, got.Trust.StructureOverlap)
+	require.Len(t, got.Warnings, 1)
+	assert.Equal(t, WarningZeroSpanTrace, got.Warnings[0].Code)
+	assert.Contains(t, got.Warnings[0].Message, "base trace")
+}
+
+func TestSummarizeDuplicateSpanIDsWarn(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "dup", "root", "checkout", "op a", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "dup", "root", "checkout", "op b", tracev1.Span_SPAN_KIND_CLIENT, 30, 40, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	got, err := Summarize(makeTrace(), makeTrace())
+	require.NoError(t, err)
+	require.Len(t, got.Warnings, 2)
+	assert.Equal(t, WarningDuplicateSpanID, got.Warnings[0].Code)
+	assert.Contains(t, got.Warnings[0].Message, "base trace has 1 span(s) with duplicate span IDs")
+	assert.Equal(t, WarningDuplicateSpanID, got.Warnings[1].Code)
+	assert.Contains(t, got.Warnings[1].Message, "compare trace has 1 span(s) with duplicate span IDs")
+}
+
+func TestSummarizeEmptySectionsEncodeAsEmptyArrays(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	got, err := Summarize(makeTrace(), makeTrace())
+	require.NoError(t, err)
+	data, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"services":[]`)
+	assert.Contains(t, string(data), `"patterns":[]`)
+}
+
+func TestSummarizeNilTrace(t *testing.T) {
+	got, err := Summarize(nil, &tempopb.Trace{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilTrace)
+	assert.Nil(t, got)
+}
+
+func TestDriftSignificantBoundary(t *testing.T) {
+	const maxInt64Value = int64(^uint64(0) >> 1)
+	tests := []struct {
+		name       string
+		baseNanos  int64
+		deltaNanos int64
+		want       bool
+	}{
+		{name: "exactly the absolute floor", baseNanos: 0, deltaNanos: driftMinNanos, want: true},
+		{name: "just below the absolute floor", baseNanos: 0, deltaNanos: driftMinNanos - 1, want: false},
+		{name: "exactly the relative threshold", baseNanos: 100_000_000, deltaNanos: 5_000_000, want: true},
+		{name: "just below the relative threshold", baseNanos: 100_000_000, deltaNanos: 4_999_999, want: false},
+		{name: "negative delta at the relative threshold", baseNanos: 100_000_000, deltaNanos: -5_000_000, want: true},
+		{name: "large value just below exact relative threshold", baseNanos: maxInt64Value, deltaNanos: maxInt64Value / 20, want: false},
+		{name: "large value at exact relative threshold", baseNanos: maxInt64Value, deltaNanos: maxInt64Value/20 + 1, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, driftSignificant(tt.baseNanos, tt.deltaNanos))
+		})
+	}
+}
+
+func TestSummarizeSystemicDriftAttribution(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(spanDurationMs uint64) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, spanDurationMs, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "backend", "root", "backend", "process", tracev1.Span_SPAN_KIND_CLIENT, 10, 10+spanDurationMs, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "db", "backend", "database", "SELECT orders", tracev1.Span_SPAN_KIND_CLIENT, 20, 20+spanDurationMs, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	// +13% per span is inside the differ's 20%/1ms duration tolerance, so the
+	// patch is empty; only the per-service aggregates can attribute the drift.
+	got, err := Summarize(makeTrace(100), makeTrace(113))
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Stats.ModifiedSpans)
+	assert.Equal(t, 0, got.Stats.FieldChanges)
+	assert.Empty(t, got.Patterns)
+	assert.Equal(t, []ServiceRollup{
+		{Name: "backend", SpanWorkDeltaMs: 13},
+		{Name: "database", SpanWorkDeltaMs: 13},
+		{Name: "frontend", SpanWorkDeltaMs: 13},
+	}, got.Services)
+}
+
+func TestSummarizeNanosecondJitterNotFlagged(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "child", "root", "checkout", "cache lookup", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	tests := []struct {
+		name       string
+		endShiftNs int64
+	}{
+		{name: "one nanosecond slower", endShiftNs: 1},
+		{name: "one nanosecond faster", endShiftNs: -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compare := makeTrace()
+			child := compare.ResourceSpans[0].ScopeSpans[0].Spans[1]
+			child.EndTimeUnixNano = uint64(int64(child.EndTimeUnixNano) + tt.endShiftNs)
+
+			got, err := Summarize(makeTrace(), compare)
+			require.NoError(t, err)
+			assert.Equal(t, 0, got.Stats.ModifiedSpans)
+			assert.Empty(t, got.Services)
+			assert.Empty(t, got.Patterns)
+			assert.Zero(t, got.Stats.SpanWorkDeltaMs)
+			assert.Equal(t, "unchanged", got.Signals.SpanWork)
+		})
+	}
+}
+
+func TestSummarizeSubMillisecondDriftAccumulatesInNanoseconds(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 5, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "a", "root", "checkout", "op a", tracev1.Span_SPAN_KIND_CLIENT, 10, 15, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "b", "root", "checkout", "op b", tracev1.Span_SPAN_KIND_CLIENT, 20, 25, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	// Every span slows by 0.4ms. Nanosecond accumulation must preserve the full
+	// 1.2ms delta in both trace stats and the service rollup.
+	compare := makeTrace()
+	for _, span := range compare.ResourceSpans[0].ScopeSpans[0].Spans {
+		span.EndTimeUnixNano += 400_000
+	}
+
+	got, err := Summarize(makeTrace(), compare)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Stats.ModifiedSpans)
+	assert.Equal(t, int64(15), got.Base.SpanWorkMs)
+	assert.Equal(t, int64(16), got.Compare.SpanWorkMs)
+	assert.Equal(t, int64(1), got.Stats.SpanWorkDeltaMs)
+	assert.Equal(t, "increased", got.Signals.SpanWork)
+	require.Len(t, got.Services, 1)
+	assert.Equal(t, int64(1), got.Services[0].SpanWorkDeltaMs)
+}
+
+func TestSummarizeErrorChurnFromMatcherCounts(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(aStatus, bStatus tracev1.Status_StatusCode) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "a", "root", "checkout", "op a", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, aStatus),
+			spanForNormalizeTest(traceID, "b", "root", "checkout", "op b", tracev1.Span_SPAN_KIND_CLIENT, 30, 40, bStatus),
+		)
+	}
+
+	got, err := Summarize(
+		makeTrace(tracev1.Status_STATUS_CODE_OK, tracev1.Status_STATUS_CODE_ERROR),
+		makeTrace(tracev1.Status_STATUS_CODE_ERROR, tracev1.Status_STATUS_CODE_OK),
+	)
+	require.NoError(t, err)
+	// The net error delta cancels to zero; only the matcher-derived counts keep
+	// the simultaneous churn visible.
+	assert.Equal(t, 0, got.Stats.ErrorSpanDelta)
+	require.Len(t, got.Services, 1)
+	assert.Equal(t, 1, got.Services[0].NewErrors)
+	assert.Equal(t, 1, got.Services[0].ResolvedErrors)
+}
+
+func TestSummarizeWarnsOnAmbiguousDuplicateErrorChurn(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(first, second tracev1.Status_StatusCode) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "first", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 10, 20, first),
+			spanForNormalizeTest(traceID, "second", "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 30, 40, second),
+		)
+	}
+
+	got, err := Summarize(
+		makeTrace(tracev1.Status_STATUS_CODE_OK, tracev1.Status_STATUS_CODE_ERROR),
+		makeTrace(tracev1.Status_STATUS_CODE_ERROR, tracev1.Status_STATUS_CODE_OK),
+	)
+	require.NoError(t, err)
+	assert.Zero(t, got.Stats.ModifiedSpans)
+	assert.Empty(t, got.Services)
+	assert.Empty(t, got.Patterns)
+	assert.Contains(t, got.Warnings, Warning{
+		Code:    WarningAmbiguousSpanMatch,
+		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
+	})
+}
+
+func TestSummarizeUsesCanonicalAmbiguousPatterns(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	span := func(id, variant string, start uint64) *tracev1.Span {
+		span := spanForNormalizeTest(traceID, id, "root", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, start, start+10, tracev1.Status_STATUS_CODE_OK)
+		span.Attributes = append(span.Attributes, stringAttribute("variant", variant))
+		return span
+	}
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		span("base-a", "a", 10),
+		span("base-b", "b", 30),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		span("compare-c", "c", 10),
+		span("compare-a", "a", 30),
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Stats.ModifiedSpans)
+	assert.Equal(t, []ServiceRollup{{Name: "backend", Modified: 1}}, got.Services)
+	require.Len(t, got.Patterns, 1)
+	require.Len(t, got.Patterns[0].Changes, 1)
+	assert.Equal(t, "b", got.Patterns[0].Changes[0].Before)
+	assert.Equal(t, "c", got.Patterns[0].Changes[0].After)
+}
+
+func TestSummarizeWarnsWhenDuplicateParentsAllChange(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(parentAService, parentBService string) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-a", "root", parentAService, "parent", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-b", "root", parentBService, "parent", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "first", "parent-a", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 20, 30, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "second", "parent-b", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 60, 70, tracev1.Status_STATUS_CODE_ERROR),
+		)
+	}
+
+	got, err := Summarize(makeTrace("a", "b"), makeTrace("c", "d"))
+	require.NoError(t, err)
+	assert.Contains(t, got.Warnings, Warning{
+		Code:    WarningAmbiguousSpanMatch,
+		Message: "1 duplicate logical span group(s) may match ambiguously; matching minimizes changes, but instance-level transitions may not identify the same physical operation",
+	})
+}
+
+func TestSummarizeKeepsOpposingTransitionsUnderDistinctParents(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(first, second tracev1.Status_StatusCode) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "gateway", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-a", "root", "a", "parent a", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "parent-b", "root", "b", "parent b", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "first", "parent-a", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 20, 30, first),
+			spanForNormalizeTest(traceID, "second", "parent-b", "backend", "duplicate", tracev1.Span_SPAN_KIND_INTERNAL, 60, 70, second),
+		)
+	}
+
+	got, err := Summarize(
+		makeTrace(tracev1.Status_STATUS_CODE_OK, tracev1.Status_STATUS_CODE_ERROR),
+		makeTrace(tracev1.Status_STATUS_CODE_ERROR, tracev1.Status_STATUS_CODE_OK),
+	)
+	require.NoError(t, err)
+	require.Len(t, got.Services, 1)
+	assert.Equal(t, 1, got.Services[0].NewErrors)
+	assert.Equal(t, 1, got.Services[0].ResolvedErrors)
+	for _, warning := range got.Warnings {
+		assert.NotEqual(t, WarningAmbiguousSpanMatch, warning.Code)
+	}
+}
+
+func TestSummarizePatternsCompressRepeatedChanges(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(childDurationMs func(i uint64) uint64) *tempopb.Trace {
+		spans := []*tracev1.Span{
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 300, tracev1.Status_STATUS_CODE_OK),
+		}
+		for i := uint64(0); i < 30; i++ {
+			start := 10 + i
+			spans = append(spans, spanForNormalizeTest(traceID, fmt.Sprintf("child-%02d", i), "root", "backend", "repeated op", tracev1.Span_SPAN_KIND_CLIENT, start, start+childDurationMs(i), tracev1.Status_STATUS_CODE_OK))
+		}
+		return traceWithNamedSpans(spans...)
+	}
+
+	base := makeTrace(func(uint64) uint64 { return 100 })
+	// Every span slows in the same direction but by different amounts (+50..+79ms,
+	// all above tolerance), so direction-based grouping must still compress them.
+	compare := makeTrace(func(i uint64) uint64 { return 150 + i })
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	require.Len(t, got.Patterns, 1)
+	pattern := got.Patterns[0]
+	assert.Equal(t, "modified", pattern.State)
+	assert.Equal(t, PatternSpan{Service: "backend", Name: "repeated op", Kind: "client"}, pattern.Span)
+	assert.Equal(t, 30, pattern.Count)
+	assert.Len(t, pattern.SampleSpans, patternSampleSpans)
+	require.NotNil(t, pattern.DurationDeltaMs)
+	assert.Equal(t, DurationDeltaStats{Min: 50, Max: 79, Total: 1935}, *pattern.DurationDeltaMs)
+	require.Len(t, pattern.Changes, 1)
+	assert.Equal(t, "duration_ms", pattern.Changes[0].Target.Name)
+	assert.Equal(t, int64(100), pattern.Changes[0].Before)
+	assert.Equal(t, int64(150), pattern.Changes[0].After)
+	assert.Nil(t, got.PatternsTruncated)
+}
+
+func TestSummarizePatternsCapWithDisclosure(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(childDurationMs uint64) *tempopb.Trace {
+		spans := []*tracev1.Span{
+			spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 300, tracev1.Status_STATUS_CODE_OK),
+		}
+		for i := uint64(0); i < 25; i++ {
+			start := 10 + i
+			spans = append(spans, spanForNormalizeTest(traceID, fmt.Sprintf("span-%02d", i), "root", "backend", fmt.Sprintf("op-%02d", i), tracev1.Span_SPAN_KIND_CLIENT, start, start+childDurationMs, tracev1.Status_STATUS_CODE_OK))
+		}
+		return traceWithNamedSpans(spans...)
+	}
+
+	// 25 distinct span names, each slowed above tolerance: 25 distinct patterns.
+	got, err := Summarize(makeTrace(100), makeTrace(150))
+	require.NoError(t, err)
+	require.Len(t, got.Patterns, patternCap)
+	assert.Equal(t, "op-00", got.Patterns[0].Span.Name)
+	assert.Equal(t, "op-19", got.Patterns[patternCap-1].Span.Name)
+	require.NotNil(t, got.PatternsTruncated)
+	assert.Equal(t, PatternsTruncated{Patterns: 5, Spans: 5}, *got.PatternsTruncated)
+}
+
+func TestSummarizeRootFallsBackForCycleOnlyTrace(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	// Every span's parent is present, forming a cycle with no structural root.
+	// The summary must still report a deterministic root (earliest by start time,
+	// then span ID) rather than leaving the root fields empty.
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "a", "b", "checkout", "span a", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "b", "a", "checkout", "span b", tracev1.Span_SPAN_KIND_CLIENT, 0, 30, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	got, err := Summarize(makeTrace(), makeTrace())
+	require.NoError(t, err)
+	assert.Equal(t, "checkout", got.Base.RootService)
+	assert.Equal(t, "span b", got.Base.RootName)
+}
+
+func TestSummarizeRootHandlesDanglingParent(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	// The true root's parent span was not returned (a partial trace), so its
+	// parent ID dangles. The root must still be identified.
+	makeTrace := func() *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "missing-parent", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "child", "root", "checkout", "cache lookup", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		)
+	}
+
+	got, err := Summarize(makeTrace(), makeTrace())
+	require.NoError(t, err)
+	assert.Equal(t, "checkout", got.Base.RootService)
+	assert.Equal(t, "GET /checkout", got.Base.RootName)
+	assert.Equal(t, "checkout", got.Compare.RootService)
+	assert.Equal(t, "GET /checkout", got.Compare.RootName)
+}
+
+func TestSummarizeTraceLatencyDeltaUsesRawNanoseconds(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(durationNanos uint64) *tempopb.Trace {
+		span := spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 1, tracev1.Status_STATUS_CODE_OK)
+		span.EndTimeUnixNano = span.StartTimeUnixNano + durationNanos
+		return traceWithNamedSpans(span)
+	}
+
+	got, err := Summarize(makeTrace(1_999_999), makeTrace(2_000_000))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), got.Base.DurationMs)
+	assert.Equal(t, int64(2), got.Compare.DurationMs)
+	assert.Zero(t, got.Stats.TraceLatencyDeltaMs)
+	assert.Equal(t, "unchanged", got.Signals.TraceLatency)
+}
+
+func TestSummarizePatternDurationTotalSumsBeforeTruncating(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(childDurationNanos uint64) *tempopb.Trace {
+		children := []*tracev1.Span{
+			spanForNormalizeTest(traceID, "a", "root", "backend", "op", tracev1.Span_SPAN_KIND_CLIENT, 10, 10, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "b", "root", "backend", "op", tracev1.Span_SPAN_KIND_CLIENT, 20, 20, tracev1.Status_STATUS_CODE_OK),
+		}
+		for _, child := range children {
+			child.EndTimeUnixNano = child.StartTimeUnixNano + childDurationNanos
+		}
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "root", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+			children[0],
+			children[1],
+		)
+	}
+
+	got, err := Summarize(makeTrace(0), makeTrace(1_500_000))
+	require.NoError(t, err)
+	require.Len(t, got.Patterns, 1)
+	require.NotNil(t, got.Patterns[0].DurationDeltaMs)
+	assert.Equal(t, DurationDeltaStats{Min: 1, Max: 1, Total: 3}, *got.Patterns[0].DurationDeltaMs)
+}
+
+func TestSummarizeGroupsInvalidDurationTransitions(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	invalid := func(span *tracev1.Span) *tracev1.Span {
+		span.StartTimeUnixNano = 0
+		return span
+	}
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "parent-a", "root", "a", "parent a", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "child-a", "parent-a", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 15, 25, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "parent-b", "root", "b", "parent b", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
+		invalid(spanForNormalizeTest(traceID, "child-b", "parent-b", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 55, 65, tracev1.Status_STATUS_CODE_OK)),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root-2", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "parent-a-2", "root-2", "a", "parent a", tracev1.Span_SPAN_KIND_INTERNAL, 10, 40, tracev1.Status_STATUS_CODE_OK),
+		invalid(spanForNormalizeTest(traceID, "child-a-2", "parent-a-2", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 15, 25, tracev1.Status_STATUS_CODE_OK)),
+		spanForNormalizeTest(traceID, "parent-b-2", "root-2", "b", "parent b", tracev1.Span_SPAN_KIND_INTERNAL, 50, 80, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "child-b-2", "parent-b-2", "db", "query", tracev1.Span_SPAN_KIND_CLIENT, 55, 65, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	require.Len(t, got.Patterns, 1)
+	assert.Equal(t, 2, got.Patterns[0].Count)
+	require.Len(t, got.Patterns[0].Changes, 1)
+	assert.Nil(t, got.Patterns[0].Changes[0].After)
+}
+
+func TestSummarizeMissingServiceUsesReferenceUnknownFallback(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(status tracev1.Status_StatusCode) *tempopb.Trace {
+		return traceWithNamedSpans(
+			spanForNormalizeTest(traceID, "missing", "", "", "missing service", tracev1.Span_SPAN_KIND_INTERNAL, 0, 10, status),
+			spanForNormalizeTest(traceID, "literal", "", "<unknown>", "literal service", tracev1.Span_SPAN_KIND_INTERNAL, 20, 30, status),
+		)
+	}
+
+	got, err := Summarize(makeTrace(tracev1.Status_STATUS_CODE_OK), makeTrace(tracev1.Status_STATUS_CODE_ERROR))
+	require.NoError(t, err)
+	require.Len(t, got.Services, 1)
+	assert.Equal(t, "<unknown>", got.Services[0].Name)
+	assert.Equal(t, 2, got.Services[0].NewErrors)
+
+	data, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"rootService"`)
+	assert.Contains(t, string(data), `"name":"\u003cunknown\u003e"`)
+	assert.Contains(t, string(data), `"service":""`)
+	assert.Contains(t, string(data), `"service":"\u003cunknown\u003e"`)
+}
+
+func TestSummarizeAddedPatternsFollowReferenceCompression(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+	root := func() *tracev1.Span {
+		return spanForNormalizeTest(traceID, "root", "", "frontend", "GET /", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	}
+	base := traceWithNamedSpans(root())
+	compare := traceWithNamedSpans(
+		root(),
+		spanForNormalizeTest(traceID, "ok", "root", "backend", "call", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+		spanForNormalizeTest(traceID, "error", "root", "backend", "call", tracev1.Span_SPAN_KIND_CLIENT, 30, 40, tracev1.Status_STATUS_CODE_ERROR),
+	)
+
+	got, err := Summarize(base, compare)
+	require.NoError(t, err)
+	require.Len(t, got.Patterns, 1)
+	assert.Equal(t, 2, got.Patterns[0].Count)
+	assert.Empty(t, got.Patterns[0].Changes)
+	assert.Nil(t, got.Patterns[0].DurationDeltaMs)
+}
+
+func TestPatternKeySeparatesNestedCollectionShapes(t *testing.T) {
+	target := Target{Type: TargetAttribute, Scope: ScopeSpan, Key: "value"}
+	a := patternInput{state: patternStateModified, ref: SpanRef{Name: "op"}, changes: []Change{{
+		Op: OperationModify, Target: target, Before: []any{[]any{}, "x"}, After: nil,
+	}}}
+	b := patternInput{state: patternStateModified, ref: SpanRef{Name: "op"}, changes: []Change{{
+		Op: OperationModify, Target: target, Before: []any{[]any{"x"}}, After: nil,
+	}}}
+
+	assert.NotEqual(t, patternKey(a), patternKey(b))
+}
+
+func TestBuildPatternsTieOrderingIsDeterministic(t *testing.T) {
+	patch := &Result{}
+	for i := 0; i < patternCap+5; i++ {
+		patch.Modified = append(patch.Modified, ModifiedSpan{
+			Span: SpanRef{Service: "backend", Name: "op", Kind: fmt.Sprintf("kind-%02d", i)},
+			Changes: []Change{{
+				Op:     OperationModify,
+				Target: Target{Type: TargetAttribute, Scope: ScopeSpan, Key: "value"},
+				Before: int64(i),
+				After:  int64(i + 1),
+			}},
+		})
+	}
+
+	var expected []byte
+	for i := 0; i < 20; i++ {
+		patterns, _ := buildPatterns(patch)
+		data, err := json.Marshal(patterns)
+		require.NoError(t, err)
+		if i == 0 {
+			expected = data
+			continue
+		}
+		assert.Equal(t, string(expected), string(data))
+	}
+}
+
+func TestSummarizeKeepsCompleteServiceSections(t *testing.T) {
+	const serviceCount = 60
+	traceID := []byte("trace-id-0000001")
+	makeTrace := func(status tracev1.Status_StatusCode) *tempopb.Trace {
+		spans := make([]*tracev1.Span, 0, serviceCount)
+		for i := 0; i < serviceCount; i++ {
+			spans = append(spans, spanForNormalizeTest(
+				traceID,
+				fmt.Sprintf("span-%02d", i),
+				"",
+				fmt.Sprintf("service-%02d", i),
+				"op",
+				tracev1.Span_SPAN_KIND_INTERNAL,
+				uint64(i*2),
+				uint64(i*2+1),
+				status,
+			))
+		}
+		return traceWithNamedSpans(spans...)
+	}
+
+	got, err := Summarize(makeTrace(tracev1.Status_STATUS_CODE_OK), makeTrace(tracev1.Status_STATUS_CODE_ERROR))
+	require.NoError(t, err)
+	assert.Len(t, got.ChangedServices, serviceCount)
+	assert.Len(t, got.Services, serviceCount)
+}
+
+func TestBuildServiceSectionsRetainsLargestWorkChange(t *testing.T) {
+	const serviceCount = 50
+	baseWork := make(map[string]int64, serviceCount+1)
+	compareWork := make(map[string]int64, serviceCount+1)
+	patch := &Result{}
+	for i := 0; i < serviceCount; i++ {
+		service := fmt.Sprintf("error-%02d", i)
+		baseWork[service] = 10_000_000
+		compareWork[service] = 10_000_000
+		patch.Modified = append(patch.Modified, ModifiedSpan{
+			Span: SpanRef{Service: service},
+			Changes: []Change{{
+				Op:     OperationModify,
+				Target: Target{Type: TargetField, Name: FieldStatus},
+				Before: "ok",
+				After:  "error",
+			}},
+		})
+	}
+	baseWork["regressor"] = 10_000_000
+	compareWork["regressor"] = 1_010_000_000
+
+	_, services := buildServiceSections(patch, baseWork, compareWork, nil)
+	require.Len(t, services, serviceCount+1)
+	assert.Equal(t, "regressor", services[0].Name)
+}
+
+func TestBuildServiceSectionsDoesNotLetJitterDisplaceErrors(t *testing.T) {
+	const serviceCount = 50
+	baseWork := make(map[string]int64, serviceCount*2)
+	compareWork := make(map[string]int64, serviceCount*2)
+	patch := &Result{}
+	for i := 0; i < serviceCount; i++ {
+		service := fmt.Sprintf("error-%02d", i)
+		baseWork[service] = 10_000_000
+		compareWork[service] = 10_000_000
+		patch.Modified = append(patch.Modified, ModifiedSpan{
+			Span: SpanRef{Service: service},
+			Changes: []Change{{
+				Op:     OperationModify,
+				Target: Target{Type: TargetField, Name: FieldStatus},
+				Before: "ok",
+				After:  "error",
+			}},
+		})
+	}
+	for i := 0; i < serviceCount; i++ {
+		service := fmt.Sprintf("jitter-%02d", i)
+		baseWork[service] = 10_000_000
+		compareWork[service] = 10_000_001
+	}
+
+	_, services := buildServiceSections(patch, baseWork, compareWork, nil)
+	require.Len(t, services, serviceCount)
+	for _, service := range services {
+		assert.Equal(t, 1, service.NewErrors)
+	}
+}
+
+func TestBuildPatternsRetainsFullExemplarData(t *testing.T) {
+	changes := make([]Change, 25)
+	for i := range changes {
+		changes[i] = Change{
+			Op:     OperationModify,
+			Target: Target{Type: TargetAttribute, Scope: ScopeSpan, Key: fmt.Sprintf("attribute-%02d", i)},
+			Before: []any{"before", int64(i)},
+			After:  []any{"after", int64(i)},
+		}
+	}
+	path := make([]int, 70)
+	patch := &Result{Modified: []ModifiedSpan{{
+		Span:    SpanRef{Path: path, Service: "service", Name: "operation", Kind: "client"},
+		Changes: changes,
+	}}}
+
+	patterns, _ := buildPatterns(patch)
+	require.Len(t, patterns, 1)
+	assert.Equal(t, changes, patterns[0].Changes)
+	require.Len(t, patterns[0].SampleSpans, 1)
+	assert.Equal(t, path, patterns[0].SampleSpans[0].Path)
+}
+
+func doubleAttribute(key string, value float64) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_DoubleValue{DoubleValue: value}},
+	}
+}
+
+func summaryFixtureTraces() (*tempopb.Trace, *tempopb.Trace) {
+	traceID := []byte("trace-id-0000001")
+	baseRoot := spanForNormalizeTest(traceID, "root", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK)
+	baseRoot.Attributes = append(baseRoot.Attributes, stringAttribute("service.version", "v1"))
+	compareRoot := spanForNormalizeTest(traceID, "root2", "", "checkout", "GET /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 110, tracev1.Status_STATUS_CODE_OK)
+	compareRoot.Attributes = append(compareRoot.Attributes, stringAttribute("service.version", "v2"))
+
+	return traceWithNamedSpans(
+			baseRoot,
+			spanForNormalizeTest(traceID, "cache", "root", "checkout", "cache lookup", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_OK),
+			spanForNormalizeTest(traceID, "db", "root", "checkout", "db query", tracev1.Span_SPAN_KIND_CLIENT, 20, 50, tracev1.Status_STATUS_CODE_OK),
+		), traceWithNamedSpans(
+			compareRoot,
+			spanForNormalizeTest(traceID, "cache2", "root2", "checkout", "cache lookup", tracev1.Span_SPAN_KIND_CLIENT, 10, 20, tracev1.Status_STATUS_CODE_ERROR),
+			spanForNormalizeTest(traceID, "db2", "root2", "checkout", "db query", tracev1.Span_SPAN_KIND_CLIENT, 20, 52, tracev1.Status_STATUS_CODE_OK),
+		)
+}

--- a/pkg/model/tracediff/types.go
+++ b/pkg/model/tracediff/types.go
@@ -1,8 +1,15 @@
 package tracediff
 
-const VersionTracePatchV0 = "trace-patch-v0"
+const (
+	VersionTracePatchV0 = "trace-patch-v0"
+	// VersionTraceSummaryV0Native is the single summary format: a compact
+	// triage/localization document computed from normalized traces and matcher
+	// results, with complete changed-service enumeration, uncapped rollups, and
+	// capped patterns.
+	VersionTraceSummaryV0Native = "trace-summary-v0-native"
+)
 
-// Format selects the output representation.
+// Format selects a diff format implemented directly by Diff.
 type Format string
 
 const (
@@ -35,9 +42,14 @@ const (
 	ScopeSpan          = "span"
 )
 
-// Warning codes in the trace-patch-v0 vocabulary.
+// Warning codes emitted by trace diff and trace-diff CLI outputs.
 const (
 	WarningHighCardinalitySpanName = "high_cardinality_span_name"
+	WarningPartialTrace            = "partial_trace"
+	WarningInvalidDuration         = "invalid_duration"
+	WarningZeroSpanTrace           = "zero_span_trace"
+	WarningDuplicateSpanID         = "duplicate_span_id"
+	WarningAmbiguousSpanMatch      = "ambiguous_span_match"
 )
 
 // Result is the trace-patch-v0 diff document.

--- a/pkg/model/tracediff/types.go
+++ b/pkg/model/tracediff/types.go
@@ -4,8 +4,7 @@ const (
 	VersionTracePatchV0 = "trace-patch-v0"
 	// VersionTraceSummaryV0Native is the single summary format: a compact
 	// triage/localization document computed from normalized traces and matcher
-	// results, with complete changed-service enumeration, uncapped rollups, and
-	// capped patterns.
+	// results, with complete changed-service enumeration and uncapped rollups.
 	VersionTraceSummaryV0Native = "trace-summary-v0-native"
 )
 

--- a/pkg/model/tracediff/types.go
+++ b/pkg/model/tracediff/types.go
@@ -48,7 +48,6 @@ const (
 	WarningInvalidDuration         = "invalid_duration"
 	WarningZeroSpanTrace           = "zero_span_trace"
 	WarningDuplicateSpanID         = "duplicate_span_id"
-	WarningAmbiguousSpanMatch      = "ambiguous_span_match"
 )
 
 // Result is the trace-patch-v0 diff document.


### PR DESCRIPTION
## What this PR does

Adds `trace-summary-v0-native`, an experimental output format for comparing two
trace JSON files:

```bash
tempo-cli experimental trace-diff \
  --trace-a before.json \
  --trace-b after.json \
  --format trace-summary-v0-native \
  --pretty
```

The command now offers two complementary outputs:

- `trace-patch-v0`: the exact mechanical change list and span-level evidence.
- `trace-summary-v0-native`: a compact first-pass view for triage and localization.

The summary reuses the existing `trace-patch-v0` matcher and combines its change
counts with whole-trace aggregates. This PR does not change span matching
behavior or the semantics of the patch format.

## Why

The full patch is useful for exact inspection, but it is not sufficient or
efficient for first-pass diagnosis:

- Large dense diffs can produce payloads that are expensive or impossible to
  fit into an LLM context.
- Trace latency is an envelope over all spans, including unchanged spans, and
  cannot always be reconstructed from a change list.
- Parent-link-only topology changes can leave the patch empty.
- Per-span duration tolerance can intentionally hide small changes that become
  significant when aggregated across a service.

`trace-summary-v0-native` computes those whole-trace facts while both normalized
traces are available, then combines them with matcher-derived change counts.
`trace-patch-v0` remains the source of truth for drill-down.

## Why this format

The shape follows the native recommendation evaluated in
[grafana/traces-microbench#4](https://github.com/grafana/traces-microbench/pull/4).
The experiments found two important constraints:

1. Whole-trace signals and service drift must be computed from traces, not
   composed only from the patch.
2. Service names cannot be silently truncated. In the many-service scenario,
   top-N service formats lost localization, while complete service enumeration
   remained reliable.

The resulting format contains:

- Base and comparison metadata, including latency envelope and total span work.
- Neutral signals for latency, work, errors, span count, and structure.
- Matching coverage ratios (`matchedSpanRatio` and `structureOverlap`). These
  describe match coverage, not match confidence.
- Aggregate change statistics from the existing patch matcher.
- Complete `changedServices` enumeration.
- Complete service rollups ranked by absolute work delta, new errors, then name.

The microbench's native format preserved triage across all evaluated scenarios,
including systemic sub-tolerance drift, while remaining substantially smaller
than the full patch for dense trace changes.

## Size tradeoff

`changedServices` and `services` are intentionally complete and therefore grow
with the number of changed services. This avoids the silent localization loss
observed with top-N service sections.

Service rollups include services with matcher changes or significant duration
drift. Structure-only services remain visible in `changedServices` even when
they do not need a service rollup.

## Additional correctness handling

- Duration deltas are subtracted in nanoseconds before conversion to integer
  milliseconds, avoiding false 1 ms boundary changes.
- The service drift threshold uses exact integer arithmetic for
  `max(1ms, 5% of base service work)`.
- Fuzzy numeric comparison handles NaN and infinities explicitly while keeping
  the existing JSON placeholders.
- Matched duration transitions use `null` on an invalid side, while whole-span
  add/remove snapshots retain the `trace-patch-v0` zero-value contract. Invalid
  spans contribute zero to summary aggregates and emit warnings.
- Raw traces and Tempo `TraceByIDResponse` files are accepted. Partial responses
  retain their server status as warnings in the output.

## What this does not do

- Does not replace `trace-patch-v0`.
- Does not add or change a matcher.
- Does not change `trace-patch-v0` matching semantics.
- Does not claim that matching coverage measures match confidence.
- Does not add a Tempo HTTP API response, automatic format selection, or MCP
  integration.

## Validation

```bash
go test ./pkg/model/tracediff ./cmd/tempo-cli
go test -race ./pkg/model/tracediff
golangci-lint run ./pkg/model/tracediff ./cmd/tempo-cli
make chlog-validate
git diff --check
```
