### PR TITLE
feat(querier): add block processing duration metric

### DIFF
--- a/.chloggen/querier-backend-processing-duration.yaml
+++ b/.chloggen/querier-backend-processing-duration.yaml
@@ -6,7 +6,7 @@ change_type: enhancement
 component: querier
 
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
-note: Add `tempo_querier_block_processing_duration_seconds` histogram for time the querier spends processing a backend block, labeled by operation.
+note: Add `tempo_querier_backend_processing_duration_seconds` histogram measuring time the querier spends processing backend blocks, labeled by operation and tenant.
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.

--- a/.chloggen/querier-block-processing-duration.yaml
+++ b/.chloggen/querier-block-processing-duration.yaml
@@ -1,0 +1,19 @@
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: querier
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Add `tempo_querier_block_processing_duration_seconds` histogram for time the querier spends processing a backend block, labeled by operation.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7525]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: zhxiaogg

--- a/modules/frontend/slos.go
+++ b/modules/frontend/slos.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/grpcutil"
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -13,10 +14,10 @@ import (
 )
 
 const (
-	traceByIDOp = "traces"
-	searchOp    = "search"
-	metadataOp  = "metadata"
-	metricsOp   = "metrics"
+	traceByIDOp = api.OpTraceByID
+	searchOp    = api.OpSearch
+	metadataOp  = api.OpMetadata
+	metricsOp   = api.OpMetrics
 
 	resultCompleted = "completed"
 	resultCanceled  = "canceled"

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -47,20 +47,20 @@ var metricMetricsLiveStoreClients = promauto.NewGauge(prometheus.GaugeOpts{
 	Help:      "The current number of livestore clients.",
 })
 
-// metricBlockProcessingDuration times how long the querier spends processing one
-// backend block (scan + interleaved object-store I/O), by operation.
-var metricBlockProcessingDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+// metricBackendProcessingDuration times how long the querier spends processing
+// backend blocks (vs recent live-store data), by operation and tenant.
+var metricBackendProcessingDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace:                       "tempo",
-	Name:                            "querier_block_processing_duration_seconds",
-	Help:                            "Time the querier spends processing one backend block request (scan + interleaved object-store I/O), by operation.",
+	Name:                            "querier_backend_processing_duration_seconds",
+	Help:                            "Time the querier spends processing backend blocks (object-store scan + interleaved I/O), by operation and tenant. Excludes recent (live-store) data.",
 	Buckets:                         prometheus.ExponentialBuckets(0.005, 4, 6),
 	NativeHistogramBucketFactor:     1.1,
 	NativeHistogramMaxBucketNumber:  100,
 	NativeHistogramMinResetDuration: time.Hour,
-}, []string{"operation"})
+}, []string{"operation", "tenant"})
 
-func observeBlockProcessing(operation string, start time.Time) {
-	metricBlockProcessingDuration.WithLabelValues(operation).Observe(time.Since(start).Seconds())
+func observeBackendProcessing(operation, tenant string, start time.Time) {
+	metricBackendProcessingDuration.WithLabelValues(operation, tenant).Observe(time.Since(start).Seconds())
 }
 
 type (
@@ -264,7 +264,7 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 
 		findStart := time.Now()
 		partialTraces, blockErrs, err := q.store.Find(ctx, userID, req.TraceID, req.BlockStart, req.BlockEnd, timeStart, timeEnd, opts)
-		observeBlockProcessing("trace-by-id", findStart)
+		observeBackendProcessing(api.OpTraceByID, userID, findStart)
 		if err != nil {
 			retErr := fmt.Errorf("error querying store in Querier.FindTraceByID: %w", err)
 			span.RecordError(retErr)
@@ -632,12 +632,11 @@ func valuesToV2Response(distinctValues *collector.DistinctValue[tempopb.TagValue
 
 // SearchBlock searches the specified subset of the block for the passed tags.
 func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockRequest) (*tempopb.SearchResponse, error) {
-	defer observeBlockProcessing("search", time.Now())
-
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting org id in Querier.BackendSearch: %w", err)
 	}
+	defer observeBackendProcessing(api.OpSearch, tenantID, time.Now())
 
 	blockID, err := backend.ParseUUID(req.BlockID)
 	if err != nil {
@@ -689,10 +688,8 @@ func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockReque
 }
 
 func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.SearchTagsBlockRequest) (*tempopb.SearchTagsV2Response, error) {
-	defer observeBlockProcessing("search-tags", time.Now())
-
 	// For the intrinsic scope there is nothing to do in the querier,
-	// these are always added by the frontend.
+	// these are always added by the frontend. Return before timing.
 	if req.SearchReq.Scope == api.ParamScopeIntrinsic {
 		return &tempopb.SearchTagsV2Response{}, nil
 	}
@@ -701,6 +698,7 @@ func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.Se
 	if err != nil {
 		return nil, fmt.Errorf("error extracting org id in Querier.BackendSearch: %w", err)
 	}
+	defer observeBackendProcessing(api.OpSearchTags, tenantID, time.Now())
 
 	blockID, err := backend.ParseUUID(req.BlockID)
 	if err != nil {
@@ -777,12 +775,11 @@ func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.Se
 }
 
 func (q *Querier) internalTagValuesSearchBlock(ctx context.Context, req *tempopb.SearchTagValuesBlockRequest) (*tempopb.SearchTagValuesResponse, error) {
-	defer observeBlockProcessing("search-tag-values", time.Now())
-
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return &tempopb.SearchTagValuesResponse{}, fmt.Errorf("error extracting org id in Querier.BackendSearch: %w", err)
 	}
+	defer observeBackendProcessing(api.OpSearchTagValues, tenantID, time.Now())
 
 	blockID, err := backend.ParseUUID(req.BlockID)
 	if err != nil {
@@ -818,12 +815,11 @@ func (q *Querier) internalTagValuesSearchBlock(ctx context.Context, req *tempopb
 }
 
 func (q *Querier) internalTagValuesSearchBlockV2(ctx context.Context, req *tempopb.SearchTagValuesBlockRequest) (*tempopb.SearchTagValuesV2Response, error) {
-	defer observeBlockProcessing("search-tag-values", time.Now())
-
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return &tempopb.SearchTagValuesV2Response{}, fmt.Errorf("error extracting org id in Querier.BackendSearch: %w", err)
 	}
+	defer observeBackendProcessing(api.OpSearchTagValues, tenantID, time.Now())
 
 	blockID, err := backend.ParseUUID(req.BlockID)
 	if err != nil {

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -47,6 +47,22 @@ var metricMetricsLiveStoreClients = promauto.NewGauge(prometheus.GaugeOpts{
 	Help:      "The current number of livestore clients.",
 })
 
+// metricBlockProcessingDuration times how long the querier spends processing one
+// backend block (scan + interleaved object-store I/O), by operation.
+var metricBlockProcessingDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace:                       "tempo",
+	Name:                            "querier_block_processing_duration_seconds",
+	Help:                            "Time the querier spends processing one backend block request (scan + interleaved object-store I/O), by operation.",
+	Buckets:                         prometheus.ExponentialBuckets(0.005, 4, 6),
+	NativeHistogramBucketFactor:     1.1,
+	NativeHistogramMaxBucketNumber:  100,
+	NativeHistogramMinResetDuration: time.Hour,
+}, []string{"operation"})
+
+func observeBlockProcessing(operation string, start time.Time) {
+	metricBlockProcessingDuration.WithLabelValues(operation).Observe(time.Since(start).Seconds())
+}
+
 type (
 	forEachFn        func(ctx context.Context, client tempopb.QuerierClient) (any, error)
 	forEachMetricsFn func(ctx context.Context, client tempopb.MetricsClient) (any, error)
@@ -246,7 +262,9 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 
 		opts := common.DefaultSearchOptionsWithMaxBytes(maxBytes)
 
+		findStart := time.Now()
 		partialTraces, blockErrs, err := q.store.Find(ctx, userID, req.TraceID, req.BlockStart, req.BlockEnd, timeStart, timeEnd, opts)
+		observeBlockProcessing("trace-by-id", findStart)
 		if err != nil {
 			retErr := fmt.Errorf("error querying store in Querier.FindTraceByID: %w", err)
 			span.RecordError(retErr)
@@ -614,6 +632,8 @@ func valuesToV2Response(distinctValues *collector.DistinctValue[tempopb.TagValue
 
 // SearchBlock searches the specified subset of the block for the passed tags.
 func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockRequest) (*tempopb.SearchResponse, error) {
+	defer observeBlockProcessing("search", time.Now())
+
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting org id in Querier.BackendSearch: %w", err)
@@ -669,6 +689,8 @@ func (q *Querier) SearchBlock(ctx context.Context, req *tempopb.SearchBlockReque
 }
 
 func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.SearchTagsBlockRequest) (*tempopb.SearchTagsV2Response, error) {
+	defer observeBlockProcessing("search-tags", time.Now())
+
 	// For the intrinsic scope there is nothing to do in the querier,
 	// these are always added by the frontend.
 	if req.SearchReq.Scope == api.ParamScopeIntrinsic {
@@ -755,6 +777,8 @@ func (q *Querier) internalTagsSearchBlockV2(ctx context.Context, req *tempopb.Se
 }
 
 func (q *Querier) internalTagValuesSearchBlock(ctx context.Context, req *tempopb.SearchTagValuesBlockRequest) (*tempopb.SearchTagValuesResponse, error) {
+	defer observeBlockProcessing("search-tag-values", time.Now())
+
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return &tempopb.SearchTagValuesResponse{}, fmt.Errorf("error extracting org id in Querier.BackendSearch: %w", err)
@@ -794,6 +818,8 @@ func (q *Querier) internalTagValuesSearchBlock(ctx context.Context, req *tempopb
 }
 
 func (q *Querier) internalTagValuesSearchBlockV2(ctx context.Context, req *tempopb.SearchTagValuesBlockRequest) (*tempopb.SearchTagValuesV2Response, error) {
+	defer observeBlockProcessing("search-tag-values", time.Now())
+
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return &tempopb.SearchTagValuesV2Response{}, fmt.Errorf("error extracting org id in Querier.BackendSearch: %w", err)

--- a/modules/querier/querier_query_range.go
+++ b/modules/querier/querier_query_range.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log/level"
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/grafana/tempo/pkg/util/log"
@@ -49,12 +50,11 @@ func (q *Querier) queryRangeRecent(ctx context.Context, req *tempopb.QueryRangeR
 }
 
 func (q *Querier) queryBlock(ctx context.Context, req *tempopb.QueryRangeRequest) (*tempopb.QueryRangeResponse, error) {
-	defer observeBlockProcessing("metrics", time.Now())
-
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting org id in Querier.queryBlock: %w", err)
 	}
+	defer observeBackendProcessing(api.OpMetrics, tenantID, time.Now())
 
 	blockID, err := backend.ParseUUID(req.BlockID)
 	if err != nil {

--- a/modules/querier/querier_query_range.go
+++ b/modules/querier/querier_query_range.go
@@ -49,6 +49,8 @@ func (q *Querier) queryRangeRecent(ctx context.Context, req *tempopb.QueryRangeR
 }
 
 func (q *Querier) queryBlock(ctx context.Context, req *tempopb.QueryRangeRequest) (*tempopb.QueryRangeResponse, error) {
+	defer observeBlockProcessing("metrics", time.Now())
+
 	tenantID, err := validation.ExtractValidTenantID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting org id in Querier.queryBlock: %w", err)

--- a/pkg/api/operations.go
+++ b/pkg/api/operations.go
@@ -1,0 +1,14 @@
+package api
+
+// Query operation names used as metric labels across the query path
+// (query-frontend and querier), kept here to avoid label drift between components.
+const (
+	OpTraceByID = "traces"
+	OpSearch    = "search"
+	OpMetadata  = "metadata"
+	OpMetrics   = "metrics"
+
+	// Finer-grained metadata ops recorded by the querier; roll up to OpMetadata.
+	OpSearchTags      = "search-tags"
+	OpSearchTagValues = "search-tag-values"
+)


### PR DESCRIPTION
## Summary

Adds `tempo_querier_backend_processing_duration_seconds` — time the querier spends processing **backend blocks** (object-store scan + interleaved I/O), as opposed to recent (live-store) data. Labeled by:
- `operation`: traces, search, search-tags, search-tag-values, metrics
- `tenant`

Instrumented at the per-block handlers (and `store.Find` for trace-by-id), so it covers all backend query types and is version-agnostic (vparquet3/4/5). Complements `tempodb_backend_request_duration_seconds`, which times only the object-store GET I/O. Intended for querier capacity/autoscaling analysis — isolating backend-block work from recent-data work.

Operation label values are defined once in `pkg/api/operations.go` and reused by both the querier and the query-frontend SLO metrics, to avoid label drift.

## Testing
`go build`, `go vet`, `gofmt`, `go test ./modules/querier/`, `make chlog-validate` pass.
