### PR TITLE
chore: Install wiresmith protobuf compiler in the build image

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d
+FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -10,6 +10,7 @@ RUN apk --update add --no-cache make git bash protoc
 # Ref: https://buf.build/docs/cli/installation/
 RUN GOBIN=/usr/local/bin go install github.com/bufbuild/buf/cmd/buf@v1.63.0
 RUN GOBIN=/usr/local/bin go install github.com/gogo/protobuf/protoc-gen-gogofaster@v1.3.2
+RUN GOBIN=/usr/local/bin go install github.com/grafana/wiresmith/cmd/wiresmith@v0.0.0-20260618160438-f15959a1e4e7
 RUN GOBIN=/usr/local/bin go install github.com/grafana/tanka/cmd/tk@v0.36.3
 RUN GOBIN=/usr/local/bin go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@v0.6.0
 


### PR DESCRIPTION
## What

Adds a `go install` of wiresmith to `build-image/Dockerfile`.

## Why

Add Wiresmith compiler to the tools image so that migration experiments can proceed without workarounds