### PR TITLE
feat: added new traces diff endpoint

### DIFF
--- a/.chloggen/feat-add-experimental-endpoint-traces-diff.yaml
+++ b/.chloggen/feat-add-experimental-endpoint-traces-diff.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: feature
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Added a new endpoint to calculate the diff between two traces. Marked as experimental
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolianr

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -498,6 +498,7 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 
 	// http trace by id endpoint
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathTraces), base.Wrap(queryFrontend.TraceByIDHandler))
+	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathTraceDiffV2), base.Wrap(queryFrontend.TraceDiffHandler))
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathTracesV2), base.Wrap(queryFrontend.TraceByIDHandlerV2))
 
 	// http search endpoints

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -47,7 +47,7 @@ type (
 )
 
 type QueryFrontend struct {
-	TraceByIDHandler, TraceByIDHandlerV2, SearchHandler                                        http.Handler
+	TraceByIDHandler, TraceByIDHandlerV2, TraceDiffHandler, SearchHandler                      http.Handler
 	SearchTagsHandler, SearchTagsV2Handler, SearchTagsValuesHandler, SearchTagsValuesV2Handler http.Handler
 	MetricsQueryInstantHandler, MetricsQueryRangeHandler                                       http.Handler
 	MCPHandler                                                                                 http.Handler
@@ -232,6 +232,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 
 	traces := newTraceIDHandler(cfg, tracePipeline, o, combiner.NewTypedTraceByID, logger, dataAccessController)
 	tracesV2 := newTraceIDV2Handler(cfg, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
+	traceDiff := newTraceDiffHandler(logger)
 	search := newSearchHTTPHandler(cfg, searchPipeline, o, logger, dataAccessController)
 	searchTags := newTagsHTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagsV2 := newTagsV2HTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
@@ -244,6 +245,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 		// http/discrete
 		TraceByIDHandler:           newHandler(cfg.Config.LogQueryRequestHeaders, traces, logger),
 		TraceByIDHandlerV2:         newHandler(cfg.Config.LogQueryRequestHeaders, tracesV2, logger),
+		TraceDiffHandler:           newHandler(cfg.Config.LogQueryRequestHeaders, traceDiff, logger),
 		SearchHandler:              newHandler(cfg.Config.LogQueryRequestHeaders, search, logger),
 		SearchTagsHandler:          newHandler(cfg.Config.LogQueryRequestHeaders, searchTags, logger),
 		SearchTagsV2Handler:        newHandler(cfg.Config.LogQueryRequestHeaders, searchTagsV2, logger),

--- a/modules/frontend/tracediff_handler.go
+++ b/modules/frontend/tracediff_handler.go
@@ -1,0 +1,49 @@
+package frontend
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level" //nolint:all //deprecated
+	"github.com/grafana/tempo/pkg/api"
+)
+
+const traceDiffNotImplementedMessage = "trace diff endpoint is not implemented"
+
+// newTraceDiffHandler creates an HTTP handler skeleton for trace diff requests.
+//
+// EXPERIMENTAL: this endpoint is not yet a stable API contract. Diff execution
+// will be added in a follow-up change.
+func newTraceDiffHandler(logger log.Logger) http.RoundTripper {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost {
+			return &http.Response{
+				StatusCode: http.StatusMethodNotAllowed,
+				Status:     http.StatusText(http.StatusMethodNotAllowed),
+				Body:       io.NopCloser(strings.NewReader(http.StatusText(http.StatusMethodNotAllowed))),
+			}, nil
+		}
+
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
+			return errResp, nil
+		}
+
+		if _, err := api.ParseTraceDiffRequest(req); err != nil {
+			return httpInvalidRequest(err), nil
+		}
+
+		level.Info(logger).Log(
+			"msg", "trace diff request",
+			"tenant", tenant,
+			"path", req.URL.Path)
+
+		return &http.Response{
+			StatusCode: http.StatusNotImplemented,
+			Status:     http.StatusText(http.StatusNotImplemented),
+			Body:       io.NopCloser(strings.NewReader(traceDiffNotImplementedMessage)),
+		}, nil
+	})
+}

--- a/modules/frontend/tracediff_handler_test.go
+++ b/modules/frontend/tracediff_handler_test.go
@@ -1,0 +1,52 @@
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/user"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraceDiffHandlerSkeleton(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		statusCode int
+	}{
+		{
+			name:       "valid post returns not implemented",
+			method:     http.MethodPost,
+			body:       `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`,
+			statusCode: http.StatusNotImplemented,
+		},
+		{
+			name:       "invalid post returns bad request",
+			method:     http.MethodPost,
+			body:       `{"base":{"traceId":"abc123"}}`,
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "get returns method not allowed",
+			method:     http.MethodGet,
+			statusCode: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newHandler(nil, newTraceDiffHandler(log.NewNopLogger()), log.NewNopLogger())
+			req := httptest.NewRequest(tt.method, "/api/v2/traces/diff", strings.NewReader(tt.body))
+			req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+
+			require.Equal(t, tt.statusCode, resp.Code)
+		})
+	}
+}

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/dskit/httpgrpc"
 	"github.com/prometheus/common/model"
 
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util"
@@ -82,6 +83,7 @@ const (
 
 	PathSearchTagValuesV2 = "/api/v2/search/tag/" + MuxVarTagInPath + "/values"
 	PathSearchTagsV2      = "/api/v2/search/tags"
+	PathTraceDiffV2       = "/api/v2/traces/diff"
 	PathTracesV2          = "/api/v2/traces/{traceID}"
 
 	QueryModeKey       = "mode"
@@ -105,6 +107,24 @@ const (
 	MarshallingFormatJSON     MarshallingFormat = HeaderAcceptJSON
 	MarshallingFormatLLM      MarshallingFormat = HeaderAcceptLLM
 )
+
+// TraceDiffRequest is the request body for the trace diff API.
+type TraceDiffRequest struct {
+	Base    TraceDiffTraceRequest `json:"base"`
+	Compare TraceDiffTraceRequest `json:"compare"`
+	Format  string                `json:"-"`
+}
+
+// TraceDiffTraceRequest identifies one side of a trace diff request.
+type TraceDiffTraceRequest struct {
+	TraceID string `json:"traceId"`
+	Start   *int64 `json:"start,omitempty"`
+	End     *int64 `json:"end,omitempty"`
+
+	TraceIDBytes []byte    `json:"-"`
+	StartTime    time.Time `json:"-"`
+	EndTime      time.Time `json:"-"`
+}
 
 // MarshalingFormatFromAcceptHeader extracts the marshaling format from the Accept header
 // It properly handles multiple media types and quality values
@@ -782,6 +802,49 @@ func extractDateRangeParams(vals url.Values) (start, end, since string) {
 	end, _ = extractQueryParam(vals, urlParamEnd)
 	since, _ = extractQueryParam(vals, urlParamSince)
 	return
+}
+
+// ParseTraceDiffRequest parses and validates the trace diff API request body.
+func ParseTraceDiffRequest(r *http.Request) (*TraceDiffRequest, error) {
+	var req TraceDiffRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, fmt.Errorf("invalid trace diff request body: %w", err)
+	}
+
+	req.Format = tracediff.VersionTracePatchV0
+
+	if err := parseTraceDiffTraceRequest("base", &req.Base); err != nil {
+		return nil, err
+	}
+	if err := parseTraceDiffTraceRequest("compare", &req.Compare); err != nil {
+		return nil, err
+	}
+
+	return &req, nil
+}
+
+func parseTraceDiffTraceRequest(name string, traceReq *TraceDiffTraceRequest) error {
+	if traceReq.TraceID == "" {
+		return fmt.Errorf("%s.traceId is required", name)
+	}
+
+	traceID, err := util.HexStringToTraceID(traceReq.TraceID)
+	if err != nil {
+		return fmt.Errorf("invalid %s.traceId: %w", name, err)
+	}
+	traceReq.TraceIDBytes = traceID
+
+	if traceReq.Start != nil {
+		traceReq.StartTime = time.Unix(*traceReq.Start, 0)
+	}
+	if traceReq.End != nil {
+		traceReq.EndTime = time.Unix(*traceReq.End, 0)
+	}
+	if traceReq.Start != nil && traceReq.End != nil && *traceReq.End <= *traceReq.Start {
+		return fmt.Errorf("%s.start must be before %s.end. received start=%d end=%d", name, name, *traceReq.Start, *traceReq.End)
+	}
+
+	return nil
 }
 
 // ParseTraceByIDRequest parses and validates params for the trace by id API.

--- a/pkg/api/http_test.go
+++ b/pkg/api/http_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/cmd/tempo-query/tempo"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/grafana/tempo/pkg/tempopb"
 )
 
@@ -516,6 +518,102 @@ func TestBuildSearchBlockRequest(t *testing.T) {
 		actualURL, err := BuildSearchBlockRequest(tc.httpReq, tc.req, string(jsonBytes))
 		assert.NoError(t, err)
 		assert.Equal(t, tc.query, actualURL.URL.String())
+	}
+}
+
+func TestParseTraceDiffRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		expectedErr string
+		assertReq   func(t *testing.T, req *TraceDiffRequest)
+	}{
+		{
+			name: "valid minimal request defaults format",
+			body: `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`,
+			assertReq: func(t *testing.T, req *TraceDiffRequest) {
+				t.Helper()
+				assert.Equal(t, tracediff.VersionTracePatchV0, req.Format)
+				assert.Equal(t, "abc123", req.Base.TraceID)
+				assert.Equal(t, "def456", req.Compare.TraceID)
+				assert.Len(t, req.Base.TraceIDBytes, 16)
+				assert.Len(t, req.Compare.TraceIDBytes, 16)
+				assert.True(t, req.Base.StartTime.IsZero())
+				assert.True(t, req.Base.EndTime.IsZero())
+				assert.True(t, req.Compare.StartTime.IsZero())
+				assert.True(t, req.Compare.EndTime.IsZero())
+			},
+		},
+		{
+			name: "valid request with independent windows",
+			body: `{"base":{"traceId":"abc123","start":10,"end":20},"compare":{"traceId":"def456","start":100,"end":200}}`,
+			assertReq: func(t *testing.T, req *TraceDiffRequest) {
+				t.Helper()
+				assert.Equal(t, tracediff.VersionTracePatchV0, req.Format)
+				assert.Equal(t, time.Unix(10, 0), req.Base.StartTime)
+				assert.Equal(t, time.Unix(20, 0), req.Base.EndTime)
+				assert.Equal(t, time.Unix(100, 0), req.Compare.StartTime)
+				assert.Equal(t, time.Unix(200, 0), req.Compare.EndTime)
+			},
+		},
+		{
+			name:        "empty body",
+			body:        "",
+			expectedErr: "invalid trace diff request body",
+		},
+		{
+			name:        "malformed json",
+			body:        `{"base":`,
+			expectedErr: "invalid trace diff request body",
+		},
+		{
+			name:        "missing base",
+			body:        `{"compare":{"traceId":"def456"}}`,
+			expectedErr: "base.traceId is required",
+		},
+		{
+			name:        "missing compare",
+			body:        `{"base":{"traceId":"abc123"}}`,
+			expectedErr: "compare.traceId is required",
+		},
+		{
+			name:        "missing base trace ID",
+			body:        `{"base":{},"compare":{"traceId":"def456"}}`,
+			expectedErr: "base.traceId is required",
+		},
+		{
+			name:        "invalid trace ID",
+			body:        `{"base":{"traceId":"not-hex"},"compare":{"traceId":"def456"}}`,
+			expectedErr: "invalid base.traceId",
+		},
+		{
+			name:        "base end equals start",
+			body:        `{"base":{"traceId":"abc123","start":10,"end":10},"compare":{"traceId":"def456"}}`,
+			expectedErr: "base.start must be before base.end. received start=10 end=10",
+		},
+		{
+			name:        "compare end before start",
+			body:        `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456","start":20,"end":10}}`,
+			expectedErr: "compare.start must be before compare.end. received start=20 end=10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, PathTraceDiffV2, strings.NewReader(tt.body))
+
+			actual, err := ParseTraceDiffRequest(req)
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, actual)
+			if tt.assertReq != nil {
+				tt.assertReq(t, actual)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
It adds a new endpoint under `/v2/traces/diff` to allow calculate the diff between two traces. Currently its just the scaffolding and basic validation.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)