### PR TITLE
add disable_multipart_upload option to S3 backend

### DIFF
--- a/.chloggen/disable-multipart-upload.yaml
+++ b/.chloggen/disable-multipart-upload.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: "Add a `disable_multipart_upload` option to the S3 backend to support S3-compatible stores that do not implement the multipart upload API."
+issues: []
+subtext:
+user: kbelokon

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1668,6 +1668,13 @@ storage:
             # Notice: ignore this option if `forcepathstyle` is set true, this option allow expose minio's sdk configure.
             [bucket_lookup_type: <int> | default = 0]
 
+            # Optional. Default is false.
+            # Write objects with a single PutObject instead of a multipart upload, for
+            # S3-compatible stores that do not implement the multipart upload API. The
+            # object is buffered to a temporary file while it is written, so it cannot
+            # exceed the 5 GiB single-PutObject limit and part_size has no effect.
+            [disable_multipart_upload: <bool>]
+
             # Optional. Default is 0 (disabled)
             # Example: "hedge_requests_at: 500ms"
             # If set to a non-zero value a second request will be issued at the provided duration. Recommended to

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1670,9 +1670,10 @@ storage:
 
             # Optional. Default is false.
             # Write objects with a single PutObject instead of a multipart upload, for
-            # S3-compatible stores that do not implement the multipart upload API. The
-            # object is buffered to a temporary file while it is written, so it cannot
-            # exceed the 5 GiB single-PutObject limit and part_size has no effect.
+            # S3-compatible stores that do not implement the multipart upload API. This
+            # applies to every object Tempo writes, including block flushes. Streaming
+            # writes are buffered to a temporary file first, so an object cannot exceed
+            # the 5 GiB single-PutObject limit and part_size has no effect.
             [disable_multipart_upload: <bool>]
 
             # Optional. Default is 0 (disabled)

--- a/docs/sources/tempo/configuration/hosted-storage/s3.md
+++ b/docs/sources/tempo/configuration/hosted-storage/s3.md
@@ -53,6 +53,8 @@ The following IAM policy shows minimal permissions required by Tempo, where the 
 
 A lifecycle policy is recommended that deletes incomplete multipart uploads after one day.
 
+This policy applies to the default upload path, which writes objects with multipart uploads. If you set `disable_multipart_upload: true`, Tempo writes each object with a single `PutObject` request and doesn't leave incomplete multipart uploads behind.
+
 ## S3-compatible local stores for testing
 
 {{< admonition type="note" >}}
@@ -170,6 +172,8 @@ The MinIO open source repository has been archived and the community edition is 
 The following example configuration uses the S3 backend. Replace the `<S3_ENDPOINT>`, `<S3_ACCESS_KEY>`, and `<S3_SECRET_KEY>` placeholders with the values for your object store.
 
 This example configuration includes the metrics-generator. To disable it, remove the `metrics_generator` block and the `processors` list from the overrides.
+
+Some S3-compatible stores don't implement the multipart upload API and reject uploads with errors such as `501 Not Implemented` on `CreateMultipartUpload`. For those stores, add `disable_multipart_upload: true` to the `s3` block so Tempo writes each object with a single `PutObject` request. Refer to the [storage block configuration](/docs/tempo/<TEMPO_VERSION>/configuration/#storage) for details.
 
 ```yaml
 stream_over_http_enabled: true

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -664,6 +664,7 @@ storage:
             metadata: {}
             native_aws_auth_enabled: false
             list_blocks_concurrency: 3
+            disable_multipart_upload: false
             sse:
                 type: ""
                 kms_key_id: ""
@@ -761,6 +762,7 @@ overrides:
                 metadata: {}
                 native_aws_auth_enabled: false
                 list_blocks_concurrency: 3
+                disable_multipart_upload: false
                 sse:
                     type: ""
                     kms_key_id: ""

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -660,6 +660,7 @@ storage:
             metadata: {}
             native_aws_auth_enabled: false
             list_blocks_concurrency: 3
+            disable_multipart_upload: false
             sse:
                 type: ""
                 kms_key_id: ""
@@ -757,6 +758,7 @@ overrides:
                 metadata: {}
                 native_aws_auth_enabled: false
                 list_blocks_concurrency: 3
+                disable_multipart_upload: false
                 sse:
                     type: ""
                     kms_key_id: ""

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -71,9 +71,14 @@ type Config struct {
 	Metadata         map[string]string `yaml:"metadata"`
 	// Deprecated
 	// See https://github.com/grafana/tempo/pull/3006 for more details
-	NativeAWSAuthEnabled  bool      `yaml:"native_aws_auth_enabled"`
-	ListBlocksConcurrency int       `yaml:"list_blocks_concurrency"`
-	SSE                   SSEConfig `yaml:"sse"`
+	NativeAWSAuthEnabled  bool `yaml:"native_aws_auth_enabled"`
+	ListBlocksConcurrency int  `yaml:"list_blocks_concurrency"`
+	// DisableMultipartUpload writes objects with a single PutObject instead of a multipart
+	// upload, for S3-compatible stores that do not implement the multipart upload API.
+	// The object is buffered to a temporary file (os.TempDir) while it is written, so it
+	// cannot exceed the 5 GiB single-PutObject limit, and part_size has no effect.
+	DisableMultipartUpload bool      `yaml:"disable_multipart_upload"`
+	SSE                    SSEConfig `yaml:"sse"`
 }
 
 func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {

--- a/tempodb/backend/s3/config.go
+++ b/tempodb/backend/s3/config.go
@@ -75,8 +75,9 @@ type Config struct {
 	ListBlocksConcurrency int  `yaml:"list_blocks_concurrency"`
 	// DisableMultipartUpload writes objects with a single PutObject instead of a multipart
 	// upload, for S3-compatible stores that do not implement the multipart upload API.
-	// The object is buffered to a temporary file (os.TempDir) while it is written, so it
-	// cannot exceed the 5 GiB single-PutObject limit, and part_size has no effect.
+	// Streaming writes buffer the object to a temporary file (os.TempDir) first; writes
+	// whose size is already known are sent straight through. Either way an object cannot
+	// exceed the 5 GiB single-PutObject limit, and part_size has no effect.
 	DisableMultipartUpload bool      `yaml:"disable_multipart_upload"`
 	SSE                    SSEConfig `yaml:"sse"`
 }

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -58,7 +58,8 @@ type appendTracker struct {
 	objectName string
 	parts      []minio.ObjectPart
 	partNum    int
-	buffer     []byte // buffer to accumulate data for R2-compliant fixed-size chunks
+	buffer     []byte   // buffer to accumulate data for R2-compliant fixed-size chunks
+	tmpFile    *os.File // buffers the object on disk when multipart upload is disabled
 }
 
 type overrideSignatureVersion struct {
@@ -230,6 +231,28 @@ func (rw *readerWriter) Append(ctx context.Context, name string, keypath backend
 	keypath = backend.KeyPathWithPrefix(keypath, rw.cfg.Prefix)
 	objectName := backend.ObjectFileName(keypath, name)
 
+	if rw.cfg.DisableMultipartUpload {
+		// Buffer the object to a temporary file and write it with a single PutObject in
+		// CloseAppend, for S3-compatible stores that do not implement the multipart upload API.
+		if tracker != nil {
+			a = tracker.(appendTracker)
+		}
+		a.objectName = objectName
+		if a.tmpFile == nil {
+			f, err := os.CreateTemp("", "tempo-s3-block-")
+			if err != nil {
+				return nil, fmt.Errorf("error creating temp file for s3 upload: %w", err)
+			}
+			a.tmpFile = f
+		}
+		if _, err := a.tmpFile.Write(buffer); err != nil {
+			_ = a.tmpFile.Close()
+			_ = os.Remove(a.tmpFile.Name())
+			return nil, fmt.Errorf("error buffering object for s3 upload: %w", err)
+		}
+		return a, nil
+	}
+
 	putObjOptions := getPutObjectOptions(rw)
 	if tracker != nil {
 		a = tracker.(appendTracker)
@@ -308,6 +331,36 @@ func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendT
 	}
 
 	a := tracker.(appendTracker)
+
+	if rw.cfg.DisableMultipartUpload {
+		f := a.tmpFile
+		if f == nil {
+			return nil
+		}
+		defer func() {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		}()
+		size, err := f.Seek(0, io.SeekEnd)
+		if err != nil {
+			return fmt.Errorf("error sizing buffered object %s: %w", a.objectName, err)
+		}
+		// A single PutObject is limited to 5 GiB by S3; objects above that need multipart,
+		// which this option disables. Fail loudly rather than send a doomed request.
+		const maxSinglePutObjectSize = 5 * 1024 * 1024 * 1024
+		if size > maxSinglePutObjectSize {
+			return fmt.Errorf("object %s is %d bytes; disable_multipart_upload writes it as a single PutObject, which S3 limits to 5 GiB", a.objectName, size)
+		}
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("error rewinding buffered object %s: %w", a.objectName, err)
+		}
+		options := getPutObjectOptions(rw)
+		options.DisableMultipart = true
+		if _, err := rw.core.Client.PutObject(ctx, rw.cfg.Bucket, a.objectName, f, size, options); err != nil {
+			return fmt.Errorf("error writing object to s3 backend, object %s: %w", a.objectName, err)
+		}
+		return nil
+	}
 
 	// Only flush buffer if using new chunking behavior (PartSize > 0)
 	if rw.cfg.PartSize > 0 && len(a.buffer) > 0 {

--- a/tempodb/backend/s3/s3.go
+++ b/tempodb/backend/s3/s3.go
@@ -185,6 +185,24 @@ func getObjectOptions(rw *readerWriter) minio.GetObjectOptions {
 	}
 }
 
+// maxSinglePutObjectSize is the largest object S3 accepts in a single PutObject request.
+// Anything above it needs a multipart upload, which disable_multipart_upload turns off.
+const maxSinglePutObjectSize = 5 * 1024 * 1024 * 1024
+
+// checkSinglePutObjectSize reports whether an object can be written with one PutObject.
+// It is only consulted when disable_multipart_upload is set: minio-go needs a known size
+// to send a single request, and S3 caps that request at 5 GiB. Failing here is better than
+// sending a doomed request or silently falling back to the multipart API the store lacks.
+func checkSinglePutObjectSize(objName string, size int64) error {
+	if size < 0 {
+		return fmt.Errorf("object %s has unknown length; disable_multipart_upload requires a known object size", objName)
+	}
+	if size > maxSinglePutObjectSize {
+		return fmt.Errorf("object %s is %d bytes; disable_multipart_upload writes it as a single PutObject, which S3 limits to 5 GiB", objName, size)
+	}
+	return nil
+}
+
 func getPutObjectPartOptions(rw *readerWriter) minio.PutObjectPartOptions {
 	return minio.PutObjectPartOptions{
 		SSE: rw.sse,
@@ -202,6 +220,17 @@ func (rw *readerWriter) Write(ctx context.Context, name string, keypath backend.
 	objName := backend.ObjectFileName(keypath, name)
 
 	putObjectOptions := getPutObjectOptions(rw)
+	if rw.cfg.DisableMultipartUpload {
+		// Pin this write to a single PutObject. Without it minio-go switches to a multipart
+		// upload for any object larger than the part size (its default is 16 MiB), and the
+		// stores this option exists for answer CreateMultipartUpload with 501 Not Implemented.
+		// Unlike Append, there is nothing to buffer here: the caller already knows the size.
+		if err := checkSinglePutObjectSize(objName, size); err != nil {
+			span.SetStatus(codes.Error, "object cannot be written as a single PutObject")
+			return err
+		}
+		putObjectOptions.DisableMultipart = true
+	}
 
 	info, err := rw.core.Client.PutObject(
 		derivedCtx,
@@ -345,11 +374,8 @@ func (rw *readerWriter) CloseAppend(ctx context.Context, tracker backend.AppendT
 		if err != nil {
 			return fmt.Errorf("error sizing buffered object %s: %w", a.objectName, err)
 		}
-		// A single PutObject is limited to 5 GiB by S3; objects above that need multipart,
-		// which this option disables. Fail loudly rather than send a doomed request.
-		const maxSinglePutObjectSize = 5 * 1024 * 1024 * 1024
-		if size > maxSinglePutObjectSize {
-			return fmt.Errorf("object %s is %d bytes; disable_multipart_upload writes it as a single PutObject, which S3 limits to 5 GiB", a.objectName, size)
+		if err := checkSinglePutObjectSize(a.objectName, size); err != nil {
+			return err
 		}
 		if _, err := f.Seek(0, io.SeekStart); err != nil {
 			return fmt.Errorf("error rewinding buffered object %s: %w", a.objectName, err)

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -929,3 +930,78 @@ func metadataMockedHandler(t *testing.T) http.HandlerFunc {
 }
 
 func timeNow() time.Time { return time.Date(2024, 5, 12, 16, 21, 24, 42, time.UTC) }
+
+func TestDisableMultipartUpload(t *testing.T) {
+	const tenant = "single-tenant"
+
+	type capture struct {
+		sawUploads atomic.Bool
+		putCount   atomic.Int32
+		putBody    atomic.Value // string
+	}
+
+	// handler that drives both the multipart flow and a single PutObject, recording which
+	// path the backend took and the body of any single PUT.
+	handler := func(c *capture) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			q := r.URL.Query()
+			switch {
+			case q.Has("uploads"): // CreateMultipartUpload
+				c.sawUploads.Store(true)
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><InitiateMultipartUploadResult><Bucket>blerg</Bucket><Key>k</Key><UploadId>test-upload-id</UploadId></InitiateMultipartUploadResult>`))
+			case q.Get("uploadId") != "" && r.Method == http.MethodPut: // UploadPart
+				c.sawUploads.Store(true)
+				w.Header().Set("ETag", `"abc"`)
+				w.WriteHeader(http.StatusOK)
+			case q.Get("uploadId") != "" && r.Method == http.MethodPost: // CompleteMultipartUpload
+				c.sawUploads.Store(true)
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUploadResult><Bucket>blerg</Bucket><Key>k</Key><ETag>"abc"</ETag></CompleteMultipartUploadResult>`))
+			case r.Method == http.MethodPut: // single PutObject
+				c.putCount.Add(1)
+				body, _ := io.ReadAll(r.Body)
+				c.putBody.Store(string(body))
+				w.Header().Set("ETag", `"abc"`)
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}
+	}
+
+	writeObject := func(t *testing.T, disable bool) *capture {
+		t.Helper()
+		c := &capture{}
+		server := testServer(t, handler(c))
+		_, w, _, err := NewNoConfirm(&Config{
+			Region:                 "blerg",
+			AccessKey:              "test",
+			SecretKey:              flagext.SecretWithValue("test"),
+			Bucket:                 "blerg",
+			Insecure:               true,
+			Endpoint:               server.URL[7:],
+			DisableMultipartUpload: disable,
+		})
+		require.NoError(t, err)
+		ctx := context.Background()
+		tracker, err := w.Append(ctx, "data", backend.KeyPath{tenant}, nil, []byte("hello "))
+		require.NoError(t, err)
+		tracker, err = w.Append(ctx, "data", backend.KeyPath{tenant}, tracker, []byte("world"))
+		require.NoError(t, err)
+		require.NoError(t, w.CloseAppend(ctx, tracker))
+		return c
+	}
+
+	t.Run("disabled writes a single PutObject with the full body", func(t *testing.T) {
+		c := writeObject(t, true)
+		require.False(t, c.sawUploads.Load(), "must not initiate a multipart upload when disable_multipart_upload is set")
+		require.Equal(t, int32(1), c.putCount.Load(), "object must be written with a single PutObject")
+		body, _ := c.putBody.Load().(string)
+		require.Contains(t, body, "hello world", "the single PutObject must carry the full buffered object in append order")
+	})
+
+	t.Run("default still uses multipart upload", func(t *testing.T) {
+		c := writeObject(t, false)
+		require.True(t, c.sawUploads.Load(), "default behavior must use a multipart upload")
+		require.Zero(t, c.putCount.Load(), "default must not take the single-PutObject path")
+	})
+}

--- a/tempodb/backend/s3/s3_test.go
+++ b/tempodb/backend/s3/s3_test.go
@@ -1005,3 +1005,102 @@ func TestDisableMultipartUpload(t *testing.T) {
 		require.Zero(t, c.putCount.Load(), "default must not take the single-PutObject path")
 	})
 }
+
+// Write() is the path the ingester uses to flush a finished block; unlike Append it hands
+// minio-go a reader and a known size, so it needs its own guard. Without one, minio-go
+// switches to a multipart upload above its default 16 MiB part size and stores that do not
+// implement the multipart API reject the object.
+func TestDisableMultipartUploadWrite(t *testing.T) {
+	const tenant = "single-tenant"
+
+	// Larger than minio-go's default 16 MiB part size, which is the threshold that decides
+	// between a single PutObject and a multipart upload when part_size is not configured.
+	body := bytes.Repeat([]byte("a"), 17*1024*1024)
+
+	type capture struct {
+		sawUploads atomic.Bool
+		putCount   atomic.Int32
+		putBytes   atomic.Int64
+		putDecoded atomic.Int64
+	}
+
+	handler := func(c *capture) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			q := r.URL.Query()
+			switch {
+			case q.Has("uploads"): // CreateMultipartUpload
+				c.sawUploads.Store(true)
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><InitiateMultipartUploadResult><Bucket>blerg</Bucket><Key>k</Key><UploadId>test-upload-id</UploadId></InitiateMultipartUploadResult>`))
+			case q.Get("uploadId") != "" && r.Method == http.MethodPut: // UploadPart
+				c.sawUploads.Store(true)
+				w.Header().Set("ETag", `"abc"`)
+				w.WriteHeader(http.StatusOK)
+			case q.Get("uploadId") != "" && r.Method == http.MethodPost: // CompleteMultipartUpload
+				c.sawUploads.Store(true)
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUploadResult><Bucket>blerg</Bucket><Key>k</Key><ETag>"abc"</ETag></CompleteMultipartUploadResult>`))
+			case r.Method == http.MethodPut: // single PutObject
+				c.putCount.Add(1)
+				// The body is framed with the streaming signature, so the bytes on the wire
+				// exceed the payload; the decoded length header carries the real object size.
+				if decoded, err := strconv.ParseInt(r.Header.Get("x-amz-decoded-content-length"), 10, 64); err == nil {
+					c.putDecoded.Store(decoded)
+				}
+				n, _ := io.Copy(io.Discard, r.Body)
+				c.putBytes.Store(n)
+				w.Header().Set("ETag", `"abc"`)
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}
+	}
+
+	newWriter := func(t *testing.T, c *capture, disable bool) backend.RawWriter {
+		t.Helper()
+		server := testServer(t, handler(c))
+		_, w, _, err := NewNoConfirm(&Config{
+			Region:                 "blerg",
+			AccessKey:              "test",
+			SecretKey:              flagext.SecretWithValue("test"),
+			Bucket:                 "blerg",
+			Insecure:               true,
+			Endpoint:               server.URL[7:],
+			DisableMultipartUpload: disable,
+		})
+		require.NoError(t, err)
+		return w
+	}
+
+	t.Run("disabled writes an over-part-size object with a single PutObject", func(t *testing.T) {
+		c := &capture{}
+		w := newWriter(t, c, true)
+		require.NoError(t, w.Write(context.Background(), "data", backend.KeyPath{tenant}, bytes.NewReader(body), int64(len(body)), nil))
+		require.False(t, c.sawUploads.Load(), "must not initiate a multipart upload when disable_multipart_upload is set")
+		require.Equal(t, int32(1), c.putCount.Load(), "object must be written with a single PutObject")
+		require.Equal(t, int64(len(body)), c.putDecoded.Load(), "the single PutObject must carry the whole object")
+		require.GreaterOrEqual(t, c.putBytes.Load(), int64(len(body)), "the request body must hold at least the whole object")
+	})
+
+	t.Run("default still uses multipart upload", func(t *testing.T) {
+		c := &capture{}
+		w := newWriter(t, c, false)
+		require.NoError(t, w.Write(context.Background(), "data", backend.KeyPath{tenant}, bytes.NewReader(body), int64(len(body)), nil))
+		require.True(t, c.sawUploads.Load(), "default behavior must use a multipart upload above the part size")
+	})
+
+	t.Run("disabled rejects an unknown length instead of failing inside minio", func(t *testing.T) {
+		c := &capture{}
+		w := newWriter(t, c, true)
+		err := w.Write(context.Background(), "data", backend.KeyPath{tenant}, bytes.NewReader(body), -1, nil)
+		require.ErrorContains(t, err, "requires a known object size")
+		require.Zero(t, c.putCount.Load())
+	})
+
+	t.Run("disabled rejects an object above the 5 GiB single-PutObject limit", func(t *testing.T) {
+		c := &capture{}
+		w := newWriter(t, c, true)
+		err := w.Write(context.Background(), "data", backend.KeyPath{tenant}, bytes.NewReader(nil), maxSinglePutObjectSize+1, nil)
+		require.ErrorContains(t, err, "S3 limits to 5 GiB")
+		require.Zero(t, c.putCount.Load())
+	})
+}


### PR DESCRIPTION
**What this PR does**:

Adds an optional `disable_multipart_upload` setting to the S3 backend. When enabled, objects are written with a single `PutObject` instead of an S3 multipart upload. The default is unchanged (multipart), so existing deployments are unaffected.

Some S3-compatible stores do not implement the multipart upload API and return `501 Not Implemented` on `CreateMultipartUpload`. Because the backend writes block data via the streaming append path (which uses multipart), compaction fails on those stores while small single-`PutObject` writes still succeed. With this option, each object is buffered to a temporary file (under `os.TempDir`) as it is appended and then written in a single `PutObject`, which those stores accept.

The option is opt-in; multipart remains the default and the recommended path. The tradeoff is the temporary on-disk buffer per in-flight object, so operators enabling it should ensure `TMPDIR` points at a location with adequate space. Because the object goes out as one request, it cannot exceed the 5 GiB single-`PutObject` limit; an object larger than that is rejected with a clear error rather than a doomed request, and `part_size` has no effect in this mode.

**Which issue(s) this PR fixes**:
Related to #6436

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)