### PR TITLE
fix(query-frontend): log the reason for failed metrics query-range requests

### DIFF
--- a/.chloggen/query-frontend-log-error-reason.yaml
+++ b/.chloggen/query-frontend-log-error-reason.yaml
@@ -1,11 +1,6 @@
 change_type: bug_fix
-
 component: query-frontend
-
-note: "Log the reason when a metrics query-range request fails with a frontend-generated error response (e.g. deny-list or sharder rejections). Previously the query-frontend logged `query range response - no resp` with a nil error, dropping the HTTP status code and the reason."
-
+note: Correctly log failure reason if query is rejected by query-frontend
 issues: []
-
 subtext:
-
 user: oleg-kozlyuk-grafana

--- a/.chloggen/query-frontend-log-error-reason.yaml
+++ b/.chloggen/query-frontend-log-error-reason.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: query-frontend
+
+note: "Log the reason when a metrics query-range request fails with a frontend-generated error response (e.g. deny-list or sharder rejections). Previously the query-frontend logged `query range response - no resp` with a nil error, dropping the HTTP status code and the reason."
+
+issues: []
+
+subtext:
+
+user: oleg-kozlyuk-grafana

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -173,14 +173,23 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 		// ask for the typed diff and use that for the SLO hook. it will have up to date metrics
 		// todo: is there a way to remove this? it can be costly for large responses
 		var bytesProcessed uint64
-		queryRangeResp, _ := combiner.GRPCFinal()
+		queryRangeResp, finalErr := combiner.GRPCFinal()
 		if queryRangeResp != nil && queryRangeResp.Metrics != nil {
 			bytesProcessed = queryRangeResp.Metrics.InspectedBytes
 		}
 
 		duration := time.Since(start)
 		postSLOHook(resp, tenant, bytesProcessed, duration, err)
-		logQueryRangeResult(req.Context(), logger, tenant, duration.Seconds(), queryRangeReq, queryRangeResp, err)
+		// When the pipeline returns an error response in-band (a frontend-generated
+		// 4xx/5xx, e.g. from a sharder or the URL deny list), resp carries the status
+		// code and RoundTrip's err is nil while GRPCFinal returns the reason. Fall back
+		// to it for logging so the result log records why the query failed; otherwise it
+		// logs "query range response - no resp" with error=null and the reason is lost.
+		logErr := err
+		if logErr == nil {
+			logErr = finalErr
+		}
+		logQueryRangeResult(req.Context(), logger, tenant, duration.Seconds(), queryRangeReq, queryRangeResp, logErr)
 		return resp, err
 	})
 }

--- a/modules/frontend/metrics_query_range_handler_test.go
+++ b/modules/frontend/metrics_query_range_handler_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/status"
 	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
@@ -25,6 +27,7 @@ import (
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1477,4 +1480,66 @@ func (m *mockRoundTripperWithCapture) RoundTrip(req pipeline.Request) (*http.Res
 
 	res, err := m.rt.RoundTrip(req)
 	return res, err
+}
+
+// recordingLogger records log lines so tests can assert on what was logged. It
+// satisfies the go-kit log.Logger interface (Log(...) error) without importing it.
+type recordingLogger struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (l *recordingLogger) Log(keyvals ...interface{}) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	fmt.Fprintln(&l.buf, keyvals...)
+	return nil
+}
+
+func (l *recordingLogger) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+// TestQueryRangeHandlerLogsErrorReason is a regression test for the HTTP metrics
+// query-range handler dropping the failure reason. When the pipeline returns an
+// error response in-band (a frontend-generated 4xx carried on the http.Response
+// with a nil Go error, e.g. from the URL deny list or a sharder), the result log
+// must record why the request failed. Previously the handler discarded the
+// combiner's error and logged "query range response - no resp" with a nil error,
+// making frontend 4xx/5xx undiagnosable from query-frontend logs.
+func TestQueryRangeHandlerLogsErrorReason(t *testing.T) {
+	const reason = "this query has been identified as one that destabilizes our system"
+
+	var cfg Config
+	cfg.RegisterFlagsAndApplyDefaults("", flag.NewFlagSet("", flag.PanicOnError))
+
+	// next stands in for the rest of the pipeline and returns a frontend 400 with a
+	// nil Go error, exactly how NewBadRequest surfaces deny-list / sharder rejections.
+	next := pipeline.AsyncRoundTripperFunc[combiner.PipelineResponse](func(_ pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+		return pipeline.NewBadRequest(fmt.Errorf("%s", reason)), nil
+	})
+
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	logger := &recordingLogger{}
+	handler := newMetricsQueryRangeHTTPHandler(cfg, next, o, logger, nil)
+
+	httpReq := httptest.NewRequest("GET", api.PathMetricsQueryRange, nil)
+	httpReq = api.BuildQueryRangeRequest(httpReq, &tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: uint64(1100 * time.Second),
+		End:   uint64(1300 * time.Second),
+		Step:  uint64(100 * time.Second),
+	}, "")
+	httpReq = httpReq.WithContext(user.InjectOrgID(httpReq.Context(), "foo"))
+
+	resp, err := handler.RoundTrip(httpReq)
+	require.NoError(t, err) // the 400 is carried in-band on resp, not as a Go error
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// the result log must record WHY the request failed, not a nil error
+	require.Contains(t, logger.String(), reason)
 }


### PR DESCRIPTION
**What this PR does**:

When the metrics query-range pipeline returns an error response *in-band* — a frontend-generated 4xx/5xx carried on the `http.Response` with a `nil` Go error (e.g. a URL deny-list or sharder rejection via `pipeline.NewBadRequest`) — the HTTP handler discarded the combiner's error (`queryRangeResp, _ := combiner.GRPCFinal()`) and logged the result with the (nil) `RoundTrip` error:

```
msg="query range response - no resp" tenant=1 error=null
```

This dropped both the HTTP status code and the failure reason. The reason is still returned to the client in the response body, but it was never recorded server-side, so frontend 4xx/5xx on metrics query-range requests were undiagnosable from query-frontend logs alone.

The streaming gRPC handler doesn't have this gap — it passes the real `RoundTrip` error into the same log call — so only the HTTP path was affected.

**Fix**: fall back to `combiner.GRPCFinal()`'s error for logging when `RoundTrip` returned no error. The `(resp, err)` returned to the client is unchanged (purely an observability fix).

After the change the same failure logs the reason:

```
msg="query range response - no resp" tenant=1 error="rpc error: code = InvalidArgument desc = <reason>"
```

**Which issue(s) this PR fixes**:
N/A — no tracking issue.

**Checklist**
- [x] Tests updated — added `TestQueryRangeHandlerLogsErrorReason`, which fails before this change (logs `error=null`) and passes after.
- [ ] Documentation added — n/a (logging only)
- [x] Changelog entry added under `.chloggen/`
