### PR TITLE
[traceql] Another sweep of correctness fixes in vp5 new fetch layer

### DIFF
--- a/.chloggen/vp5-spanonly-fetch-fix-2.yaml
+++ b/.chloggen/vp5-spanonly-fetch-fix-2.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: traceql
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Fixes additional correctness issues in the new vParquet5 faster fetch layer, including trace instrinsics such as `{ trace:rootService="..." } | rate()`, `span:childCount`, and array operations.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mdisibio

--- a/.chloggen/vp5-spanonly-fetch-fix-2.yaml
+++ b/.chloggen/vp5-spanonly-fetch-fix-2.yaml
@@ -8,7 +8,7 @@ change_type: bug_fix
 component: traceql
 
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
-note: Fixes additional correctness issues in the new vParquet5 faster fetch layer, including trace instrinsics such as `{ trace:rootService="..." } | rate()`, `span:childCount`, and array operations.
+note: Fixes additional correctness issues in the new vParquet5 faster fetch layer, including trace intrinsics such as `{ trace:rootService="..." } | rate()`, `span:childCount`, and array operations.
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -119,7 +119,10 @@ func create(makeIter, makeNilIter makeIterFn,
 	// anywhere, except in the case of the empty query: {}
 	batchRequireAtLeastOneMatchOverall := len(conditions) > 0 && len(catConditions.trace) == 0
 
-	traceIters, traceOptional := createTraceIterators(makeIter, catConditions.trace, start, end, allConditions, dedicatedColumns, selectAll)
+	traceIters, traceOptional, err := createTraceIterators(makeIter, catConditions.trace, start, end, allConditions, dedicatedColumns, selectAll)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	resIters, resOptional, err := createResourceIterators(makeIter, makeNilIter, catConditions.resource, allConditions, dedicatedColumns, selectAll)
 	if err != nil {
@@ -243,7 +246,7 @@ func createTraceIterators(
 	allConditions bool,
 	_ backend.DedicatedColumns,
 	selectAll bool,
-) (required, optional []parquetquery.Iterator) {
+) (required, optional []parquetquery.Iterator, err error) {
 	var alwaysOptional []parquetquery.Iterator
 
 	for _, cond := range conditions {
@@ -253,13 +256,36 @@ func createTraceIterators(
 				// This is expected to quit early, so it is always optional below.
 				alwaysOptional = append(alwaysOptional, makeIter(columnPathTraceID, parquetquery.NewCallbackPredicate(cond.CallBack), columnPathTraceID))
 			} else {
-				// This starts as optional but can be moved to required for better performance.
-				optional = append(optional, makeIter(columnPathTraceID, nil, columnPathTraceID))
+				pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+				if err != nil {
+					return nil, nil, err
+				}
+				optional = append(optional, makeIter(columnPathTraceID, pred, columnPathTraceID))
 			}
+		case traceql.IntrinsicTraceRootService:
+			pred, err := createStringPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, nil, err
+			}
+			optional = append(optional, makeIter(columnPathRootServiceName, pred, columnPathRootServiceName))
+		case traceql.IntrinsicTraceRootSpan:
+			pred, err := createStringPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, nil, err
+			}
+			optional = append(optional, makeIter(columnPathRootSpanName, pred, columnPathRootSpanName))
 		case traceql.IntrinsicTraceDuration:
-			optional = append(optional, makeIter(columnPathDurationNanos, nil, columnPathDurationNanos))
+			pred, err := createDurationPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, nil, err
+			}
+			optional = append(optional, makeIter(columnPathDurationNanos, pred, columnPathDurationNanos))
 		case traceql.IntrinsicTraceStartTime:
-			optional = append(optional, makeIter(columnPathStartTimeUnixNano, nil, columnPathStartTimeUnixNano))
+			if start == 0 && end == 0 {
+				optional = append(optional, makeIter(columnPathStartTimeUnixNano, nil, columnPathStartTimeUnixNano))
+			}
+		case traceql.IntrinsicServiceStats:
+			optional = append(optional, createServiceStatsIterator(makeIter))
 		}
 	}
 
@@ -301,7 +327,7 @@ func createTraceIterators(
 
 	optional = append(optional, alwaysOptional...)
 
-	return required, optional
+	return required, optional, nil
 }
 
 func createResourceIterators(
@@ -351,7 +377,7 @@ func createResourceIterators(
 			}
 
 			// Compatible type?
-			if entry.typ == operandType(cond.Operands) {
+			if isMatchingColumnType(entry.typ, operandType(cond.Operands)) {
 				pred, err := createPredicate(cond.Op, cond.Operands)
 				if err != nil {
 					return nil, nil, fmt.Errorf("creating predicate: %w", err)
@@ -369,7 +395,7 @@ func createResourceIterators(
 
 			// Compatible type?
 			typ, _ := c.Type.ToStaticType()
-			if typ == operandType(cond.Operands) {
+			if isMatchingColumnType(typ, operandType(cond.Operands)) {
 				pred, err := createPredicate(cond.Op, cond.Operands)
 				if err != nil {
 					return nil, nil, fmt.Errorf("creating predicate: %w", err)
@@ -639,6 +665,14 @@ func createSpanIterators(
 			addPredicate(columnPathSpanParentID, pred)
 			columnSelectAs[columnPathSpanParentID] = columnPathSpanParentID
 			continue
+		case traceql.IntrinsicChildCount:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			addPredicate(columnPathSpanChildCount, pred)
+			columnSelectAs[columnPathSpanChildCount] = columnPathSpanChildCount
+			continue
 		default:
 			panic("unhandled intrinsic: " + cond.Attribute.String())
 		}
@@ -651,7 +685,7 @@ func createSpanIterators(
 
 			// Compatible type?
 			typ, _ := c.Type.ToStaticType()
-			if typ == operandType(cond.Operands) {
+			if isMatchingColumnType(typ, operandType(cond.Operands)) {
 				pred, err := createPredicate(cond.Op, cond.Operands)
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("creating predicate: %w", err)
@@ -852,6 +886,10 @@ func createEventIterators(
 		}
 
 		genericConditions = append(genericConditions, cond)
+	}
+
+	for columnPath, predicates := range columnPredicates {
+		optional = append(optional, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
 	}
 
 	attrIter, err := createScopedAttributeIterator(
@@ -1265,6 +1303,7 @@ func (c *spanCollector2) Reset(rowNumber parquetquery.RowNumber) {
 	case rowNumber[DefinitionLevelTrace] != c.at.rowNum[DefinitionLevelTrace]:
 		// New trace
 		c.at.traceAttrs = c.at.traceAttrs[:0]
+		clear(c.spansetBuffer.ServiceStats)
 		fallthrough
 	case rowNumber[DefinitionLevelResourceSpans] != c.at.rowNum[DefinitionLevelResourceSpans]:
 		// New batch
@@ -1344,6 +1383,11 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			default:
 				panic("unhandled scopedAttribute: " + v.a.Scope.String())
 			}
+		case traceql.ServiceStats:
+			if c.spansetBuffer.ServiceStats == nil {
+				c.spansetBuffer.ServiceStats = map[string]traceql.ServiceStats{}
+			}
+			c.spansetBuffer.ServiceStats[e.Key] = v
 		default:
 			panic("unhandled other entry value type: " + "key:" + e.Key)
 		}
@@ -1367,7 +1411,9 @@ func (c *spanCollector2) Collect(res *parquetquery.IteratorResult, param any) {
 			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceIDAttribute, traceql.NewStaticString(util.TraceIDToHexString(kv.Value.ByteArray()))})
 		case columnPathDurationNanos:
 			sp.traceAttrs = append(sp.traceAttrs, attrVal{traceql.IntrinsicTraceDurationAttribute, traceql.NewStaticDuration(time.Duration(kv.Value.Uint64()))})
-		case columnPathStartTimeUnixNano, columnPathEndTimeUnixNano:
+		case columnPathStartTimeUnixNano:
+			c.spansetBuffer.StartTimeUnixNanos = kv.Value.Uint64()
+		case columnPathEndTimeUnixNano:
 			// TODO
 			return
 		// --------------------

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -1304,6 +1304,7 @@ func (c *spanCollector2) Reset(rowNumber parquetquery.RowNumber) {
 		// New trace
 		c.at.traceAttrs = c.at.traceAttrs[:0]
 		clear(c.spansetBuffer.ServiceStats)
+		c.spansetBuffer.StartTimeUnixNanos = 0
 		fallthrough
 	case rowNumber[DefinitionLevelResourceSpans] != c.at.rowNum[DefinitionLevelResourceSpans]:
 		// New batch

--- a/tempodb/encoding/vparquet5/block_traceql_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_test.go
@@ -654,7 +654,10 @@ func searchesThatMatch(t *testing.T, traceIDText string) []struct {
 		// Events
 		{"event:name", traceql.MustExtractFetchSpansRequestWithMetadata(`{event:name = "e1"}`)},
 		{"event:timeSinceStart", traceql.MustExtractFetchSpansRequestWithMetadata(`{event:timeSinceStart > 2ms}`)},
-		{"event.message", traceql.MustExtractFetchSpansRequestWithMetadata(`{event.message =~ "exception"}`)},
+		{"event:message", traceql.MustExtractFetchSpansRequestWithMetadata(`{event.message =~ "exception"}`)},
+		// Event dedicated attributes
+		{"event.dedicated.event.1", traceql.MustExtractFetchSpansRequestWithMetadata(`{event.dedicated.event.1 = "dedicated-event-attr-value-1"}`)},
+		{"event.dedicated.event.2", traceql.MustExtractFetchSpansRequestWithMetadata(`{event.dedicated.event.2 = "dedicated-event-attr-value-2"}`)},
 		// Links
 		{"link:spanID", traceql.MustExtractFetchSpansRequestWithMetadata(`{link:spanID = "1234567890abcdef"}`)},
 		{"link:traceID", traceql.MustExtractFetchSpansRequestWithMetadata(`{link:traceID = "1234567890abcdef1234567890abcdef"}`)},
@@ -806,6 +809,8 @@ func searchesThatDontMatch(t *testing.T) []struct {
 		{"Matches neither condition", traceql.MustExtractFetchSpansRequestWithMetadata(`{.foo = "xyz" || .` + LabelHTTPStatusCode + " = 1000}")},
 		{"Resource dedicated attributes does not match", traceql.MustExtractFetchSpansRequestWithMetadata(`{resource.dedicated.resource.3 = "dedicated-resource-attr-value-4"}`)},
 		{"Resource dedicated attributes does not match", traceql.MustExtractFetchSpansRequestWithMetadata(`{span.dedicated.span.2 = "dedicated-span-attr-value-5"}`)},
+		{"Event dedicated attributes does not match", traceql.MustExtractFetchSpansRequestWithMetadata(`{event.dedicated.event.1 = "dedicated-event-attr-value-2"}`)},
+		{"Event dedicated attributes does not match", traceql.MustExtractFetchSpansRequestWithMetadata(`{event.dedicated.event.2 = "dedicated-event-attr-value-1"}`)},
 		{"Blob test 1", traceql.MustExtractFetchSpansRequestWithMetadata(`{span.dedicated.span.5 = "dedicated-span-attr-value-asdf"}`)},
 		{"Blob test 2", traceql.MustExtractFetchSpansRequestWithMetadata(`{span.dedicated.span.5 =~ "dedicated-span-attr-value-asdf"}`)},
 		{"Blob test 3", traceql.MustExtractFetchSpansRequestWithMetadata(`{span.dedicated.span.5 = ""}`)},

--- a/tempodb/tempodb_metrics_test.go
+++ b/tempodb/tempodb_metrics_test.go
@@ -16,6 +16,7 @@ import (
 	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/backend/local"
@@ -24,6 +25,9 @@ import (
 	"github.com/grafana/tempo/tempodb/wal"
 	"github.com/stretchr/testify/require"
 )
+
+// queryRangeTestCasesTraceIDHex is the trace ID for span 30 in TestTempoDBQueryRange and the rate_with_traceid_filter case in queryRangeTestCases.
+const queryRangeTestCasesTraceIDHex = "0102030405060708090a0b0c0d0e0f10"
 
 func requestWithDefaultRange(q string) *tempopb.QueryRangeRequest {
 	return &tempopb.QueryRangeRequest{
@@ -104,6 +108,158 @@ var queryRangeTestCases = []struct {
 					{TimestampMs: 30_000, Value: 2 * 8.0 / 15.0},
 					{TimestampMs: 45_000, Value: 2 * 7.0 / 15.0},
 					{TimestampMs: 60_000, Value: 2 * 3.0 / 15.0},
+				},
+			},
+		},
+	},
+	{
+		name: "rate_with_rootservice_filter",
+		req:  requestWithDefaultRange(`{ rootServiceName="even" } | rate()`),
+		expectedL1: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 7.0 / 15.0}, // Interval (0, 15], 7 spans at 2, 4, 6, 8, 10, 12, 14
+					{TimestampMs: 30_000, Value: 8.0 / 15.0}, // Interval (15, 30], 8 spans at 16, 18, 20, 22, 24, 26, 28, 30
+					{TimestampMs: 45_000, Value: 7.0 / 15.0}, // Interval (30, 45], 7 spans at 32, 34, 36, 38, 40, 42, 44
+					{TimestampMs: 60_000, Value: 3.0 / 15.0}, // Interval (45, 50], 3 spans at 46, 48, 50
+				},
+			},
+		},
+		expectedL2: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				// with two sources rate will be doubled
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 2 * 7.0 / 15.0},
+					{TimestampMs: 30_000, Value: 2 * 8.0 / 15.0},
+					{TimestampMs: 45_000, Value: 2 * 7.0 / 15.0},
+					{TimestampMs: 60_000, Value: 2 * 3.0 / 15.0},
+				},
+			},
+		},
+	},
+	{
+		name: "rate_with_rootname_filter",
+		req:  requestWithDefaultRange(`{ rootName="test" } | rate()`),
+		expectedL1: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 1.0},        // Interval (0, 15], 15 spans at 1-15
+					{TimestampMs: 30_000, Value: 1.0},        // Interval (15, 30], 15 spans
+					{TimestampMs: 45_000, Value: 1.0},        // Interval (30, 45], 15 spans
+					{TimestampMs: 60_000, Value: 5.0 / 15.0}, // Interval (45, 50], 5 spans
+				},
+			},
+		},
+		expectedL2: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				// with two sources rate will be doubled
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 2 * 15.0 / 15.0},
+					{TimestampMs: 30_000, Value: 2 * 1.0},
+					{TimestampMs: 45_000, Value: 2 * 1.0},
+					{TimestampMs: 60_000, Value: 2 * 5.0 / 15.0},
+				},
+			},
+		},
+	},
+	{
+		name: "rate_with_traceduration_filter",
+		req:  requestWithDefaultRange(`{ traceDuration > 25s } | rate()`),
+		expectedL1: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 0},          // Interval (0, 15], no spans with duration > 25s
+					{TimestampMs: 30_000, Value: 5.0 / 15.0}, // Interval (15, 30], spans 26-30
+					{TimestampMs: 45_000, Value: 1.0},        // Interval (30, 45], spans 31-45
+					{TimestampMs: 60_000, Value: 5.0 / 15.0}, // Interval (45, 50], spans 46-50
+				},
+			},
+		},
+		expectedL2: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 0},
+					{TimestampMs: 30_000, Value: 2 * 5.0 / 15.0},
+					{TimestampMs: 45_000, Value: 2 * 1.0},
+					{TimestampMs: 60_000, Value: 2 * 5.0 / 15.0},
+				},
+			},
+		},
+	},
+	{
+		name: "rate_with_traceid_filter",
+		req:  requestWithDefaultRange(`{ trace:id="` + queryRangeTestCasesTraceIDHex + `" } | rate()`),
+		expectedL1: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 0},
+					{TimestampMs: 30_000, Value: 1.0 / 15.0}, // span 30 starts at 30s
+					{TimestampMs: 45_000, Value: 0},
+					{TimestampMs: 60_000, Value: 0},
+				},
+			},
+		},
+		expectedL2: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 0},
+					{TimestampMs: 30_000, Value: 2.0 / 15.0},
+					{TimestampMs: 45_000, Value: 0},
+					{TimestampMs: 60_000, Value: 0},
+				},
+			},
+		},
+	},
+	{
+		name: "rate_with_childcount_filter",
+		req:  requestWithDefaultRange(`{ span:childCount = 0 } | rate()`),
+		expectedL1: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 1.0},        // Interval (0, 15], 15 spans at 1-15
+					{TimestampMs: 30_000, Value: 1.0},        // Interval (15, 30], 15 spans
+					{TimestampMs: 45_000, Value: 1.0},        // Interval (30, 45], 15 spans
+					{TimestampMs: 60_000, Value: 5.0 / 15.0}, // Interval (45, 50], 5 spans
+				},
+			},
+		},
+		expectedL2: []*tempopb.TimeSeries{
+			{
+				Labels: []common_v1.KeyValue{
+					tempopb.MakeKeyValueString("__name__", "rate"),
+				},
+				Samples: []tempopb.Sample{
+					{TimestampMs: 15_000, Value: 2 * 15.0 / 15.0},
+					{TimestampMs: 30_000, Value: 2 * 1.0},
+					{TimestampMs: 45_000, Value: 2 * 1.0},
+					{TimestampMs: 60_000, Value: 2 * 5.0 / 15.0},
 				},
 			},
 		},
@@ -2614,11 +2770,18 @@ func TestTempoDBQueryRange(t *testing.T) {
 	require.NoError(t, err)
 	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
 
+	knownTraceID, err := util.HexStringToTraceID(queryRangeTestCasesTraceIDHex)
+	require.NoError(t, err)
+
 	totalSpans := 100
 	for i := 1; i <= totalSpans; i++ {
 		tid := test.ValidTraceID(nil)
+		if i == 30 {
+			tid = knownTraceID
+		}
 
 		sp := test.MakeSpan(tid)
+		sp.ParentSpanId = nil // ensure root span/service names are populated
 
 		// Start time is i seconds
 		sp.StartTimeUnixNano = uint64(i * int(time.Second))


### PR DESCRIPTION
**What this PR does**:
I found that the new vp5 fetch layer wasn't correctly evaluating the query `{trace:rootService="..."}|rate()`, and it was due to not quite finishing that part of code.  So I did a larger comparison on the old and new fetch layers and this PR resolves this and a couple more issues.    

* Missing predicates on other trace intrinsics: trace:id, etc
* Event-level dedicated columns
* Service stats
* Array-value in query <-- I think this one is not actually triggerable because currently the only way to get it is by letting the query optimizer rewrite A || B to IN [A,B], which also precludes using this fetch layer. But good to fix anyways because soon these will be first class language syntax.

Of course the test suite, as large as it is, still doesn't cover 100% of cases between all fields and all possible combinations of configurations.  I'm thinking about how to solve that better, but for now this PR does add some more cases.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)