### PR TITLE
parquetquery: use map lookup for large ByteIn/ByteNotIn predicates

### DIFF
--- a/.chloggen/parquetquery-bytein-map-lookup.yaml
+++ b/.chloggen/parquetquery-bytein-map-lookup.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: speed up `ByteInPredicate`/`ByteNotInPredicate` by using a map lookup instead of a linear scan for large value sets.
+issues: []
+subtext:
+user: mapno

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -82,12 +82,11 @@ func (p *ByteInPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
 		return true // no index: keep column chunk
 	}
 
-	for _, subs := range p.values {
-		for i := 0; i < ci.NumPages(); i++ {
-			minVal := ci.MinValue(i).ByteArray()
-			maxVal := ci.MaxValue(i).ByteArray()
-			ok := bytes.Compare(minVal, subs) <= 0 && bytes.Compare(maxVal, subs) >= 0
-			if ok {
+	for i := 0; i < ci.NumPages(); i++ {
+		minVal := ci.MinValue(i).ByteArray()
+		maxVal := ci.MaxValue(i).ByteArray()
+		for _, subs := range p.values {
+			if bytes.Compare(minVal, subs) <= 0 && bytes.Compare(maxVal, subs) >= 0 {
 				// At least one page in this chunk matches
 				return true
 			}

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -30,27 +30,35 @@ func NewStringNotEqualPredicate(s string) Predicate {
 	return NewByteNotEqualPredicate([]byte(s))
 }
 
+// byteInMapThreshold is the number of values at or above which KeepValue uses a
+// map lookup instead of a linear scan. Below it the scan is faster (lower overhead).
+const byteInMapThreshold = 8
+
 // ByteInPredicate checks for any of the given strings. Case-sensitive exact byte matching
 type ByteInPredicate struct {
-	values [][]byte
+	values    [][]byte
+	valuesMap map[string]struct{} // set when len(values) >= byteInMapThreshold
 }
 
 var _ Predicate = (*ByteInPredicate)(nil)
 
 func NewStringInPredicate(ss []string) Predicate {
-	p := &ByteInPredicate{
-		values: make([][]byte, len(ss)),
-	}
+	bb := make([][]byte, len(ss))
 	for i := range ss {
-		p.values[i] = []byte(ss[i])
+		bb[i] = []byte(ss[i])
 	}
-	return p
+	return NewByteInPredicate(bb)
 }
 
 func NewByteInPredicate(bb [][]byte) Predicate {
-	return &ByteInPredicate{
-		values: bb,
+	p := &ByteInPredicate{values: bb}
+	if len(bb) >= byteInMapThreshold {
+		p.valuesMap = make(map[string]struct{}, len(bb))
+		for _, b := range bb {
+			p.valuesMap[string(b)] = struct{}{}
+		}
 	}
+	return p
 }
 
 func (p *ByteInPredicate) String() string {
@@ -90,6 +98,10 @@ func (p *ByteInPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
 
 func (p *ByteInPredicate) KeepValue(v pq.Value) bool {
 	ba := v.ByteArray()
+	if p.valuesMap != nil {
+		_, ok := p.valuesMap[string(ba)]
+		return ok
+	}
 	for _, ss := range p.values {
 		if bytes.Equal(ba, ss) {
 			return true
@@ -105,25 +117,29 @@ func (p *ByteInPredicate) KeepPage(pq.Page) bool {
 
 // ByteNotInPredicate checks for any of the given strings. Case-sensitive exact byte matching
 type ByteNotInPredicate struct {
-	values [][]byte
+	values    [][]byte
+	valuesMap map[string]struct{} // set when len(values) >= byteInMapThreshold
 }
 
 var _ Predicate = (*ByteNotInPredicate)(nil)
 
 func NewStringNotInPredicate(ss []string) Predicate {
-	p := &ByteNotInPredicate{
-		values: make([][]byte, len(ss)),
-	}
+	bb := make([][]byte, len(ss))
 	for i := range ss {
-		p.values[i] = []byte(ss[i])
+		bb[i] = []byte(ss[i])
 	}
-	return p
+	return NewByteNotInPredicate(bb)
 }
 
 func NewByteNotInPredicate(bb [][]byte) Predicate {
-	return &ByteNotInPredicate{
-		values: bb,
+	p := &ByteNotInPredicate{values: bb}
+	if len(bb) >= byteInMapThreshold {
+		p.valuesMap = make(map[string]struct{}, len(bb))
+		for _, b := range bb {
+			p.valuesMap[string(b)] = struct{}{}
+		}
 	}
+	return p
 }
 
 func (p *ByteNotInPredicate) String() string {
@@ -147,6 +163,10 @@ func (p *ByteNotInPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
 
 func (p *ByteNotInPredicate) KeepValue(v pq.Value) bool {
 	ba := v.ByteArray()
+	if p.valuesMap != nil {
+		_, ok := p.valuesMap[string(ba)]
+		return !ok
+	}
 	for _, ss := range p.values {
 		if bytes.Equal(ba, ss) {
 			return false

--- a/pkg/parquetquery/predicates_test.go
+++ b/pkg/parquetquery/predicates_test.go
@@ -3,6 +3,8 @@ package parquetquery
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"math/rand"
 	"testing"
 
 	"github.com/google/uuid"
@@ -466,5 +468,75 @@ func TestIntNotInPredicate(t *testing.T) {
 		t.Run(tC.testName, func(t *testing.T) {
 			testPredicate(t, tC)
 		})
+	}
+}
+
+const benchByteInLetters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
+
+func randStringN(r *rand.Rand, n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = benchByteInLetters[r.Intn(len(benchByteInLetters))]
+	}
+	return string(b)
+}
+
+// benchByteInData builds the predicate needles plus a 1000-value workload that
+// is ~50% hits and ~50% misses, so both the matching and non-matching paths are
+// exercised.
+func benchByteInData(numNeedles, keyLen int) (needles []string, values []parquet.Value) {
+	r := rand.New(rand.NewSource(int64(numNeedles*1000 + keyLen)))
+
+	needles = make([]string, numNeedles)
+	for i := range needles {
+		needles[i] = randStringN(r, keyLen)
+	}
+
+	values = make([]parquet.Value, 1000)
+	for i := range values {
+		if i%2 == 0 {
+			values[i] = parquet.ValueOf(needles[i%numNeedles])
+		} else {
+			values[i] = parquet.ValueOf(randStringN(r, keyLen))
+		}
+	}
+	return needles, values
+}
+
+// BenchmarkByteInPredicate exercises the production constructor, which picks the
+// slice or map implementation based on byteInMapThreshold.
+func BenchmarkByteInPredicate(b *testing.B) {
+	for _, numNeedles := range []int{1, 4, 8, 16, 64, 256} {
+		for _, keyLen := range []int{8, 36} {
+			needles, values := benchByteInData(numNeedles, keyLen)
+			p := NewStringInPredicate(needles)
+
+			b.Run(fmt.Sprintf("needles=%d/keyLen=%d", numNeedles, keyLen), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					for _, v := range values {
+						p.KeepValue(v)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkByteNotInPredicate(b *testing.B) {
+	for _, numNeedles := range []int{1, 4, 8, 16, 64, 256} {
+		for _, keyLen := range []int{8, 36} {
+			needles, values := benchByteInData(numNeedles, keyLen)
+			p := NewStringNotInPredicate(needles)
+
+			b.Run(fmt.Sprintf("needles=%d/keyLen=%d", numNeedles, keyLen), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					for _, v := range values {
+						p.KeepValue(v)
+					}
+				}
+			})
+		}
 	}
 }

--- a/pkg/parquetquery/predicates_test.go
+++ b/pkg/parquetquery/predicates_test.go
@@ -118,6 +118,21 @@ func TestNewStringInPredicate(t *testing.T) {
 				require.NoError(t, w.Write(&testDictString{"abc"}))
 			},
 		},
+		{
+			testName: "map path (>= byteInMapThreshold needles)",
+			predicate: func() Predicate {
+				// >= byteInMapThreshold needles forces the map-backed KeepValue path
+				return NewStringInPredicate([]string{"abc", "acd", "n0", "n1", "n2", "n3", "n4", "n5"})
+			}(),
+			keptChunks: 1,
+			keptPages:  1,
+			keptValues: 2,
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testDictString{"abc"})) // kept
+				require.NoError(t, w.Write(&testDictString{"acd"})) // kept
+				require.NoError(t, w.Write(&testDictString{"cde"})) // skipped
+			},
+		},
 	}
 
 	for _, tC := range testCases {
@@ -199,6 +214,22 @@ func TestNewStringNotInPredicate(t *testing.T) {
 			writeData: func(w *parquet.Writer) { //nolint:all
 				require.NoError(t, w.Write(&testDictString{"xyz"}))
 				require.NoError(t, w.Write(&testDictString{"xyz"}))
+			},
+		},
+		{
+			testName: "map path (>= byteInMapThreshold needles)",
+			predicate: func() Predicate {
+				// >= byteInMapThreshold needles forces the map-backed KeepValue path
+				return NewStringNotInPredicate([]string{"abc", "acd", "n0", "n1", "n2", "n3", "n4", "n5"})
+			}(),
+			keptChunks: 1,
+			keptPages:  1,
+			keptValues: 2,
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testDictString{"abc"})) // skipped
+				require.NoError(t, w.Write(&testDictString{"acd"})) // skipped
+				require.NoError(t, w.Write(&testDictString{"cde"})) // kept
+				require.NoError(t, w.Write(&testDictString{"xde"})) // kept
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does**:

Two small optimizations to `ByteInPredicate`/`ByteNotInPredicate`:

1. **Map lookup for large value sets.** Build a lookup map and do an O(1) `KeepValue` lookup instead of a linear scan once the set reaches `byteInMapThreshold` (8). Smaller sets keep the scan, which is faster there. Behaviour is unchanged and allocations stay at zero.
2. **Hoist page bounds in `KeepColumnChunk`.** Loop pages on the outside and needles on the inside so `MinValue`/`MaxValue` are read once per page instead of once per (needle × page).

<details>
<summary>Benchmark (1000 values, ~50% hits, `main` vs this PR, n=10)</summary>

```
                                            │    sec/op     │   sec/op     vs base                │
ByteInPredicate/needles=1/keyLen=8-12           4.889µ ± 1%   4.884µ ± 0%        ~ (p=0.093 n=10)
ByteInPredicate/needles=1/keyLen=36-12          5.728µ ± 0%   6.028µ ± 0%   +5.24% (p=0.000 n=10)
ByteInPredicate/needles=4/keyLen=8-12           11.29µ ± 0%   11.13µ ± 0%   -1.42% (p=0.000 n=10)
ByteInPredicate/needles=4/keyLen=36-12          11.76µ ± 1%   11.93µ ± 0%   +1.46% (p=0.000 n=10)
ByteInPredicate/needles=8/keyLen=8-12           18.95µ ± 1%   14.14µ ± 0%  -25.35% (p=0.000 n=10)
ByteInPredicate/needles=8/keyLen=36-12          20.62µ ± 0%   14.50µ ± 0%  -29.67% (p=0.000 n=10)
ByteInPredicate/needles=16/keyLen=8-12          38.45µ ± 1%   14.40µ ± 1%  -62.56% (p=0.000 n=10)
ByteInPredicate/needles=16/keyLen=36-12         42.70µ ± 0%   12.76µ ± 0%  -70.13% (p=0.000 n=10)
ByteInPredicate/needles=64/keyLen=8-12         134.94µ ± 0%   10.62µ ± 0%  -92.13% (p=0.000 n=10)
ByteInPredicate/needles=64/keyLen=36-12        153.42µ ± 0%   14.16µ ± 0%  -90.77% (p=0.000 n=10)
ByteInPredicate/needles=256/keyLen=8-12        499.07µ ± 0%   11.88µ ± 0%  -97.62% (p=0.000 n=10)
ByteInPredicate/needles=256/keyLen=36-12       578.52µ ± 0%   14.44µ ± 0%  -97.50% (p=0.000 n=10)
ByteNotInPredicate/needles=1/keyLen=8-12        4.893µ ± 0%   4.907µ ± 0%   +0.28% (p=0.005 n=10)
ByteNotInPredicate/needles=1/keyLen=36-12       5.742µ ± 0%   6.043µ ± 0%   +5.24% (p=0.000 n=10)
ByteNotInPredicate/needles=4/keyLen=8-12        11.30µ ± 1%   11.07µ ± 0%   -2.00% (p=0.000 n=10)
ByteNotInPredicate/needles=4/keyLen=36-12       11.71µ ± 0%   11.88µ ± 0%   +1.37% (p=0.000 n=10)
ByteNotInPredicate/needles=8/keyLen=8-12        18.97µ ± 2%   14.09µ ± 0%  -25.75% (p=0.000 n=10)
ByteNotInPredicate/needles=8/keyLen=36-12       20.63µ ± 0%   14.81µ ± 0%  -28.18% (p=0.000 n=10)
ByteNotInPredicate/needles=16/keyLen=8-12       38.76µ ± 0%   12.71µ ± 0%  -67.21% (p=0.000 n=10)
ByteNotInPredicate/needles=16/keyLen=36-12      42.85µ ± 0%   12.72µ ± 0%  -70.31% (p=0.000 n=10)
ByteNotInPredicate/needles=64/keyLen=8-12      134.88µ ± 0%   11.29µ ± 1%  -91.63% (p=0.000 n=10)
ByteNotInPredicate/needles=64/keyLen=36-12     153.52µ ± 0%   12.50µ ± 0%  -91.86% (p=0.000 n=10)
ByteNotInPredicate/needles=256/keyLen=8-12     499.48µ ± 0%   11.59µ ± 0%  -97.68% (p=0.000 n=10)
ByteNotInPredicate/needles=256/keyLen=36-12    578.79µ ± 1%   14.23µ ± 0%  -97.54% (p=0.000 n=10)
geomean                                         39.49µ        11.08µ       -71.95%
```

Allocations are unchanged at 0 B/op, 0 allocs/op across all cases.
</details>

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`