### PR TITLE
docs: add documentation for recent merged PRs

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -734,7 +734,7 @@ GET /api/metrics/query?q={status=error}|count_over_time()by(resource.service.nam
 ### Trace diff
 
 {{< admonition type="warning" >}}
-This endpoint is EXPERIMENTAL. The request format and behavior may change in future releases. The diff computation isn't implemented yet; the endpoint currently returns `501 Not Implemented` for valid requests.
+This endpoint is experimental. The request format and behavior may change in future releases. The diff computation isn't implemented yet; the endpoint currently returns `501 Not Implemented` for valid requests.
 {{< /admonition >}}
 
 Compare two traces and produce a structural diff. Send a `POST` request with a JSON body that identifies both traces by their IDs.

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -737,7 +737,7 @@ GET /api/metrics/query?q={status=error}|count_over_time()by(resource.service.nam
 This endpoint is experimental. The request format and behavior may change in future releases. The diff computation isn't implemented yet; the endpoint currently returns `501 Not Implemented` for valid requests.
 {{< /admonition >}}
 
-Compare two traces and produce a structural diff. Send a `POST` request with a JSON body that identifies both traces by their IDs.
+This endpoint will compare two traces and produce a structural diff. Send a `POST` request with a JSON body that identifies both traces by their IDs.
 
 ```
 POST /api/v2/traces/diff
@@ -763,19 +763,19 @@ Request body:
 Parameters:
 
 - `base.traceId`
-   Trace ID for the baseline trace, as a hexadecimal string.
+  Trace ID for the baseline trace, as a hexadecimal string.
 - `base.start`
-   Optional. Start of the time range to search for the baseline trace (unix epoch seconds).
+  Optional. Start of the time range to search for the baseline trace (UNIX epoch seconds).
 - `base.end`
-   Optional. End of the time range to search for the baseline trace (unix epoch seconds).
+  Optional. End of the time range to search for the baseline trace (UNIX epoch seconds).
 - `compare.traceId`
-   Trace ID for the comparison trace, as a hexadecimal string.
+  Trace ID for the comparison trace, as a hexadecimal string.
 - `compare.start`
-   Optional. Start of the time range to search for the comparison trace (unix epoch seconds).
+  Optional. Start of the time range to search for the comparison trace (UNIX epoch seconds).
 - `compare.end`
-   Optional. End of the time range to search for the comparison trace (unix epoch seconds).
+  Optional. End of the time range to search for the comparison trace (UNIX epoch seconds).
 
-When `start` and `end` are provided for a trace, Tempo only searches blocks within that time range. If omitted, Tempo searches across all blocks.
+When `start` and `end` are provided, the request validates that `start` is before `end`. When the endpoint is fully implemented, these fields will limit block search to that time range. If omitted, Tempo will search across all blocks.
 
 Only `POST` is allowed. Other methods return `405 Method Not Allowed`.
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -41,6 +41,7 @@ For externally supported gRPC API, [refer to Tempo gRPC API](#tempo-grpc-api).
 | [Search tag values V2](#search-tag-values-v2)                                         | Query-frontend                            | HTTP | `GET /api/v2/search/tag/<tag>/values`                     |
 | [TraceQL Metrics](#traceql-metrics)                                                   | Query-frontend                            | HTTP | `GET /api/metrics/query_range`                            |
 | [TraceQL Metrics (instant)](#instant)                                                 | Query-frontend                            | HTTP | `GET /api/metrics/query`                                  |
+| [Trace diff](#trace-diff) (\*)                                                        | Query-frontend                            | HTTP | `POST /api/v2/traces/diff`                                |
 | [Query Echo Endpoint](#query-echo-endpoint)                                           | Query-frontend                            | HTTP | `GET /api/echo`                                           |
 | [Overrides API](#overrides-api)                                                       | Query-frontend                            | HTTP | `GET,POST,PATCH,DELETE /api/overrides`                    |
 | Memberlist                                                                            | Distributor, Querier, Live store          | HTTP | `GET /memberlist`                                         |
@@ -351,7 +352,7 @@ The keys in `additionalMetrics` are stable and additive: clients should treat un
 ### Search tags
 
 Live store configuration `complete_block_timeout` affects how long tags are available for search.
-Tag search is supported in blocks as well, based on the start and end query parameters. 
+Tag search is supported in blocks as well, based on the start and end query parameters.
 Tag value search is also supported.
 
 This endpoint retrieves all discovered tag names that can be used in search.
@@ -729,6 +730,54 @@ Actual API parameters must be URL-encoded. This example is left unencoded for re
 ```
 GET /api/metrics/query?q={status=error}|count_over_time()by(resource.service.name)
 ```
+
+### Trace diff
+
+{{< admonition type="warning" >}}
+This endpoint is EXPERIMENTAL. The request format and behavior may change in future releases. The diff computation isn't implemented yet; the endpoint currently returns `501 Not Implemented` for valid requests.
+{{< /admonition >}}
+
+Compare two traces and produce a structural diff. Send a `POST` request with a JSON body that identifies both traces by their IDs.
+
+```
+POST /api/v2/traces/diff
+```
+
+Request body:
+
+```json
+{
+  "base": {
+    "traceId": "<BASE_TRACE_ID>",
+    "start": 1700000000,
+    "end": 1700003600
+  },
+  "compare": {
+    "traceId": "<COMPARE_TRACE_ID>",
+    "start": 1700100000,
+    "end": 1700103600
+  }
+}
+```
+
+Parameters:
+
+- `base.traceId`
+   Trace ID for the baseline trace, as a hexadecimal string.
+- `base.start`
+   Optional. Start of the time range to search for the baseline trace (unix epoch seconds).
+- `base.end`
+   Optional. End of the time range to search for the baseline trace (unix epoch seconds).
+- `compare.traceId`
+   Trace ID for the comparison trace, as a hexadecimal string.
+- `compare.start`
+   Optional. Start of the time range to search for the comparison trace (unix epoch seconds).
+- `compare.end`
+   Optional. End of the time range to search for the comparison trace (unix epoch seconds).
+
+When `start` and `end` are provided for a trace, Tempo only searches blocks within that time range. If omitted, Tempo searches across all blocks.
+
+Only `POST` is allowed. Other methods return `405 Method Not Allowed`.
 
 ### Query Echo endpoint
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2359,8 +2359,7 @@ overrides:
 
       # Per-user max duration for metrics queries. If this value is set to 0 (default), then metrics max_duration
       #  in the front-end configuration is used. This limit is enforced against the user-provided time range,
-      #  not the post-alignment range. Queries whose entire window falls within query_end_cutoff are rejected
-      #  with a 400 error.
+      #  not the post-alignment range. Queries whose entire window falls within query_end_cutoff are rejected.
       [max_metrics_duration: <duration> | default = 0s]
 
       # Per-user option to left-pad trace IDs with zeros to 32 hex characters in search API responses.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1193,9 +1193,9 @@ When set to `0`, there is no maximum and users can request any number of spans, 
 
 You can set the maximum length of a query using `query_frontend.max_query_expression_size_bytes` configuration parameter for the query-frontend. The default value is 128 KB.
 
-This limit is used to protect the system’s stability from potential abuse or mistakes, when running a large potentially expensive query.
+This limit protects system stability from potential abuse or mistakes when running large, potentially expensive queries. Tempo enforces this limit before parsing the TraceQL expression, so queries that exceed the configured size are rejected immediately with a clear error message.
 
-You can set the value lower of higher by setting it in the `query_frontend` configuration section, for example:
+You can set the value lower or higher in the `query_frontend` configuration section, for example:
 
 ```
 query_frontend:
@@ -2358,7 +2358,9 @@ overrides:
       [max_search_duration: <duration> | default = 0s]
 
       # Per-user max duration for metrics queries. If this value is set to 0 (default), then metrics max_duration
-      #  in the front-end configuration is used.
+      #  in the front-end configuration is used. This limit is enforced against the user-provided time range,
+      #  not the post-alignment range. Queries whose entire window falls within query_end_cutoff are rejected
+      #  with a 400 error.
       [max_metrics_duration: <duration> | default = 0s]
 
       # Per-user option to left-pad trace IDs with zeros to 32 hex characters in search API responses.

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -863,7 +863,7 @@ tempo-cli gen attr-index --add-intrinsics ./path/to/block
 ## Experimental trace diff
 
 {{< admonition type="warning" >}}
-This command is EXPERIMENTAL. The output format and behavior may change in future releases.
+This command is experimental. The output format and behavior may change in future releases.
 {{< /admonition >}}
 
 Compare two local trace JSON files and produce a structural diff in `trace-patch-v0` format. The diff output identifies spans that were added, removed, or modified between a baseline trace and a comparison trace.

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -860,6 +860,45 @@ Example with intrinsic attributes:
 tempo-cli gen attr-index --add-intrinsics ./path/to/block
 ```
 
+## Experimental trace diff
+
+{{< admonition type="warning" >}}
+This command is EXPERIMENTAL. The output format and behavior may change in future releases.
+{{< /admonition >}}
+
+Compare two local trace JSON files and produce a structural diff in `trace-patch-v0` format. The diff output identifies spans that were added, removed, or modified between a baseline trace and a comparison trace.
+
+Use this command to compare traces captured at different times or from different environments, for example, to understand how a deployment changed trace structure.
+
+```bash
+tempo-cli experimental trace-diff --trace-a <BASELINE_PATH> --trace-b <COMPARISON_PATH>
+```
+
+Arguments:
+
+- `--trace-a <path>` (required) Path to the baseline trace JSON file.
+- `--trace-b <path>` (required) Path to the comparison trace JSON file.
+
+Options:
+
+- `--format <value>` Output format (default: `trace-patch-v0`).
+- `-o, --out <path>` File to write output to. If not specified, output is printed to `stdout`.
+- `--pretty` Pretty-print JSON output.
+
+The input files can be either raw OpenTelemetry JSON traces or Tempo `TraceByIDResponse` JSON responses.
+
+Example:
+
+```bash
+tempo-cli experimental trace-diff --trace-a baseline.json --trace-b compare.json --pretty
+```
+
+Example writing output to a file:
+
+```bash
+tempo-cli experimental trace-diff --trace-a baseline.json --trace-b compare.json -o diff-output.json
+```
+
 ## Drop traces by ID
 
 Rewrites all blocks for a tenant that contain specific trace IDs. The traces are dropped from

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -881,7 +881,7 @@ Arguments:
 
 Options:
 
-- `--format <value>` Output format (default: `trace-patch-v0`).
+- `--format <value>` Output format. Currently only `trace-patch-v0` is supported (default).
 - `-o, --out <path>` File to write output to. If not specified, output is printed to `stdout`.
 - `--pretty` Pretty-print JSON output.
 


### PR DESCRIPTION
Document four recently merged PRs that were missing documentation:

- **#7468**: Add experimental `trace-diff` CLI command to `tempo_cli.md` (@javiermolinar)
- **#7523**: Add experimental `POST /api/v2/traces/diff` endpoint to API docs (@javiermolinar)
- **#7245**: Clarify that `max_query_expression_size_bytes` is enforced before parsing (@carles-grafana)
- **#7170**: Clarify `max_metrics_duration` validation against user-provided range (@carles-grafana)

Identified via docs-pr-check scan of merged PRs from the past three weeks.