### PR TITLE
feat: implement diff endpoint internals

### DIFF
--- a/.chloggen/feat-implement-diff-endpoint.yaml
+++ b/.chloggen/feat-implement-diff-endpoint.yaml
@@ -8,7 +8,7 @@ change_type: feature
 component: query-frontend
 
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
-note: Implements the diff endpoint. No cache or extra protection mechanimsn yet
+note: Implements the diff endpoint. No cache or extra protection mechanisms yet
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.

--- a/.chloggen/feat-implement-diff-endpoint.yaml
+++ b/.chloggen/feat-implement-diff-endpoint.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: feature
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Implements the diff endpoint. No cache or extra protection mechanimsn yet
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolinar

--- a/integration/api/api_test.go
+++ b/integration/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/grafana/tempo/integration/util"
 	"github.com/grafana/tempo/pkg/collector"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/grafana/tempo/pkg/search"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
@@ -567,6 +569,71 @@ func TestTraceByIDandTraceQL(t *testing.T) {
 			util.SearchStreamAndAssertTrace(t, ctx, grpcClient, i, now.Add(-time.Hour).Unix(), now.Add(time.Hour).Unix())
 		}
 	})
+}
+
+func TestTraceDiff(t *testing.T) {
+	util.RunIntegrationTests(t, util.TestHarnessConfig{
+		Components: util.ComponentsRecentDataQuerying | util.ComponentsBackendQuerying,
+	}, func(h *util.TempoHarness) {
+		h.WaitTracesWritable(t)
+
+		infos := tempoUtil.NewTraceInfos(time.Now(), 2, "")
+		for _, info := range infos {
+			require.NoError(t, h.WriteTraceInfo(info, ""))
+		}
+
+		h.WaitTracesQueryable(t, len(infos))
+		callTraceDiffAndAssert(t, h, infos[0], infos[1])
+
+		h.WaitTracesWrittenToBackend(t, len(infos))
+		h.ForceBackendQuerying(t)
+		callTraceDiffAndAssert(t, h, infos[0], infos[1])
+	})
+}
+
+func callTraceDiffAndAssert(t *testing.T, h *util.TempoHarness, base, compare *tempoUtil.TraceInfo) {
+	t.Helper()
+
+	body := strings.NewReader(fmt.Sprintf(`{"base":{"traceId":"%s"},"compare":{"traceId":"%s"}}`, base.HexID(), compare.HexID()))
+	req, err := http.NewRequest(http.MethodPost, h.BaseURL()+"/api/v2/traces/diff", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+
+	var result tracediff.Result
+	require.NoError(t, json.Unmarshal(respBody, &result))
+	require.Equal(t, tracediff.VersionTracePatchV0, result.Version)
+	require.Equal(t, base.HexID(), result.Base.TraceID)
+	require.Equal(t, compare.HexID(), result.Compare.TraceID)
+
+	baseTrace, err := base.ConstructTraceFromEpoch()
+	require.NoError(t, err)
+	compareTrace, err := compare.ConstructTraceFromEpoch()
+	require.NoError(t, err)
+	require.Equal(t, countTraceDiffSpans(baseTrace), result.Base.SpanCount)
+	require.Equal(t, countTraceDiffSpans(compareTrace), result.Compare.SpanCount)
+	require.Equal(t, result.Base.SpanCount, result.Stats.SpanCountA)
+	require.Equal(t, result.Compare.SpanCount, result.Stats.SpanCountB)
+}
+
+func countTraceDiffSpans(trace *tempopb.Trace) int {
+	if trace == nil {
+		return 0
+	}
+	var count int
+	for _, rs := range trace.ResourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			count += len(ss.Spans)
+		}
+	}
+	return count
 }
 
 func TestStreamingSearch_badRequest(t *testing.T) {

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -232,7 +232,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 
 	traces := newTraceIDHandler(cfg, tracePipeline, o, combiner.NewTypedTraceByID, logger, dataAccessController)
 	tracesV2 := newTraceIDV2Handler(cfg, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
-	traceDiff := newTraceDiffHandler(logger)
+	traceDiff := newTraceDiffHandler(cfg, apiPrefix, tracePipeline, o, combiner.NewTypedTraceByIDV2, cacheProvider, logger, dataAccessController)
 	search := newSearchHTTPHandler(cfg, searchPipeline, o, logger, dataAccessController)
 	searchTags := newTagsHTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagsV2 := newTagsV2HTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)

--- a/modules/frontend/tracediff_handler.go
+++ b/modules/frontend/tracediff_handler.go
@@ -1,22 +1,50 @@
 package frontend
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"path"
+	"strconv"
 	"strings"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level" //nolint:all //deprecated
+	"github.com/gorilla/mux"
+	"github.com/grafana/tempo/modules/frontend/combiner"
+	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/cache"
+	"github.com/grafana/tempo/pkg/model/tracediff"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-const traceDiffNotImplementedMessage = "trace diff endpoint is not implemented"
+const (
+	traceByIDStartParam = "start"
+	traceByIDEndParam   = "end"
+)
 
-// newTraceDiffHandler creates an HTTP handler skeleton for trace diff requests.
-//
-// EXPERIMENTAL: this endpoint is not yet a stable API contract. Diff execution
-// will be added in a follow-up change.
-func newTraceDiffHandler(logger log.Logger) http.RoundTripper {
+var (
+	errTraceDiffTraceNotFound = errors.New("trace not found")
+	errTraceDiffPartialTrace  = errors.New("partial traces cannot be diffed")
+)
+
+// newTraceDiffHandler creates an HTTP handler for trace diff requests.
+// EXPERIMENTAL: this endpoint is not yet a stable API contract.
+func newTraceDiffHandler(_ Config, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], _ cache.Provider, logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+	fetchTrace := func(ctx context.Context, tenant string, traceReq api.TraceDiffTraceRequest, headers http.Header) (*tempopb.TraceByIDResponse, error) {
+		return fetchTraceForDiff(ctx, tenant, traceReq, headers, apiPrefix, tracePipeline, o, combinerFn, logger, dataAccessController)
+	}
+
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodPost {
 			return &http.Response{
@@ -31,19 +59,215 @@ func newTraceDiffHandler(logger log.Logger) http.RoundTripper {
 			return errResp, nil
 		}
 
-		if _, err := api.ParseTraceDiffRequest(req); err != nil {
+		diffReq, err := api.ParseTraceDiffRequest(req)
+		if err != nil {
 			return httpInvalidRequest(err), nil
 		}
 
 		level.Info(logger).Log(
 			"msg", "trace diff request",
 			"tenant", tenant,
-			"path", req.URL.Path)
+			"path", req.URL.Path,
+			"base_trace_id", diffReq.Base.TraceID,
+			"base_start", traceDiffTimeParam(diffReq.Base.Start),
+			"base_end", traceDiffTimeParam(diffReq.Base.End),
+			"compare_trace_id", diffReq.Compare.TraceID,
+			"compare_start", traceDiffTimeParam(diffReq.Compare.Start),
+			"compare_end", traceDiffTimeParam(diffReq.Compare.End))
 
-		return &http.Response{
-			StatusCode: http.StatusNotImplemented,
-			Status:     http.StatusText(http.StatusNotImplemented),
-			Body:       io.NopCloser(strings.NewReader(traceDiffNotImplementedMessage)),
-		}, nil
+		baseResp, compareResp, err := fetchTracesForDiff(req.Context(), tenant, diffReq, req.Header, fetchTrace)
+		if err != nil {
+			return traceDiffErrorResponse(err), nil
+		}
+
+		result, err := tracediff.Diff(baseResp.Trace, compareResp.Trace, tracediff.Format(diffReq.Format))
+		if err != nil {
+			return traceDiffErrorResponse(err), nil
+		}
+
+		body, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("marshal trace diff response: %w", err)
+		}
+		return traceDiffJSONResponse(body), nil
 	})
+}
+
+func traceDiffTimeParam(v *int64) any {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// It builds an http request to pass to the TraceByIdHandler
+func buildTraceDiffTraceByIDRequest(ctx context.Context, apiPrefix string, traceReq api.TraceDiffTraceRequest, headers http.Header) *http.Request {
+	u := &url.URL{
+		Path: path.Join(apiPrefix, "/api/v2/traces", traceReq.TraceID),
+	}
+	q := u.Query()
+	if traceReq.Start != nil {
+		q.Set(traceByIDStartParam, strconv.FormatInt(*traceReq.Start, 10))
+	}
+	if traceReq.End != nil {
+		q.Set(traceByIDEndParam, strconv.FormatInt(*traceReq.End, 10))
+	}
+	u.RawQuery = q.Encode()
+
+	reqHeaders := headers.Clone()
+	if reqHeaders == nil {
+		reqHeaders = http.Header{}
+	}
+
+	req := (&http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Header: reqHeaders,
+		Body:   http.NoBody,
+	}).WithContext(ctx)
+	req.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
+
+	return mux.SetURLVars(req, map[string]string{"traceID": traceReq.TraceID})
+}
+
+func fetchTraceForDiff(ctx context.Context, tenant string, traceReq api.TraceDiffTraceRequest, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) (*tempopb.TraceByIDResponse, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	traceByIDReq := buildTraceDiffTraceByIDRequest(ctx, apiPrefix, traceReq, headers)
+	traceRedactor, err := traceRedactorForDiff(traceByIDReq, logger, dataAccessController)
+	if err != nil {
+		return nil, fmt.Errorf("authorize trace %s: %w", traceReq.TraceID, err)
+	}
+
+	resps, err := tracePipeline.RoundTrip(pipeline.NewHTTPRequest(traceByIDReq))
+	if err != nil {
+		return nil, fmt.Errorf("fetch trace %s: %w", traceReq.TraceID, err)
+	}
+
+	comb := combinerFn(o.MaxBytesPerTrace(tenant), api.MarshallingFormatProtobuf, traceRedactor)
+	for {
+		resp, done, err := resps.Next(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read trace %s response: %w", traceReq.TraceID, err)
+		}
+		if resp != nil {
+			if err := comb.AddResponse(resp); err != nil {
+				return nil, fmt.Errorf("combine trace %s response: %w", traceReq.TraceID, err)
+			}
+		}
+		if comb.ShouldQuit() || done {
+			break
+		}
+	}
+
+	traceResp, err := comb.GRPCFinal()
+	if err != nil {
+		return nil, fmt.Errorf("finalize trace %s response: %w", traceReq.TraceID, err)
+	}
+	if traceResp == nil || !traceHasSpans(traceResp.Trace) {
+		return nil, fmt.Errorf("trace %s: %w", traceReq.TraceID, errTraceDiffTraceNotFound)
+	}
+	if traceResp.GetStatus() == tempopb.PartialStatus_PARTIAL {
+		return nil, fmt.Errorf("trace %s: %w", traceReq.TraceID, errTraceDiffPartialTrace)
+	}
+	return traceResp, nil
+}
+
+func fetchTracesForDiff(ctx context.Context, tenant string, diffReq *api.TraceDiffRequest, headers http.Header, fetchTrace func(context.Context, string, api.TraceDiffTraceRequest, http.Header) (*tempopb.TraceByIDResponse, error)) (*tempopb.TraceByIDResponse, *tempopb.TraceByIDResponse, error) {
+	g, ctx := errgroup.WithContext(ctx)
+	var (
+		baseResp       *tempopb.TraceByIDResponse
+		compareResp    *tempopb.TraceByIDResponse
+		baseHeaders    = headers.Clone()
+		compareHeaders = headers.Clone()
+	)
+
+	g.Go(func() error {
+		resp, err := fetchTrace(ctx, tenant, diffReq.Base, baseHeaders)
+		if err != nil {
+			return fmt.Errorf("fetch base trace: %w", err)
+		}
+		baseResp = resp
+		return nil
+	})
+	g.Go(func() error {
+		resp, err := fetchTrace(ctx, tenant, diffReq.Compare, compareHeaders)
+		if err != nil {
+			return fmt.Errorf("fetch compare trace: %w", err)
+		}
+		compareResp = resp
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, nil, err
+	}
+	return baseResp, compareResp, nil
+}
+
+func traceRedactorForDiff(req *http.Request, logger log.Logger, dataAccessController DataAccessController) (combiner.TraceRedactor, error) {
+	if dataAccessController == nil {
+		return nil, nil
+	}
+
+	traceRedactor, err := dataAccessController.HandleHTTPTraceByIDReq(req)
+	if err != nil {
+		level.Error(logger).Log("msg", "trace diff: failed to get trace redactor", "err", err)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	return traceRedactor, nil
+}
+
+func traceHasSpans(trace *tempopb.Trace) bool {
+	if trace == nil {
+		return false
+	}
+	for _, rs := range trace.ResourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			if len(ss.Spans) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func traceDiffJSONResponse(body []byte) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     http.StatusText(http.StatusOK),
+		Header: http.Header{
+			api.HeaderContentType: []string{api.HeaderAcceptJSON},
+		},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+func traceDiffErrorResponse(err error) *http.Response {
+	statusCode := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, errTraceDiffTraceNotFound):
+		statusCode = http.StatusNotFound
+	case errors.Is(err, errTraceDiffPartialTrace):
+		statusCode = http.StatusUnprocessableEntity
+	case status.Code(err) == codes.NotFound:
+		statusCode = http.StatusNotFound
+	case status.Code(err) == codes.InvalidArgument:
+		statusCode = http.StatusBadRequest
+	case status.Code(err) == codes.ResourceExhausted:
+		statusCode = http.StatusTooManyRequests
+	}
+
+	body := err.Error()
+	if statusCode == http.StatusNotFound {
+		body = http.StatusText(statusCode)
+	}
+
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
 }

--- a/modules/frontend/tracediff_handler_test.go
+++ b/modules/frontend/tracediff_handler_test.go
@@ -1,15 +1,288 @@
 package frontend
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
+	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/modules/frontend/combiner"
+	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/tempopb"
+	tempotest "github.com/grafana/tempo/pkg/util/test"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBuildTraceDiffTraceByIDRequest(t *testing.T) {
+	start := int64(100)
+	end := int64(200)
+
+	req := buildTraceDiffTraceByIDRequest(context.Background(), "", api.TraceDiffTraceRequest{
+		TraceID: "abc123",
+		Start:   &start,
+		End:     &end,
+	}, nil)
+
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, "/api/v2/traces/abc123", req.URL.Path)
+	require.Equal(t, "100", req.URL.Query().Get("start"))
+	require.Equal(t, "200", req.URL.Query().Get("end"))
+	require.Equal(t, api.HeaderAcceptProtobuf, req.Header.Get(api.HeaderAccept))
+
+	_, err := api.ParseTraceID(req)
+	require.NoError(t, err)
+
+	_, _, queryMode, startTime, endTime, err := api.ParseTraceByIDRequest(req)
+	require.NoError(t, err)
+	require.Equal(t, api.QueryModeAll, queryMode)
+	require.Equal(t, time.Unix(start, 0), startTime)
+	require.Equal(t, time.Unix(end, 0), endTime)
+}
+
+func TestTraceDiffHandlerFetchTraceForDiff(t *testing.T) {
+	traceID := "abc123"
+	trace := tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})
+	traceByIDResp := &tempopb.TraceByIDResponse{
+		Trace: trace,
+		Metrics: &tempopb.TraceByIDMetrics{
+			InspectedBytes: 123,
+		},
+	}
+	respBytes, err := proto.Marshal(traceByIDResp)
+	require.NoError(t, err)
+
+	var gotReq *http.Request
+	tracePipeline := pipeline.AsyncRoundTripperFunc[combiner.PipelineResponse](func(req pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+		gotReq = req.HTTPRequest()
+		return pipeline.NewHTTPToAsyncResponse(&http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				api.HeaderContentType: []string{api.HeaderAcceptProtobuf},
+			},
+			Body: io.NopCloser(bytes.NewReader(respBytes)),
+		}), nil
+	})
+
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	actual, err := fetchTraceForDiff(context.Background(), "test-tenant", api.TraceDiffTraceRequest{TraceID: traceID}, nil, "/tempo", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.True(t, proto.Equal(trace, actual.Trace))
+	require.Equal(t, uint64(123), actual.Metrics.GetInspectedBytes())
+	require.NotNil(t, gotReq)
+	require.Equal(t, "/tempo/api/v2/traces/abc123", gotReq.URL.Path)
+	require.Equal(t, api.HeaderAcceptProtobuf, gotReq.Header.Get(api.HeaderAccept))
+}
+
+func traceDiffTestPipeline(t *testing.T, traces map[string]*tempopb.TraceByIDResponse) pipeline.AsyncRoundTripper[combiner.PipelineResponse] {
+	t.Helper()
+	return pipeline.AsyncRoundTripperFunc[combiner.PipelineResponse](func(req pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+		tracePath := req.HTTPRequest().URL.Path
+		traceID := tracePath[strings.LastIndex(tracePath, "/")+1:]
+		traceResp, ok := traces[traceID]
+		if !ok {
+			return pipeline.NewHTTPToAsyncResponse(&http.Response{
+				StatusCode: http.StatusNotFound,
+				Status:     http.StatusText(http.StatusNotFound),
+				Body:       io.NopCloser(strings.NewReader("trace not found")),
+			}), nil
+		}
+
+		respBytes, err := proto.Marshal(traceResp)
+		require.NoError(t, err)
+		return pipeline.NewHTTPToAsyncResponse(&http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				api.HeaderContentType: []string{api.HeaderAcceptProtobuf},
+			},
+			Body: io.NopCloser(bytes.NewReader(respBytes)),
+		}), nil
+	})
+}
+
+type traceDiffDataAccessController struct {
+	mu       sync.Mutex
+	redactor combiner.TraceRedactor
+	err      error
+	calls    int
+}
+
+func (c *traceDiffDataAccessController) HandleHTTPSearchReq(_ *http.Request) error { return nil }
+
+func (c *traceDiffDataAccessController) HandleHTTPTagsReq(_ *http.Request) error { return nil }
+
+func (c *traceDiffDataAccessController) HandleHTTPTagsV2Req(_ *http.Request) error { return nil }
+
+func (c *traceDiffDataAccessController) HandleHTTPTagValuesReq(_ *http.Request) error { return nil }
+
+func (c *traceDiffDataAccessController) HandleHTTPTagValuesV2Req(_ *http.Request) error { return nil }
+
+func (c *traceDiffDataAccessController) HandleHTTPQueryRangeReq(_ *http.Request) error { return nil }
+
+func (c *traceDiffDataAccessController) HandleHTTPQueryInstantReq(_ *http.Request) error { return nil }
+
+func (c *traceDiffDataAccessController) HandleHTTPTraceByIDReq(_ *http.Request) (combiner.TraceRedactor, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.calls++
+	return c.redactor, c.err
+}
+
+func (c *traceDiffDataAccessController) HandleGRPCSearchReq(_ context.Context, _ *tempopb.SearchRequest) error {
+	return nil
+}
+
+func (c *traceDiffDataAccessController) HandleGRPCTagsReq(_ context.Context, _ *tempopb.SearchTagsRequest) error {
+	return nil
+}
+
+func (c *traceDiffDataAccessController) HandleGRPCTagsV2Req(_ context.Context, _ *tempopb.SearchTagsRequest) error {
+	return nil
+}
+
+func (c *traceDiffDataAccessController) HandleGRPCTagValuesReq(_ context.Context, _ *tempopb.SearchTagValuesRequest) error {
+	return nil
+}
+
+func (c *traceDiffDataAccessController) HandleGRPCTagValuesV2Req(_ context.Context, _ *tempopb.SearchTagValuesRequest) error {
+	return nil
+}
+
+func (c *traceDiffDataAccessController) HandleGRPCQueryRangeReq(_ context.Context, _ *tempopb.QueryRangeRequest) error {
+	return nil
+}
+
+func (c *traceDiffDataAccessController) HandleGRPCQueryInstantReq(_ context.Context, _ *tempopb.QueryInstantRequest) error {
+	return nil
+}
+
+func (c *traceDiffDataAccessController) callCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+type traceDiffHidingRedactor struct{}
+
+func (traceDiffHidingRedactor) RedactTraceAttributes(_ *tempopb.Trace) error {
+	return combiner.ErrTraceHidden
+}
+
+func TestTraceDiffHandlerReturnsDiff(t *testing.T) {
+	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(`{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`))
+	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, api.HeaderAcceptJSON, resp.Header().Get(api.HeaderContentType))
+	require.Contains(t, resp.Body.String(), `"version":"trace-patch-v0"`)
+}
+
+func TestTraceDiffHandlerAppliesTraceRedactor(t *testing.T) {
+	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	dataAccessController := &traceDiffDataAccessController{redactor: traceDiffHidingRedactor{}}
+	handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), dataAccessController), log.NewNopLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(`{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`))
+	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusNotFound, resp.Code)
+	require.Equal(t, http.StatusText(http.StatusNotFound), resp.Body.String())
+	require.Positive(t, dataAccessController.callCount())
+}
+
+func TestTraceDiffHandlerMapsWrappedTraceFetchStatus(t *testing.T) {
+	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(`{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`))
+	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusNotFound, resp.Code)
+	require.Equal(t, http.StatusText(http.StatusNotFound), resp.Body.String())
+}
+
+func TestTraceDiffHandlerDataAccessErrorReturnsBadRequest(t *testing.T) {
+	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	dataAccessController := &traceDiffDataAccessController{err: errors.New("policy rejected")}
+	handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), dataAccessController), log.NewNopLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(`{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`))
+	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Contains(t, resp.Body.String(), "policy rejected")
+	require.Positive(t, dataAccessController.callCount())
+}
+
+func TestTraceDiffHandlerRejectsPartialTraces(t *testing.T) {
+	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": &tempopb.TraceByIDResponse{
+			Trace:  tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56}),
+			Status: tempopb.PartialStatus_PARTIAL,
+		},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(`{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`))
+	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+	require.Contains(t, resp.Body.String(), errTraceDiffPartialTrace.Error())
+}
 
 func TestTraceDiffHandlerSkeleton(t *testing.T) {
 	tests := []struct {
@@ -18,12 +291,6 @@ func TestTraceDiffHandlerSkeleton(t *testing.T) {
 		body       string
 		statusCode int
 	}{
-		{
-			name:       "valid post returns not implemented",
-			method:     http.MethodPost,
-			body:       `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`,
-			statusCode: http.StatusNotImplemented,
-		},
 		{
 			name:       "invalid post returns bad request",
 			method:     http.MethodPost,
@@ -39,7 +306,7 @@ func TestTraceDiffHandlerSkeleton(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := newHandler(nil, newTraceDiffHandler(log.NewNopLogger()), log.NewNopLogger())
+			handler := newHandler(nil, newTraceDiffHandler(Config{}, "", nil, nil, nil, nil, log.NewNopLogger(), nil), log.NewNopLogger())
 			req := httptest.NewRequest(tt.method, "/api/v2/traces/diff", strings.NewReader(tt.body))
 			req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
 			resp := httptest.NewRecorder()

--- a/modules/frontend/tracediff_handler_test.go
+++ b/modules/frontend/tracediff_handler_test.go
@@ -184,8 +184,8 @@ func (traceDiffHidingRedactor) RedactTraceAttributes(_ *tempopb.Trace) error {
 
 func TestTraceDiffHandlerReturnsDiff(t *testing.T) {
 	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
-		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
-		"def456": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
+		"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": {Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
@@ -204,8 +204,8 @@ func TestTraceDiffHandlerReturnsDiff(t *testing.T) {
 
 func TestTraceDiffHandlerAppliesTraceRedactor(t *testing.T) {
 	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
-		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
-		"def456": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
+		"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": {Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestTraceDiffHandlerAppliesTraceRedactor(t *testing.T) {
 
 func TestTraceDiffHandlerMapsWrappedTraceFetchStatus(t *testing.T) {
 	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
-		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
@@ -243,8 +243,8 @@ func TestTraceDiffHandlerMapsWrappedTraceFetchStatus(t *testing.T) {
 
 func TestTraceDiffHandlerDataAccessErrorReturnsBadRequest(t *testing.T) {
 	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
-		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
-		"def456": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
+		"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": {Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
@@ -264,8 +264,8 @@ func TestTraceDiffHandlerDataAccessErrorReturnsBadRequest(t *testing.T) {
 
 func TestTraceDiffHandlerRejectsPartialTraces(t *testing.T) {
 	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
-		"abc123": &tempopb.TraceByIDResponse{Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
-		"def456": &tempopb.TraceByIDResponse{
+		"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+		"def456": {
 			Trace:  tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56}),
 			Status: tempopb.PartialStatus_PARTIAL,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

It implements the diff handler. Internally it relies on the TraceById pipeline so all the machinery (middlewares, sharder, combiner, etc) its preserved.

The handler fetch two traces concurrently and the it diff them. The fetchTraceForDiff handler is used to avoid marshalling and unmarshalling the traces. So the response from combiner.GRPCFinal is used directly for the diff.

Partial traces are not diffed.

It doesn't include yet a cache layer or memory protection mechanisms besides the existing MaxTraceBytes

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)