### PR TITLE
feat: make automemlimit refresh interval configurable

### DIFF
--- a/cmd/tempo/app/automemlimit.go
+++ b/cmd/tempo/app/automemlimit.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/KimMachineGun/automemlimit/memlimit"
 )
@@ -26,7 +25,7 @@ func InitAutoMemLimit(config *Config) {
 				memlimit.FromSystem,
 			),
 		),
-		memlimit.WithRefreshInterval(15*time.Second),
+		memlimit.WithRefreshInterval(config.Memory.AutoMemLimitRefreshInterval),
 		memlimit.WithLogger(logger),
 	)
 	if err != nil {

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -87,8 +87,8 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 
 	// Memory settings
 	c.Memory = MemoryConfig{
-		AutoMemLimitEnabled:         false,
-		AutoMemLimitRatio:           0.8,
+		AutoMemLimitEnabled: false,
+		AutoMemLimitRatio:   0.8,
 		AutoMemLimitRefreshInterval: 15 * time.Second,
 	}
 

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -35,8 +35,8 @@ const defaultGRPCCompression = "snappy"
 
 // MemoryConfig configures memory management settings
 type MemoryConfig struct {
-	AutoMemLimitEnabled         bool          `yaml:"automemlimit_enabled"`
-	AutoMemLimitRatio           float64       `yaml:"automemlimit_ratio"`
+	AutoMemLimitEnabled bool    `yaml:"automemlimit_enabled"`
+	AutoMemLimitRatio   float64 `yaml:"automemlimit_ratio"`
 	AutoMemLimitRefreshInterval time.Duration `yaml:"automemlimit_refresh_interval"`
 }
 

--- a/cmd/tempo/app/config.go
+++ b/cmd/tempo/app/config.go
@@ -35,8 +35,9 @@ const defaultGRPCCompression = "snappy"
 
 // MemoryConfig configures memory management settings
 type MemoryConfig struct {
-	AutoMemLimitEnabled bool    `yaml:"automemlimit_enabled"`
-	AutoMemLimitRatio   float64 `yaml:"automemlimit_ratio"`
+	AutoMemLimitEnabled         bool          `yaml:"automemlimit_enabled"`
+	AutoMemLimitRatio           float64       `yaml:"automemlimit_ratio"`
+	AutoMemLimitRefreshInterval time.Duration `yaml:"automemlimit_refresh_interval"`
 }
 
 // Config is the root config for App.
@@ -86,8 +87,9 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 
 	// Memory settings
 	c.Memory = MemoryConfig{
-		AutoMemLimitEnabled: false,
-		AutoMemLimitRatio:   0.8,
+		AutoMemLimitEnabled:         false,
+		AutoMemLimitRatio:           0.8,
+		AutoMemLimitRefreshInterval: 15 * time.Second,
 	}
 
 	// global settings
@@ -98,6 +100,11 @@ func (c *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
 	f.BoolVar(&c.EnableGoRuntimeMetrics, "enable-go-runtime-metrics", false, "Set to true to enable all Go runtime metrics")
 	f.DurationVar(&c.ShutdownDelay, "shutdown-delay", 0, "How long to wait between SIGTERM and shutdown. After receiving SIGTERM, Tempo will report not-ready status via /ready endpoint.")
 	f.BoolVar(&c.SpanProfiling, "span-profiling", false, "Set to true to enable span profiling (pyroscope pprof labels on OTel spans).")
+
+	// Memory settings flags
+	f.BoolVar(&c.Memory.AutoMemLimitEnabled, "memory.automemlimit-enabled", c.Memory.AutoMemLimitEnabled, "Set to true to enable automatic memory limit calculation.")
+	f.Float64Var(&c.Memory.AutoMemLimitRatio, "memory.automemlimit-ratio", c.Memory.AutoMemLimitRatio, "Ratio of system memory to use as the Go memory limit.")
+	f.DurationVar(&c.Memory.AutoMemLimitRefreshInterval, "memory.automemlimit-refresh-interval", c.Memory.AutoMemLimitRefreshInterval, "Interval at which to refresh the Go memory limit.")
 
 	// Server settings
 	flagext.DefaultValues(&c.Server)

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -213,7 +213,7 @@ For the full list of `internal_server` options, refer to the [manifest](/docs/te
 ## Memory
 
 Tempo supports automatic GOMEMLIMIT configuration using the [automemlimit](https://github.com/KimMachineGun/automemlimit) library.
-When enabled, it automatically sets Go's memory limit based on available container (via CGroups) or system memory every 15 seconds.
+When enabled, it automatically sets Go's memory limit based on available container (via CGroups) or system memory.
 For information on memory considerations across deployment modes, refer to the [Deployment modes](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/deployment-modes/) documentation.
 
 NOTE: enabling this will override value set in GOMEMLIMIT environment variable
@@ -228,6 +228,9 @@ memory:
     # Ratio of available memory to use for GOMEMLIMIT.
     # For example, 0.8 means 80% of available memory will be used for GOMEMLIMIT.
     [automemlimit_ratio: <float> | default = 0.8]
+
+    # Interval at which to refresh the Go memory limit.
+    [automemlimit_refresh_interval: <duration> | default = 15s]
 ```
 
 ## Distributor


### PR DESCRIPTION
Resolves #7420. This change makes the Go memory limit refresh interval configurable, allowing users to customize how often Tempo checks and updates the memory limit based on available system memory.