### PR TITLE
test: cover malformed attribute value and filter pass-through

### DIFF
--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -214,6 +214,24 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 				"foo_bar":        "",
 			},
 		},
+		{
+			// a malformed attribute value must not drop the metric series.
+			name:          "Dimension with malformed key=value value is preserved",
+			dimensions:    []string{"deployment.environment"},
+			expectedCount: 10.0,
+			expectedBuckets: map[float64]float64{
+				0.5:         0.0,
+				1.0:         10.0,
+				math.Inf(1): 10.0,
+			},
+			labels: map[string]string{
+				"service":                "test-service",
+				"span_name":              "test",
+				"status_code":            "STATUS_CODE_OK",
+				"status_message":         "OK",
+				"deployment_environment": "deployment.environment=production",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -244,6 +262,11 @@ func TestSpanMetrics_dimensions(t *testing.T) {
 					s.Attributes = append(s.Attributes, &common_v1.KeyValue{
 						Key:   "bar",
 						Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "bar-value"}},
+					})
+					// malformed value; only used by the malformed-value case.
+					s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+						Key:   "deployment.environment",
+						Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "deployment.environment=production"}},
 					})
 				}
 			}
@@ -685,6 +708,48 @@ func TestTargetInfoEnabled(t *testing.T) {
 		"instance": "abc-instance-id-test-def",
 		"cluster":  "eu-west-0",
 		"ip":       "1.1.1.1",
+	})
+
+	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", lbls))
+}
+
+func TestTargetInfoWithMalformedAttributeValue(t *testing.T) {
+	// a malformed attribute value must not drop target_info.
+	testRegistry := registry.NewTestRegistry()
+	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered", "span-metrics")
+	invalidUTF8SpanLabelsCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "invalid_utf8", "span-metrics")
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.EnableTargetInfo = true
+	cfg.HistogramBuckets = []float64{0.5, 1}
+
+	p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8SpanLabelsCounter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	batch := test.MakeBatch(10, nil)
+	batch.Resource.Attributes = []*common_v1.KeyValue{
+		{
+			Key:   "service.name",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "test-service"}},
+		},
+		{
+			Key:   "service.instance.id",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "abc-instance-id-test-def"}},
+		},
+		{
+			Key:   "deployment.environment",
+			Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: "deployment.environment=production"}},
+		},
+	}
+
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{batch}})
+
+	lbls := labels.FromMap(map[string]string{
+		"job":                    "test-service",
+		"instance":               "abc-instance-id-test-def",
+		"deployment_environment": "deployment.environment=production",
 	})
 
 	assert.Equal(t, 1.0, testRegistry.Query("traces_target_info", lbls))

--- a/pkg/spanfilter/spanfilter_test.go
+++ b/pkg/spanfilter/spanfilter_test.go
@@ -719,6 +719,114 @@ func TestSpanMetrics_applyFilterPolicy(t *testing.T) {
 	}
 }
 
+// reproduces a representative span_metrics filter_policies config to prove a typical instrumented
+// HTTP service's span shape is not excluded by it.
+func TestSpanFilter_serviceTraceShapeNotExcluded(t *testing.T) {
+	policies := []config.FilterPolicy{
+		{
+			Include: &config.PolicyMatch{
+				MatchType: config.Regex,
+				Attributes: []config.MatchPolicyAttribute{
+					{Key: "kind", Value: "SPAN_KIND_(SERVER|CONSUMER|CLIENT|PRODUCER)"},
+				},
+			},
+		},
+		{
+			Exclude: &config.PolicyMatch{
+				MatchType: config.Strict,
+				Attributes: []config.MatchPolicyAttribute{
+					{Key: "kind", Value: "SPAN_KIND_SERVER"},
+					{Key: "span.url.path", Value: "/healthz"},
+				},
+			},
+		},
+		{
+			Exclude: &config.PolicyMatch{
+				MatchType: config.Strict,
+				Attributes: []config.MatchPolicyAttribute{
+					{Key: "kind", Value: "SPAN_KIND_SERVER"},
+					{Key: "span.url.path", Value: "/health"},
+				},
+			},
+		},
+		{
+			Exclude: &config.PolicyMatch{
+				MatchType: config.Strict,
+				Attributes: []config.MatchPolicyAttribute{
+					{Key: "resource.span.metrics.skip", Value: true},
+				},
+			},
+		},
+	}
+
+	sf, err := NewSpanFilter(policies)
+	require.NoError(t, err)
+
+	// representative HTTP service span: clean service identity, a malformed deployment.environment,
+	// and old-style http.* attributes (no span.url.path).
+	resource := &v1.Resource{
+		Attributes: []*commonv1.KeyValue{
+			strAttr("service.name", "checkout-service"),
+			strAttr("service.namespace", "shop"),
+			strAttr("deployment.environment", "deployment.environment=production"),
+		},
+	}
+
+	httpServerAttrs := []*commonv1.KeyValue{
+		strAttr("http.method", "POST"),
+		strAttr("http.target", "/v1/checkout"),
+		strAttr("http.route", "/v1/checkout"),
+	}
+
+	cases := []struct {
+		name   string
+		span   *tracev1.Span
+		expect bool
+	}{
+		{
+			name:   "server root span on a non-health path passes",
+			span:   &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_SERVER, Name: "POST /v1/checkout", Attributes: httpServerAttrs},
+			expect: true,
+		},
+		{
+			name:   "client span passes",
+			span:   &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_CLIENT, Name: "grpc.example.OrderService/Commit"},
+			expect: true,
+		},
+		{
+			name:   "internal span is dropped by the include policy",
+			span:   &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_INTERNAL, Name: "middleware - corsMiddleware"},
+			expect: false,
+		},
+		{
+			// the health excludes key on span.url.path, which this service never emits, so even
+			// its /health endpoint would not be excluded.
+			name:   "server span with http.target=/health still passes (excludes key on span.url.path)",
+			span:   &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_SERVER, Name: "GET /health", Attributes: []*commonv1.KeyValue{strAttr("http.target", "/health")}},
+			expect: true,
+		},
+		{
+			// sanity: a span that does set span.url.path=/health is correctly excluded.
+			name:   "server span with span.url.path=/health is excluded",
+			span:   &tracev1.Span{Kind: tracev1.Span_SPAN_KIND_SERVER, Name: "GET /health", Attributes: []*commonv1.KeyValue{strAttr("url.path", "/health")}},
+			expect: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expect, sf.ApplyFilterPolicy(resource, tc.span))
+		})
+	}
+}
+
+func strAttr(key, value string) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: value}},
+	}
+}
+
 func BenchmarkSpanFilter_applyFilterPolicyNone(b *testing.B) {
 	// Read the file generated above
 	data, err := os.ReadFile("testbatch100k")


### PR DESCRIPTION
**What this PR does**:
Regression tests that a malformed attribute value does not drop span metrics or target_info.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)