### PR TITLE
feat(parquetquery): dictionary-index pushdown for string predicates

### DIFF
--- a/.chloggen/dict-index-pushdown.yaml
+++ b/.chloggen/dict-index-pushdown.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: speed up dictionary-resolvable string filters (equality, `IN`, regex, substring) by resolving the predicate against the column-chunk dictionary once and matching rows by dictionary index instead of materializing and re-evaluating the predicate per value.
+issues: []
+subtext:
+user: zhxiaogg

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -476,21 +476,14 @@ type SyncIterator struct {
 
 	maxDefinitionLevel int
 
-	// Dictionary fast-path state. When the filter is a DictionaryPredicate and a
-	// page is dictionary-encoded, the predicate is resolved once over the chunk
-	// dictionary into a match bitmap, and rows are matched by their integer
-	// dictionary index instead of being materialized and byte-compared per row.
-	// The per-page decoding lives in indexReader; the remaining fields outlive a
-	// single page:
-	//   - whole iterator: indexReaderDisabled (test-only), indexReaderPagesUsed (observability)
-	//   - per column chunk: indexReaderChecked, indexReaderMatches
-	indexReaderDisabled  bool   // test-only: force the per-row path (set directly by in-package tests)
-	indexReaderPagesUsed int    // pages served via the fast path (observability/tests)
-	indexReaderChecked   bool   // whether the match bitmap was resolved for the current chunk
-	indexReaderMatches   []bool // match bitmap indexed by dictionary index; nil => pushdown declined
-	// indexReader serves the current dictionary-encoded page on the fast path; nil
-	// when the page uses the per-row path. See indexValueReader.
-	indexReader *indexValueReader
+	// Dictionary fast-path state: when the filter is a DictionaryPredicate over a
+	// dictionary-encoded chunk, the predicate is resolved once into a per-index match
+	// bitmap and rows match by integer index instead of per-row materialization.
+	indexReaderDisabled  bool              // test-only: force the per-row path
+	indexReaderPagesUsed int               // pages served via the fast path (tests/observability)
+	indexReaderChecked   bool              // match bitmap resolved for the current chunk?
+	indexReaderMatches   []bool            // match bitmap by dictionary index; nil => no pushdown
+	indexReader          *indexValueReader // current page's reader; nil on the per-row path
 
 	interner   *intern.Interner
 	makeResult func(t RowNumber, v *pq.Value) *IteratorResult
@@ -498,11 +491,9 @@ type SyncIterator struct {
 
 var _ Iterator = (*SyncIterator)(nil)
 
-// enterColumnChunk applies the column-chunk filter and, if the chunk is kept,
-// makes it current. Returns false when the chunk can be skipped (the caller must
-// continue to the next row group). For a dictionary-pushable predicate it resolves
-// the per-index match bitmap here and installs it, so the per-page readers reuse it
-// instead of rescanning the dictionary.
+// enterColumnChunk applies the column-chunk filter and makes the chunk current,
+// returning false if it can be skipped. For a dictionary-pushable predicate the
+// match bitmap is resolved here so the per-page readers reuse it.
 func (c *SyncIterator) enterColumnChunk(rg pq.RowGroup, minRN, maxRN RowNumber, cc *ColumnChunkHelper) bool {
 	keep, matches := c.keepColumnChunk(cc)
 	if !keep {
@@ -510,24 +501,18 @@ func (c *SyncIterator) enterColumnChunk(rg pq.RowGroup, minRN, maxRN RowNumber, 
 		return false
 	}
 	c.setRowGroup(rg, minRN, maxRN, cc)
-	// setRowGroup cleared the per-chunk bitmap; install the one we just resolved so
-	// indexReaderFor doesn't scan the dictionary a second time.
-	if matches != nil {
+	if matches != nil { // reinstate the bitmap setRowGroup cleared, so indexReaderFor reuses it
 		c.indexReaderChecked = true
 		c.indexReaderMatches = matches
 	}
 	return true
 }
 
-// keepColumnChunk reports whether cc can contain matching rows. For a dictionary-
-// pushable predicate on a dictionary-encoded chunk it resolves the per-index match
-// bitmap once - the same dictionary scan the generic KeepColumnChunk would do to
-// test for any match - and returns it (non-nil) so the caller can reuse it for the
-// per-page readers. The chunk is skipped when no dictionary entry matches.
-//
-// For substring/regex predicates this bypasses KeepColumnChunk's per-chunk match-
-// cache reset. That is safe: those caches are pure value->bool memoization, so they
-// stay correct, and they remain bounded by the column's distinct dictionary values.
+// keepColumnChunk reports whether cc can match. For a dictionary-pushable predicate
+// it resolves the per-index match bitmap once (the scan KeepColumnChunk would do
+// anyway to test for any match) and returns it for the per-page readers; the chunk
+// is skipped when no entry matches. This bypasses KeepColumnChunk's per-chunk cache
+// reset for substring/regex, which is safe because KeepIndexes resets them instead.
 func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool, matches []bool) {
 	if c.filter == nil {
 		return true, nil
@@ -535,18 +520,16 @@ func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool, matche
 	if dp, ok := c.filter.(DictionaryPredicate); ok && !c.indexReaderDisabled {
 		if dict := cc.Dictionary(); dict != nil {
 			if m := dp.KeepIndexes(dict); m != nil {
-				return anyTrue(m), m
+				return slices.Contains(m, true), m
 			}
 		}
 	}
 	return c.filter.KeepColumnChunk(cc), nil
 }
 
-// indexReaderFor returns a dictionary fast-path reader for pg, or nil when
-// pushdown does not apply (disabled, non-dictionary predicate, non-dictionary
-// page, or the predicate declined). The match bitmap is resolved against the
-// chunk dictionary once and reused across all of the chunk's pages; when it is
-// nil the caller uses the per-row path.
+// indexReaderFor returns a fast-path reader for pg, or nil when pushdown doesn't
+// apply (disabled, non-dictionary predicate/page, or the predicate declined). The
+// match bitmap is resolved once per chunk and reused across its pages.
 func (c *SyncIterator) indexReaderFor(pg pq.Page) *indexValueReader {
 	if c.indexReaderDisabled {
 		return nil
@@ -573,11 +556,8 @@ func (c *SyncIterator) indexReaderFor(pg pq.Page) *indexValueReader {
 	return newIndexValueReader(c.indexReaderMatches, pg)
 }
 
-// indexValueReader serves one dictionary-encoded page on the fast path. The
-// predicate is pre-resolved into matches (indexed by dictionary index) and shared
-// across all pages in the chunk; the reader decodes this page's levels and
-// indices and advances one slot per next() call. It is a pure page decoder: row
-// numbers are tracked by the caller, driven by the levels next() returns.
+// indexValueReader serves one dictionary-encoded page on the fast path, matching
+// each row by its integer dictionary index against the chunk's match bitmap.
 type indexValueReader struct {
 	matches []bool        // match bitmap indexed by dictionary index (chunk-scoped)
 	dict    pq.Dictionary // dictionary the matches were built against
@@ -603,22 +583,18 @@ func newIndexValueReader(matches []bool, pg pq.Page) *indexValueReader {
 		indices:   data.Int32(),
 		defLevels: defLevels,
 		repLevels: pg.RepetitionLevels(),
-		// A present (non-null) leaf carries the maximum definition level seen on the
-		// page. (The iterator's maxDefinitionLevel is a row-number tracking cap, not
-		// necessarily this leaf's level, so we derive it from the page.) On a page with
-		// no present values this collapses to the null level, so the valueN bound in
-		// next() is what keeps such pages from indexing past the empty indices slice.
+		// Present (non-null) leaves sit at the page's max definition level. (We derive
+		// it from the page, not the iterator's maxDefinitionLevel, which is a row-number
+		// cap rather than this leaf's level.)
 		pageMaxDef: maxByte(defLevels),
 	}
 }
 
 // nextMatch advances over slots until it materializes a matching value or the page
-// is exhausted (ok=false). It owns the per-slot loop so a predicate-bound scan stays
-// in one tight loop rather than paying a method call per non-matching slot. Row
-// numbers are tracked exactly as the per-row path does: curr and pageN are advanced
-// for every slot (present, null, or filtered) via the caller's pointers, and
-// maxDefLevel is the row-number tracking cap. The returned value points at a reused
-// buffer, valid until the next call.
+// is exhausted (ok=false). It owns the per-slot loop (one tight loop, not a method
+// call per slot) and advances the caller's row number over every slot — present,
+// null, or filtered — via curr/pageN. The returned value points at a reused buffer,
+// valid until the next call.
 func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel int) (*pq.Value, bool) {
 	numSlots := len(r.indices)
 	if r.defLevels != nil {
@@ -630,9 +606,7 @@ func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel in
 		if r.repLevels != nil {
 			repLvl = int(r.repLevels[r.slotN])
 		}
-		// Required columns have no definition levels; every value is present at the
-		// page's (possibly zero) definition level.
-		defLvl := int(r.pageMaxDef)
+		defLvl := int(r.pageMaxDef) // required columns have no levels; every slot is present
 		if r.defLevels != nil {
 			defLvl = int(r.defLevels[r.slotN])
 		}
@@ -640,10 +614,9 @@ func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel in
 		r.slotN++
 		(*pageN)++
 
-		// Null/empty slot: not present at the leaf, so no value and no dictionary index
-		// is consumed. The valueN bound also guards pages that carry definition levels
-		// but no present values (an all-null page, where indices is empty), so we never
-		// index past indices/matches.
+		// Null/empty slot consumes no index. The valueN bound also covers a page with
+		// definition levels but no present values (all-null page, empty indices), so we
+		// never index past indices/matches.
 		if (r.defLevels != nil && byte(defLvl) != r.pageMaxDef) || r.valueN >= len(r.indices) {
 			continue
 		}
@@ -654,8 +627,7 @@ func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel in
 			continue
 		}
 
-		// Materialize only matching values, stamping the page levels and column so the
-		// result is indistinguishable from the per-row path.
+		// Stamp page levels + column so the result matches the per-row path.
 		r.value = r.dict.Index(idx).Level(repLvl, defLvl, r.col)
 		return &r.value, true
 	}
@@ -922,9 +894,8 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 		return
 	}
 
-	// The dictionary fast path tracks its cursor against the whole page; reslicing
-	// would require rebuilding that state, so we let next() advance to the target
-	// instead. Correctness is unaffected, only the large-skip shortcut is skipped.
+	// The fast path's cursor tracks the whole page, so skip the reslice shortcut and
+	// let nextMatch advance to the target (correct, just not the large-skip fast path).
 	if c.indexReader != nil {
 		return
 	}
@@ -1028,14 +999,11 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.setPage(pg)
 		}
 
-		// Dictionary fast path: match rows by integer dictionary index. The reader
-		// advances the row number over every slot (present, null, or filtered-out),
-		// exactly as the per-row path does, and returns only matched values.
+		// Dictionary fast path: match rows by integer dictionary index.
 		if c.indexReader != nil {
 			v, ok := c.indexReader.nextMatch(&c.curr, &c.currPageN, c.maxDefinitionLevel)
 			if !ok {
-				// Page exhausted, move on.
-				c.setPage(nil)
+				c.setPage(nil) // page exhausted
 				continue
 			}
 			return c.curr, v, nil
@@ -1087,8 +1055,7 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroupMax = max
 	c.currChunk = cc
 
-	// The match bitmap is resolved once per column chunk (all data pages in a chunk
-	// share the same dictionary) and reset when the chunk changes.
+	// Reset the per-chunk match bitmap; each chunk has its own dictionary.
 	c.indexReaderChecked = false
 	c.indexReaderMatches = nil
 }
@@ -1128,23 +1095,15 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 	}
 }
 
+// maxByte returns the largest byte in b, or 0 when b is empty (so a required
+// column with no definition levels yields a present level of 0). slices.Max is
+// not used because it panics on an empty slice.
 func maxByte(b []byte) byte {
 	var m byte
 	for _, v := range b {
-		if v > m {
-			m = v
-		}
+		m = max(m, v)
 	}
 	return m
-}
-
-func anyTrue(b []bool) bool {
-	for _, v := range b {
-		if v {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *SyncIterator) closeCurrRowGroup() {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -438,6 +438,20 @@ func SyncIteratorOptMaxDefinitionLevel(maxDefinitionLevel int) SyncIteratorOpt {
 	}
 }
 
+// SyncIteratorOptDisableDictPushdown turns off the dictionary fast path, forcing
+// per-row predicate evaluation. Primarily useful for testing and benchmarking.
+func SyncIteratorOptDisableDictPushdown() SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.dict.disabled = true
+	}
+}
+
+// DictFastPathPages reports how many pages were served via the dictionary fast
+// path. Used by tests to confirm the optimization engaged.
+func (c *SyncIterator) DictFastPathPages() int {
+	return c.dict.pagesUsed
+}
+
 // SyncIterator is a synchronous column iterator. It scans through the given row
 // groups and column, and applies the optional predicate to each chunk, page, and value.
 // Results are read by calling Next() until it returns nil.
@@ -470,11 +484,103 @@ type SyncIterator struct {
 
 	maxDefinitionLevel int
 
+	// Dictionary fast path state. See dictScan.
+	dict dictScan
+
 	interner   *intern.Interner
 	makeResult func(t RowNumber, v *pq.Value) *IteratorResult
 }
 
 var _ Iterator = (*SyncIterator)(nil)
+
+// dictScan holds the dictionary fast-path state. When the filter is a
+// DictionaryPredicate and the current page is dictionary-encoded, the predicate
+// is resolved once over the dictionary into keep, and rows are matched by their
+// integer dictionary index instead of being materialized and byte-compared per
+// row. State has three lifetimes, made explicit by reset methods:
+//   - whole iterator: disabled (config), pagesUsed (observability)
+//   - per column chunk (resetChunk): checked, keep, dict
+//   - per page (resetPage): everything else
+type dictScan struct {
+	disabled  bool // config: force the per-row path
+	pagesUsed int  // pages served via the fast path (observability/tests)
+
+	// per chunk
+	checked bool          // whether keep was resolved for the current chunk
+	keep    []bool        // keep bitmap indexed by dictionary index; nil => pushdown declined
+	dict    pq.Dictionary // the dictionary keep was built against
+
+	// per page
+	active     bool    // fast path engaged for the current page
+	indices    []int32 // present-value dictionary indexes for the current page
+	defLevels  []byte  // nil for required columns
+	repLevels  []byte  // nil for non-repeated columns
+	pageMaxDef byte    // definition level of a present (non-null) value
+	slotN      int     // cursor over level slots (present + null)
+	valueN     int     // cursor over indices (present only)
+
+	value pq.Value // reused return buffer for matched values
+}
+
+// resetChunk clears the per-chunk keep bitmap. Called when the iterator advances
+// to a new column chunk (all pages in a chunk share one dictionary).
+func (d *dictScan) resetChunk() {
+	d.checked = false
+	d.keep = nil
+	d.dict = nil
+}
+
+// resetPage clears the per-page cursors. The per-chunk keep bitmap is preserved.
+func (d *dictScan) resetPage() {
+	d.active = false
+	d.indices = nil
+	d.defLevels = nil
+	d.repLevels = nil
+	d.pageMaxDef = 0
+	d.slotN = 0
+	d.valueN = 0
+}
+
+// setupPage enables the fast path for pg when filter can be resolved against the
+// chunk dictionary. The keep bitmap is computed once per chunk and reused across
+// the chunk's pages; only the per-page cursors are refreshed here. When pushdown
+// does not apply, active stays false and the caller uses the per-row path.
+func (d *dictScan) setupPage(filter Predicate, pg pq.Page) {
+	if d.disabled {
+		return
+	}
+	dp, ok := filter.(DictionaryPredicate)
+	if !ok {
+		return
+	}
+	dict := pg.Dictionary()
+	if dict == nil {
+		return // page is not dictionary-encoded
+	}
+
+	// Resolve the predicate against the dictionary once per chunk.
+	if !d.checked {
+		d.checked = true
+		d.keep = dp.KeepIndexes(dict)
+		d.dict = dict
+	}
+	if d.keep == nil {
+		return // predicate declined dictionary pushdown for this chunk
+	}
+
+	d.defLevels = pg.DefinitionLevels()
+	d.repLevels = pg.RepetitionLevels()
+	data := pg.Data()
+	d.indices = data.Int32()
+	// A present (non-null) leaf carries the maximum definition level seen on the
+	// page. Required columns have no definition levels and every index is present.
+	d.pageMaxDef = maxByte(d.defLevels)
+
+	d.slotN = 0
+	d.valueN = 0
+	d.active = true
+	d.pagesUsed++
+}
 
 // NewSyncIterator iterates values in a column of a parquet file. Required values
 // are the numeric column index and the row groups to iterate over.  The column index
@@ -739,6 +845,13 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 		return
 	}
 
+	// The dictionary fast path tracks its cursor against the whole page; reslicing
+	// would require rebuilding that state, so we let next() advance to the target
+	// instead. Correctness is unaffected, only the large-skip shortcut is skipped.
+	if c.dict.active {
+		return
+	}
+
 	const magicThreshold = 1000
 	shouldSkip := false
 
@@ -841,6 +954,17 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.setPage(pg)
 		}
 
+		// Dictionary fast path: match rows by integer dictionary index.
+		if c.dict.active {
+			rn, v, ok := c.nextDict()
+			if !ok {
+				// Page exhausted, move on.
+				c.setPage(nil)
+				continue
+			}
+			return rn, v, nil
+		}
+
 		// Read next batch of values if needed
 		if c.currBuf == nil {
 			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
@@ -886,6 +1010,10 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroupMin = min
 	c.currRowGroupMax = max
 	c.currChunk = cc
+
+	// The dictionary keep bitmap is resolved once per column chunk (all data pages
+	// in a chunk share the same dictionary) and reset when the chunk changes.
+	c.dict.resetChunk()
 }
 
 func (c *SyncIterator) setPage(pg pq.Page) {
@@ -902,6 +1030,7 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 	c.currPageMin = EmptyRowNumber()
 	c.currBufN = 0
 	c.currPageN = 0
+	c.dict.resetPage()
 
 	// If we don't immediately have a new incoming page
 	// then return the buffer to the pool.
@@ -918,7 +1047,67 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 		c.currPageMin = c.curr
 		c.currPageMax = rn
 		c.currValues = pg.Values()
+		c.dict.setupPage(c.filter, pg)
 	}
+}
+
+func maxByte(b []byte) byte {
+	var m byte
+	for _, v := range b {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// nextDict advances the dictionary fast path by one matching row in the current
+// page. ok is false when the page is exhausted. Row numbers are tracked across
+// every slot (including nulls) exactly as the per-row path does, but only present
+// values consume a dictionary index and only matching indexes are materialized.
+func (c *SyncIterator) nextDict() (RowNumber, *pq.Value, bool) {
+	d := &c.dict
+
+	numSlots := len(d.indices)
+	if d.defLevels != nil {
+		numSlots = len(d.defLevels)
+	}
+
+	for d.slotN < numSlots {
+		repLvl := 0
+		if d.repLevels != nil {
+			repLvl = int(d.repLevels[d.slotN])
+		}
+		// Required columns have no definition levels; every value is present at the
+		// page's (possibly zero) definition level.
+		defLvl := int(d.pageMaxDef)
+		if d.defLevels != nil {
+			defLvl = int(d.defLevels[d.slotN])
+		}
+
+		c.curr.Next(repLvl, defLvl, c.maxDefinitionLevel)
+		d.slotN++
+		c.currPageN++
+
+		// Null slot: no value present and no dictionary index consumed. The gated
+		// predicates never keep nulls, matching the per-row path.
+		if d.defLevels != nil && byte(defLvl) != d.pageMaxDef {
+			continue
+		}
+
+		idx := d.indices[d.valueN]
+		d.valueN++
+
+		if !d.keep[idx] {
+			continue
+		}
+
+		// Materialize only matching values, stamping the page levels and column so
+		// the result is indistinguishable from the per-row path.
+		d.value = d.dict.Index(idx).Level(repLvl, defLvl, c.currPage.Column())
+		return c.curr, &d.value, true
+	}
+	return EmptyRowNumber(), nil, false
 }
 
 func (c *SyncIterator) closeCurrRowGroup() {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -438,18 +438,10 @@ func SyncIteratorOptMaxDefinitionLevel(maxDefinitionLevel int) SyncIteratorOpt {
 	}
 }
 
-// SyncIteratorOptDisableDictPushdown turns off the dictionary fast path, forcing
-// per-row predicate evaluation. Primarily useful for testing and benchmarking.
-func SyncIteratorOptDisableDictPushdown() SyncIteratorOpt {
-	return func(i *SyncIterator) {
-		i.dict.disabled = true
-	}
-}
-
-// DictFastPathPages reports how many pages were served via the dictionary fast
-// path. Used by tests to confirm the optimization engaged.
-func (c *SyncIterator) DictFastPathPages() int {
-	return c.dict.pagesUsed
+// dictFastPathPages reports how many pages were served via the dictionary fast
+// path. Used by in-package tests to confirm the optimization engaged.
+func (c *SyncIterator) dictFastPathPages() int {
+	return c.indexReaderPagesUsed
 }
 
 // SyncIterator is a synchronous column iterator. It scans through the given row
@@ -484,8 +476,21 @@ type SyncIterator struct {
 
 	maxDefinitionLevel int
 
-	// Dictionary fast path state. See dictScan.
-	dict dictScan
+	// Dictionary fast-path state. When the filter is a DictionaryPredicate and a
+	// page is dictionary-encoded, the predicate is resolved once over the chunk
+	// dictionary into a match bitmap, and rows are matched by their integer
+	// dictionary index instead of being materialized and byte-compared per row.
+	// The per-page decoding lives in indexReader; the remaining fields outlive a
+	// single page:
+	//   - whole iterator: indexReaderDisabled (test-only), indexReaderPagesUsed (observability)
+	//   - per column chunk: indexReaderChecked, indexReaderMatches
+	indexReaderDisabled  bool   // test-only: force the per-row path (set directly by in-package tests)
+	indexReaderPagesUsed int    // pages served via the fast path (observability/tests)
+	indexReaderChecked   bool   // whether the match bitmap was resolved for the current chunk
+	indexReaderMatches   []bool // match bitmap indexed by dictionary index; nil => pushdown declined
+	// indexReader serves the current dictionary-encoded page on the fast path; nil
+	// when the page uses the per-row path. See indexValueReader.
+	indexReader *indexValueReader
 
 	interner   *intern.Interner
 	makeResult func(t RowNumber, v *pq.Value) *IteratorResult
@@ -493,93 +498,168 @@ type SyncIterator struct {
 
 var _ Iterator = (*SyncIterator)(nil)
 
-// dictScan holds the dictionary fast-path state. When the filter is a
-// DictionaryPredicate and the current page is dictionary-encoded, the predicate
-// is resolved once over the dictionary into keep, and rows are matched by their
-// integer dictionary index instead of being materialized and byte-compared per
-// row. State has three lifetimes, made explicit by reset methods:
-//   - whole iterator: disabled (config), pagesUsed (observability)
-//   - per column chunk (resetChunk): checked, keep, dict
-//   - per page (resetPage): everything else
-type dictScan struct {
-	disabled  bool // config: force the per-row path
-	pagesUsed int  // pages served via the fast path (observability/tests)
+// enterColumnChunk applies the column-chunk filter and, if the chunk is kept,
+// makes it current. Returns false when the chunk can be skipped (the caller must
+// continue to the next row group). For a dictionary-pushable predicate it resolves
+// the per-index match bitmap here and installs it, so the per-page readers reuse it
+// instead of rescanning the dictionary.
+func (c *SyncIterator) enterColumnChunk(rg pq.RowGroup, minRN, maxRN RowNumber, cc *ColumnChunkHelper) bool {
+	keep, matches := c.keepColumnChunk(cc)
+	if !keep {
+		cc.Close()
+		return false
+	}
+	c.setRowGroup(rg, minRN, maxRN, cc)
+	// setRowGroup cleared the per-chunk bitmap; install the one we just resolved so
+	// indexReaderFor doesn't scan the dictionary a second time.
+	if matches != nil {
+		c.indexReaderChecked = true
+		c.indexReaderMatches = matches
+	}
+	return true
+}
 
-	// per chunk
-	checked bool          // whether keep was resolved for the current chunk
-	keep    []bool        // keep bitmap indexed by dictionary index; nil => pushdown declined
-	dict    pq.Dictionary // the dictionary keep was built against
+// keepColumnChunk reports whether cc can contain matching rows. For a dictionary-
+// pushable predicate on a dictionary-encoded chunk it resolves the per-index match
+// bitmap once - the same dictionary scan the generic KeepColumnChunk would do to
+// test for any match - and returns it (non-nil) so the caller can reuse it for the
+// per-page readers. The chunk is skipped when no dictionary entry matches.
+//
+// For substring/regex predicates this bypasses KeepColumnChunk's per-chunk match-
+// cache reset. That is safe: those caches are pure value->bool memoization, so they
+// stay correct, and they remain bounded by the column's distinct dictionary values.
+func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool, matches []bool) {
+	if c.filter == nil {
+		return true, nil
+	}
+	if dp, ok := c.filter.(DictionaryPredicate); ok && !c.indexReaderDisabled {
+		if dict := cc.Dictionary(); dict != nil {
+			if m := dp.KeepIndexes(dict); m != nil {
+				return anyTrue(m), m
+			}
+		}
+	}
+	return c.filter.KeepColumnChunk(cc), nil
+}
 
-	// per page
-	active     bool    // fast path engaged for the current page
-	indices    []int32 // present-value dictionary indexes for the current page
+// indexReaderFor returns a dictionary fast-path reader for pg, or nil when
+// pushdown does not apply (disabled, non-dictionary predicate, non-dictionary
+// page, or the predicate declined). The match bitmap is resolved against the
+// chunk dictionary once and reused across all of the chunk's pages; when it is
+// nil the caller uses the per-row path.
+func (c *SyncIterator) indexReaderFor(pg pq.Page) *indexValueReader {
+	if c.indexReaderDisabled {
+		return nil
+	}
+	dp, ok := c.filter.(DictionaryPredicate)
+	if !ok {
+		return nil
+	}
+	dict := pg.Dictionary()
+	if dict == nil {
+		return nil // page is not dictionary-encoded
+	}
+
+	// Resolve the predicate against the dictionary once per chunk.
+	if !c.indexReaderChecked {
+		c.indexReaderChecked = true
+		c.indexReaderMatches = dp.KeepIndexes(dict)
+	}
+	if c.indexReaderMatches == nil {
+		return nil // predicate declined dictionary pushdown for this chunk
+	}
+
+	c.indexReaderPagesUsed++
+	return newIndexValueReader(c.indexReaderMatches, pg)
+}
+
+// indexValueReader serves one dictionary-encoded page on the fast path. The
+// predicate is pre-resolved into matches (indexed by dictionary index) and shared
+// across all pages in the chunk; the reader decodes this page's levels and
+// indices and advances one slot per next() call. It is a pure page decoder: row
+// numbers are tracked by the caller, driven by the levels next() returns.
+type indexValueReader struct {
+	matches []bool        // match bitmap indexed by dictionary index (chunk-scoped)
+	dict    pq.Dictionary // dictionary the matches were built against
+	col     int           // column index, stamped onto materialized values
+
+	indices    []int32 // present-value dictionary indexes for this page
 	defLevels  []byte  // nil for required columns
 	repLevels  []byte  // nil for non-repeated columns
-	pageMaxDef byte    // definition level of a present (non-null) value
+	pageMaxDef byte    // definition level of a present (non-null) leaf value on this page
 	slotN      int     // cursor over level slots (present + null)
 	valueN     int     // cursor over indices (present only)
 
 	value pq.Value // reused return buffer for matched values
 }
 
-// resetChunk clears the per-chunk keep bitmap. Called when the iterator advances
-// to a new column chunk (all pages in a chunk share one dictionary).
-func (d *dictScan) resetChunk() {
-	d.checked = false
-	d.keep = nil
-	d.dict = nil
-}
-
-// resetPage clears the per-page cursors. The per-chunk keep bitmap is preserved.
-func (d *dictScan) resetPage() {
-	d.active = false
-	d.indices = nil
-	d.defLevels = nil
-	d.repLevels = nil
-	d.pageMaxDef = 0
-	d.slotN = 0
-	d.valueN = 0
-}
-
-// setupPage enables the fast path for pg when filter can be resolved against the
-// chunk dictionary. The keep bitmap is computed once per chunk and reused across
-// the chunk's pages; only the per-page cursors are refreshed here. When pushdown
-// does not apply, active stays false and the caller uses the per-row path.
-func (d *dictScan) setupPage(filter Predicate, pg pq.Page) {
-	if d.disabled {
-		return
-	}
-	dp, ok := filter.(DictionaryPredicate)
-	if !ok {
-		return
-	}
-	dict := pg.Dictionary()
-	if dict == nil {
-		return // page is not dictionary-encoded
-	}
-
-	// Resolve the predicate against the dictionary once per chunk.
-	if !d.checked {
-		d.checked = true
-		d.keep = dp.KeepIndexes(dict)
-		d.dict = dict
-	}
-	if d.keep == nil {
-		return // predicate declined dictionary pushdown for this chunk
-	}
-
-	d.defLevels = pg.DefinitionLevels()
-	d.repLevels = pg.RepetitionLevels()
+func newIndexValueReader(matches []bool, pg pq.Page) *indexValueReader {
+	defLevels := pg.DefinitionLevels()
 	data := pg.Data()
-	d.indices = data.Int32()
-	// A present (non-null) leaf carries the maximum definition level seen on the
-	// page. Required columns have no definition levels and every index is present.
-	d.pageMaxDef = maxByte(d.defLevels)
+	return &indexValueReader{
+		matches:   matches,
+		dict:      pg.Dictionary(),
+		col:       pg.Column(),
+		indices:   data.Int32(),
+		defLevels: defLevels,
+		repLevels: pg.RepetitionLevels(),
+		// A present (non-null) leaf carries the maximum definition level seen on the
+		// page. (The iterator's maxDefinitionLevel is a row-number tracking cap, not
+		// necessarily this leaf's level, so we derive it from the page.) On a page with
+		// no present values this collapses to the null level, so the valueN bound in
+		// next() is what keeps such pages from indexing past the empty indices slice.
+		pageMaxDef: maxByte(defLevels),
+	}
+}
 
-	d.slotN = 0
-	d.valueN = 0
-	d.active = true
-	d.pagesUsed++
+// nextMatch advances over slots until it materializes a matching value or the page
+// is exhausted (ok=false). It owns the per-slot loop so a predicate-bound scan stays
+// in one tight loop rather than paying a method call per non-matching slot. Row
+// numbers are tracked exactly as the per-row path does: curr and pageN are advanced
+// for every slot (present, null, or filtered) via the caller's pointers, and
+// maxDefLevel is the row-number tracking cap. The returned value points at a reused
+// buffer, valid until the next call.
+func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel int) (*pq.Value, bool) {
+	numSlots := len(r.indices)
+	if r.defLevels != nil {
+		numSlots = len(r.defLevels)
+	}
+
+	for r.slotN < numSlots {
+		repLvl := 0
+		if r.repLevels != nil {
+			repLvl = int(r.repLevels[r.slotN])
+		}
+		// Required columns have no definition levels; every value is present at the
+		// page's (possibly zero) definition level.
+		defLvl := int(r.pageMaxDef)
+		if r.defLevels != nil {
+			defLvl = int(r.defLevels[r.slotN])
+		}
+		curr.Next(repLvl, defLvl, maxDefLevel)
+		r.slotN++
+		(*pageN)++
+
+		// Null/empty slot: not present at the leaf, so no value and no dictionary index
+		// is consumed. The valueN bound also guards pages that carry definition levels
+		// but no present values (an all-null page, where indices is empty), so we never
+		// index past indices/matches.
+		if (r.defLevels != nil && byte(defLvl) != r.pageMaxDef) || r.valueN >= len(r.indices) {
+			continue
+		}
+
+		idx := r.indices[r.valueN]
+		r.valueN++
+		if !r.matches[idx] {
+			continue
+		}
+
+		// Materialize only matching values, stamping the page levels and column so the
+		// result is indistinguishable from the per-row path.
+		r.value = r.dict.Index(idx).Level(repLvl, defLvl, r.col)
+		return &r.value, true
+	}
+	return nil, false
 }
 
 // NewSyncIterator iterates values in a column of a parquet file. Required values
@@ -762,13 +842,10 @@ func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int) (done
 		}
 
 		cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-		if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
-			cc.Close()
+		// This row group matches the row number; check the filter.
+		if !c.enterColumnChunk(rg, minRN, maxRN, cc) {
 			continue
 		}
-
-		// This row group matches both row number and filter.
-		c.setRowGroup(rg, minRN, maxRN, cc)
 	}
 
 	return c.currRowGroup == nil
@@ -848,7 +925,7 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 	// The dictionary fast path tracks its cursor against the whole page; reslicing
 	// would require rebuilding that state, so we let next() advance to the target
 	// instead. Correctness is unaffected, only the large-skip shortcut is skipped.
-	if c.dict.active {
+	if c.indexReader != nil {
 		return
 	}
 
@@ -927,12 +1004,9 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-			if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
-				cc.Close()
+			if !c.enterColumnChunk(rg, minRN, maxRN, cc) {
 				continue
 			}
-
-			c.setRowGroup(rg, minRN, maxRN, cc)
 		}
 
 		if c.currPage == nil {
@@ -954,15 +1028,17 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.setPage(pg)
 		}
 
-		// Dictionary fast path: match rows by integer dictionary index.
-		if c.dict.active {
-			rn, v, ok := c.nextDict()
+		// Dictionary fast path: match rows by integer dictionary index. The reader
+		// advances the row number over every slot (present, null, or filtered-out),
+		// exactly as the per-row path does, and returns only matched values.
+		if c.indexReader != nil {
+			v, ok := c.indexReader.nextMatch(&c.curr, &c.currPageN, c.maxDefinitionLevel)
 			if !ok {
 				// Page exhausted, move on.
 				c.setPage(nil)
 				continue
 			}
-			return rn, v, nil
+			return c.curr, v, nil
 		}
 
 		// Read next batch of values if needed
@@ -1011,9 +1087,10 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroupMax = max
 	c.currChunk = cc
 
-	// The dictionary keep bitmap is resolved once per column chunk (all data pages
-	// in a chunk share the same dictionary) and reset when the chunk changes.
-	c.dict.resetChunk()
+	// The match bitmap is resolved once per column chunk (all data pages in a chunk
+	// share the same dictionary) and reset when the chunk changes.
+	c.indexReaderChecked = false
+	c.indexReaderMatches = nil
 }
 
 func (c *SyncIterator) setPage(pg pq.Page) {
@@ -1030,7 +1107,7 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 	c.currPageMin = EmptyRowNumber()
 	c.currBufN = 0
 	c.currPageN = 0
-	c.dict.resetPage()
+	c.indexReader = nil
 
 	// If we don't immediately have a new incoming page
 	// then return the buffer to the pool.
@@ -1047,7 +1124,7 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 		c.currPageMin = c.curr
 		c.currPageMax = rn
 		c.currValues = pg.Values()
-		c.dict.setupPage(c.filter, pg)
+		c.indexReader = c.indexReaderFor(pg)
 	}
 }
 
@@ -1061,53 +1138,13 @@ func maxByte(b []byte) byte {
 	return m
 }
 
-// nextDict advances the dictionary fast path by one matching row in the current
-// page. ok is false when the page is exhausted. Row numbers are tracked across
-// every slot (including nulls) exactly as the per-row path does, but only present
-// values consume a dictionary index and only matching indexes are materialized.
-func (c *SyncIterator) nextDict() (RowNumber, *pq.Value, bool) {
-	d := &c.dict
-
-	numSlots := len(d.indices)
-	if d.defLevels != nil {
-		numSlots = len(d.defLevels)
+func anyTrue(b []bool) bool {
+	for _, v := range b {
+		if v {
+			return true
+		}
 	}
-
-	for d.slotN < numSlots {
-		repLvl := 0
-		if d.repLevels != nil {
-			repLvl = int(d.repLevels[d.slotN])
-		}
-		// Required columns have no definition levels; every value is present at the
-		// page's (possibly zero) definition level.
-		defLvl := int(d.pageMaxDef)
-		if d.defLevels != nil {
-			defLvl = int(d.defLevels[d.slotN])
-		}
-
-		c.curr.Next(repLvl, defLvl, c.maxDefinitionLevel)
-		d.slotN++
-		c.currPageN++
-
-		// Null slot: no value present and no dictionary index consumed. The gated
-		// predicates never keep nulls, matching the per-row path.
-		if d.defLevels != nil && byte(defLvl) != d.pageMaxDef {
-			continue
-		}
-
-		idx := d.indices[d.valueN]
-		d.valueN++
-
-		if !d.keep[idx] {
-			continue
-		}
-
-		// Materialize only matching values, stamping the page levels and column so
-		// the result is indistinguishable from the per-row path.
-		d.value = d.dict.Index(idx).Level(repLvl, defLvl, c.currPage.Column())
-		return c.curr, &d.value, true
-	}
-	return EmptyRowNumber(), nil, false
+	return false
 }
 
 func (c *SyncIterator) closeCurrRowGroup() {

--- a/pkg/parquetquery/iters_dict_bench_test.go
+++ b/pkg/parquetquery/iters_dict_bench_test.go
@@ -36,10 +36,8 @@ func BenchmarkSyncIteratorDictPushdown(b *testing.B) {
 				SyncIteratorOptSelectAs("S"),
 				SyncIteratorOptPredicate(NewStringInPredicate(targets)),
 			}
-			if disable {
-				opts = append(opts, SyncIteratorOptDisableDictPushdown())
-			}
 			iter := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+			iter.indexReaderDisabled = disable // test-only: force the per-row baseline
 			var count int
 			for {
 				res, err := iter.Next()

--- a/pkg/parquetquery/iters_dict_bench_test.go
+++ b/pkg/parquetquery/iters_dict_bench_test.go
@@ -1,0 +1,63 @@
+package parquetquery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// BenchmarkSyncIteratorDictPushdown compares the dictionary fast path against the
+// per-row byte-compare path for an exact-match string filter, the dominant shape
+// of live-store metrics queries.
+func BenchmarkSyncIteratorDictPushdown(b *testing.B) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	// Low-cardinality column (like span:name / service.name) with a small set of
+	// distinct values repeated across many rows.
+	alphabet := make([]string, 32)
+	for i := range alphabet {
+		alphabet[i] = fmt.Sprintf("operation-name-%02d", i)
+	}
+	rows := make([]row, 200_000)
+	for i := range rows {
+		rows[i] = row{S: alphabet[i%len(alphabet)]}
+	}
+
+	ctx := context.Background()
+	pf := createFileWith(b, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, "S")
+	targets := []string{alphabet[3], alphabet[17], alphabet[28]}
+
+	run := func(b *testing.B, disable bool) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			opts := []SyncIteratorOpt{
+				SyncIteratorOptSelectAs("S"),
+				SyncIteratorOptPredicate(NewStringInPredicate(targets)),
+			}
+			if disable {
+				opts = append(opts, SyncIteratorOptDisableDictPushdown())
+			}
+			iter := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+			var count int
+			for {
+				res, err := iter.Next()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if res == nil {
+					break
+				}
+				count++
+			}
+			iter.Close()
+			if count == 0 {
+				b.Fatal("expected matches")
+			}
+		}
+	}
+
+	b.Run("per-row", func(b *testing.B) { run(b, true) })
+	b.Run("dict-pushdown", func(b *testing.B) { run(b, false) })
+}

--- a/pkg/parquetquery/iters_dict_test.go
+++ b/pkg/parquetquery/iters_dict_test.go
@@ -40,10 +40,11 @@ func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred 
 			SyncIteratorOptPredicate(makePred()),
 			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
 		}
-		if disable {
-			opts = append(opts, SyncIteratorOptDisableDictPushdown())
-		}
-		return NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+		it := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+		// indexReaderDisabled is test-only state; the fast path is always on in prod.
+		// It is read lazily on the first page, so setting it post-construction is fine.
+		it.indexReaderDisabled = disable
+		return it
 	}
 
 	fast := newIter(false)
@@ -55,8 +56,8 @@ func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred 
 	slowRes := collectStringResults(t, slow, "S")
 
 	require.Equal(t, slowRes, fastRes, "dictionary fast path must match per-row results")
-	require.Greater(t, fast.DictFastPathPages(), 0, "fast path should have engaged")
-	require.Equal(t, 0, slow.DictFastPathPages(), "slow path should not use dict fast path")
+	require.Greater(t, fast.dictFastPathPages(), 0, "fast path should have engaged")
+	require.Equal(t, 0, slow.dictFastPathPages(), "slow path should not use dict fast path")
 }
 
 func TestSyncIteratorDictPushdownRequired(t *testing.T) {
@@ -166,5 +167,51 @@ func TestSyncIteratorDictPushdownFallsBackForNonDictPredicate(t *testing.T) {
 
 	got := collectStringResults(t, iter, "S")
 	require.NotEmpty(t, got)
-	require.Equal(t, 0, iter.DictFastPathPages(), "non-dictionary predicate must not use dict fast path")
+	require.Equal(t, 0, iter.dictFastPathPages(), "non-dictionary predicate must not use dict fast path")
+}
+
+// TestIndexValueReaderNoPresentValues guards the fast path against dictionary-
+// encoded pages that carry definition levels but no present leaf values (e.g. an
+// all-null optional page or a repeated page of only empty lists). There indices
+// is empty, so naively treating slots as present would index out of bounds. The
+// page must yield no matches, advance the row-number cursor once per slot (as the
+// per-row path does), and never panic.
+func TestIndexValueReaderNoPresentValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		defLevels []byte
+		repLevels []byte
+	}{
+		// All-null optional page: every slot below the present level, so pageMaxDef
+		// collapses to the null level and only the valueN bound prevents the panic.
+		{name: "all-null optional", defLevels: []byte{0, 0, 0, 0}},
+		// Repeated page of empty lists: rep=0 starts each row, def below present.
+		{name: "all-empty repeated", defLevels: []byte{0, 0, 0}, repLevels: []byte{0, 0, 0}},
+		// Pathological: a slot sits at pageMaxDef (looks present) but no index backs
+		// it. The bounds guard must treat it as null rather than indexing past indices.
+		{name: "present level without index", defLevels: []byte{1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &indexValueReader{
+				matches:    nil, // never consulted: no present values
+				dict:       nil,
+				indices:    nil, // empty: no present values on the page
+				defLevels:  tc.defLevels,
+				repLevels:  tc.repLevels,
+				pageMaxDef: maxByte(tc.defLevels), // mirrors newIndexValueReader
+			}
+
+			require.NotPanics(t, func() {
+				curr := EmptyRowNumber()
+				pageN := 0
+				v, ok := r.nextMatch(&curr, &pageN, MaxDefinitionLevel)
+				require.False(t, ok, "an all-null page must yield no matches")
+				require.Nil(t, v)
+				// Every slot must still have been walked (row numbers advanced).
+				require.Equal(t, len(tc.defLevels), pageN, "every slot should advance the cursor")
+			})
+		})
+	}
 }

--- a/pkg/parquetquery/iters_dict_test.go
+++ b/pkg/parquetquery/iters_dict_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 // collectStringResults drains an iterator returning (rowNumber, value-as-string)
-// pairs so that the dictionary fast path and the per-row slow path can be compared
-// for exact equivalence.
-func collectStringResults(t *testing.T, iter Iterator, selectAs string) []string {
+// pairs (the value is read from the "S" select, which every test here uses) so the
+// dictionary fast path and the per-row slow path can be compared for equivalence.
+func collectStringResults(t *testing.T, iter Iterator) []string {
 	t.Helper()
 	var out []string
 	for {
@@ -20,7 +20,7 @@ func collectStringResults(t *testing.T, iter Iterator, selectAs string) []string
 		if res == nil {
 			break
 		}
-		vals := res.ToMap()[selectAs]
+		vals := res.ToMap()["S"]
 		require.Len(t, vals, 1)
 		out = append(out, fmt.Sprintf("%v=%s", res.RowNumber, vals[0].String()))
 	}
@@ -52,8 +52,8 @@ func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred 
 	slow := newIter(true)
 	defer slow.Close()
 
-	fastRes := collectStringResults(t, fast, "S")
-	slowRes := collectStringResults(t, slow, "S")
+	fastRes := collectStringResults(t, fast)
+	slowRes := collectStringResults(t, slow)
 
 	require.Equal(t, slowRes, fastRes, "dictionary fast path must match per-row results")
 	require.Greater(t, fast.dictFastPathPages(), 0, "fast path should have engaged")
@@ -165,7 +165,7 @@ func TestSyncIteratorDictPushdownFallsBackForNonDictPredicate(t *testing.T) {
 	)
 	defer iter.Close()
 
-	got := collectStringResults(t, iter, "S")
+	got := collectStringResults(t, iter)
 	require.NotEmpty(t, got)
 	require.Equal(t, 0, iter.dictFastPathPages(), "non-dictionary predicate must not use dict fast path")
 }
@@ -214,4 +214,60 @@ func TestIndexValueReaderNoPresentValues(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestSyncIteratorDictPushdownOr drives the fast path through OrPredicate, whose
+// KeepIndexes ORs its dictionary-pushable children's bitmaps.
+func TestSyncIteratorDictPushdownOr(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		rows = append(rows, row{S: alphabet[i%len(alphabet)]})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate {
+		return NewOrPredicate(
+			NewByteEqualPredicate([]byte("alpha")),
+			NewByteEqualPredicate([]byte("delta")),
+		)
+	})
+}
+
+// TestSyncIteratorDictPushdownSkipsChunkWithNoMatch covers the chunk-skip path:
+// when no dictionary entry matches, the whole chunk is skipped before any page is
+// read, so the fast path serves zero pages while still returning correct (empty)
+// results identical to the per-row path.
+func TestSyncIteratorDictPushdownSkipsChunkWithNoMatch(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie"}
+	var rows []row
+	for i := 0; i < 4000; i++ {
+		rows = append(rows, row{S: alphabet[i%len(alphabet)]})
+	}
+	ctx := context.Background()
+	pf := createFileWith(t, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, "S")
+
+	newIter := func(disable bool) *SyncIterator {
+		it := NewSyncIterator(ctx, pf.RowGroups(), idx,
+			SyncIteratorOptSelectAs("S"),
+			SyncIteratorOptPredicate(NewStringInPredicate([]string{"no-such-value"})),
+			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
+		)
+		it.indexReaderDisabled = disable
+		return it
+	}
+
+	fast := newIter(false)
+	defer fast.Close()
+	slow := newIter(true)
+	defer slow.Close()
+
+	require.Empty(t, collectStringResults(t, fast))
+	require.Empty(t, collectStringResults(t, slow))
+	require.Equal(t, 0, fast.dictFastPathPages(), "a chunk with no matching dict entry should be skipped, not scanned")
 }

--- a/pkg/parquetquery/iters_dict_test.go
+++ b/pkg/parquetquery/iters_dict_test.go
@@ -1,0 +1,170 @@
+package parquetquery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// collectStringResults drains an iterator returning (rowNumber, value-as-string)
+// pairs so that the dictionary fast path and the per-row slow path can be compared
+// for exact equivalence.
+func collectStringResults(t *testing.T, iter Iterator, selectAs string) []string {
+	t.Helper()
+	var out []string
+	for {
+		res, err := iter.Next()
+		require.NoError(t, err)
+		if res == nil {
+			break
+		}
+		vals := res.ToMap()[selectAs]
+		require.Len(t, vals, 1)
+		out = append(out, fmt.Sprintf("%v=%s", res.RowNumber, vals[0].String()))
+	}
+	return out
+}
+
+func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred func() Predicate) {
+	ctx := context.Background()
+	pf := createFileWith(t, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, colPath)
+	require.GreaterOrEqual(t, idx, 0)
+
+	newIter := func(disable bool) *SyncIterator {
+		// Fresh predicate per iterator: some predicates (e.g. substring) memoize.
+		opts := []SyncIteratorOpt{
+			SyncIteratorOptSelectAs("S"),
+			SyncIteratorOptPredicate(makePred()),
+			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
+		}
+		if disable {
+			opts = append(opts, SyncIteratorOptDisableDictPushdown())
+		}
+		return NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+	}
+
+	fast := newIter(false)
+	defer fast.Close()
+	slow := newIter(true)
+	defer slow.Close()
+
+	fastRes := collectStringResults(t, fast, "S")
+	slowRes := collectStringResults(t, slow, "S")
+
+	require.Equal(t, slowRes, fastRes, "dictionary fast path must match per-row results")
+	require.Greater(t, fast.DictFastPathPages(), 0, "fast path should have engaged")
+	require.Equal(t, 0, slow.DictFastPathPages(), "slow path should not use dict fast path")
+}
+
+func TestSyncIteratorDictPushdownRequired(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		rows = append(rows, row{S: alphabet[i%len(alphabet)]})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate { return NewStringInPredicate([]string{"bravo", "delta"}) })
+}
+
+func TestSyncIteratorDictPushdownOptionalWithNulls(t *testing.T) {
+	type row struct {
+		S *string `parquet:",dict,optional"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		if i%7 == 0 {
+			rows = append(rows, row{S: nil}) // null
+			continue
+		}
+		v := alphabet[i%len(alphabet)]
+		rows = append(rows, row{S: &v})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate { return NewStringInPredicate([]string{"alpha", "charlie"}) })
+}
+
+func TestSyncIteratorDictPushdownRepeated(t *testing.T) {
+	type row struct {
+		S []string `parquet:",dict,list"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	var rows []row
+	for i := 0; i < 3000; i++ {
+		switch i % 4 {
+		case 0:
+			rows = append(rows, row{S: nil}) // empty list
+		case 1:
+			rows = append(rows, row{S: []string{alphabet[i%len(alphabet)]}})
+		default:
+			rows = append(rows, row{S: []string{
+				alphabet[i%len(alphabet)],
+				alphabet[(i+2)%len(alphabet)],
+			}})
+		}
+	}
+	runDictEquivalence(t, rows, "S.list.element", func() Predicate { return NewStringInPredicate([]string{"bravo", "echo"}) })
+}
+
+func TestSyncIteratorDictPushdownRegex(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		rows = append(rows, row{S: fmt.Sprintf("svc-%d", i%6)})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate {
+		p, err := NewRegexInPredicate([]string{"svc-[1-3]"})
+		require.NoError(t, err)
+		return p
+	})
+}
+
+func TestSyncIteratorDictPushdownSubstring(t *testing.T) {
+	type row struct {
+		S *string `parquet:",dict,optional"`
+	}
+	words := []string{"alpha-one", "bravo-two", "charlie-one", "delta-three"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		if i%9 == 0 {
+			rows = append(rows, row{S: nil})
+			continue
+		}
+		v := words[i%len(words)]
+		rows = append(rows, row{S: &v})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate { return NewSubstringPredicate("one") })
+}
+
+// A predicate that does not implement DictionaryPredicate must use the per-row
+// path (no fast path engaged) and still return correct results.
+func TestSyncIteratorDictPushdownFallsBackForNonDictPredicate(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	var rows []row
+	for i := 0; i < 1000; i++ {
+		rows = append(rows, row{S: fmt.Sprintf("svc-%d", i%5)})
+	}
+	ctx := context.Background()
+	pf := createFileWith(t, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, "S")
+
+	// ByteNotInPredicate keeps nulls, so it intentionally does not implement
+	// DictionaryPredicate.
+	iter := NewSyncIterator(ctx, pf.RowGroups(), idx,
+		SyncIteratorOptSelectAs("S"),
+		SyncIteratorOptPredicate(NewStringNotInPredicate([]string{"svc-1", "svc-2"})),
+	)
+	defer iter.Close()
+
+	got := collectStringResults(t, iter, "S")
+	require.NotEmpty(t, got)
+	require.Equal(t, 0, iter.DictFastPathPages(), "non-dictionary predicate must not use dict fast path")
+}

--- a/pkg/parquetquery/predicates_dict.go
+++ b/pkg/parquetquery/predicates_dict.go
@@ -45,14 +45,10 @@ func (p ByteEqualPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 }
 
 // regex and substring matching are pure functions of the value and reject nulls,
-// so they resolve against the dictionary just like exact matches. This is an even
-// bigger win for them because the per-row cost (regex / bytes.Contains) is far
-// higher than a byte comparison.
-//
-// These predicates memoize per-value match results and rely on a per-chunk reset
-// to keep that memoization bounded. The dictionary fast path resolves the bitmap
-// via KeepIndexes instead of KeepColumnChunk, so the reset lives here too - one
-// KeepIndexes call per column chunk - keeping the cache bounded over a long scan.
+// so they push down like exact matches (an even bigger win, since the per-row cost
+// is a regex / bytes.Contains rather than a byte compare). They memoize per value
+// and rely on a per-chunk reset to stay bounded; the fast path calls KeepIndexes
+// rather than KeepColumnChunk, so the reset lives here too — once per chunk.
 func (p *regexPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 	p.matcher.Reset()
 	return dictionaryKeepIndexes(dict, p.KeepValue)
@@ -63,19 +59,15 @@ func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 	return dictionaryKeepIndexes(dict, p.KeepValue)
 }
 
-// KeepIndexes supports dictionary pushdown only when every child is itself
-// dictionary-pushable. A nil child means "match all" and a non-dictionary child
-// (e.g. regex on a value the dictionary doesn't narrow) would require per-row
-// evaluation, so in both cases we return nil to disable the optimization.
-//
-// The bitmap is the OR of the children's bitmaps rather than a scan over the OR's
-// KeepValue, so each child's own KeepIndexes runs (resetting its memoization) and
-// the per-chunk bound is preserved for substring/regex children.
+// KeepIndexes pushes down only when every child does. It ORs the children's bitmaps
+// (rather than scanning the OR's KeepValue) so each child's own KeepIndexes runs,
+// preserving the per-chunk reset for substring/regex children. A nil child ("match
+// all") or a non-pushable child disables the optimization.
 func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 	var out []bool
 	for _, child := range p.preds {
 		if child == nil {
-			return nil // nil child means "match all" - not pushable
+			return nil
 		}
 		dp, ok := child.(DictionaryPredicate)
 		if !ok {
@@ -83,7 +75,7 @@ func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 		}
 		keep := dp.KeepIndexes(dict)
 		if keep == nil {
-			return nil // child declined pushdown for this dictionary
+			return nil // child declined for this dictionary
 		}
 		if out == nil {
 			out = keep

--- a/pkg/parquetquery/predicates_dict.go
+++ b/pkg/parquetquery/predicates_dict.go
@@ -48,11 +48,18 @@ func (p ByteEqualPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 // so they resolve against the dictionary just like exact matches. This is an even
 // bigger win for them because the per-row cost (regex / bytes.Contains) is far
 // higher than a byte comparison.
+//
+// These predicates memoize per-value match results and rely on a per-chunk reset
+// to keep that memoization bounded. The dictionary fast path resolves the bitmap
+// via KeepIndexes instead of KeepColumnChunk, so the reset lives here too - one
+// KeepIndexes call per column chunk - keeping the cache bounded over a long scan.
 func (p *regexPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	p.matcher.Reset()
 	return dictionaryKeepIndexes(dict, p.KeepValue)
 }
 
 func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	p.matches = make(map[string]bool, len(p.matches))
 	return dictionaryKeepIndexes(dict, p.KeepValue)
 }
 
@@ -60,14 +67,31 @@ func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 // dictionary-pushable. A nil child means "match all" and a non-dictionary child
 // (e.g. regex on a value the dictionary doesn't narrow) would require per-row
 // evaluation, so in both cases we return nil to disable the optimization.
+//
+// The bitmap is the OR of the children's bitmaps rather than a scan over the OR's
+// KeepValue, so each child's own KeepIndexes runs (resetting its memoization) and
+// the per-chunk bound is preserved for substring/regex children.
 func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	var out []bool
 	for _, child := range p.preds {
 		if child == nil {
+			return nil // nil child means "match all" - not pushable
+		}
+		dp, ok := child.(DictionaryPredicate)
+		if !ok {
 			return nil
 		}
-		if _, ok := child.(DictionaryPredicate); !ok {
-			return nil
+		keep := dp.KeepIndexes(dict)
+		if keep == nil {
+			return nil // child declined pushdown for this dictionary
+		}
+		if out == nil {
+			out = keep
+			continue
+		}
+		for i := range keep {
+			out[i] = out[i] || keep[i]
 		}
 	}
-	return dictionaryKeepIndexes(dict, p.KeepValue)
+	return out
 }

--- a/pkg/parquetquery/predicates_dict.go
+++ b/pkg/parquetquery/predicates_dict.go
@@ -1,0 +1,73 @@
+package parquetquery
+
+import pq "github.com/parquet-go/parquet-go"
+
+// DictionaryPredicate is an optional interface implemented by predicates that can
+// be evaluated directly against a column-chunk dictionary.
+//
+// When a column chunk is dictionary-encoded the iterator resolves the predicate
+// once over the (small) set of distinct dictionary values into a per-index keep
+// bitmap, then matches each row by its integer dictionary index. This avoids
+// materializing the value and running a byte comparison for every row, which
+// dominates CPU for exact-match string filters (service.name, span:name, etc.).
+//
+// Implementations must only advertise support when their KeepValue semantics over
+// present (non-null) values fully capture matching - i.e. the predicate does not
+// depend on null-ness beyond what KeepValue already returns for a present value.
+type DictionaryPredicate interface {
+	Predicate
+
+	// KeepIndexes resolves the predicate against dict and returns a bitmap of
+	// length dict.Len() where entry i is true iff dict.Index(i) satisfies the
+	// predicate. Returning nil signals that the predicate cannot be pushed down
+	// to the dictionary and the caller must fall back to per-row evaluation.
+	KeepIndexes(dict pq.Dictionary) []bool
+}
+
+// dictionaryKeepIndexes builds the keep bitmap by evaluating keep against every
+// distinct dictionary value once. The dictionary is small relative to the number
+// of rows, so this is paid once per column chunk rather than once per row.
+func dictionaryKeepIndexes(dict pq.Dictionary, keep func(pq.Value) bool) []bool {
+	n := dict.Len()
+	out := make([]bool, n)
+	for i := 0; i < n; i++ {
+		out[i] = keep(dict.Index(int32(i)))
+	}
+	return out
+}
+
+func (p *ByteInPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+func (p ByteEqualPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+// regex and substring matching are pure functions of the value and reject nulls,
+// so they resolve against the dictionary just like exact matches. This is an even
+// bigger win for them because the per-row cost (regex / bytes.Contains) is far
+// higher than a byte comparison.
+func (p *regexPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+// KeepIndexes supports dictionary pushdown only when every child is itself
+// dictionary-pushable. A nil child means "match all" and a non-dictionary child
+// (e.g. regex on a value the dictionary doesn't narrow) would require per-row
+// evaluation, so in both cases we return nil to disable the optimization.
+func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	for _, child := range p.preds {
+		if child == nil {
+			return nil
+		}
+		if _, ok := child.(DictionaryPredicate); !ok {
+			return nil
+		}
+	}
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}

--- a/pkg/parquetquery/predicates_dict_test.go
+++ b/pkg/parquetquery/predicates_dict_test.go
@@ -1,0 +1,67 @@
+package parquetquery
+
+import (
+	"testing"
+
+	pq "github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+// byteArrayDict builds a real parquet byte-array dictionary containing the given
+// values in order, so tests exercise the same Dictionary implementation used at
+// query time.
+func byteArrayDict(t testing.TB, values ...string) pq.Dictionary {
+	t.Helper()
+	dict := pq.ByteArrayType.NewDictionary(0, 0, pq.ByteArrayType.NewValues(nil, nil))
+	vals := make([]pq.Value, len(values))
+	for i, v := range values {
+		vals[i] = pq.ByteArrayValue([]byte(v))
+	}
+	idx := make([]int32, len(vals))
+	dict.Insert(idx, vals)
+	return dict
+}
+
+func TestByteInPredicateKeepIndexes(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo", "charlie", "delta")
+
+	p := NewStringInPredicate([]string{"bravo", "delta", "missing"})
+	dp, ok := p.(DictionaryPredicate)
+	require.True(t, ok, "ByteInPredicate should implement DictionaryPredicate")
+
+	require.Equal(t, []bool{false, true, false, true}, dp.KeepIndexes(dict))
+}
+
+func TestByteEqualPredicateKeepIndexes(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo", "charlie")
+
+	p := NewByteEqualPredicate([]byte("charlie"))
+	dp, ok := any(p).(DictionaryPredicate)
+	require.True(t, ok, "ByteEqualPredicate should implement DictionaryPredicate")
+
+	require.Equal(t, []bool{false, false, true}, dp.KeepIndexes(dict))
+}
+
+func TestOrPredicateKeepIndexes(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo", "charlie", "delta")
+
+	// OR of exact matches -> union of matching indexes
+	p := NewOrPredicate(
+		NewByteEqualPredicate([]byte("alpha")),
+		NewByteEqualPredicate([]byte("delta")),
+	)
+	require.Equal(t, []bool{true, false, false, true}, p.KeepIndexes(dict))
+}
+
+func TestOrPredicateKeepIndexesUnsupportedChild(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo")
+
+	// A child that is not dictionary-pushable (NOT IN keeps nulls, so it does not
+	// implement DictionaryPredicate) disables the optimization, signalled by a nil
+	// bitmap so the caller falls back to per-row evaluation.
+	p := NewOrPredicate(
+		NewByteEqualPredicate([]byte("alpha")),
+		NewStringNotInPredicate([]string{"bravo"}),
+	)
+	require.Nil(t, p.KeepIndexes(dict))
+}

--- a/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
+++ b/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
@@ -63,31 +63,37 @@ func BenchmarkBackendBlockMetricsQuery(b *testing.B) {
 		Exemplars: uint32(intEnv("VP5_BENCH_EXEMPLARS", 0)),
 	}
 
+	var em traceql.EvaluatorMetrics
 	b.ResetTimer()
 	for b.Loop() {
 		eval, err := e.CompileMetricsQueryRange(req, traceql.WithUnsafeHints(true))
 		require.NoError(b, err)
 		require.NoError(b, eval.Do(ctx, f, st, end, int(req.MaxSeries)))
 		_ = eval.Results()
-
-		em := eval.Metrics()
-		b.ReportMetric(float64(em.Bytes)/1024.0/1024.0, "MB_io/op")
-		b.ReportMetric(float64(em.SpansTotal), "spans/op")
+		em = eval.Metrics()
 	}
+	// Report once after the loop: ReportMetric overwrites, so calling it per
+	// iteration only adds overhead and keeps the last iteration's values anyway.
+	b.ReportMetric(float64(em.Bytes)/1024.0/1024.0, "MB_io/op")
+	b.ReportMetric(float64(em.SpansTotal), "spans/op")
 }
 
+// durationEnv reads a duration from name, falling back to def when unset, invalid,
+// or non-positive (a negative step would overflow the uint64 request field).
 func durationEnv(name string, def time.Duration) time.Duration {
 	if v := os.Getenv(name); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			return d
 		}
 	}
 	return def
 }
 
+// intEnv reads a non-negative int from name, falling back to def when unset,
+// invalid, or negative (a negative value would overflow the uint32 request field).
 func intEnv(name string, def int) int {
 	if v := os.Getenv(name); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			return n
 		}
 	}

--- a/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
+++ b/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
@@ -1,0 +1,95 @@
+package vparquet5
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkBackendBlockMetricsQuery runs an arbitrary metrics query_range against
+// a block on local disk. It is opt-in: the query and the block location are
+// supplied entirely via environment variables and the benchmark skips when they
+// are not set, so it never runs as part of a normal `go test`/CI run and embeds
+// no query or data in the source tree.
+//
+//	VP5_BENCH_PATH      backend root (block lives at <PATH>/<TENANTID>/<BLOCKID>)
+//	VP5_BENCH_TENANTID  tenant id (default "1")
+//	VP5_BENCH_BLOCKID   block guid
+//	VP5_BENCH_QUERY     TraceQL metrics query to run
+//	VP5_BENCH_STEP      step duration (default "1m")
+//	VP5_BENCH_EXEMPLARS exemplars per series (default 0)
+//
+// Example:
+//
+//	VP5_BENCH_PATH=/path/to/blocks VP5_BENCH_TENANTID=1 \
+//	VP5_BENCH_BLOCKID=<guid> VP5_BENCH_QUERY='{ name = "foo" } | rate()' \
+//	go test ./tempodb/encoding/vparquet5/ -run '^$' -bench BenchmarkBackendBlockMetricsQuery -cpuprofile cpu.out
+func BenchmarkBackendBlockMetricsQuery(b *testing.B) {
+	query := os.Getenv("VP5_BENCH_QUERY")
+	if query == "" || os.Getenv("VP5_BENCH_PATH") == "" || os.Getenv("VP5_BENCH_BLOCKID") == "" {
+		b.Skip("set VP5_BENCH_QUERY, VP5_BENCH_PATH and VP5_BENCH_BLOCKID to run this benchmark")
+	}
+
+	var (
+		e     = traceql.NewEngine()
+		ctx   = context.Background()
+		opts  = common.DefaultSearchOptions()
+		block = blockForBenchmarks(b)
+		st    = uint64(block.meta.StartTime.UnixNano())
+		end   = uint64(block.meta.EndTime.UnixNano())
+		f     = traceql.NewSpansetFetcherWrapperBoth(
+			func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+				return block.Fetch(ctx, req, opts)
+			},
+			func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansOnlyResponse, error) {
+				return block.FetchSpans(ctx, req, opts)
+			},
+		)
+	)
+
+	req := &tempopb.QueryRangeRequest{
+		Query:     query,
+		Step:      uint64(durationEnv("VP5_BENCH_STEP", time.Minute)),
+		Start:     st,
+		End:       end,
+		MaxSeries: 1000,
+		Exemplars: uint32(intEnv("VP5_BENCH_EXEMPLARS", 0)),
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		eval, err := e.CompileMetricsQueryRange(req, traceql.WithUnsafeHints(true))
+		require.NoError(b, err)
+		require.NoError(b, eval.Do(ctx, f, st, end, int(req.MaxSeries)))
+		_ = eval.Results()
+
+		em := eval.Metrics()
+		b.ReportMetric(float64(em.Bytes)/1024.0/1024.0, "MB_io/op")
+		b.ReportMetric(float64(em.SpansTotal), "spans/op")
+	}
+}
+
+func durationEnv(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+func intEnv(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}


### PR DESCRIPTION
**What this PR does**

Adds a dictionary fast path to `SyncIterator` for string predicates that are a pure function of the value — equality, `IN`, `OR`-of-those, regex, and substring.

Normally these materialize every value and re-run the predicate per row. When a column chunk is dictionary-encoded, this resolves the predicate **once** against the dictionary into a keep bitmap and matches each row by its integer dictionary index — no per-row materialization or re-evaluation. It's an opt-in `DictionaryPredicate` interface, so non-implementers and non-dictionary pages keep the existing per-row path. Results and I/O are unchanged; only public `parquet-go` APIs are used.

Also adds an opt-in, env-parameterized `BenchmarkBackendBlockMetricsQuery` (query + block supplied via env vars, skips by default — no query or data in the source tree).

**Benchmarks**

Microbenchmark (low-cardinality string column, exact-match `IN`): **~2.3×** (2522 → 1097 µs/op).

Metrics `query_range` (string filters + `quantile_over_time`) over one production vParquet5 block — `benchstat`, n=6, **identical results and bytes read** in every case:

| scenario | matched spans | before | after | Δ time | Δ allocs/op | Δ B/op |
|---|---:|---:|---:|---:|---:|---:|
| equality, no matches (predicate-bound) | 0 | 104.5 ms | 68.4 ms | **−34.5%** | −0.3% | ~0 |
| substring `=~ ".*…"` | 8,413 | 42.0 ms | 29.9 ms | **−28.8%** | ~0 | +9.8% |
| regex, prefix-anchored | 8,413 | 40.1 ms | 30.0 ms | **−25.2%** | ~0 | +8.9% |
| equality `OR`-list | 7,538 | 104.4 ms | 78.2 ms | **−25.2%** | −0.3% | −6.1% |

CPU-only win: the per-row `KeepValue` + materialization frames leave the profile, replaced by a single index-match path. Allocation *count* is flat across all scenarios; total *bytes* allocated shift slightly and inconsistently (−6% to +10%), dwarfed by the time saved. Gains are largest for predicate-bound queries, where per-row evaluation dominates over work this doesn't touch (decompression, aggregation).

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
