### PR TITLE
[storage] vParquet5 better trace organization and compression

### DIFF
--- a/.chloggen/vp5-better-trace-organization.yaml
+++ b/.chloggen/vp5-better-trace-organization.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Internally sorts traces more intentionally before writing for better compression and reduced storage size.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: Traces are now sorted by service, scope, span name, and then status.  This new sorting colocates data better, including of attributes and events, etc and results in about 10% storage savings, and less I/O during reads.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mdisibio

--- a/cmd/tempo-cli/cmd-parquet-rewrite.go
+++ b/cmd/tempo-cli/cmd-parquet-rewrite.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/parquet-go/parquet-go"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet3"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet4"
+	"github.com/grafana/tempo/tempodb/encoding/vparquet5"
+)
+
+// parquetRewrite is a command that rewrites a parquet block on disk using the latest code for that encoding, and optionally
+// a new set of dedicated columns.  This command is useful to test changes of things like encoding, compression, or different
+// dedicated columns, or other code changes.
+type parquetRewrite struct {
+	In               string   `arg:"" help:"The input parquet block to read from."`
+	Out              string   `arg:"" help:"The output folder to write block to." default:"./out" optional:""`
+	DedicatedColumns []string `arg:"" help:"List of dedicated columns to convert. Overwrites existing dedicated columns" optional:""`
+}
+
+func (cmd *parquetRewrite) Run() error {
+	cmd.In = getPathToBlockDir(cmd.In)
+
+	meta, err := readBlockMeta(cmd.In)
+	if err != nil {
+		return err
+	}
+
+	enc, err := encoding.FromVersionForWrites(meta.Version)
+	if err != nil {
+		return fmt.Errorf("detect encoding from block meta: %w", err)
+	}
+
+	in, pf, iter, err := openParquetForRewrite(cmd.In, meta)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	defer iter.Close()
+
+	outR, outW, _, err := local.New(&local.Config{
+		Path: cmd.Out,
+	})
+	if err != nil {
+		return err
+	}
+
+	dedicatedCols, err := parseDedicatedColumns(cmd.DedicatedColumns, meta.DedicatedColumns)
+	if err != nil {
+		return err
+	}
+
+	blockCfg := &common.BlockConfig{
+		BloomFP:             common.DefaultBloomFP,
+		BloomShardSizeBytes: common.DefaultBloomShardSizeBytes,
+		Version:             enc.Version(),
+		RowGroupSizeBytes:   100 * 1024 * 1024,
+	}
+
+	newMeta := *meta
+	newMeta.Version = enc.Version()
+	newMeta.DedicatedColumns = dedicatedCols
+
+	fmt.Printf("Detected encoding %s from block meta\n", meta.Version)
+	fmt.Printf("Rewriting %s block in %s\n", enc.Version(), filepath.Join(cmd.Out, meta.TenantID, newMeta.BlockID.String()))
+	fmt.Printf("Converting rows 0 to %d\n", pf.NumRows())
+	outMeta, err := enc.CreateBlock(context.Background(), blockCfg, &newMeta, iter, backend.NewReader(outR), backend.NewWriter(outW))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully created block with size=%d and footerSize=%d\n", outMeta.Size_, outMeta.FooterSize)
+	return nil
+}
+
+func parseDedicatedColumns(fromCLI []string, fromMeta backend.DedicatedColumns) (backend.DedicatedColumns, error) {
+	if len(fromCLI) == 0 {
+		return fromMeta, nil
+	}
+
+	dedicatedCols := make(backend.DedicatedColumns, 0, len(fromCLI))
+	for _, col := range fromCLI {
+		var (
+			typ     = backend.DedicatedColumnTypeString
+			options = backend.DedicatedColumnOptions{}
+		)
+
+		col, blob := strings.CutPrefix(col, "blob/")
+		if blob {
+			options = append(options, backend.DedicatedColumnOptionBlob)
+		}
+
+		col, isInt := strings.CutPrefix(col, "int/")
+		if isInt {
+			typ = backend.DedicatedColumnTypeInt
+		}
+
+		att, err := traceql.ParseIdentifier(col)
+		if err != nil {
+			return nil, err
+		}
+
+		var scope backend.DedicatedColumnScope
+		switch att.Scope {
+		case traceql.AttributeScopeSpan:
+			scope = backend.DedicatedColumnScopeSpan
+		case traceql.AttributeScopeResource:
+			scope = backend.DedicatedColumnScopeResource
+		case traceql.AttributeScopeEvent:
+			scope = backend.DedicatedColumnScopeEvent
+		default:
+			return nil, fmt.Errorf("dedicated columns must be scoped: %s", att.Scope)
+		}
+
+		fmt.Printf("add dedicated column scope=%s type=%s name=%s\n", scope, typ, att.Name)
+
+		dedicatedCols = append(dedicatedCols, backend.DedicatedColumn{
+			Scope:   scope,
+			Name:    att.Name,
+			Type:    typ,
+			Options: options,
+		})
+	}
+
+	return dedicatedCols, nil
+}
+
+func openParquetForRewrite(blockPath string, meta *backend.BlockMeta) (*os.File, *parquet.File, common.Iterator, error) {
+	inFile := filepath.Join(blockPath, "data.parquet")
+	in, err := os.Open(inFile)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	inStat, err := in.Stat()
+	if err != nil {
+		_ = in.Close()
+		return nil, nil, nil, err
+	}
+
+	var (
+		fileOptions   []parquet.FileOption
+		readerOptions []parquet.ReaderOption
+	)
+
+	switch meta.Version {
+	case vparquet3.VersionString, vparquet4.VersionString:
+	case vparquet5.VersionString:
+		schema, _, ro := vparquet5.SchemaWithDynamicChanges(meta.DedicatedColumns)
+		readerOptions = ro
+		fileOptions = []parquet.FileOption{parquet.FileSchema(schema)}
+	default:
+		_ = in.Close()
+		return nil, nil, nil, fmt.Errorf("unsupported block version %q", meta.Version)
+	}
+
+	pf, err := parquet.OpenFile(in, inStat.Size(), fileOptions...)
+	if err != nil {
+		_ = in.Close()
+		return nil, nil, nil, err
+	}
+
+	var iter common.Iterator
+	switch meta.Version {
+	case vparquet3.VersionString:
+		iter = &parquetIterator3{
+			r: parquet.NewGenericReader[*vparquet3.Trace](pf),
+			m: meta,
+		}
+	case vparquet4.VersionString:
+		iter = &parquetIterator4{
+			r: parquet.NewGenericReader[*vparquet4.Trace](pf),
+			m: meta,
+		}
+	case vparquet5.VersionString:
+		iter = &parquetIterator5{
+			r: parquet.NewGenericReader[*vparquet5.Trace](pf, readerOptions...),
+			m: meta,
+		}
+	}
+
+	return in, pf, iter, nil
+}
+
+type parquetIterator5 struct {
+	r *parquet.GenericReader[*vparquet5.Trace]
+	m *backend.BlockMeta
+	i int
+}
+
+func (i *parquetIterator5) Next(_ context.Context) (common.ID, *tempopb.Trace, error) {
+	traces := []*vparquet5.Trace{{}}
+
+	i.i++
+	if i.i%1000 == 0 {
+		fmt.Println(i.i)
+	}
+
+	_, err := i.r.Read(traces)
+	if errors.Is(err, io.EOF) {
+		return nil, nil, io.EOF
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pqTrace := traces[0]
+	pbTrace := vparquet5.ParquetTraceToTempopbTrace(i.m, pqTrace)
+	return pqTrace.TraceID, pbTrace, nil
+}
+
+func (i *parquetIterator5) Close() {
+	_ = i.r.Close()
+}

--- a/cmd/tempo-cli/cmd-parquet-rewrite.go
+++ b/cmd/tempo-cli/cmd-parquet-rewrite.go
@@ -209,16 +209,17 @@ func (i *parquetIterator5) Next(_ context.Context) (common.ID, *tempopb.Trace, e
 		fmt.Println(i.i)
 	}
 
-	_, err := i.r.Read(traces)
-	if errors.Is(err, io.EOF) {
-		return nil, nil, io.EOF
-	}
-	if err != nil {
+	n, err := i.r.Read(traces)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, nil, err
+	}
+	if n == 0 {
+		return nil, nil, io.EOF
 	}
 
 	pqTrace := traces[0]
 	pbTrace := vparquet5.ParquetTraceToTempopbTrace(i.m, pqTrace)
+
 	return pqTrace.TraceID, pbTrace, nil
 }
 

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -80,6 +80,7 @@ var cli struct {
 	Parquet struct {
 		Convert3to4 convertParquet3to4 `cmd:"" help:"convert an existing vParquet3 file to vParquet4 block"`
 		Convert4to5 convertParquet4to5 `cmd:"" help:"convert an existing vParquet4 file to vParquet5 block"`
+		Rewrite     parquetRewrite     `cmd:"" help:"rewrite an existing parquet block using its detected encoding"`
 	} `cmd:""`
 
 	Migrate struct {

--- a/tempodb/encoding/vparquet5/block_autocomplete.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete.go
@@ -77,7 +77,7 @@ func (b *backendBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsR
 	}
 
 	// report metrics with defer to handle early exit
-	defer mcb(rr.BytesRead())
+	defer func() { mcb(rr.BytesRead()) }()
 
 	// track sent tag names to avoid duplicates. this is a perf improvement
 	sentKeys := make(map[tagNameKey]struct{})
@@ -223,7 +223,7 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagV
 		return err
 	}
 	// report metrics with defer to handle early exit
-	defer mcb(rr.BytesRead())
+	defer func() { mcb(rr.BytesRead()) }()
 
 	// track sent tag values to avoid duplicates. this is a perf improvement
 	sentVals := make(map[traceql.StaticMapKey]struct{})

--- a/tempodb/encoding/vparquet5/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete_test.go
@@ -1201,6 +1201,14 @@ func BenchmarkFetchTagValues(b *testing.B) {
 			tag:   "resource.namespace",
 			query: `{span.http.status_code=200}`,
 		},
+		{
+			tag:   "span.gen_ai.provider.name",
+			query: `{ span.gen_ai.agent.name = "fe-grafana-assistant" && span.gen_ai.operation.name = "execute_tool" && span.gen_ai.provider.name != "" }`,
+		},
+		{
+			tag:   "span.gen_ai.provider.name",
+			query: `{ span.gen_ai.agent.name = "fe-grafana-assistant"}`,
+		},
 		// pathologic cases
 		/*
 			{
@@ -1252,6 +1260,9 @@ func BenchmarkFetchTagValues(b *testing.B) {
 				err := block.FetchTagValues(ctx, autocompleteReq, traceql.MakeCollectTagValueFunc(distinctValues.Collect), mc.Add, opts)
 				require.NoError(b, err)
 			}
+
+			b.SetBytes(int64(mc.TotalValue()) / int64(b.N))
+			b.ReportMetric(float64(mc.TotalValue())/float64(b.N)/1024.0/1024.0, "MB_IO/op")
 		})
 	}
 }
@@ -1314,6 +1325,9 @@ func BenchmarkFetchTags(b *testing.B) {
 					}, mc.Add, opts)
 					require.NoError(b, err)
 				}
+
+				b.SetBytes(int64(mc.TotalValue()) / int64(b.N))
+				b.ReportMetric(float64(mc.TotalValue())/float64(b.N)/1024.0/1024.0, "MB_IO/op")
 			})
 		}
 	}

--- a/tempodb/encoding/vparquet5/rebatch_trace.go
+++ b/tempodb/encoding/vparquet5/rebatch_trace.go
@@ -94,15 +94,6 @@ func rebatchTrace(trace *Trace) {
 			rs.ScopeSpans = rs.ScopeSpans[:len(uniqueIndexes)]
 		}
 	}
-
-	// Sort spans by time
-	/*for _, rs := range trace.ResourceSpans {
-		for _, ss := range rs.ScopeSpans {
-			slices.SortFunc(ss.Spans, func(i, j Span) int {
-				return cmp.Compare(i.StartTimeUnixNano, j.StartTimeUnixNano)
-			})
-		}
-	}*/
 }
 
 func scopeSpanHash(ss *ScopeSpans) uint64 {
@@ -136,6 +127,16 @@ func resourceSpanHash(rs *ResourceSpans) uint64 {
 	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String08...)
 	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String09...)
 	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String10...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String11...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String12...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String13...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String14...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String15...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String16...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String17...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String18...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String19...)
+	hash = addHashStr(hash, rs.Resource.DedicatedAttributes.String20...)
 
 	hash = addHashInt(hash, rs.Resource.DedicatedAttributes.Int01...)
 	hash = addHashInt(hash, rs.Resource.DedicatedAttributes.Int02...)

--- a/tempodb/encoding/vparquet5/schema.go
+++ b/tempodb/encoding/vparquet5/schema.go
@@ -575,24 +575,35 @@ func finalizeTrace(trace *Trace) (*Trace, bool) {
 }
 
 func sortTrace(trace *Trace) {
-	// Sort bottom up, spans by name then status, resources by service name
-	sort.Slice(trace.ResourceSpans, func(i, j int) bool {
-		return trace.ResourceSpans[i].Resource.ServiceName < trace.ResourceSpans[j].Resource.ServiceName
-	})
 	for _, rs := range trace.ResourceSpans {
-		sort.Slice(rs.ScopeSpans, func(i, j int) bool {
+		sort.SliceStable(rs.ScopeSpans, func(i, j int) bool {
 			return rs.ScopeSpans[i].Scope.Name < rs.ScopeSpans[j].Scope.Name
 		})
 		for _, ss := range rs.ScopeSpans {
-			sort.Slice(ss.Spans, func(i, j int) bool {
-				a, b := ss.Spans[i], ss.Spans[j]
-				if a.Name != b.Name {
-					return a.Name < b.Name
+			sort.SliceStable(ss.Spans, func(i, j int) bool {
+				left, right := ss.Spans[i], ss.Spans[j]
+				if left.Name != right.Name {
+					return left.Name < right.Name
 				}
-				return a.StatusCode < b.StatusCode
+				return left.StatusCode < right.StatusCode
 			})
 		}
 	}
+	sort.SliceStable(trace.ResourceSpans, func(i, j int) bool {
+		left, right := trace.ResourceSpans[i], trace.ResourceSpans[j]
+		if left.Resource.ServiceName != right.Resource.ServiceName {
+			return left.Resource.ServiceName < right.Resource.ServiceName
+		}
+
+		// Identical services, sort by first span name.
+		if len(left.ScopeSpans[0].Spans) == 0 {
+			return true
+		}
+		if len(right.ScopeSpans[0].Spans) == 0 {
+			return false
+		}
+		return left.ScopeSpans[0].Spans[0].Name < right.ScopeSpans[0].Spans[0].Name
+	})
 }
 
 func instrumentationScopeToParquet(s *v1.InstrumentationScope, ss *InstrumentationScope) {

--- a/tempodb/encoding/vparquet5/schema.go
+++ b/tempodb/encoding/vparquet5/schema.go
@@ -2,6 +2,7 @@ package vparquet5
 
 import (
 	"bytes"
+	"sort"
 	"strings"
 
 	"github.com/golang/protobuf/jsonpb" //nolint:all //deprecated
@@ -569,7 +570,29 @@ func writeAttrs(input []*v1.KeyValue, generic *[]Attribute, dedicated *Dedicated
 // as a boolean indicating whether the trace is a connected graph.
 func finalizeTrace(trace *Trace) (*Trace, bool) {
 	rebatchTrace(trace)
+	sortTrace(trace)
 	return trace, assignNestedSetModelBoundsAndServiceStats(trace)
+}
+
+func sortTrace(trace *Trace) {
+	// Sort bottom up, spans by name then status, resources by service name
+	sort.Slice(trace.ResourceSpans, func(i, j int) bool {
+		return trace.ResourceSpans[i].Resource.ServiceName < trace.ResourceSpans[j].Resource.ServiceName
+	})
+	for _, rs := range trace.ResourceSpans {
+		sort.Slice(rs.ScopeSpans, func(i, j int) bool {
+			return rs.ScopeSpans[i].Scope.Name < rs.ScopeSpans[j].Scope.Name
+		})
+		for _, ss := range rs.ScopeSpans {
+			sort.Slice(ss.Spans, func(i, j int) bool {
+				a, b := ss.Spans[i], ss.Spans[j]
+				if a.Name != b.Name {
+					return a.Name < b.Name
+				}
+				return a.StatusCode < b.StatusCode
+			})
+		}
+	}
 }
 
 func instrumentationScopeToParquet(s *v1.InstrumentationScope, ss *InstrumentationScope) {

--- a/tempodb/encoding/vparquet5/schema_test.go
+++ b/tempodb/encoding/vparquet5/schema_test.go
@@ -704,27 +704,10 @@ func TestTraceToParquet(t *testing.T) {
 						SpanCount: 2,
 						Spans: []Span{
 							{
-								Name:              "span-with-link",
-								SpanID:            []byte{0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
-								NestedSetLeft:     1,
-								NestedSetRight:    2,
-								ParentID:          -1,
-								StartTimeUnixNano: 1500,
-								DurationNano:      1500,
-								Links: []Link{{
-									TraceID: traceID,
-									SpanID:  []byte{0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
-									Attrs: []Attribute{
-										attr("link.attr", "aaa"),
-									},
-									TraceState: "link trace state",
-								}},
-							},
-							{
 								Name:              "span-with-event",
 								SpanID:            []byte{0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
-								NestedSetLeft:     3,
-								NestedSetRight:    4,
+								NestedSetLeft:     1,
+								NestedSetRight:    2,
 								ParentID:          -1,
 								StartTimeUnixNano: 1000,
 								DurationNano:      3000,
@@ -738,6 +721,23 @@ func TestTraceToParquet(t *testing.T) {
 										String01: []string{"dedicated-event-attr-value-1"},
 										String02: []string{"dedicated-event-attr-value-2"},
 									},
+								}},
+							},
+							{
+								Name:              "span-with-link",
+								SpanID:            []byte{0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+								NestedSetLeft:     3,
+								NestedSetRight:    4,
+								ParentID:          -1,
+								StartTimeUnixNano: 1500,
+								DurationNano:      1500,
+								Links: []Link{{
+									TraceID: traceID,
+									SpanID:  []byte{0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+									Attrs: []Attribute{
+										attr("link.attr", "aaa"),
+									},
+									TraceState: "link trace state",
 								}},
 							},
 						},

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -393,6 +393,27 @@ func traceQLNilRunner(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSea
 	}
 }
 
+func sortSearchResultsForTesting(traces []*tempopb.TraceSearchMetadata) {
+	for _, tr := range traces {
+		for _, ss := range tr.SpanSets {
+			sort.Slice(ss.Spans, func(i, j int) bool {
+				return ss.Spans[i].SpanID < ss.Spans[j].SpanID
+			})
+		}
+		sort.Slice(tr.SpanSets, func(i, j int) bool {
+			left := tr.SpanSets[i].Spans
+			right := tr.SpanSets[j].Spans
+			if len(left) == 0 {
+				return len(right) > 0
+			}
+			if len(right) == 0 {
+				return false
+			}
+			return left[0].SpanID < right[0].SpanID
+		})
+	}
+}
+
 func groupTraceQLRunner(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceSearchMetadata, _, _ []*tempopb.SearchRequest, meta *backend.BlockMeta, r Reader, _ common.BackendBlock) {
 	ctx := context.Background()
 	e := traceql.NewEngine()
@@ -576,6 +597,8 @@ func groupTraceQLRunner(t *testing.T, _ *tempopb.Trace, wantMeta *tempopb.TraceS
 		}
 
 		require.NotNil(t, res, "search request: %v", tc)
+		sortSearchResultsForTesting(tc.expected)
+		sortSearchResultsForTesting(res.Traces)
 		require.Equal(t, tc.expected, res.Traces, "search request", tc.req)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
1. This updates vParquet5 to more intentionally sort each trace's internal content before writing to disk.   It now sorts by service name, scope, and span name/status, instead of span start time.  This is much more effective at co-locating like data not just on these core fields, but most importantly also span attributes and events.   I.e. all spans of ServiceA/OperationA will have more similar attributes to each other, than spans from other services, or different spans within the same service. 

~The result is ~10+% reduced file size, and significantly reduced I/O on any read touching the shared attribute columns.  However in my local benchmarks there's not really any change to the wall-clock time, because I'm not introducing synthetic delays on I/O, i.e. it's on SSD so i/o is essentially free. But I expect these savings to be apparent in real deployments on object storage, and should also use memcache more efficiently.~

The savings are more modest, see comment below...

2. This introduces a new tempo-cli command `parquet rewrite` which rewrites a block in the same encoding (but with any code changes), and potentially new dedicated columns.  This is what I used to test this PR.  This is useful in the future to also test things like changes to encoding or compression, row group sizes, etc.

3. Fixes a bug in vp5 rebatching where it wasn't updated for the 10 new resource dedicated columns.  Since this has never tripped any test failure ever, I think it's probably exceedingly rare and hard to hit.  It would only be triggered if there are resource batches which are configured for 11+ dedicated columns, and have the first 10 columns identical.  Generally your columns are the most used ones, which means they have going to be well-populated and variable.

4. Fixes a minor bug in that FetchTags/TagValues weren't reporting bytes read due to bad defer statements.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)