### PR TITLE
feat: add list_objects_version option to S3 backend

### DIFF
--- a/.chloggen/s3-list-objects-version.yaml
+++ b/.chloggen/s3-list-objects-version.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: "Add a `list_objects_version` option to the S3 backend to support S3-compatible stores that do not implement ListObjectsV2."
+issues: []
+subtext:
+user: kbelokon

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1668,6 +1668,11 @@ storage:
             # Notice: ignore this option if `forcepathstyle` is set true, this option allow expose minio's sdk configure.
             [bucket_lookup_type: <int> | default = 0]
 
+            # Optional. Default is v2.
+            # Use a specific version of the S3 list objects API. Supported values are v1 and v2.
+            # Set to v1 for S3-compatible stores that do not implement ListObjectsV2 pagination correctly.
+            [list_objects_version: <string>]
+
             # Optional. Default is 0 (disabled)
             # Example: "hedge_requests_at: 500ms"
             # If set to a non-zero value a second request will be issued at the provided duration. Recommended to

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -664,6 +664,7 @@ storage:
             metadata: {}
             native_aws_auth_enabled: false
             list_blocks_concurrency: 3
+            list_objects_version: v2
             sse:
                 type: ""
                 kms_key_id: ""
@@ -761,6 +762,7 @@ overrides:
                 metadata: {}
                 native_aws_auth_enabled: false
                 list_blocks_concurrency: 3
+                list_objects_version: v2
                 sse:
                     type: ""
                     kms_key_id: ""

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -660,6 +660,7 @@ storage:
             metadata: {}
             native_aws_auth_enabled: false
             list_blocks_concurrency: 3
+            list_objects_version: v2
             sse:
                 type: ""
                 kms_key_id: ""
@@ -757,6 +758,7 @@ overrides:
                 metadata: {}
                 native_aws_auth_enabled: false
                 list_blocks_concurrency: 3
+                list_objects_version: v2
                 sse:
                     type: ""
                     kms_key_id: ""

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -18,6 +18,10 @@ const (
 	SignatureVersionV4 = "v4"
 	SignatureVersionV2 = "v2"
 
+	// ListObjectsVersionV1 / V2 select which S3 list objects API the backend uses.
+	ListObjectsVersionV1 = "v1"
+	ListObjectsVersionV2 = "v2"
+
 	// SSEKMS config type constant to configure S3 server side encryption using KMS
 	// https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 	SSEKMS = "SSE-KMS"
@@ -71,9 +75,12 @@ type Config struct {
 	Metadata         map[string]string `yaml:"metadata"`
 	// Deprecated
 	// See https://github.com/grafana/tempo/pull/3006 for more details
-	NativeAWSAuthEnabled  bool      `yaml:"native_aws_auth_enabled"`
-	ListBlocksConcurrency int       `yaml:"list_blocks_concurrency"`
-	SSE                   SSEConfig `yaml:"sse"`
+	NativeAWSAuthEnabled  bool `yaml:"native_aws_auth_enabled"`
+	ListBlocksConcurrency int  `yaml:"list_blocks_concurrency"`
+	// ListObjectsVersion selects the S3 list objects API version ("v1" or "v2"); defaults to v2.
+	// Set "v1" for S3-compatible stores that do not implement ListObjectsV2 pagination correctly.
+	ListObjectsVersion string    `yaml:"list_objects_version"`
+	SSE                SSEConfig `yaml:"sse"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -91,6 +98,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	f.StringVar(&cfg.SSE.KMSEncryptionContext, util.PrefixConfig(prefix, "s3.sse.kms-encryption-context"), "", "KMS Encryption Context used for object encryption. It expects JSON formatted string.")
 	f.Var(&cfg.SSE.CustomerEncryptionKey, util.PrefixConfig(prefix, "s3.sse.encryption-key"), "SSE-C Encryption Key used for object encryption.")
 	cfg.HedgeRequestsUpTo = 2
+	cfg.ListObjectsVersion = ListObjectsVersionV2
 	cfg.RetryMaxAttempts = minio.MaxRetry
 	cfg.RetryBackoffInitial = minio.DefaultRetryUnit
 	cfg.RetryBackoffMax = minio.DefaultRetryCap

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -119,6 +119,12 @@ func internalNew(cfg *Config, confirm bool) (*readerWriter, error) {
 		return nil, fmt.Errorf("config is nil")
 	}
 
+	switch cfg.ListObjectsVersion {
+	case "", ListObjectsVersionV1, ListObjectsVersionV2:
+	default:
+		return nil, fmt.Errorf("unsupported s3 list_objects_version %q, supported values are v1 and v2", cfg.ListObjectsVersion)
+	}
+
 	l := log.Logger
 
 	// Global minio settings that affect all minio clients in the process
@@ -393,6 +399,42 @@ func (rw *readerWriter) List(_ context.Context, keypath backend.KeyPath) ([]stri
 	return objects, nil
 }
 
+// listObjects lists one page of objects under prefix using the V1 or V2 S3 list API
+// depending on cfg.ListObjectsVersion (default v2). startAfter bounds the listing from
+// below (sharded listing); token carries the cursor returned by the previous page. It
+// returns the page contents, the cursor for the next page, and whether more pages remain.
+func (rw *readerWriter) listObjects(prefix, startAfter, token string) (contents []minio.ObjectInfo, next string, truncated bool, err error) {
+	if rw.cfg.ListObjectsVersion == ListObjectsVersionV1 {
+		marker := token
+		if marker == "" {
+			marker = startAfter
+		}
+		res, err := rw.core.ListObjects(rw.cfg.Bucket, prefix, marker, "", 0)
+		if err != nil {
+			return nil, "", false, err
+		}
+		next = res.NextMarker
+		truncated = res.IsTruncated
+		// The low-level minio-go Core does not derive NextMarker when the request omits a
+		// delimiter, so fall back to the last key to advance pagination.
+		if next == "" && truncated && len(res.Contents) > 0 {
+			next = res.Contents[len(res.Contents)-1].Key
+		}
+		// If the response is truncated but offers no way to advance the marker (no
+		// NextMarker and an empty page), stop rather than re-issue the same request.
+		if next == "" && truncated {
+			truncated = false
+		}
+		return res.Contents, next, truncated, nil
+	}
+
+	res, err := rw.core.ListObjectsV2(rw.cfg.Bucket, prefix, startAfter, token, "", 0)
+	if err != nil {
+		return nil, "", false, err
+	}
+	return res.Contents, res.NextContinuationToken, res.IsTruncated, nil
+}
+
 func (rw *readerWriter) ListBlocks(
 	ctx context.Context,
 	tenant string,
@@ -427,22 +469,24 @@ func (rw *readerWriter) ListBlocks(
 
 			var (
 				err        error
-				res        minio.ListBucketV2Result
+				contents   []minio.ObjectInfo
+				truncated  = true
+				token      string
 				startAfter = prefix + minUUID.String()
 			)
 
-			for res.IsTruncated = true; res.IsTruncated; {
+			for truncated {
 				if ctx.Err() != nil {
 					return
 				}
 
-				res, err = rw.core.ListObjectsV2(rw.cfg.Bucket, prefix, startAfter, res.NextContinuationToken, "", 0)
+				contents, token, truncated, err = rw.listObjects(prefix, startAfter, token)
 				if err != nil {
 					errChan <- fmt.Errorf("error finding objects in s3 bucket, bucket: %s: %w", rw.cfg.Bucket, err)
 					return
 				}
 
-				for _, c := range res.Contents {
+				for _, c := range contents {
 					// i.e: <blockID>/meta
 					parts := strings.Split(strings.TrimPrefix(c.Key, prefix), "/")
 					if len(parts) != 2 {
@@ -512,23 +556,20 @@ func (rw *readerWriter) Find(ctx context.Context, keypath backend.KeyPath, f bac
 
 	nextToken := ""
 	isTruncated := true
-	var res minio.ListBucketV2Result
+	var contents []minio.ObjectInfo
 
 	for isTruncated {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			res, err = rw.core.ListObjectsV2(rw.cfg.Bucket, prefix, "", nextToken, "", 0)
+			contents, nextToken, isTruncated, err = rw.listObjects(prefix, "", nextToken)
 			if err != nil {
 				return fmt.Errorf("error finding objects in s3 bucket, bucket: %s: %w", rw.cfg.Bucket, err)
 			}
 
-			isTruncated = res.IsTruncated
-			nextToken = res.NextContinuationToken
-
-			if len(res.Contents) > 0 {
-				for _, c := range res.Contents {
+			if len(contents) > 0 {
+				for _, c := range contents {
 					opts := backend.FindMatch{
 						Key:      strings.TrimPrefix(c.Key, rw.cfg.Prefix),
 						Modified: c.LastModified,

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -731,6 +731,184 @@ func TestListBlocksWithPrefix(t *testing.T) {
 	}
 }
 
+func TestListObjectsVersion(t *testing.T) {
+	const (
+		tenant   = "single-tenant"
+		liveID   = "00000000-0000-0000-0000-0000000000aa"
+		liveKey  = tenant + "/" + liveID + "/meta.json"
+		compID   = "00000000-0000-0000-0000-0000000000bb"
+		compKey  = tenant + "/" + compID + "/meta.compacted.json"
+		live2ID  = "00000000-0000-0000-0000-0000000000cc"
+		live2Key = tenant + "/" + live2ID + "/meta.json"
+	)
+
+	v1Page := func(truncated bool, nextMarker string, keys ...string) string {
+		var sb strings.Builder
+		sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Name>blerg</Name>`)
+		if truncated {
+			sb.WriteString(`<IsTruncated>true</IsTruncated>`)
+		} else {
+			sb.WriteString(`<IsTruncated>false</IsTruncated>`)
+		}
+		sb.WriteString(`<NextMarker>` + nextMarker + `</NextMarker>`)
+		for _, k := range keys {
+			sb.WriteString(`<Contents><Key>` + k + `</Key><LastModified>2024-03-01T00:00:00.000Z</LastModified><ETag>&quot;abc&quot;</ETag><Size>398</Size><StorageClass>STANDARD</StorageClass></Contents>`)
+		}
+		sb.WriteString(`</ListBucketResult>`)
+		return sb.String()
+	}
+
+	v2Page := func(keys ...string) string {
+		var sb strings.Builder
+		sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Name>blerg</Name><IsTruncated>false</IsTruncated>`)
+		for _, k := range keys {
+			sb.WriteString(`<Contents><Key>` + k + `</Key><LastModified>2024-03-01T00:00:00.000Z</LastModified><ETag>&quot;abc&quot;</ETag><Size>398</Size><StorageClass>STANDARD</StorageClass></Contents>`)
+		}
+		sb.WriteString(`</ListBucketResult>`)
+		return sb.String()
+	}
+
+	tests := []struct {
+		name               string
+		listObjectsVersion string
+		liveBlockIDs       []uuid.UUID
+		compactedBlockIDs  []uuid.UUID
+		httpHandler        func(t *testing.T) http.HandlerFunc
+	}{
+		{
+			// (a) default → V2 on the wire
+			name:               "default uses v2",
+			listObjectsVersion: "",
+			liveBlockIDs:       []uuid.UUID{uuid.MustParse(liveID)},
+			compactedBlockIDs:  []uuid.UUID{uuid.MustParse(compID)},
+			httpHandler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != getMethod {
+						return
+					}
+					assert.Equal(t, "2", r.URL.Query().Get("list-type"), "default must use ListObjectsV2 on the wire")
+					_, _ = w.Write([]byte(v2Page(liveKey, compKey)))
+				}
+			},
+		},
+		{
+			// (b) v1 single page → no list-type
+			name:               "v1 single page",
+			listObjectsVersion: ListObjectsVersionV1,
+			liveBlockIDs:       []uuid.UUID{uuid.MustParse(liveID)},
+			compactedBlockIDs:  []uuid.UUID{uuid.MustParse(compID)},
+			httpHandler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != getMethod {
+						return
+					}
+					assert.Equal(t, "", r.URL.Query().Get("list-type"), "v1 must not send list-type")
+					_, _ = w.Write([]byte(v1Page(false, "", liveKey, compKey)))
+				}
+			},
+		},
+		{
+			// (c) v1 truncated two-page → page 2 carries the expected marker
+			name:               "v1 truncated two pages with NextMarker",
+			listObjectsVersion: ListObjectsVersionV1,
+			liveBlockIDs:       []uuid.UUID{uuid.MustParse(liveID), uuid.MustParse(live2ID)},
+			compactedBlockIDs:  []uuid.UUID{},
+			httpHandler: func(t *testing.T) http.HandlerFunc {
+				var calls int
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != getMethod {
+						return
+					}
+					assert.Equal(t, "", r.URL.Query().Get("list-type"), "v1 must not send list-type")
+					calls++
+					if calls == 1 {
+						// page 1: truncated, advertise NextMarker = liveKey
+						_, _ = w.Write([]byte(v1Page(true, liveKey, liveKey)))
+						return
+					}
+					// page 2: must carry the marker advertised by page 1
+					assert.Equal(t, liveKey, r.URL.Query().Get("marker"), "page 2 must use NextMarker from page 1")
+					_, _ = w.Write([]byte(v1Page(false, "", live2Key)))
+				}
+			},
+		},
+		{
+			// (d) v1 truncated with EMPTY NextMarker → terminates via last key
+			name:               "v1 truncated empty NextMarker terminates",
+			listObjectsVersion: ListObjectsVersionV1,
+			liveBlockIDs:       []uuid.UUID{uuid.MustParse(liveID)},
+			compactedBlockIDs:  []uuid.UUID{uuid.MustParse(compID)},
+			httpHandler: func(t *testing.T) http.HandlerFunc {
+				var calls int
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != getMethod {
+						return
+					}
+					assert.Equal(t, "", r.URL.Query().Get("list-type"), "v1 must not send list-type")
+					calls++
+					if calls == 1 {
+						// page 1: truncated, EMPTY NextMarker, single Contents (liveKey)
+						_, _ = w.Write([]byte(v1Page(true, "", liveKey)))
+						return
+					}
+					// page 2: marker must fall back to the last key of page 1
+					assert.Equal(t, liveKey, r.URL.Query().Get("marker"), "page 2 must fall back to last key when NextMarker empty")
+					_, _ = w.Write([]byte(v1Page(false, "", compKey)))
+				}
+			},
+		},
+		{
+			// (e) v1 truncated with empty NextMarker AND empty page → must terminate, not spin
+			name:               "v1 truncated empty page terminates",
+			listObjectsVersion: ListObjectsVersionV1,
+			liveBlockIDs:       []uuid.UUID{},
+			compactedBlockIDs:  []uuid.UUID{},
+			httpHandler: func(t *testing.T) http.HandlerFunc {
+				var calls int
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != getMethod {
+						return
+					}
+					calls++
+					if calls > 1 {
+						// A correct implementation cannot advance the marker on an empty,
+						// NextMarker-less truncated page, so it must stop after page 1.
+						t.Errorf("must not re-request after a non-advancing truncated page (call %d)", calls)
+						_, _ = w.Write([]byte(v1Page(false, "")))
+						return
+					}
+					// page 1: truncated, empty NextMarker, no Contents
+					_, _ = w.Write([]byte(v1Page(true, "")))
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := testServer(t, tc.httpHandler(t))
+			r, _, _, err := NewNoConfirm(&Config{
+				Region:                "blerg",
+				AccessKey:             "test",
+				SecretKey:             flagext.SecretWithValue("test"),
+				Bucket:                "blerg",
+				Insecure:              true,
+				Endpoint:              server.URL[7:],
+				ListBlocksConcurrency: 1,
+				ListObjectsVersion:    tc.listObjectsVersion,
+			})
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			blockIDs, compactedBlockIDs, err := r.ListBlocks(ctx, tenant)
+			assert.NoError(t, err)
+
+			assert.ElementsMatchf(t, tc.liveBlockIDs, blockIDs, "Block IDs did not match")
+			assert.ElementsMatchf(t, tc.compactedBlockIDs, compactedBlockIDs, "Compacted block IDs did not match")
+		})
+	}
+}
+
 func TestObjectStorageClass(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
**What this PR does**:

Adds an optional `list_objects_version` setting to the S3 backend, letting operators select the V1 (`ListObjects`, marker-based) list API instead of `ListObjectsV2`. The default is unchanged — V2 — so existing deployments are unaffected; only backends that explicitly set `list_objects_version: v1` change behavior.

Some S3-compatible stores return a truncated `ListObjectsV2` response without a `NextContinuationToken`. The backend cannot paginate that response, so the blocklist poller fails in `ListBlocks`/`Find` and the block list is never built. Known affected backends include Ceph RGW (pre-Nautilus, e.g. mimic 13.2.2 — Ceph tracker #37801), Dell ECS (#5703, #558), and RustFS / some MinIO and ECS configurations (#6436). The V1 marker-based list API paginates correctly on these stores.

This is the same `list_objects_version` option already exposed across the Grafana stack — Mimir (#5099), Cortex (#6280), and Thanos/objstore (#3312) — with the same name and values, so the knob is consistent for operators running Tempo alongside them. Tempo calls minio-go's low-level `Core` API directly (it does not vendor objstore), so the switch is implemented at the two `ListObjectsV2` call sites rather than passed through.

V1 is opt-in only and the default stays V2; V2 remains the recommended, more efficient path, and the option description notes the tradeoff. This is distinct from #6114, which set `maxKeys=1` on the startup confirmation list — that change does not touch the blocklist poller's `ListBlocks`/`Find` pagination, which is what this option addresses.

**Which issue(s) this PR fixes**:
Related to #5703, #6436

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)