### PR TITLE
ci: fix sign-and-attest GAR auth for attestation push

### DIFF
--- a/.chloggen/fix-tempo-vulture-signing-auth.yaml
+++ b/.chloggen/fix-tempo-vulture-signing-auth.yaml
@@ -1,5 +1,5 @@
 change_type: enhancement
 component: operations
 note: Fix GAR authentication for tempo-vulture attestation push and add missing attestations permission in release-tag workflow.
-issues: [7499]
+issues: [7534]
 user: mattdurham

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -92,6 +92,10 @@ jobs:
           REGISTRY: ${{ inputs.registry }}
         run: |
           token="$(gcloud auth print-access-token)"
+          if [[ -z "$token" ]]; then
+            echo "::error::gcloud auth print-access-token returned an empty token"
+            exit 1
+          fi
           enc="$(printf 'oauth2accesstoken:%s' "$token" | base64 -w0)"
           cfg="${HOME}/.docker/config.json"
           mkdir -p "${HOME}/.docker"
@@ -99,6 +103,7 @@ jobs:
           tmp="$(mktemp)"
           jq --arg reg "$REGISTRY" --arg a "$enc" '.auths[$reg] = {auth: $a}' "$cfg" > "$tmp"
           mv "$tmp" "$cfg"
+          chmod 0600 "$cfg"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -79,6 +79,27 @@ jobs:
           username: oauth2accesstoken # literal magic string required by GAR; not a secret — tells GAR the password is an OAuth2 access token
           password: ${{ steps.gar_auth.outputs.access_token }}
 
+      - name: Add static registry credentials
+        # login-to-gar configures a gcloud docker *credential helper*. cosign
+        # understands credential helpers, but actions/attest (push-to-registry)
+        # only reads static `auths` from the docker config and does not invoke
+        # helpers — so without this it fails with "No credentials found for
+        # registry ...". Write a static auth entry (additive; cosign still works)
+        # using a short-lived GAR access token from the gcloud auth above.
+        # Note: oauth2accesstoken is a magic literal string required by GAR —
+        # not a secret. It tells GAR the password field is an OAuth2 access token.
+        env:
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          token="$(gcloud auth print-access-token)"
+          enc="$(printf 'oauth2accesstoken:%s' "$token" | base64 -w0)"
+          cfg="${HOME}/.docker/config.json"
+          mkdir -p "${HOME}/.docker"
+          [ -f "$cfg" ] || echo '{}' > "$cfg"
+          tmp="$(mktemp)"
+          jq --arg reg "$REGISTRY" --arg a "$enc" '.auths[$reg] = {auth: $a}' "$cfg" > "$tmp"
+          mv "$tmp" "$cfg"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:


### PR DESCRIPTION
Follow-up to #7499.

## Problem

`actions/attest-build-provenance` (with `push-to-registry: true`) reads only static `auths` from the docker config — it does not invoke credential helpers. `login-to-gar` sets up a gcloud credential helper, so attestation fails with `No credentials found for registry us-docker.pkg.dev`.

Note: a previous attempt used `google-github-actions/auth` with `token_format: access_token` + `docker/login-action`, but that requires a service account to impersonate. Tempo uses **direct WIF principal bindings** to GAR (no service account), so that approach fails with `must specify a service_account`.

## Fix

After `login-to-gar`, add a step that calls `gcloud auth print-access-token` and writes a static `auths` entry to the docker config. Both cosign (credential-helper-aware) and `actions/attest` (static-auths only) can then authenticate from the same credentials.

Also adds `attestations: write` to the `build-docker` call in `release-tag.yml` to prevent `startup_failure` from the nested permission ceiling.

## Testing

Verified via `workflow_dispatch` on this branch against a real vulture digest — job completed successfully in 33s: https://github.com/grafana/tempo/actions/runs/28170016423