### PR TITLE
refactor(parquetquery): split SyncIterator into chunk + page readers

### DIFF
--- a/.chloggen/dict-index-pushdown.yaml
+++ b/.chloggen/dict-index-pushdown.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: storage
+note: speed up dictionary-resolvable string filters (equality, `IN`, regex, substring) by resolving the predicate against the column-chunk dictionary once and matching rows by dictionary index instead of materializing and re-evaluating the predicate per value.
+issues: []
+subtext:
+user: zhxiaogg

--- a/pkg/parquetquery/chunk_reader.go
+++ b/pkg/parquetquery/chunk_reader.go
@@ -1,0 +1,201 @@
+package parquetquery
+
+import (
+	"errors"
+	"io"
+	"slices"
+
+	pq "github.com/parquet-go/parquet-go"
+)
+
+// chunkReader scans a single column chunk page by page on behalf of SyncIterator. It
+// resolves the dictionary keep bitmap once per chunk, tracks the current page's
+// row-number bounds, and drives two page readers - choosing the dictionary fast path
+// when a page supports it, else the buffered per-row path.
+//
+// SyncIterator keeps the row-group navigation and the shared row number (curr), which
+// is passed in by pointer so the scan can advance it. The current page object lives in
+// the active page reader, not here.
+type chunkReader struct {
+	// config, copied from the iterator
+	filter       Predicate
+	maxDef       int  // per-column max definition level, handed to readers at setup
+	dictDisabled bool // never use the dictionary fast path (test-only)
+
+	chunk *ColumnChunkHelper // current column chunk
+
+	// Dictionary state, resolved once per chunk by admitChunk. keep[dictIndex] reports
+	// whether that dictionary value matches; nil when the fast path does not apply.
+	keep          []bool
+	dictionary    pq.Dictionary
+	dictPagesUsed int // pages served by the fast path (observability/tests)
+
+	// row-number bounds of the current page; the page object itself lives in the reader
+	havePage bool
+	pageMin  RowNumber
+	pageMax  RowNumber // exclusive: first row number of the next page
+
+	// the two page readers; dictActive selects which one serves the current page
+	bufferedReader bufferedPageReader
+	dictReader     dictPageReader
+	dictActive     bool
+}
+
+// dictFastPathPages reports how many pages the dictionary fast path served. Used by
+// in-package tests to confirm it engaged.
+func (c *SyncIterator) dictFastPathPages() int {
+	return c.chunk.dictPagesUsed
+}
+
+func (cr *chunkReader) hasPage() bool { return cr.havePage }
+
+// admitChunk reports whether cc must be scanned, resolving the dictionary keep bitmap
+// along the way. When the predicate resolves against the dictionary, the keep bitmap
+// also answers the chunk-skip question, so we avoid a second dictionary scan in
+// KeepColumnChunk.
+func (cr *chunkReader) admitChunk(cc *ColumnChunkHelper) bool {
+	resolved := cr.resolveChunk(cc)
+	switch {
+	case cr.filter == nil:
+		return true
+	case resolved:
+		return slices.Contains(cr.keep, true)
+	default:
+		return cr.filter.KeepColumnChunk(cc)
+	}
+}
+
+// resolveChunk evaluates the predicate against the chunk's dictionary into keep,
+// returning true when a usable bitmap was produced. It returns false (keep nil) when
+// the fast path does not apply: disabled, the filter is not a DictionaryPredicate, the
+// predicate declines (e.g. OR with a non-dictionary child), or the chunk is not
+// dictionary-encoded.
+func (cr *chunkReader) resolveChunk(cc *ColumnChunkHelper) bool {
+	cr.keep = nil
+	cr.dictionary = nil
+	if cr.dictDisabled {
+		return false
+	}
+	dp, ok := cr.filter.(DictionaryPredicate)
+	if !ok {
+		return false
+	}
+	dictionary := cc.Dictionary()
+	if dictionary == nil {
+		return false
+	}
+	cr.dictionary = dictionary
+	cr.keep = dp.KeepIndexes(dictionary) // nil if the predicate declines
+	return cr.keep != nil
+}
+
+func (cr *chunkReader) setChunk(cc *ColumnChunkHelper) {
+	cr.chunk = cc
+}
+
+// closeChunk releases the current page and closes the chunk. keep/dictionary are left
+// alone: admitChunk resolves them for the next chunk, and resolveChunk clears them at
+// the start of each chunk.
+func (cr *chunkReader) closeChunk(curr *RowNumber) {
+	if cr.chunk != nil {
+		cr.chunk.Close()
+		cr.chunk = nil
+	}
+	cr.setPage(curr, nil)
+}
+
+// loadPage advances to the next page that must be scanned, skipping pages the page
+// predicate rejects and (when seekTo is non-nil) pages that end before seekTo. curr is
+// advanced over skipped pages. ok is false when the chunk is exhausted.
+func (cr *chunkReader) loadPage(curr *RowNumber, seekTo *RowNumber, definitionLevel int) (ok bool, err error) {
+	for {
+		pg, err := cr.chunk.NextPage()
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, err
+		}
+		if pg == nil || errors.Is(err, io.EOF) {
+			return false, nil // chunk exhausted
+		}
+
+		// Skip pages that end before the seek target.
+		if seekTo != nil {
+			endRN := *curr
+			endRN.Skip(pg.NumRows() + 1)
+			if CompareRowNumbers(definitionLevel, *seekTo, endRN) >= 0 {
+				curr.Skip(pg.NumRows())
+				pq.Release(pg)
+				continue
+			}
+		}
+
+		if cr.filter != nil && !cr.filter.KeepPage(pg) {
+			curr.Skip(pg.NumRows())
+			pq.Release(pg)
+			continue
+		}
+		cr.setPage(curr, pg)
+		return true, nil
+	}
+}
+
+// setPage swaps in pg as the current page (nil to clear). The outgoing page is released
+// (by the active reader) and curr repositioned to its end; the incoming page's bounds
+// are computed and the matching page reader is set up.
+func (cr *chunkReader) setPage(curr *RowNumber, pg pq.Page) {
+	if cr.havePage {
+		*curr = cr.pageMax.Preceding() // reposition to the end of the outgoing page
+	}
+
+	// Reset both readers - whichever held the page releases it.
+	cr.bufferedReader.reset()
+	cr.dictReader.reset()
+	cr.dictActive = false
+	cr.havePage = false
+	cr.pageMin = EmptyRowNumber()
+	cr.pageMax = EmptyRowNumber()
+
+	if pg == nil {
+		cr.bufferedReader.release() // no more pages: free the batch buffer
+		return
+	}
+
+	end := *curr
+	end.Skip(pg.NumRows() + 1) // exclusive upper bound: first row of the next page
+	cr.pageMin = *curr
+	cr.pageMax = end
+	cr.havePage = true
+
+	if cr.keep != nil && pg.Dictionary() != nil {
+		cr.dictReader.setup(pg, cr.keep, cr.dictionary, cr.maxDef)
+		cr.dictActive = true
+		cr.dictPagesUsed++
+	} else {
+		cr.bufferedReader.setup(pg, cr.maxDef)
+	}
+}
+
+// pastPage reports whether seekTo is at or beyond the end of the current page.
+func (cr *chunkReader) pastPage(seekTo RowNumber, definitionLevel int) bool {
+	return CompareRowNumbers(definitionLevel, seekTo, cr.pageMax) >= 0
+}
+
+// next returns the next matching value in the current page via the active reader.
+func (cr *chunkReader) next(curr *RowNumber) (*pq.Value, bool, error) {
+	if cr.dictActive {
+		return cr.dictReader.next(curr)
+	}
+	return cr.bufferedReader.next(curr)
+}
+
+// seekWithinPage moves toward row number to. The buffered reader may reslice the page
+// straight to the target for a large skip; the dictionary reader tracks its cursor
+// against the whole page and cannot reslice, so it always advances via next (correct,
+// just without the shortcut).
+func (cr *chunkReader) seekWithinPage(curr *RowNumber, to RowNumber, definitionLevel int) {
+	if cr.dictActive {
+		return
+	}
+	if newMin, ok := cr.bufferedReader.reslice(curr, cr.pageMin, to, definitionLevel); ok {
+		cr.pageMin = newMin
+	}
+}

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -476,21 +476,14 @@ type SyncIterator struct {
 
 	maxDefinitionLevel int
 
-	// Dictionary fast-path state. When the filter is a DictionaryPredicate and a
-	// page is dictionary-encoded, the predicate is resolved once over the chunk
-	// dictionary into a match bitmap, and rows are matched by their integer
-	// dictionary index instead of being materialized and byte-compared per row.
-	// The per-page decoding lives in indexReader; the remaining fields outlive a
-	// single page:
-	//   - whole iterator: indexReaderDisabled (test-only), indexReaderPagesUsed (observability)
-	//   - per column chunk: indexReaderChecked, indexReaderMatches
-	indexReaderDisabled  bool   // test-only: force the per-row path (set directly by in-package tests)
-	indexReaderPagesUsed int    // pages served via the fast path (observability/tests)
-	indexReaderChecked   bool   // whether the match bitmap was resolved for the current chunk
-	indexReaderMatches   []bool // match bitmap indexed by dictionary index; nil => pushdown declined
-	// indexReader serves the current dictionary-encoded page on the fast path; nil
-	// when the page uses the per-row path. See indexValueReader.
-	indexReader *indexValueReader
+	// Dictionary fast-path state: when the filter is a DictionaryPredicate over a
+	// dictionary-encoded chunk, the predicate is resolved once into a per-index match
+	// bitmap and rows match by integer index instead of per-row materialization.
+	indexReaderDisabled  bool              // test-only: force the per-row path
+	indexReaderPagesUsed int               // pages served via the fast path (tests/observability)
+	indexReaderChecked   bool              // match bitmap resolved for the current chunk?
+	indexReaderMatches   []bool            // match bitmap by dictionary index; nil => no pushdown
+	indexReader          *indexValueReader // current page's reader; nil on the per-row path
 
 	interner   *intern.Interner
 	makeResult func(t RowNumber, v *pq.Value) *IteratorResult
@@ -498,11 +491,9 @@ type SyncIterator struct {
 
 var _ Iterator = (*SyncIterator)(nil)
 
-// enterColumnChunk applies the column-chunk filter and, if the chunk is kept,
-// makes it current. Returns false when the chunk can be skipped (the caller must
-// continue to the next row group). For a dictionary-pushable predicate it resolves
-// the per-index match bitmap here and installs it, so the per-page readers reuse it
-// instead of rescanning the dictionary.
+// enterColumnChunk applies the column-chunk filter and makes the chunk current,
+// returning false if it can be skipped. For a dictionary-pushable predicate the
+// match bitmap is resolved here so the per-page readers reuse it.
 func (c *SyncIterator) enterColumnChunk(rg pq.RowGroup, minRN, maxRN RowNumber, cc *ColumnChunkHelper) bool {
 	keep, matches := c.keepColumnChunk(cc)
 	if !keep {
@@ -510,24 +501,18 @@ func (c *SyncIterator) enterColumnChunk(rg pq.RowGroup, minRN, maxRN RowNumber, 
 		return false
 	}
 	c.setRowGroup(rg, minRN, maxRN, cc)
-	// setRowGroup cleared the per-chunk bitmap; install the one we just resolved so
-	// indexReaderFor doesn't scan the dictionary a second time.
-	if matches != nil {
+	if matches != nil { // reinstate the bitmap setRowGroup cleared, so indexReaderFor reuses it
 		c.indexReaderChecked = true
 		c.indexReaderMatches = matches
 	}
 	return true
 }
 
-// keepColumnChunk reports whether cc can contain matching rows. For a dictionary-
-// pushable predicate on a dictionary-encoded chunk it resolves the per-index match
-// bitmap once - the same dictionary scan the generic KeepColumnChunk would do to
-// test for any match - and returns it (non-nil) so the caller can reuse it for the
-// per-page readers. The chunk is skipped when no dictionary entry matches.
-//
-// For substring/regex predicates this bypasses KeepColumnChunk's per-chunk match-
-// cache reset. That is safe: those caches are pure value->bool memoization, so they
-// stay correct, and they remain bounded by the column's distinct dictionary values.
+// keepColumnChunk reports whether cc can match. For a dictionary-pushable predicate
+// it resolves the per-index match bitmap once (the scan KeepColumnChunk would do
+// anyway to test for any match) and returns it for the per-page readers; the chunk
+// is skipped when no entry matches. This bypasses KeepColumnChunk's per-chunk cache
+// reset for substring/regex, which is safe because KeepIndexes resets them instead.
 func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool, matches []bool) {
 	if c.filter == nil {
 		return true, nil
@@ -535,18 +520,16 @@ func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool, matche
 	if dp, ok := c.filter.(DictionaryPredicate); ok && !c.indexReaderDisabled {
 		if dict := cc.Dictionary(); dict != nil {
 			if m := dp.KeepIndexes(dict); m != nil {
-				return anyTrue(m), m
+				return slices.Contains(m, true), m
 			}
 		}
 	}
 	return c.filter.KeepColumnChunk(cc), nil
 }
 
-// indexReaderFor returns a dictionary fast-path reader for pg, or nil when
-// pushdown does not apply (disabled, non-dictionary predicate, non-dictionary
-// page, or the predicate declined). The match bitmap is resolved against the
-// chunk dictionary once and reused across all of the chunk's pages; when it is
-// nil the caller uses the per-row path.
+// indexReaderFor returns a fast-path reader for pg, or nil when pushdown doesn't
+// apply (disabled, non-dictionary predicate/page, or the predicate declined). The
+// match bitmap is resolved once per chunk and reused across its pages.
 func (c *SyncIterator) indexReaderFor(pg pq.Page) *indexValueReader {
 	if c.indexReaderDisabled {
 		return nil
@@ -573,11 +556,8 @@ func (c *SyncIterator) indexReaderFor(pg pq.Page) *indexValueReader {
 	return newIndexValueReader(c.indexReaderMatches, pg)
 }
 
-// indexValueReader serves one dictionary-encoded page on the fast path. The
-// predicate is pre-resolved into matches (indexed by dictionary index) and shared
-// across all pages in the chunk; the reader decodes this page's levels and
-// indices and advances one slot per next() call. It is a pure page decoder: row
-// numbers are tracked by the caller, driven by the levels next() returns.
+// indexValueReader serves one dictionary-encoded page on the fast path, matching
+// each row by its integer dictionary index against the chunk's match bitmap.
 type indexValueReader struct {
 	matches []bool        // match bitmap indexed by dictionary index (chunk-scoped)
 	dict    pq.Dictionary // dictionary the matches were built against
@@ -603,22 +583,18 @@ func newIndexValueReader(matches []bool, pg pq.Page) *indexValueReader {
 		indices:   data.Int32(),
 		defLevels: defLevels,
 		repLevels: pg.RepetitionLevels(),
-		// A present (non-null) leaf carries the maximum definition level seen on the
-		// page. (The iterator's maxDefinitionLevel is a row-number tracking cap, not
-		// necessarily this leaf's level, so we derive it from the page.) On a page with
-		// no present values this collapses to the null level, so the valueN bound in
-		// next() is what keeps such pages from indexing past the empty indices slice.
+		// Present (non-null) leaves sit at the page's max definition level. (We derive
+		// it from the page, not the iterator's maxDefinitionLevel, which is a row-number
+		// cap rather than this leaf's level.)
 		pageMaxDef: maxByte(defLevels),
 	}
 }
 
 // nextMatch advances over slots until it materializes a matching value or the page
-// is exhausted (ok=false). It owns the per-slot loop so a predicate-bound scan stays
-// in one tight loop rather than paying a method call per non-matching slot. Row
-// numbers are tracked exactly as the per-row path does: curr and pageN are advanced
-// for every slot (present, null, or filtered) via the caller's pointers, and
-// maxDefLevel is the row-number tracking cap. The returned value points at a reused
-// buffer, valid until the next call.
+// is exhausted (ok=false). It owns the per-slot loop (one tight loop, not a method
+// call per slot) and advances the caller's row number over every slot — present,
+// null, or filtered — via curr/pageN. The returned value points at a reused buffer,
+// valid until the next call.
 func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel int) (*pq.Value, bool) {
 	numSlots := len(r.indices)
 	if r.defLevels != nil {
@@ -630,9 +606,7 @@ func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel in
 		if r.repLevels != nil {
 			repLvl = int(r.repLevels[r.slotN])
 		}
-		// Required columns have no definition levels; every value is present at the
-		// page's (possibly zero) definition level.
-		defLvl := int(r.pageMaxDef)
+		defLvl := int(r.pageMaxDef) // required columns have no levels; every slot is present
 		if r.defLevels != nil {
 			defLvl = int(r.defLevels[r.slotN])
 		}
@@ -640,10 +614,9 @@ func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel in
 		r.slotN++
 		(*pageN)++
 
-		// Null/empty slot: not present at the leaf, so no value and no dictionary index
-		// is consumed. The valueN bound also guards pages that carry definition levels
-		// but no present values (an all-null page, where indices is empty), so we never
-		// index past indices/matches.
+		// Null/empty slot consumes no index. The valueN bound also covers a page with
+		// definition levels but no present values (all-null page, empty indices), so we
+		// never index past indices/matches.
 		if (r.defLevels != nil && byte(defLvl) != r.pageMaxDef) || r.valueN >= len(r.indices) {
 			continue
 		}
@@ -654,8 +627,7 @@ func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel in
 			continue
 		}
 
-		// Materialize only matching values, stamping the page levels and column so the
-		// result is indistinguishable from the per-row path.
+		// Stamp page levels + column so the result matches the per-row path.
 		r.value = r.dict.Index(idx).Level(repLvl, defLvl, r.col)
 		return &r.value, true
 	}
@@ -922,9 +894,8 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 		return
 	}
 
-	// The dictionary fast path tracks its cursor against the whole page; reslicing
-	// would require rebuilding that state, so we let next() advance to the target
-	// instead. Correctness is unaffected, only the large-skip shortcut is skipped.
+	// The fast path's cursor tracks the whole page, so skip the reslice shortcut and
+	// let nextMatch advance to the target (correct, just not the large-skip fast path).
 	if c.indexReader != nil {
 		return
 	}
@@ -1028,14 +999,11 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.setPage(pg)
 		}
 
-		// Dictionary fast path: match rows by integer dictionary index. The reader
-		// advances the row number over every slot (present, null, or filtered-out),
-		// exactly as the per-row path does, and returns only matched values.
+		// Dictionary fast path: match rows by integer dictionary index.
 		if c.indexReader != nil {
 			v, ok := c.indexReader.nextMatch(&c.curr, &c.currPageN, c.maxDefinitionLevel)
 			if !ok {
-				// Page exhausted, move on.
-				c.setPage(nil)
+				c.setPage(nil) // page exhausted
 				continue
 			}
 			return c.curr, v, nil
@@ -1087,8 +1055,7 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroupMax = max
 	c.currChunk = cc
 
-	// The match bitmap is resolved once per column chunk (all data pages in a chunk
-	// share the same dictionary) and reset when the chunk changes.
+	// Reset the per-chunk match bitmap; each chunk has its own dictionary.
 	c.indexReaderChecked = false
 	c.indexReaderMatches = nil
 }
@@ -1128,23 +1095,15 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 	}
 }
 
+// maxByte returns the largest byte in b, or 0 when b is empty (so a required
+// column with no definition levels yields a present level of 0). slices.Max is
+// not used because it panics on an empty slice.
 func maxByte(b []byte) byte {
 	var m byte
 	for _, v := range b {
-		if v > m {
-			m = v
-		}
+		m = max(m, v)
 	}
 	return m
-}
-
-func anyTrue(b []bool) bool {
-	for _, v := range b {
-		if v {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *SyncIterator) closeCurrRowGroup() {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -3,9 +3,7 @@ package parquetquery
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"math"
 	"slices"
 	"sync"
@@ -425,7 +423,7 @@ func SyncIteratorOptSelectAs(selectAs string) SyncIteratorOpt {
 // values are unpacked from the column on each read.
 func SyncIteratorOptBufferSize(bufferSize int) SyncIteratorOpt {
 	return func(i *SyncIterator) {
-		i.readSize = bufferSize
+		i.chunk.bufferedReader.readSize = bufferSize
 	}
 }
 
@@ -434,14 +432,8 @@ func SyncIteratorOptBufferSize(bufferSize int) SyncIteratorOpt {
 // required for correct behavior.
 func SyncIteratorOptMaxDefinitionLevel(maxDefinitionLevel int) SyncIteratorOpt {
 	return func(i *SyncIterator) {
-		i.maxDefinitionLevel = maxDefinitionLevel
+		i.chunk.maxDef = maxDefinitionLevel
 	}
-}
-
-// dictFastPathPages reports how many pages were served via the dictionary fast
-// path. Used by in-package tests to confirm the optimization engaged.
-func (c *SyncIterator) dictFastPathPages() int {
-	return c.indexReaderPagesUsed
 }
 
 // SyncIterator is a synchronous column iterator. It scans through the given row
@@ -455,7 +447,6 @@ type SyncIterator struct {
 	rgs        []pq.RowGroup
 	rgsMin     []RowNumber
 	rgsMax     []RowNumber // Exclusive, row number of next one past the row group
-	readSize   int
 	filter     Predicate
 
 	// Status
@@ -464,175 +455,18 @@ type SyncIterator struct {
 	currRowGroup    pq.RowGroup
 	currRowGroupMin RowNumber
 	currRowGroupMax RowNumber
-	currChunk       *ColumnChunkHelper
-	currPage        pq.Page
-	currPageMin     RowNumber
-	currPageMax     RowNumber
-	currValues      pq.ValueReader
-	currBuf         []pq.Value
-	currBufN        int
-	currPageN       int
 	at              IteratorResult // Current value pointed at by iterator. Returned by call Next and SeekTo, valid until next call.
 
-	maxDefinitionLevel int
-
-	// Dictionary fast-path state: when the filter is a DictionaryPredicate over a
-	// dictionary-encoded chunk, the predicate is resolved once into a per-index match
-	// bitmap and rows match by integer index instead of per-row materialization.
-	indexReaderDisabled  bool              // test-only: force the per-row path
-	indexReaderPagesUsed int               // pages served via the fast path (tests/observability)
-	indexReaderChecked   bool              // match bitmap resolved for the current chunk?
-	indexReaderMatches   []bool            // match bitmap by dictionary index; nil => no pushdown
-	indexReader          *indexValueReader // current page's reader; nil on the per-row path
+	// chunk scans the current column chunk: dictionary resolution, page navigation,
+	// seek, and dispatch to a per-row or dictionary-index page reader. The iterator
+	// owns curr and hands it in by pointer so the scan can advance it.
+	chunk chunkReader
 
 	interner   *intern.Interner
 	makeResult func(t RowNumber, v *pq.Value) *IteratorResult
 }
 
 var _ Iterator = (*SyncIterator)(nil)
-
-// enterColumnChunk applies the column-chunk filter and makes the chunk current,
-// returning false if it can be skipped. For a dictionary-pushable predicate the
-// match bitmap is resolved here so the per-page readers reuse it.
-func (c *SyncIterator) enterColumnChunk(rg pq.RowGroup, minRN, maxRN RowNumber, cc *ColumnChunkHelper) bool {
-	keep, matches := c.keepColumnChunk(cc)
-	if !keep {
-		cc.Close()
-		return false
-	}
-	c.setRowGroup(rg, minRN, maxRN, cc)
-	if matches != nil { // reinstate the bitmap setRowGroup cleared, so indexReaderFor reuses it
-		c.indexReaderChecked = true
-		c.indexReaderMatches = matches
-	}
-	return true
-}
-
-// keepColumnChunk reports whether cc can match. For a dictionary-pushable predicate
-// it resolves the per-index match bitmap once (the scan KeepColumnChunk would do
-// anyway to test for any match) and returns it for the per-page readers; the chunk
-// is skipped when no entry matches. This bypasses KeepColumnChunk's per-chunk cache
-// reset for substring/regex, which is safe because KeepIndexes resets them instead.
-func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool, matches []bool) {
-	if c.filter == nil {
-		return true, nil
-	}
-	if dp, ok := c.filter.(DictionaryPredicate); ok && !c.indexReaderDisabled {
-		if dict := cc.Dictionary(); dict != nil {
-			if m := dp.KeepIndexes(dict); m != nil {
-				return slices.Contains(m, true), m
-			}
-		}
-	}
-	return c.filter.KeepColumnChunk(cc), nil
-}
-
-// indexReaderFor returns a fast-path reader for pg, or nil when pushdown doesn't
-// apply (disabled, non-dictionary predicate/page, or the predicate declined). The
-// match bitmap is resolved once per chunk and reused across its pages.
-func (c *SyncIterator) indexReaderFor(pg pq.Page) *indexValueReader {
-	if c.indexReaderDisabled {
-		return nil
-	}
-	dp, ok := c.filter.(DictionaryPredicate)
-	if !ok {
-		return nil
-	}
-	dict := pg.Dictionary()
-	if dict == nil {
-		return nil // page is not dictionary-encoded
-	}
-
-	// Resolve the predicate against the dictionary once per chunk.
-	if !c.indexReaderChecked {
-		c.indexReaderChecked = true
-		c.indexReaderMatches = dp.KeepIndexes(dict)
-	}
-	if c.indexReaderMatches == nil {
-		return nil // predicate declined dictionary pushdown for this chunk
-	}
-
-	c.indexReaderPagesUsed++
-	return newIndexValueReader(c.indexReaderMatches, pg)
-}
-
-// indexValueReader serves one dictionary-encoded page on the fast path, matching
-// each row by its integer dictionary index against the chunk's match bitmap.
-type indexValueReader struct {
-	matches []bool        // match bitmap indexed by dictionary index (chunk-scoped)
-	dict    pq.Dictionary // dictionary the matches were built against
-	col     int           // column index, stamped onto materialized values
-
-	indices    []int32 // present-value dictionary indexes for this page
-	defLevels  []byte  // nil for required columns
-	repLevels  []byte  // nil for non-repeated columns
-	pageMaxDef byte    // definition level of a present (non-null) leaf value on this page
-	slotN      int     // cursor over level slots (present + null)
-	valueN     int     // cursor over indices (present only)
-
-	value pq.Value // reused return buffer for matched values
-}
-
-func newIndexValueReader(matches []bool, pg pq.Page) *indexValueReader {
-	defLevels := pg.DefinitionLevels()
-	data := pg.Data()
-	return &indexValueReader{
-		matches:   matches,
-		dict:      pg.Dictionary(),
-		col:       pg.Column(),
-		indices:   data.Int32(),
-		defLevels: defLevels,
-		repLevels: pg.RepetitionLevels(),
-		// Present (non-null) leaves sit at the page's max definition level. (We derive
-		// it from the page, not the iterator's maxDefinitionLevel, which is a row-number
-		// cap rather than this leaf's level.)
-		pageMaxDef: maxByte(defLevels),
-	}
-}
-
-// nextMatch advances over slots until it materializes a matching value or the page
-// is exhausted (ok=false). It owns the per-slot loop (one tight loop, not a method
-// call per slot) and advances the caller's row number over every slot — present,
-// null, or filtered — via curr/pageN. The returned value points at a reused buffer,
-// valid until the next call.
-func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel int) (*pq.Value, bool) {
-	numSlots := len(r.indices)
-	if r.defLevels != nil {
-		numSlots = len(r.defLevels)
-	}
-
-	for r.slotN < numSlots {
-		repLvl := 0
-		if r.repLevels != nil {
-			repLvl = int(r.repLevels[r.slotN])
-		}
-		defLvl := int(r.pageMaxDef) // required columns have no levels; every slot is present
-		if r.defLevels != nil {
-			defLvl = int(r.defLevels[r.slotN])
-		}
-		curr.Next(repLvl, defLvl, maxDefLevel)
-		r.slotN++
-		(*pageN)++
-
-		// Null/empty slot consumes no index. The valueN bound also covers a page with
-		// definition levels but no present values (all-null page, empty indices), so we
-		// never index past indices/matches.
-		if (r.defLevels != nil && byte(defLvl) != r.pageMaxDef) || r.valueN >= len(r.indices) {
-			continue
-		}
-
-		idx := r.indices[r.valueN]
-		r.valueN++
-		if !r.matches[idx] {
-			continue
-		}
-
-		// Stamp page levels + column so the result matches the per-row path.
-		r.value = r.dict.Index(idx).Level(repLvl, defLvl, r.col)
-		return &r.value, true
-	}
-	return nil, false
-}
 
 // NewSyncIterator iterates values in a column of a parquet file. Required values
 // are the numeric column index and the row groups to iterate over.  The column index
@@ -657,20 +491,25 @@ func NewSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, opts ..
 
 	// Create the iterator
 	i := &SyncIterator{
-		column:             column,
-		rgs:                rgs,
-		readSize:           1000, // default value
-		rgsMin:             rgsMin,
-		rgsMax:             rgsMax,
-		curr:               EmptyRowNumber(),
-		at:                 IteratorResult{},
-		maxDefinitionLevel: MaxDefinitionLevel, // default value
+		column: column,
+		rgs:    rgs,
+		rgsMin: rgsMin,
+		rgsMax: rgsMax,
+		curr:   EmptyRowNumber(),
+		at:     IteratorResult{},
 	}
+	i.chunk.maxDef = MaxDefinitionLevel    // default value
+	i.chunk.bufferedReader.readSize = 1000 // default value
 
 	// Apply options
 	for _, opt := range opts {
 		opt(i)
 	}
+
+	// The predicate lives on the iterator but is applied by the chunk reader (chunk,
+	// page) and the buffered page reader (per value); share it down.
+	i.chunk.filter = i.filter
+	i.chunk.bufferedReader.filter = i.filter
 
 	// Default value, always clone results until we have
 	// checked the column type and determined it isn't needed.
@@ -815,9 +654,11 @@ func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int) (done
 
 		cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
 		// This row group matches the row number; check the filter.
-		if !c.enterColumnChunk(rg, minRN, maxRN, cc) {
+		if !c.chunk.admitChunk(cc) {
+			cc.Close()
 			continue
 		}
+		c.setRowGroup(rg, minRN, maxRN, cc)
 	}
 
 	return c.currRowGroup == nil
@@ -826,139 +667,30 @@ func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int) (done
 // seekPages skips ahead in the current row group to the page that could contain the value at
 // the desired row number. Does nothing if the current page is already the correct one.
 func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bool, err error) {
-	if c.currPage != nil && CompareRowNumbers(definitionLevel, seekTo, c.currPageMax) >= 0 {
-		// Value not in this page
-		c.setPage(nil)
+	if c.chunk.hasPage() && c.chunk.pastPage(seekTo, definitionLevel) {
+		// Value not in this page.
+		c.chunk.setPage(&c.curr, nil)
 	}
 
-	if c.currPage == nil {
-		// TODO (mdisibio)   :((((((((
-		//    pages.SeekToRow is more costly than expected.  It doesn't reuse existing i/o
-		// so it can't be called naively every time we swap pages. We need to figure out
-		// a way to determine when it is worth calling here.
-		/*
-			// Seek into the pages. This is relative to the start of the row group
-			if seekTo[0] > 0 {
-				// Determine row delta. We subtract 1 because curr points at the previous row
-				skip := seekTo[0] - c.currRowGroupMin[0] - 1
-				if skip > 0 {
-					if err := c.currPages.SeekToRow(skip); err != nil {
-						return true, err
-					}
-					c.curr.Skip(skip)
-				}
-			}*/
-
-		for c.currPage == nil {
-			pg, err := c.currChunk.NextPage()
-			if pg == nil || err != nil {
-				// No more pages in this column chunk,
-				// cleanup and exit.
-				if errors.Is(err, io.EOF) {
-					err = nil
-				}
-				pq.Release(pg)
-				c.closeCurrRowGroup()
-				return true, err
-			}
-
-			// Skip based on row number?
-			newRN := c.curr
-			newRN.Skip(pg.NumRows() + 1)
-			if CompareRowNumbers(definitionLevel, seekTo, newRN) >= 0 {
-				c.curr.Skip(pg.NumRows())
-				pq.Release(pg)
-				continue
-			}
-
-			// Skip based on filter?
-			if c.filter != nil && !c.filter.KeepPage(pg) {
-				c.curr.Skip(pg.NumRows())
-				pq.Release(pg)
-				continue
-			}
-
-			c.setPage(pg)
+	if !c.chunk.hasPage() {
+		ok, err := c.chunk.loadPage(&c.curr, &seekTo, definitionLevel)
+		if err != nil {
+			return true, err
+		}
+		if !ok {
+			// No more pages in this column chunk; clean up and exit.
+			c.closeCurrRowGroup()
+			return true, nil
 		}
 	}
 
 	return false, nil
 }
 
-// seekWithinPage decides if it should reslice the current page to jump directly to the desired row number
-// or allow the iterator to call Next() until it finds the desired row number. it uses the magicThreshold
-// as its balance point. if the number of Next()s to skip is less than the magicThreshold, it will not reslice
+// seekWithinPage moves toward the desired row number within the current page,
+// reslicing straight to it for a large skip (delegated to the chunk reader).
 func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
-	rowSkipRelative := int(to[0] - c.curr[0])
-	if rowSkipRelative == 0 {
-		return
-	}
-
-	// The fast path's cursor tracks the whole page, so skip the reslice shortcut and
-	// let nextMatch advance to the target (correct, just not the large-skip fast path).
-	if c.indexReader != nil {
-		return
-	}
-
-	const magicThreshold = 1000
-	shouldSkip := false
-
-	if definitionLevel == 0 {
-		// if definition level is 0 there is always a 1:1 ratio between Next()s and rows. it's only deeper
-		// levels of nesting we have to manually count
-		shouldSkip = rowSkipRelative > magicThreshold
-	} else {
-		// this is a nested iterator, let's count the Next()s required to get to the desired row number
-		// and decide if we should skip or not
-		replvls := c.currPage.RepetitionLevels()
-		nextsRequired := 0
-
-		for i := c.currPageN; i < len(replvls); i++ {
-			nextsRequired++
-
-			if nextsRequired > magicThreshold {
-				shouldSkip = true
-				break
-			}
-
-			if replvls[i] == 0 { // 0 rep lvl indicates a new row
-				rowSkipRelative-- // decrement the number of rows we need to skip
-				if rowSkipRelative <= 0 {
-					// if we hit here we skipped all rows and did not exceed the magic threshold, so we're leaving shouldSkip false
-					break
-				}
-			}
-		}
-	}
-
-	if !shouldSkip {
-		return
-	}
-
-	// skips are calculated off the start of the page
-	rowSkip := to[0] - c.currPageMin[0]
-	if rowSkip < 1 {
-		return
-	}
-	if rowSkip > int32(c.currPage.NumRows()) {
-		return
-	}
-
-	// reslice the page to jump directly to the desired row number
-	pg := c.currPage.Slice(int64(rowSkip-1), c.currPage.NumRows())
-
-	// remove all detail below the row number
-	c.curr = TruncateRowNumber(0, to)
-	c.curr = c.curr.Preceding()
-
-	// reset buffers and other vars
-	pq.Release(c.currPage)
-	c.currPage = pg
-	c.currPageMin = c.curr
-	c.currValues = pg.Values()
-	c.currPageN = 0
-	syncIteratorPoolPut(c.currBuf)
-	c.currBuf = nil
+	c.chunk.seekWithinPage(&c.curr, to, definitionLevel)
 }
 
 // next is the core functionality of this iterator and returns the next matching result. This
@@ -975,75 +707,34 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-			if !c.enterColumnChunk(rg, minRN, maxRN, cc) {
+			if !c.chunk.admitChunk(cc) {
+				cc.Close()
 				continue
 			}
+			c.setRowGroup(rg, minRN, maxRN, cc)
 		}
 
-		if c.currPage == nil {
-			pg, err := c.currChunk.NextPage()
-			if err != nil && !errors.Is(err, io.EOF) {
+		if !c.chunk.hasPage() {
+			ok, err := c.chunk.loadPage(&c.curr, nil, 0)
+			if err != nil {
 				return EmptyRowNumber(), nil, err
 			}
-			if pg == nil || errors.Is(err, io.EOF) {
-				// This row group is exhausted
+			if !ok {
+				// This row group is exhausted.
 				c.closeCurrRowGroup()
 				continue
 			}
-			if c.filter != nil && !c.filter.KeepPage(pg) {
-				// This page filtered out
-				c.curr.Skip(pg.NumRows())
-				pq.Release(pg)
-				continue
-			}
-			c.setPage(pg)
 		}
 
-		// Dictionary fast path: match rows by integer dictionary index.
-		if c.indexReader != nil {
-			v, ok := c.indexReader.nextMatch(&c.curr, &c.currPageN, c.maxDefinitionLevel)
-			if !ok {
-				c.setPage(nil) // page exhausted
-				continue
-			}
-			return c.curr, v, nil
+		v, ok, err := c.chunk.next(&c.curr)
+		if err != nil {
+			return EmptyRowNumber(), nil, err
 		}
-
-		// Read next batch of values if needed
-		if c.currBuf == nil {
-			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
+		if !ok {
+			c.chunk.setPage(&c.curr, nil) // page exhausted; load the next on the next loop
+			continue
 		}
-		if c.currBufN >= len(c.currBuf) || len(c.currBuf) == 0 {
-			c.currBuf = c.currBuf[:cap(c.currBuf)]
-			n, err := c.currValues.ReadValues(c.currBuf)
-			if err != nil && !errors.Is(err, io.EOF) {
-				return EmptyRowNumber(), nil, err
-			}
-			c.currBuf = c.currBuf[:n]
-			c.currBufN = 0
-			if n == 0 {
-				// This value reader and page are exhausted.
-				c.setPage(nil)
-				continue
-			}
-		}
-
-		// Consume current buffer until empty
-		for c.currBufN < len(c.currBuf) {
-			v := &c.currBuf[c.currBufN]
-
-			// Inspect all values to track the current row number,
-			// even if the value is filtered out next.
-			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
-			c.currBufN++
-			c.currPageN++
-
-			if c.filter != nil && !c.filter.KeepValue(*v) {
-				continue
-			}
-
-			return c.curr, v, nil
-		}
+		return c.curr, v, nil
 	}
 }
 
@@ -1053,69 +744,14 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroup = rg
 	c.currRowGroupMin = min
 	c.currRowGroupMax = max
-	c.currChunk = cc
-
-	// Reset the per-chunk match bitmap; each chunk has its own dictionary.
-	c.indexReaderChecked = false
-	c.indexReaderMatches = nil
-}
-
-func (c *SyncIterator) setPage(pg pq.Page) {
-	// Handle an outgoing page
-	if c.currPage != nil {
-		c.curr = c.currPageMax.Preceding() // Reposition current row number to end of this page.
-		pq.Release(c.currPage)
-		c.currPage = nil
-	}
-
-	// Reset value buffers
-	c.currValues = nil
-	c.currPageMax = EmptyRowNumber()
-	c.currPageMin = EmptyRowNumber()
-	c.currBufN = 0
-	c.currPageN = 0
-	c.indexReader = nil
-
-	// If we don't immediately have a new incoming page
-	// then return the buffer to the pool.
-	if pg == nil && c.currBuf != nil {
-		syncIteratorPoolPut(c.currBuf)
-		c.currBuf = nil
-	}
-
-	// Handle an incoming page
-	if pg != nil {
-		rn := c.curr
-		rn.Skip(pg.NumRows() + 1) // Exclusive upper bound, points at the first rownumber in the next page
-		c.currPage = pg
-		c.currPageMin = c.curr
-		c.currPageMax = rn
-		c.currValues = pg.Values()
-		c.indexReader = c.indexReaderFor(pg)
-	}
-}
-
-// maxByte returns the largest byte in b, or 0 when b is empty (so a required
-// column with no definition levels yields a present level of 0). slices.Max is
-// not used because it panics on an empty slice.
-func maxByte(b []byte) byte {
-	var m byte
-	for _, v := range b {
-		m = max(m, v)
-	}
-	return m
+	c.chunk.setChunk(cc)
 }
 
 func (c *SyncIterator) closeCurrRowGroup() {
-	if c.currChunk != nil {
-		c.currChunk.Close()
-	}
-
+	c.chunk.closeChunk(&c.curr)
 	c.currRowGroup = nil
 	c.currRowGroupMin = EmptyRowNumber()
 	c.currRowGroupMax = EmptyRowNumber()
-	c.currChunk = nil
-	c.setPage(nil)
 }
 
 // Several variations of optimized makeResult functions:

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -438,6 +438,20 @@ func SyncIteratorOptMaxDefinitionLevel(maxDefinitionLevel int) SyncIteratorOpt {
 	}
 }
 
+// SyncIteratorOptDisableDictPushdown turns off the dictionary fast path, forcing
+// per-row predicate evaluation. Primarily useful for testing and benchmarking.
+func SyncIteratorOptDisableDictPushdown() SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.dict.disabled = true
+	}
+}
+
+// DictFastPathPages reports how many pages were served via the dictionary fast
+// path. Used by tests to confirm the optimization engaged.
+func (c *SyncIterator) DictFastPathPages() int {
+	return c.dict.pagesUsed
+}
+
 // SyncIterator is a synchronous column iterator. It scans through the given row
 // groups and column, and applies the optional predicate to each chunk, page, and value.
 // Results are read by calling Next() until it returns nil.
@@ -470,11 +484,103 @@ type SyncIterator struct {
 
 	maxDefinitionLevel int
 
+	// Dictionary fast path state. See dictScan.
+	dict dictScan
+
 	interner   *intern.Interner
 	makeResult func(t RowNumber, v *pq.Value) *IteratorResult
 }
 
 var _ Iterator = (*SyncIterator)(nil)
+
+// dictScan holds the dictionary fast-path state. When the filter is a
+// DictionaryPredicate and the current page is dictionary-encoded, the predicate
+// is resolved once over the dictionary into keep, and rows are matched by their
+// integer dictionary index instead of being materialized and byte-compared per
+// row. State has three lifetimes, made explicit by reset methods:
+//   - whole iterator: disabled (config), pagesUsed (observability)
+//   - per column chunk (resetChunk): checked, keep, dict
+//   - per page (resetPage): everything else
+type dictScan struct {
+	disabled  bool // config: force the per-row path
+	pagesUsed int  // pages served via the fast path (observability/tests)
+
+	// per chunk
+	checked bool          // whether keep was resolved for the current chunk
+	keep    []bool        // keep bitmap indexed by dictionary index; nil => pushdown declined
+	dict    pq.Dictionary // the dictionary keep was built against
+
+	// per page
+	active     bool    // fast path engaged for the current page
+	indices    []int32 // present-value dictionary indexes for the current page
+	defLevels  []byte  // nil for required columns
+	repLevels  []byte  // nil for non-repeated columns
+	pageMaxDef byte    // definition level of a present (non-null) value
+	slotN      int     // cursor over level slots (present + null)
+	valueN     int     // cursor over indices (present only)
+
+	value pq.Value // reused return buffer for matched values
+}
+
+// resetChunk clears the per-chunk keep bitmap. Called when the iterator advances
+// to a new column chunk (all pages in a chunk share one dictionary).
+func (d *dictScan) resetChunk() {
+	d.checked = false
+	d.keep = nil
+	d.dict = nil
+}
+
+// resetPage clears the per-page cursors. The per-chunk keep bitmap is preserved.
+func (d *dictScan) resetPage() {
+	d.active = false
+	d.indices = nil
+	d.defLevels = nil
+	d.repLevels = nil
+	d.pageMaxDef = 0
+	d.slotN = 0
+	d.valueN = 0
+}
+
+// setupPage enables the fast path for pg when filter can be resolved against the
+// chunk dictionary. The keep bitmap is computed once per chunk and reused across
+// the chunk's pages; only the per-page cursors are refreshed here. When pushdown
+// does not apply, active stays false and the caller uses the per-row path.
+func (d *dictScan) setupPage(filter Predicate, pg pq.Page) {
+	if d.disabled {
+		return
+	}
+	dp, ok := filter.(DictionaryPredicate)
+	if !ok {
+		return
+	}
+	dict := pg.Dictionary()
+	if dict == nil {
+		return // page is not dictionary-encoded
+	}
+
+	// Resolve the predicate against the dictionary once per chunk.
+	if !d.checked {
+		d.checked = true
+		d.keep = dp.KeepIndexes(dict)
+		d.dict = dict
+	}
+	if d.keep == nil {
+		return // predicate declined dictionary pushdown for this chunk
+	}
+
+	d.defLevels = pg.DefinitionLevels()
+	d.repLevels = pg.RepetitionLevels()
+	data := pg.Data()
+	d.indices = data.Int32()
+	// A present (non-null) leaf carries the maximum definition level seen on the
+	// page. Required columns have no definition levels and every index is present.
+	d.pageMaxDef = maxByte(d.defLevels)
+
+	d.slotN = 0
+	d.valueN = 0
+	d.active = true
+	d.pagesUsed++
+}
 
 // NewSyncIterator iterates values in a column of a parquet file. Required values
 // are the numeric column index and the row groups to iterate over.  The column index
@@ -739,6 +845,13 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 		return
 	}
 
+	// The dictionary fast path tracks its cursor against the whole page; reslicing
+	// would require rebuilding that state, so we let next() advance to the target
+	// instead. Correctness is unaffected, only the large-skip shortcut is skipped.
+	if c.dict.active {
+		return
+	}
+
 	const magicThreshold = 1000
 	shouldSkip := false
 
@@ -841,6 +954,17 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.setPage(pg)
 		}
 
+		// Dictionary fast path: match rows by integer dictionary index.
+		if c.dict.active {
+			rn, v, ok := c.nextDict()
+			if !ok {
+				// Page exhausted, move on.
+				c.setPage(nil)
+				continue
+			}
+			return rn, v, nil
+		}
+
 		// Read next batch of values if needed
 		if c.currBuf == nil {
 			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
@@ -886,6 +1010,10 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroupMin = min
 	c.currRowGroupMax = max
 	c.currChunk = cc
+
+	// The dictionary keep bitmap is resolved once per column chunk (all data pages
+	// in a chunk share the same dictionary) and reset when the chunk changes.
+	c.dict.resetChunk()
 }
 
 func (c *SyncIterator) setPage(pg pq.Page) {
@@ -902,6 +1030,7 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 	c.currPageMin = EmptyRowNumber()
 	c.currBufN = 0
 	c.currPageN = 0
+	c.dict.resetPage()
 
 	// If we don't immediately have a new incoming page
 	// then return the buffer to the pool.
@@ -918,7 +1047,67 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 		c.currPageMin = c.curr
 		c.currPageMax = rn
 		c.currValues = pg.Values()
+		c.dict.setupPage(c.filter, pg)
 	}
+}
+
+func maxByte(b []byte) byte {
+	var m byte
+	for _, v := range b {
+		if v > m {
+			m = v
+		}
+	}
+	return m
+}
+
+// nextDict advances the dictionary fast path by one matching row in the current
+// page. ok is false when the page is exhausted. Row numbers are tracked across
+// every slot (including nulls) exactly as the per-row path does, but only present
+// values consume a dictionary index and only matching indexes are materialized.
+func (c *SyncIterator) nextDict() (RowNumber, *pq.Value, bool) {
+	d := &c.dict
+
+	numSlots := len(d.indices)
+	if d.defLevels != nil {
+		numSlots = len(d.defLevels)
+	}
+
+	for d.slotN < numSlots {
+		repLvl := 0
+		if d.repLevels != nil {
+			repLvl = int(d.repLevels[d.slotN])
+		}
+		// Required columns have no definition levels; every value is present at the
+		// page's (possibly zero) definition level.
+		defLvl := int(d.pageMaxDef)
+		if d.defLevels != nil {
+			defLvl = int(d.defLevels[d.slotN])
+		}
+
+		c.curr.Next(repLvl, defLvl, c.maxDefinitionLevel)
+		d.slotN++
+		c.currPageN++
+
+		// Null slot: no value present and no dictionary index consumed. The gated
+		// predicates never keep nulls, matching the per-row path.
+		if d.defLevels != nil && byte(defLvl) != d.pageMaxDef {
+			continue
+		}
+
+		idx := d.indices[d.valueN]
+		d.valueN++
+
+		if !d.keep[idx] {
+			continue
+		}
+
+		// Materialize only matching values, stamping the page levels and column so
+		// the result is indistinguishable from the per-row path.
+		d.value = d.dict.Index(idx).Level(repLvl, defLvl, c.currPage.Column())
+		return c.curr, &d.value, true
+	}
+	return EmptyRowNumber(), nil, false
 }
 
 func (c *SyncIterator) closeCurrRowGroup() {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -438,18 +438,10 @@ func SyncIteratorOptMaxDefinitionLevel(maxDefinitionLevel int) SyncIteratorOpt {
 	}
 }
 
-// SyncIteratorOptDisableDictPushdown turns off the dictionary fast path, forcing
-// per-row predicate evaluation. Primarily useful for testing and benchmarking.
-func SyncIteratorOptDisableDictPushdown() SyncIteratorOpt {
-	return func(i *SyncIterator) {
-		i.dict.disabled = true
-	}
-}
-
-// DictFastPathPages reports how many pages were served via the dictionary fast
-// path. Used by tests to confirm the optimization engaged.
-func (c *SyncIterator) DictFastPathPages() int {
-	return c.dict.pagesUsed
+// dictFastPathPages reports how many pages were served via the dictionary fast
+// path. Used by in-package tests to confirm the optimization engaged.
+func (c *SyncIterator) dictFastPathPages() int {
+	return c.indexReaderPagesUsed
 }
 
 // SyncIterator is a synchronous column iterator. It scans through the given row
@@ -484,8 +476,21 @@ type SyncIterator struct {
 
 	maxDefinitionLevel int
 
-	// Dictionary fast path state. See dictScan.
-	dict dictScan
+	// Dictionary fast-path state. When the filter is a DictionaryPredicate and a
+	// page is dictionary-encoded, the predicate is resolved once over the chunk
+	// dictionary into a match bitmap, and rows are matched by their integer
+	// dictionary index instead of being materialized and byte-compared per row.
+	// The per-page decoding lives in indexReader; the remaining fields outlive a
+	// single page:
+	//   - whole iterator: indexReaderDisabled (test-only), indexReaderPagesUsed (observability)
+	//   - per column chunk: indexReaderChecked, indexReaderMatches
+	indexReaderDisabled  bool   // test-only: force the per-row path (set directly by in-package tests)
+	indexReaderPagesUsed int    // pages served via the fast path (observability/tests)
+	indexReaderChecked   bool   // whether the match bitmap was resolved for the current chunk
+	indexReaderMatches   []bool // match bitmap indexed by dictionary index; nil => pushdown declined
+	// indexReader serves the current dictionary-encoded page on the fast path; nil
+	// when the page uses the per-row path. See indexValueReader.
+	indexReader *indexValueReader
 
 	interner   *intern.Interner
 	makeResult func(t RowNumber, v *pq.Value) *IteratorResult
@@ -493,93 +498,168 @@ type SyncIterator struct {
 
 var _ Iterator = (*SyncIterator)(nil)
 
-// dictScan holds the dictionary fast-path state. When the filter is a
-// DictionaryPredicate and the current page is dictionary-encoded, the predicate
-// is resolved once over the dictionary into keep, and rows are matched by their
-// integer dictionary index instead of being materialized and byte-compared per
-// row. State has three lifetimes, made explicit by reset methods:
-//   - whole iterator: disabled (config), pagesUsed (observability)
-//   - per column chunk (resetChunk): checked, keep, dict
-//   - per page (resetPage): everything else
-type dictScan struct {
-	disabled  bool // config: force the per-row path
-	pagesUsed int  // pages served via the fast path (observability/tests)
+// enterColumnChunk applies the column-chunk filter and, if the chunk is kept,
+// makes it current. Returns false when the chunk can be skipped (the caller must
+// continue to the next row group). For a dictionary-pushable predicate it resolves
+// the per-index match bitmap here and installs it, so the per-page readers reuse it
+// instead of rescanning the dictionary.
+func (c *SyncIterator) enterColumnChunk(rg pq.RowGroup, minRN, maxRN RowNumber, cc *ColumnChunkHelper) bool {
+	keep, matches := c.keepColumnChunk(cc)
+	if !keep {
+		cc.Close()
+		return false
+	}
+	c.setRowGroup(rg, minRN, maxRN, cc)
+	// setRowGroup cleared the per-chunk bitmap; install the one we just resolved so
+	// indexReaderFor doesn't scan the dictionary a second time.
+	if matches != nil {
+		c.indexReaderChecked = true
+		c.indexReaderMatches = matches
+	}
+	return true
+}
 
-	// per chunk
-	checked bool          // whether keep was resolved for the current chunk
-	keep    []bool        // keep bitmap indexed by dictionary index; nil => pushdown declined
-	dict    pq.Dictionary // the dictionary keep was built against
+// keepColumnChunk reports whether cc can contain matching rows. For a dictionary-
+// pushable predicate on a dictionary-encoded chunk it resolves the per-index match
+// bitmap once - the same dictionary scan the generic KeepColumnChunk would do to
+// test for any match - and returns it (non-nil) so the caller can reuse it for the
+// per-page readers. The chunk is skipped when no dictionary entry matches.
+//
+// For substring/regex predicates this bypasses KeepColumnChunk's per-chunk match-
+// cache reset. That is safe: those caches are pure value->bool memoization, so they
+// stay correct, and they remain bounded by the column's distinct dictionary values.
+func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool, matches []bool) {
+	if c.filter == nil {
+		return true, nil
+	}
+	if dp, ok := c.filter.(DictionaryPredicate); ok && !c.indexReaderDisabled {
+		if dict := cc.Dictionary(); dict != nil {
+			if m := dp.KeepIndexes(dict); m != nil {
+				return anyTrue(m), m
+			}
+		}
+	}
+	return c.filter.KeepColumnChunk(cc), nil
+}
 
-	// per page
-	active     bool    // fast path engaged for the current page
-	indices    []int32 // present-value dictionary indexes for the current page
+// indexReaderFor returns a dictionary fast-path reader for pg, or nil when
+// pushdown does not apply (disabled, non-dictionary predicate, non-dictionary
+// page, or the predicate declined). The match bitmap is resolved against the
+// chunk dictionary once and reused across all of the chunk's pages; when it is
+// nil the caller uses the per-row path.
+func (c *SyncIterator) indexReaderFor(pg pq.Page) *indexValueReader {
+	if c.indexReaderDisabled {
+		return nil
+	}
+	dp, ok := c.filter.(DictionaryPredicate)
+	if !ok {
+		return nil
+	}
+	dict := pg.Dictionary()
+	if dict == nil {
+		return nil // page is not dictionary-encoded
+	}
+
+	// Resolve the predicate against the dictionary once per chunk.
+	if !c.indexReaderChecked {
+		c.indexReaderChecked = true
+		c.indexReaderMatches = dp.KeepIndexes(dict)
+	}
+	if c.indexReaderMatches == nil {
+		return nil // predicate declined dictionary pushdown for this chunk
+	}
+
+	c.indexReaderPagesUsed++
+	return newIndexValueReader(c.indexReaderMatches, pg)
+}
+
+// indexValueReader serves one dictionary-encoded page on the fast path. The
+// predicate is pre-resolved into matches (indexed by dictionary index) and shared
+// across all pages in the chunk; the reader decodes this page's levels and
+// indices and advances one slot per next() call. It is a pure page decoder: row
+// numbers are tracked by the caller, driven by the levels next() returns.
+type indexValueReader struct {
+	matches []bool        // match bitmap indexed by dictionary index (chunk-scoped)
+	dict    pq.Dictionary // dictionary the matches were built against
+	col     int           // column index, stamped onto materialized values
+
+	indices    []int32 // present-value dictionary indexes for this page
 	defLevels  []byte  // nil for required columns
 	repLevels  []byte  // nil for non-repeated columns
-	pageMaxDef byte    // definition level of a present (non-null) value
+	pageMaxDef byte    // definition level of a present (non-null) leaf value on this page
 	slotN      int     // cursor over level slots (present + null)
 	valueN     int     // cursor over indices (present only)
 
 	value pq.Value // reused return buffer for matched values
 }
 
-// resetChunk clears the per-chunk keep bitmap. Called when the iterator advances
-// to a new column chunk (all pages in a chunk share one dictionary).
-func (d *dictScan) resetChunk() {
-	d.checked = false
-	d.keep = nil
-	d.dict = nil
-}
-
-// resetPage clears the per-page cursors. The per-chunk keep bitmap is preserved.
-func (d *dictScan) resetPage() {
-	d.active = false
-	d.indices = nil
-	d.defLevels = nil
-	d.repLevels = nil
-	d.pageMaxDef = 0
-	d.slotN = 0
-	d.valueN = 0
-}
-
-// setupPage enables the fast path for pg when filter can be resolved against the
-// chunk dictionary. The keep bitmap is computed once per chunk and reused across
-// the chunk's pages; only the per-page cursors are refreshed here. When pushdown
-// does not apply, active stays false and the caller uses the per-row path.
-func (d *dictScan) setupPage(filter Predicate, pg pq.Page) {
-	if d.disabled {
-		return
-	}
-	dp, ok := filter.(DictionaryPredicate)
-	if !ok {
-		return
-	}
-	dict := pg.Dictionary()
-	if dict == nil {
-		return // page is not dictionary-encoded
-	}
-
-	// Resolve the predicate against the dictionary once per chunk.
-	if !d.checked {
-		d.checked = true
-		d.keep = dp.KeepIndexes(dict)
-		d.dict = dict
-	}
-	if d.keep == nil {
-		return // predicate declined dictionary pushdown for this chunk
-	}
-
-	d.defLevels = pg.DefinitionLevels()
-	d.repLevels = pg.RepetitionLevels()
+func newIndexValueReader(matches []bool, pg pq.Page) *indexValueReader {
+	defLevels := pg.DefinitionLevels()
 	data := pg.Data()
-	d.indices = data.Int32()
-	// A present (non-null) leaf carries the maximum definition level seen on the
-	// page. Required columns have no definition levels and every index is present.
-	d.pageMaxDef = maxByte(d.defLevels)
+	return &indexValueReader{
+		matches:   matches,
+		dict:      pg.Dictionary(),
+		col:       pg.Column(),
+		indices:   data.Int32(),
+		defLevels: defLevels,
+		repLevels: pg.RepetitionLevels(),
+		// A present (non-null) leaf carries the maximum definition level seen on the
+		// page. (The iterator's maxDefinitionLevel is a row-number tracking cap, not
+		// necessarily this leaf's level, so we derive it from the page.) On a page with
+		// no present values this collapses to the null level, so the valueN bound in
+		// next() is what keeps such pages from indexing past the empty indices slice.
+		pageMaxDef: maxByte(defLevels),
+	}
+}
 
-	d.slotN = 0
-	d.valueN = 0
-	d.active = true
-	d.pagesUsed++
+// nextMatch advances over slots until it materializes a matching value or the page
+// is exhausted (ok=false). It owns the per-slot loop so a predicate-bound scan stays
+// in one tight loop rather than paying a method call per non-matching slot. Row
+// numbers are tracked exactly as the per-row path does: curr and pageN are advanced
+// for every slot (present, null, or filtered) via the caller's pointers, and
+// maxDefLevel is the row-number tracking cap. The returned value points at a reused
+// buffer, valid until the next call.
+func (r *indexValueReader) nextMatch(curr *RowNumber, pageN *int, maxDefLevel int) (*pq.Value, bool) {
+	numSlots := len(r.indices)
+	if r.defLevels != nil {
+		numSlots = len(r.defLevels)
+	}
+
+	for r.slotN < numSlots {
+		repLvl := 0
+		if r.repLevels != nil {
+			repLvl = int(r.repLevels[r.slotN])
+		}
+		// Required columns have no definition levels; every value is present at the
+		// page's (possibly zero) definition level.
+		defLvl := int(r.pageMaxDef)
+		if r.defLevels != nil {
+			defLvl = int(r.defLevels[r.slotN])
+		}
+		curr.Next(repLvl, defLvl, maxDefLevel)
+		r.slotN++
+		(*pageN)++
+
+		// Null/empty slot: not present at the leaf, so no value and no dictionary index
+		// is consumed. The valueN bound also guards pages that carry definition levels
+		// but no present values (an all-null page, where indices is empty), so we never
+		// index past indices/matches.
+		if (r.defLevels != nil && byte(defLvl) != r.pageMaxDef) || r.valueN >= len(r.indices) {
+			continue
+		}
+
+		idx := r.indices[r.valueN]
+		r.valueN++
+		if !r.matches[idx] {
+			continue
+		}
+
+		// Materialize only matching values, stamping the page levels and column so the
+		// result is indistinguishable from the per-row path.
+		r.value = r.dict.Index(idx).Level(repLvl, defLvl, r.col)
+		return &r.value, true
+	}
+	return nil, false
 }
 
 // NewSyncIterator iterates values in a column of a parquet file. Required values
@@ -762,13 +842,10 @@ func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int) (done
 		}
 
 		cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-		if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
-			cc.Close()
+		// This row group matches the row number; check the filter.
+		if !c.enterColumnChunk(rg, minRN, maxRN, cc) {
 			continue
 		}
-
-		// This row group matches both row number and filter.
-		c.setRowGroup(rg, minRN, maxRN, cc)
 	}
 
 	return c.currRowGroup == nil
@@ -848,7 +925,7 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 	// The dictionary fast path tracks its cursor against the whole page; reslicing
 	// would require rebuilding that state, so we let next() advance to the target
 	// instead. Correctness is unaffected, only the large-skip shortcut is skipped.
-	if c.dict.active {
+	if c.indexReader != nil {
 		return
 	}
 
@@ -927,12 +1004,9 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-			if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
-				cc.Close()
+			if !c.enterColumnChunk(rg, minRN, maxRN, cc) {
 				continue
 			}
-
-			c.setRowGroup(rg, minRN, maxRN, cc)
 		}
 
 		if c.currPage == nil {
@@ -954,15 +1028,17 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.setPage(pg)
 		}
 
-		// Dictionary fast path: match rows by integer dictionary index.
-		if c.dict.active {
-			rn, v, ok := c.nextDict()
+		// Dictionary fast path: match rows by integer dictionary index. The reader
+		// advances the row number over every slot (present, null, or filtered-out),
+		// exactly as the per-row path does, and returns only matched values.
+		if c.indexReader != nil {
+			v, ok := c.indexReader.nextMatch(&c.curr, &c.currPageN, c.maxDefinitionLevel)
 			if !ok {
 				// Page exhausted, move on.
 				c.setPage(nil)
 				continue
 			}
-			return rn, v, nil
+			return c.curr, v, nil
 		}
 
 		// Read next batch of values if needed
@@ -1011,9 +1087,10 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroupMax = max
 	c.currChunk = cc
 
-	// The dictionary keep bitmap is resolved once per column chunk (all data pages
-	// in a chunk share the same dictionary) and reset when the chunk changes.
-	c.dict.resetChunk()
+	// The match bitmap is resolved once per column chunk (all data pages in a chunk
+	// share the same dictionary) and reset when the chunk changes.
+	c.indexReaderChecked = false
+	c.indexReaderMatches = nil
 }
 
 func (c *SyncIterator) setPage(pg pq.Page) {
@@ -1030,7 +1107,7 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 	c.currPageMin = EmptyRowNumber()
 	c.currBufN = 0
 	c.currPageN = 0
-	c.dict.resetPage()
+	c.indexReader = nil
 
 	// If we don't immediately have a new incoming page
 	// then return the buffer to the pool.
@@ -1047,7 +1124,7 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 		c.currPageMin = c.curr
 		c.currPageMax = rn
 		c.currValues = pg.Values()
-		c.dict.setupPage(c.filter, pg)
+		c.indexReader = c.indexReaderFor(pg)
 	}
 }
 
@@ -1061,53 +1138,13 @@ func maxByte(b []byte) byte {
 	return m
 }
 
-// nextDict advances the dictionary fast path by one matching row in the current
-// page. ok is false when the page is exhausted. Row numbers are tracked across
-// every slot (including nulls) exactly as the per-row path does, but only present
-// values consume a dictionary index and only matching indexes are materialized.
-func (c *SyncIterator) nextDict() (RowNumber, *pq.Value, bool) {
-	d := &c.dict
-
-	numSlots := len(d.indices)
-	if d.defLevels != nil {
-		numSlots = len(d.defLevels)
+func anyTrue(b []bool) bool {
+	for _, v := range b {
+		if v {
+			return true
+		}
 	}
-
-	for d.slotN < numSlots {
-		repLvl := 0
-		if d.repLevels != nil {
-			repLvl = int(d.repLevels[d.slotN])
-		}
-		// Required columns have no definition levels; every value is present at the
-		// page's (possibly zero) definition level.
-		defLvl := int(d.pageMaxDef)
-		if d.defLevels != nil {
-			defLvl = int(d.defLevels[d.slotN])
-		}
-
-		c.curr.Next(repLvl, defLvl, c.maxDefinitionLevel)
-		d.slotN++
-		c.currPageN++
-
-		// Null slot: no value present and no dictionary index consumed. The gated
-		// predicates never keep nulls, matching the per-row path.
-		if d.defLevels != nil && byte(defLvl) != d.pageMaxDef {
-			continue
-		}
-
-		idx := d.indices[d.valueN]
-		d.valueN++
-
-		if !d.keep[idx] {
-			continue
-		}
-
-		// Materialize only matching values, stamping the page levels and column so
-		// the result is indistinguishable from the per-row path.
-		d.value = d.dict.Index(idx).Level(repLvl, defLvl, c.currPage.Column())
-		return c.curr, &d.value, true
-	}
-	return EmptyRowNumber(), nil, false
+	return false
 }
 
 func (c *SyncIterator) closeCurrRowGroup() {

--- a/pkg/parquetquery/iters_dict_bench_test.go
+++ b/pkg/parquetquery/iters_dict_bench_test.go
@@ -37,7 +37,7 @@ func BenchmarkSyncIteratorDictPushdown(b *testing.B) {
 				SyncIteratorOptPredicate(NewStringInPredicate(targets)),
 			}
 			iter := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
-			iter.indexReaderDisabled = disable // test-only: force the per-row baseline
+			iter.chunk.dictDisabled = disable // test-only: force the per-row baseline
 			var count int
 			for {
 				res, err := iter.Next()

--- a/pkg/parquetquery/iters_dict_bench_test.go
+++ b/pkg/parquetquery/iters_dict_bench_test.go
@@ -36,10 +36,8 @@ func BenchmarkSyncIteratorDictPushdown(b *testing.B) {
 				SyncIteratorOptSelectAs("S"),
 				SyncIteratorOptPredicate(NewStringInPredicate(targets)),
 			}
-			if disable {
-				opts = append(opts, SyncIteratorOptDisableDictPushdown())
-			}
 			iter := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+			iter.indexReaderDisabled = disable // test-only: force the per-row baseline
 			var count int
 			for {
 				res, err := iter.Next()

--- a/pkg/parquetquery/iters_dict_bench_test.go
+++ b/pkg/parquetquery/iters_dict_bench_test.go
@@ -1,0 +1,63 @@
+package parquetquery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// BenchmarkSyncIteratorDictPushdown compares the dictionary fast path against the
+// per-row byte-compare path for an exact-match string filter, the dominant shape
+// of live-store metrics queries.
+func BenchmarkSyncIteratorDictPushdown(b *testing.B) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	// Low-cardinality column (like span:name / service.name) with a small set of
+	// distinct values repeated across many rows.
+	alphabet := make([]string, 32)
+	for i := range alphabet {
+		alphabet[i] = fmt.Sprintf("operation-name-%02d", i)
+	}
+	rows := make([]row, 200_000)
+	for i := range rows {
+		rows[i] = row{S: alphabet[i%len(alphabet)]}
+	}
+
+	ctx := context.Background()
+	pf := createFileWith(b, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, "S")
+	targets := []string{alphabet[3], alphabet[17], alphabet[28]}
+
+	run := func(b *testing.B, disable bool) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			opts := []SyncIteratorOpt{
+				SyncIteratorOptSelectAs("S"),
+				SyncIteratorOptPredicate(NewStringInPredicate(targets)),
+			}
+			if disable {
+				opts = append(opts, SyncIteratorOptDisableDictPushdown())
+			}
+			iter := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+			var count int
+			for {
+				res, err := iter.Next()
+				if err != nil {
+					b.Fatal(err)
+				}
+				if res == nil {
+					break
+				}
+				count++
+			}
+			iter.Close()
+			if count == 0 {
+				b.Fatal("expected matches")
+			}
+		}
+	}
+
+	b.Run("per-row", func(b *testing.B) { run(b, true) })
+	b.Run("dict-pushdown", func(b *testing.B) { run(b, false) })
+}

--- a/pkg/parquetquery/iters_dict_test.go
+++ b/pkg/parquetquery/iters_dict_test.go
@@ -40,10 +40,11 @@ func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred 
 			SyncIteratorOptPredicate(makePred()),
 			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
 		}
-		if disable {
-			opts = append(opts, SyncIteratorOptDisableDictPushdown())
-		}
-		return NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+		it := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+		// indexReaderDisabled is test-only state; the fast path is always on in prod.
+		// It is read lazily on the first page, so setting it post-construction is fine.
+		it.indexReaderDisabled = disable
+		return it
 	}
 
 	fast := newIter(false)
@@ -55,8 +56,8 @@ func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred 
 	slowRes := collectStringResults(t, slow, "S")
 
 	require.Equal(t, slowRes, fastRes, "dictionary fast path must match per-row results")
-	require.Greater(t, fast.DictFastPathPages(), 0, "fast path should have engaged")
-	require.Equal(t, 0, slow.DictFastPathPages(), "slow path should not use dict fast path")
+	require.Greater(t, fast.dictFastPathPages(), 0, "fast path should have engaged")
+	require.Equal(t, 0, slow.dictFastPathPages(), "slow path should not use dict fast path")
 }
 
 func TestSyncIteratorDictPushdownRequired(t *testing.T) {
@@ -166,5 +167,51 @@ func TestSyncIteratorDictPushdownFallsBackForNonDictPredicate(t *testing.T) {
 
 	got := collectStringResults(t, iter, "S")
 	require.NotEmpty(t, got)
-	require.Equal(t, 0, iter.DictFastPathPages(), "non-dictionary predicate must not use dict fast path")
+	require.Equal(t, 0, iter.dictFastPathPages(), "non-dictionary predicate must not use dict fast path")
+}
+
+// TestIndexValueReaderNoPresentValues guards the fast path against dictionary-
+// encoded pages that carry definition levels but no present leaf values (e.g. an
+// all-null optional page or a repeated page of only empty lists). There indices
+// is empty, so naively treating slots as present would index out of bounds. The
+// page must yield no matches, advance the row-number cursor once per slot (as the
+// per-row path does), and never panic.
+func TestIndexValueReaderNoPresentValues(t *testing.T) {
+	cases := []struct {
+		name      string
+		defLevels []byte
+		repLevels []byte
+	}{
+		// All-null optional page: every slot below the present level, so pageMaxDef
+		// collapses to the null level and only the valueN bound prevents the panic.
+		{name: "all-null optional", defLevels: []byte{0, 0, 0, 0}},
+		// Repeated page of empty lists: rep=0 starts each row, def below present.
+		{name: "all-empty repeated", defLevels: []byte{0, 0, 0}, repLevels: []byte{0, 0, 0}},
+		// Pathological: a slot sits at pageMaxDef (looks present) but no index backs
+		// it. The bounds guard must treat it as null rather than indexing past indices.
+		{name: "present level without index", defLevels: []byte{1}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &indexValueReader{
+				matches:    nil, // never consulted: no present values
+				dict:       nil,
+				indices:    nil, // empty: no present values on the page
+				defLevels:  tc.defLevels,
+				repLevels:  tc.repLevels,
+				pageMaxDef: maxByte(tc.defLevels), // mirrors newIndexValueReader
+			}
+
+			require.NotPanics(t, func() {
+				curr := EmptyRowNumber()
+				pageN := 0
+				v, ok := r.nextMatch(&curr, &pageN, MaxDefinitionLevel)
+				require.False(t, ok, "an all-null page must yield no matches")
+				require.Nil(t, v)
+				// Every slot must still have been walked (row numbers advanced).
+				require.Equal(t, len(tc.defLevels), pageN, "every slot should advance the cursor")
+			})
+		})
+	}
 }

--- a/pkg/parquetquery/iters_dict_test.go
+++ b/pkg/parquetquery/iters_dict_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 // collectStringResults drains an iterator returning (rowNumber, value-as-string)
-// pairs so that the dictionary fast path and the per-row slow path can be compared
-// for exact equivalence.
-func collectStringResults(t *testing.T, iter Iterator, selectAs string) []string {
+// pairs (the value is read from the "S" select, which every test here uses) so the
+// dictionary fast path and the per-row slow path can be compared for equivalence.
+func collectStringResults(t *testing.T, iter Iterator) []string {
 	t.Helper()
 	var out []string
 	for {
@@ -20,7 +20,7 @@ func collectStringResults(t *testing.T, iter Iterator, selectAs string) []string
 		if res == nil {
 			break
 		}
-		vals := res.ToMap()[selectAs]
+		vals := res.ToMap()["S"]
 		require.Len(t, vals, 1)
 		out = append(out, fmt.Sprintf("%v=%s", res.RowNumber, vals[0].String()))
 	}
@@ -52,8 +52,8 @@ func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred 
 	slow := newIter(true)
 	defer slow.Close()
 
-	fastRes := collectStringResults(t, fast, "S")
-	slowRes := collectStringResults(t, slow, "S")
+	fastRes := collectStringResults(t, fast)
+	slowRes := collectStringResults(t, slow)
 
 	require.Equal(t, slowRes, fastRes, "dictionary fast path must match per-row results")
 	require.Greater(t, fast.dictFastPathPages(), 0, "fast path should have engaged")
@@ -165,7 +165,7 @@ func TestSyncIteratorDictPushdownFallsBackForNonDictPredicate(t *testing.T) {
 	)
 	defer iter.Close()
 
-	got := collectStringResults(t, iter, "S")
+	got := collectStringResults(t, iter)
 	require.NotEmpty(t, got)
 	require.Equal(t, 0, iter.dictFastPathPages(), "non-dictionary predicate must not use dict fast path")
 }
@@ -214,4 +214,60 @@ func TestIndexValueReaderNoPresentValues(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestSyncIteratorDictPushdownOr drives the fast path through OrPredicate, whose
+// KeepIndexes ORs its dictionary-pushable children's bitmaps.
+func TestSyncIteratorDictPushdownOr(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		rows = append(rows, row{S: alphabet[i%len(alphabet)]})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate {
+		return NewOrPredicate(
+			NewByteEqualPredicate([]byte("alpha")),
+			NewByteEqualPredicate([]byte("delta")),
+		)
+	})
+}
+
+// TestSyncIteratorDictPushdownSkipsChunkWithNoMatch covers the chunk-skip path:
+// when no dictionary entry matches, the whole chunk is skipped before any page is
+// read, so the fast path serves zero pages while still returning correct (empty)
+// results identical to the per-row path.
+func TestSyncIteratorDictPushdownSkipsChunkWithNoMatch(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie"}
+	var rows []row
+	for i := 0; i < 4000; i++ {
+		rows = append(rows, row{S: alphabet[i%len(alphabet)]})
+	}
+	ctx := context.Background()
+	pf := createFileWith(t, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, "S")
+
+	newIter := func(disable bool) *SyncIterator {
+		it := NewSyncIterator(ctx, pf.RowGroups(), idx,
+			SyncIteratorOptSelectAs("S"),
+			SyncIteratorOptPredicate(NewStringInPredicate([]string{"no-such-value"})),
+			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
+		)
+		it.indexReaderDisabled = disable
+		return it
+	}
+
+	fast := newIter(false)
+	defer fast.Close()
+	slow := newIter(true)
+	defer slow.Close()
+
+	require.Empty(t, collectStringResults(t, fast))
+	require.Empty(t, collectStringResults(t, slow))
+	require.Equal(t, 0, fast.dictFastPathPages(), "a chunk with no matching dict entry should be skipped, not scanned")
 }

--- a/pkg/parquetquery/iters_dict_test.go
+++ b/pkg/parquetquery/iters_dict_test.go
@@ -41,9 +41,9 @@ func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred 
 			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
 		}
 		it := NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
-		// indexReaderDisabled is test-only state; the fast path is always on in prod.
-		// It is read lazily on the first page, so setting it post-construction is fine.
-		it.indexReaderDisabled = disable
+		// dictDisabled is test-only state; the fast path is always on in prod. It is
+		// read lazily per chunk, so setting it post-construction is fine.
+		it.chunk.dictDisabled = disable
 		return it
 	}
 
@@ -170,47 +170,44 @@ func TestSyncIteratorDictPushdownFallsBackForNonDictPredicate(t *testing.T) {
 	require.Equal(t, 0, iter.dictFastPathPages(), "non-dictionary predicate must not use dict fast path")
 }
 
-// TestIndexValueReaderNoPresentValues guards the fast path against dictionary-
-// encoded pages that carry definition levels but no present leaf values (e.g. an
-// all-null optional page or a repeated page of only empty lists). There indices
-// is empty, so naively treating slots as present would index out of bounds. The
-// page must yield no matches, advance the row-number cursor once per slot (as the
-// per-row path does), and never panic.
-func TestIndexValueReaderNoPresentValues(t *testing.T) {
+// TestDictPageReaderNoPresentValues guards the fast path against dictionary-encoded
+// pages that carry definition levels but no present leaf values (e.g. an all-null
+// optional page or a repeated page of only empty lists). There dictIndexes is empty,
+// so naively treating slots as present would index out of bounds. The page must yield
+// no matches and never panic.
+func TestDictPageReaderNoPresentValues(t *testing.T) {
 	cases := []struct {
 		name      string
 		defLevels []byte
 		repLevels []byte
 	}{
-		// All-null optional page: every slot below the present level, so pageMaxDef
-		// collapses to the null level and only the valueN bound prevents the panic.
+		// All-null optional page: every slot below the present level, so presentDefLevel
+		// collapses to the null level and only the valuePos bound prevents the panic.
 		{name: "all-null optional", defLevels: []byte{0, 0, 0, 0}},
 		// Repeated page of empty lists: rep=0 starts each row, def below present.
 		{name: "all-empty repeated", defLevels: []byte{0, 0, 0}, repLevels: []byte{0, 0, 0}},
-		// Pathological: a slot sits at pageMaxDef (looks present) but no index backs
-		// it. The bounds guard must treat it as null rather than indexing past indices.
+		// Pathological: a slot sits at presentDefLevel (looks present) but no index
+		// backs it. The bounds guard must treat it as null rather than indexing past.
 		{name: "present level without index", defLevels: []byte{1}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := &indexValueReader{
-				matches:    nil, // never consulted: no present values
-				dict:       nil,
-				indices:    nil, // empty: no present values on the page
-				defLevels:  tc.defLevels,
-				repLevels:  tc.repLevels,
-				pageMaxDef: maxByte(tc.defLevels), // mirrors newIndexValueReader
+			r := &dictPageReader{
+				keep:            nil, // never consulted: no present values
+				dictionary:      nil,
+				dictIndexes:     nil, // empty: no present values on the page
+				defLevels:       tc.defLevels,
+				repLevels:       tc.repLevels,
+				presentDefLevel: maxByte(tc.defLevels), // mirrors setup
 			}
 
 			require.NotPanics(t, func() {
 				curr := EmptyRowNumber()
-				pageN := 0
-				v, ok := r.nextMatch(&curr, &pageN, MaxDefinitionLevel)
+				v, ok, err := r.next(&curr)
+				require.NoError(t, err)
 				require.False(t, ok, "an all-null page must yield no matches")
 				require.Nil(t, v)
-				// Every slot must still have been walked (row numbers advanced).
-				require.Equal(t, len(tc.defLevels), pageN, "every slot should advance the cursor")
 			})
 		})
 	}
@@ -258,7 +255,7 @@ func TestSyncIteratorDictPushdownSkipsChunkWithNoMatch(t *testing.T) {
 			SyncIteratorOptPredicate(NewStringInPredicate([]string{"no-such-value"})),
 			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
 		)
-		it.indexReaderDisabled = disable
+		it.chunk.dictDisabled = disable
 		return it
 	}
 

--- a/pkg/parquetquery/iters_dict_test.go
+++ b/pkg/parquetquery/iters_dict_test.go
@@ -1,0 +1,170 @@
+package parquetquery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// collectStringResults drains an iterator returning (rowNumber, value-as-string)
+// pairs so that the dictionary fast path and the per-row slow path can be compared
+// for exact equivalence.
+func collectStringResults(t *testing.T, iter Iterator, selectAs string) []string {
+	t.Helper()
+	var out []string
+	for {
+		res, err := iter.Next()
+		require.NoError(t, err)
+		if res == nil {
+			break
+		}
+		vals := res.ToMap()[selectAs]
+		require.Len(t, vals, 1)
+		out = append(out, fmt.Sprintf("%v=%s", res.RowNumber, vals[0].String()))
+	}
+	return out
+}
+
+func runDictEquivalence[T any](t *testing.T, rows []T, colPath string, makePred func() Predicate) {
+	ctx := context.Background()
+	pf := createFileWith(t, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, colPath)
+	require.GreaterOrEqual(t, idx, 0)
+
+	newIter := func(disable bool) *SyncIterator {
+		// Fresh predicate per iterator: some predicates (e.g. substring) memoize.
+		opts := []SyncIteratorOpt{
+			SyncIteratorOptSelectAs("S"),
+			SyncIteratorOptPredicate(makePred()),
+			SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel),
+		}
+		if disable {
+			opts = append(opts, SyncIteratorOptDisableDictPushdown())
+		}
+		return NewSyncIterator(ctx, pf.RowGroups(), idx, opts...)
+	}
+
+	fast := newIter(false)
+	defer fast.Close()
+	slow := newIter(true)
+	defer slow.Close()
+
+	fastRes := collectStringResults(t, fast, "S")
+	slowRes := collectStringResults(t, slow, "S")
+
+	require.Equal(t, slowRes, fastRes, "dictionary fast path must match per-row results")
+	require.Greater(t, fast.DictFastPathPages(), 0, "fast path should have engaged")
+	require.Equal(t, 0, slow.DictFastPathPages(), "slow path should not use dict fast path")
+}
+
+func TestSyncIteratorDictPushdownRequired(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		rows = append(rows, row{S: alphabet[i%len(alphabet)]})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate { return NewStringInPredicate([]string{"bravo", "delta"}) })
+}
+
+func TestSyncIteratorDictPushdownOptionalWithNulls(t *testing.T) {
+	type row struct {
+		S *string `parquet:",dict,optional"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		if i%7 == 0 {
+			rows = append(rows, row{S: nil}) // null
+			continue
+		}
+		v := alphabet[i%len(alphabet)]
+		rows = append(rows, row{S: &v})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate { return NewStringInPredicate([]string{"alpha", "charlie"}) })
+}
+
+func TestSyncIteratorDictPushdownRepeated(t *testing.T) {
+	type row struct {
+		S []string `parquet:",dict,list"`
+	}
+	alphabet := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	var rows []row
+	for i := 0; i < 3000; i++ {
+		switch i % 4 {
+		case 0:
+			rows = append(rows, row{S: nil}) // empty list
+		case 1:
+			rows = append(rows, row{S: []string{alphabet[i%len(alphabet)]}})
+		default:
+			rows = append(rows, row{S: []string{
+				alphabet[i%len(alphabet)],
+				alphabet[(i+2)%len(alphabet)],
+			}})
+		}
+	}
+	runDictEquivalence(t, rows, "S.list.element", func() Predicate { return NewStringInPredicate([]string{"bravo", "echo"}) })
+}
+
+func TestSyncIteratorDictPushdownRegex(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		rows = append(rows, row{S: fmt.Sprintf("svc-%d", i%6)})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate {
+		p, err := NewRegexInPredicate([]string{"svc-[1-3]"})
+		require.NoError(t, err)
+		return p
+	})
+}
+
+func TestSyncIteratorDictPushdownSubstring(t *testing.T) {
+	type row struct {
+		S *string `parquet:",dict,optional"`
+	}
+	words := []string{"alpha-one", "bravo-two", "charlie-one", "delta-three"}
+	var rows []row
+	for i := 0; i < 5000; i++ {
+		if i%9 == 0 {
+			rows = append(rows, row{S: nil})
+			continue
+		}
+		v := words[i%len(words)]
+		rows = append(rows, row{S: &v})
+	}
+	runDictEquivalence(t, rows, "S", func() Predicate { return NewSubstringPredicate("one") })
+}
+
+// A predicate that does not implement DictionaryPredicate must use the per-row
+// path (no fast path engaged) and still return correct results.
+func TestSyncIteratorDictPushdownFallsBackForNonDictPredicate(t *testing.T) {
+	type row struct {
+		S string `parquet:",dict"`
+	}
+	var rows []row
+	for i := 0; i < 1000; i++ {
+		rows = append(rows, row{S: fmt.Sprintf("svc-%d", i%5)})
+	}
+	ctx := context.Background()
+	pf := createFileWith(t, ctx, rows)
+	idx, _, _ := GetColumnIndexByPath(pf, "S")
+
+	// ByteNotInPredicate keeps nulls, so it intentionally does not implement
+	// DictionaryPredicate.
+	iter := NewSyncIterator(ctx, pf.RowGroups(), idx,
+		SyncIteratorOptSelectAs("S"),
+		SyncIteratorOptPredicate(NewStringNotInPredicate([]string{"svc-1", "svc-2"})),
+	)
+	defer iter.Close()
+
+	got := collectStringResults(t, iter, "S")
+	require.NotEmpty(t, got)
+	require.Equal(t, 0, iter.DictFastPathPages(), "non-dictionary predicate must not use dict fast path")
+}

--- a/pkg/parquetquery/nil_iter.go
+++ b/pkg/parquetquery/nil_iter.go
@@ -2,9 +2,7 @@ package parquetquery
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 
 	pq "github.com/parquet-go/parquet-go"
 )
@@ -25,6 +23,9 @@ func NewNilSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, opts
 		SyncIterator:          *syncIterator,
 		lastRowNumberReturned: EmptyRowNumber(),
 	}
+	// The nil iterator must see every value (it tracks scope across the whole page),
+	// so it always uses the per-row buffered reader, never the dictionary fast path.
+	i.chunk.dictDisabled = true
 
 	return i
 }
@@ -102,17 +103,18 @@ func (c *NilSyncIterator) next() (RowNumber, *pq.Value, error) {
 		if valueFound || !scopeHasValues || !scopeRow.Valid() {
 			return RowNumber{}, false
 		}
-		if EqualRowNumber(c.maxDefinitionLevel, c.lastRowNumberReturned, c.curr) {
+		if EqualRowNumber(c.chunk.maxDef, c.lastRowNumberReturned, c.curr) {
 			return RowNumber{}, false
 		}
 		c.lastRowNumberReturned = scopeRow
 		return scopeRow, true
 	}
 
+	// advanceValue consumes the peeked value and advances the row number, exactly as
+	// the per-row path does - tracking scope membership and whether the filter matched.
 	advanceValue := func(v *pq.Value) {
-		c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
-		c.currBufN++
-		c.currPageN++
+		c.chunk.bufferedReader.consume()
+		c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.chunk.maxDef)
 
 		if !v.IsNull() {
 			scopeHasValues = true
@@ -134,93 +136,73 @@ func (c *NilSyncIterator) next() (RowNumber, *pq.Value, error) {
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-			if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
+			// dictDisabled is set, so admitChunk reduces to the filter's KeepColumnChunk.
+			if !c.chunk.admitChunk(cc) {
 				cc.Close()
 				continue
 			}
-
 			c.setRowGroup(rg, minRN, maxRN, cc)
 		}
 
-		if c.currPage == nil {
-			pg, err := c.currChunk.NextPage()
-			if err != nil && !errors.Is(err, io.EOF) {
+		if !c.chunk.hasPage() {
+			ok, err := c.chunk.loadPage(&c.curr, nil, 0)
+			if err != nil {
 				return EmptyRowNumber(), nil, err
 			}
-			if pg == nil || errors.Is(err, io.EOF) {
-				// This row group is exhausted
+			if !ok {
+				// This row group is exhausted.
 				c.closeCurrRowGroup()
 				continue
 			}
-			if c.filter != nil && !c.filter.KeepPage(pg) {
-				// This page filtered out
-				c.curr.Skip(pg.NumRows())
-				pq.Release(pg)
-				continue
-			}
-			c.setPage(pg)
 		}
 
-		// Read next batch of values if needed
-		if c.currBuf == nil {
-			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
+		// Peek at the next value (no filtering); dictDisabled guarantees the buffered
+		// reader is the active one. advanceValue consumes it; on a scope-exit emission
+		// we return without consuming, so the value is re-peeked on the next call.
+		v, ok, err := c.chunk.bufferedReader.peek()
+		if err != nil {
+			return EmptyRowNumber(), nil, err
+		}
+		if !ok {
+			// This page is exhausted.
+			c.chunk.setPage(&c.curr, nil)
+			continue
 		}
 
-		if c.currBufN >= len(c.currBuf) || len(c.currBuf) == 0 {
-			c.currBuf = c.currBuf[:cap(c.currBuf)]
-			n, err := c.currValues.ReadValues(c.currBuf)
-			if err != nil && !errors.Is(err, io.EOF) {
-				return EmptyRowNumber(), nil, err
-			}
-			c.currBuf = c.currBuf[:n]
-			c.currBufN = 0
-			if n == 0 {
-				// This value reader and page are exhausted.
-				c.setPage(nil)
-				continue
-			}
-		}
+		r := v.RepetitionLevel()
+		d := v.DefinitionLevel()
+		maxD := c.chunk.maxDef
 
-		// Consume current buffer until empty
-		for c.currBufN < len(c.currBuf) {
-			var (
-				v    = &c.currBuf[c.currBufN]
-				r    = v.RepetitionLevel()
-				d    = v.DefinitionLevel()
-				maxD = c.maxDefinitionLevel
-			)
-
-			if r < maxD {
-				// This means we are moving on to the next row.
-				// Before doing so, see if we need to emit a response for the row we are exiting.
-				if rn, ok := tryEmitNilOnScopeExit(); ok {
-					return rn, &emptyNilValue, nil
-				}
-
-				// new level reset
-				valueFound = false
-				scopeHasValues = false
-				advanceValue(v)
-				scopeRow = c.curr
-
-				if r <= d && d == maxD-1 && v.IsNull() {
-					// Empty repeated values for this level, which means the value doesn't exist.
-					// However because we checking that we are the second to last level, it means
-					// we are also ensuring there is an owning row defined at this level.
-					// In this case we emit a nil immediately upon entering the scope
-					// because this is the only row for it.
-					c.lastRowNumberReturned = c.curr
-					return c.curr, &emptyNilValue, nil
-				}
-
-				// Neither of the above cases matched,
-				// so we are just entering a new row
-				continue
+		if r < maxD {
+			// This means we are moving on to the next row.
+			// Before doing so, see if we need to emit a response for the row we are exiting.
+			if rn, ok := tryEmitNilOnScopeExit(); ok {
+				return rn, &emptyNilValue, nil
 			}
 
-			// Inspect all values to track the current row number,
-			// even if the value is filtered out next.
+			// new level reset
+			valueFound = false
+			scopeHasValues = false
 			advanceValue(v)
+			scopeRow = c.curr
+
+			if r <= d && d == maxD-1 && v.IsNull() {
+				// Empty repeated values for this level, which means the value doesn't exist.
+				// However because we checking that we are the second to last level, it means
+				// we are also ensuring there is an owning row defined at this level.
+				// In this case we emit a nil immediately upon entering the scope
+				// because this is the only row for it.
+				c.lastRowNumberReturned = c.curr
+				return c.curr, &emptyNilValue, nil
+			}
+
+			// Neither of the above cases matched,
+			// so we are just entering a new row
+			continue
 		}
+
+		// Inspect all values to track the current row number,
+		// even if the value is filtered out next.
+		advanceValue(v)
 	}
 }

--- a/pkg/parquetquery/page_reader.go
+++ b/pkg/parquetquery/page_reader.go
@@ -1,0 +1,291 @@
+package parquetquery
+
+import (
+	"errors"
+	"io"
+
+	pq "github.com/parquet-go/parquet-go"
+)
+
+// pageReader scans one parquet page, returning matching values and advancing the
+// shared row number. chunkReader owns one of each implementation and picks per page:
+//   - dictPageReader     when the page is dictionary-encoded and the predicate was
+//     resolved into a keep bitmap; matches rows by dictionary index.
+//   - bufferedPageReader otherwise; materializes values and runs the predicate.
+//
+// Both advance curr across every value - including filtered and null ones - so row
+// numbers stay correct no matter which reader runs. maxDef is configured at setup
+// (an immutable per-column constant), so only curr is passed per call.
+type pageReader interface {
+	// next returns the next matching value, advancing curr. ok is false at end of page.
+	next(curr *RowNumber) (*pq.Value, bool, error)
+	// reset releases the page and drops per-page state so the reader can be reused.
+	reset()
+}
+
+var (
+	_ pageReader = (*bufferedPageReader)(nil)
+	_ pageReader = (*dictPageReader)(nil)
+)
+
+// bufferedPageReader materializes the page's values in batches and applies the value
+// predicate to each one. It owns its page (and reslicing it on seek) and a pooled
+// batch buffer reused across the chunk's pages.
+type bufferedPageReader struct {
+	filter   Predicate // value predicate (shared with chunkReader)
+	readSize int       // values per ReadValues batch
+	maxDef   int       // row-number tracking cap
+
+	page    pq.Page
+	values  pq.ValueReader
+	buf     []pq.Value // current batch; retained across pages, freed by release
+	bufPos  int        // next value to read from buf
+	pagePos int        // values consumed so far in the page (used by reslice)
+}
+
+func (b *bufferedPageReader) setup(pg pq.Page, maxDef int) {
+	b.page = pg
+	b.maxDef = maxDef
+	b.values = pg.Values()
+	b.bufPos = 0
+	b.pagePos = 0
+}
+
+// reset releases the page and clears the per-page cursors; the batch buffer is kept
+// for the next page and freed separately by release.
+func (b *bufferedPageReader) reset() {
+	if b.page != nil {
+		pq.Release(b.page)
+		b.page = nil
+	}
+	b.values = nil
+	b.bufPos = 0
+	b.pagePos = 0
+}
+
+// release returns the batch buffer to the pool. Called when the chunk has no more pages.
+func (b *bufferedPageReader) release() {
+	if b.buf != nil {
+		syncIteratorPoolPut(b.buf)
+		b.buf = nil
+	}
+}
+
+func (b *bufferedPageReader) next(curr *RowNumber) (*pq.Value, bool, error) {
+	if b.buf == nil {
+		b.buf = syncIteratorPoolGet(b.readSize, 0)
+	}
+	for {
+		// Refill the batch once the current one is drained.
+		if b.bufPos >= len(b.buf) || len(b.buf) == 0 {
+			b.buf = b.buf[:cap(b.buf)]
+			n, err := b.values.ReadValues(b.buf)
+			if err != nil && !errors.Is(err, io.EOF) {
+				return nil, false, err
+			}
+			b.buf = b.buf[:n]
+			b.bufPos = 0
+			if n == 0 {
+				return nil, false, nil // end of page
+			}
+		}
+
+		for b.bufPos < len(b.buf) {
+			v := &b.buf[b.bufPos]
+
+			// Advance the row number for every value, so it stays accurate even when
+			// the value is filtered out below.
+			curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), b.maxDef)
+			b.bufPos++
+			b.pagePos++
+
+			if b.filter != nil && !b.filter.KeepValue(*v) {
+				continue
+			}
+			return v, true, nil
+		}
+	}
+}
+
+// peek returns the current value on the page without consuming it; ok is false at end
+// of page. Used by NilSyncIterator, which inspects a value to decide scope membership
+// and may return (emitting a synthetic nil) before consuming it. The pointer is valid
+// until the next consume (which may refill the batch).
+func (b *bufferedPageReader) peek() (*pq.Value, bool, error) {
+	if b.buf == nil {
+		b.buf = syncIteratorPoolGet(b.readSize, 0)
+	}
+	if b.bufPos >= len(b.buf) || len(b.buf) == 0 {
+		b.buf = b.buf[:cap(b.buf)]
+		n, err := b.values.ReadValues(b.buf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, false, err
+		}
+		b.buf = b.buf[:n]
+		b.bufPos = 0
+		if n == 0 {
+			return nil, false, nil // end of page
+		}
+	}
+	return &b.buf[b.bufPos], true, nil
+}
+
+// consume advances past the value most recently returned by peek.
+func (b *bufferedPageReader) consume() {
+	b.bufPos++
+	b.pagePos++
+}
+
+// reslice jumps straight to row number to by replacing the page with a slice starting
+// there, when the skip is large enough to be worth it (magicThreshold Next()s). It
+// returns the new page-min row number and true when it resliced; otherwise pageMin and
+// false (the caller advances via next instead). Buffered-only: the dictionary reader
+// cannot reslice.
+func (b *bufferedPageReader) reslice(curr *RowNumber, pageMin, to RowNumber, definitionLevel int) (RowNumber, bool) {
+	rowSkipRelative := int(to[0] - curr[0])
+	if rowSkipRelative == 0 {
+		return pageMin, false
+	}
+
+	const magicThreshold = 1000
+	shouldSkip := false
+	if definitionLevel == 0 {
+		// One Next() per row at definition level 0.
+		shouldSkip = rowSkipRelative > magicThreshold
+	} else {
+		// Nested column: count the Next()s needed to reach the target row.
+		replvls := b.page.RepetitionLevels()
+		nextsRequired := 0
+		for i := b.pagePos; i < len(replvls); i++ {
+			nextsRequired++
+			if nextsRequired > magicThreshold {
+				shouldSkip = true
+				break
+			}
+			if replvls[i] == 0 { // a 0 repetition level starts a new row
+				rowSkipRelative--
+				if rowSkipRelative <= 0 {
+					break
+				}
+			}
+		}
+	}
+	if !shouldSkip {
+		return pageMin, false
+	}
+
+	// Reslice from the start of the page to the target row.
+	rowSkip := to[0] - pageMin[0]
+	if rowSkip < 1 || rowSkip > int32(b.page.NumRows()) {
+		return pageMin, false
+	}
+	pg := b.page.Slice(int64(rowSkip-1), b.page.NumRows())
+	*curr = TruncateRowNumber(0, to).Preceding() // drop detail below the row number
+
+	pq.Release(b.page)
+	b.release() // discard the stale batch buffer
+	b.setup(pg, b.maxDef)
+	return *curr, true
+}
+
+// dictPageReader matches rows by their dictionary index against the chunk's keep
+// bitmap, materializing only the values that match.
+//
+// A dictionary-encoded page has one entry per row position ("slot"). Present
+// (non-null) slots carry a dictionary index in dictIndexes; null slots do not. A slot
+// is present when its definition level equals presentDefLevel.
+type dictPageReader struct {
+	// (keep, dictionary): the chunk-scope decision, resolved once by chunkReader and
+	// lent to the reader for the page. keep is indexed by the same dictionary indexes
+	// dictionary resolves.
+	keep       []bool        // keep[dictIndex]: does that dictionary value match?
+	dictionary pq.Dictionary // resolves a dictionary index back to its value
+	maxDef     int           // row-number tracking cap
+
+	page        pq.Page // owned; released on reset
+	column      int     // column index, for stamping a matched value
+	dictIndexes []int32 // dictionary index of each present value, in page order
+	defLevels   []byte  // per slot; nil for required columns (every slot present)
+	repLevels   []byte  // per slot; nil for non-repeated columns
+
+	presentDefLevel byte // definition level that marks a present (non-null) leaf
+	slotPos         int  // next slot to read (present or null)
+	valuePos        int  // next present value (index into dictIndexes)
+
+	value pq.Value // reused buffer for the returned value
+}
+
+func (d *dictPageReader) setup(pg pq.Page, keep []bool, dictionary pq.Dictionary, maxDef int) {
+	d.page = pg
+	d.keep = keep
+	d.dictionary = dictionary
+	d.maxDef = maxDef
+	d.column = pg.Column()
+	d.defLevels = pg.DefinitionLevels()
+	d.repLevels = pg.RepetitionLevels()
+	data := pg.Data()
+	d.dictIndexes = data.Int32()
+	// The highest definition level on the page marks a present leaf; required columns
+	// have no definition levels, in which case every slot is present.
+	d.presentDefLevel = maxByte(d.defLevels)
+	d.slotPos = 0
+	d.valuePos = 0
+}
+
+// reset releases the page and drops all per-page state.
+func (d *dictPageReader) reset() {
+	if d.page != nil {
+		pq.Release(d.page)
+	}
+	*d = dictPageReader{}
+}
+
+func (d *dictPageReader) next(curr *RowNumber) (*pq.Value, bool, error) {
+	numSlots := len(d.dictIndexes)
+	if d.defLevels != nil {
+		numSlots = len(d.defLevels)
+	}
+
+	for d.slotPos < numSlots {
+		repLvl := 0
+		if d.repLevels != nil {
+			repLvl = int(d.repLevels[d.slotPos])
+		}
+		defLvl := int(d.presentDefLevel)
+		if d.defLevels != nil {
+			defLvl = int(d.defLevels[d.slotPos])
+		}
+
+		// Advance the row number for every slot, present or null.
+		curr.Next(repLvl, defLvl, d.maxDef)
+		d.slotPos++
+
+		// Skip null/empty slots: a lower definition level, or no dictionary index left
+		// to consume. The valuePos bound also covers pages with no present values at all
+		// (all null, or only empty lists), where presentDefLevel collapses to the null
+		// level. The gated predicates never keep nulls, matching the per-row path.
+		if (d.defLevels != nil && byte(defLvl) != d.presentDefLevel) || d.valuePos >= len(d.dictIndexes) {
+			continue
+		}
+
+		idx := d.dictIndexes[d.valuePos]
+		d.valuePos++
+		if !d.keep[idx] {
+			continue
+		}
+
+		// Materialize only matches, stamping the page levels and column so the result is
+		// indistinguishable from the per-row path.
+		d.value = d.dictionary.Index(idx).Level(repLvl, defLvl, d.column)
+		return &d.value, true, nil
+	}
+	return nil, false, nil
+}
+
+func maxByte(b []byte) byte {
+	var m byte
+	for _, v := range b {
+		m = max(m, v)
+	}
+	return m
+}

--- a/pkg/parquetquery/predicates_dict.go
+++ b/pkg/parquetquery/predicates_dict.go
@@ -45,14 +45,10 @@ func (p ByteEqualPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 }
 
 // regex and substring matching are pure functions of the value and reject nulls,
-// so they resolve against the dictionary just like exact matches. This is an even
-// bigger win for them because the per-row cost (regex / bytes.Contains) is far
-// higher than a byte comparison.
-//
-// These predicates memoize per-value match results and rely on a per-chunk reset
-// to keep that memoization bounded. The dictionary fast path resolves the bitmap
-// via KeepIndexes instead of KeepColumnChunk, so the reset lives here too - one
-// KeepIndexes call per column chunk - keeping the cache bounded over a long scan.
+// so they push down like exact matches (an even bigger win, since the per-row cost
+// is a regex / bytes.Contains rather than a byte compare). They memoize per value
+// and rely on a per-chunk reset to stay bounded; the fast path calls KeepIndexes
+// rather than KeepColumnChunk, so the reset lives here too — once per chunk.
 func (p *regexPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 	p.matcher.Reset()
 	return dictionaryKeepIndexes(dict, p.KeepValue)
@@ -63,19 +59,15 @@ func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 	return dictionaryKeepIndexes(dict, p.KeepValue)
 }
 
-// KeepIndexes supports dictionary pushdown only when every child is itself
-// dictionary-pushable. A nil child means "match all" and a non-dictionary child
-// (e.g. regex on a value the dictionary doesn't narrow) would require per-row
-// evaluation, so in both cases we return nil to disable the optimization.
-//
-// The bitmap is the OR of the children's bitmaps rather than a scan over the OR's
-// KeepValue, so each child's own KeepIndexes runs (resetting its memoization) and
-// the per-chunk bound is preserved for substring/regex children.
+// KeepIndexes pushes down only when every child does. It ORs the children's bitmaps
+// (rather than scanning the OR's KeepValue) so each child's own KeepIndexes runs,
+// preserving the per-chunk reset for substring/regex children. A nil child ("match
+// all") or a non-pushable child disables the optimization.
 func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 	var out []bool
 	for _, child := range p.preds {
 		if child == nil {
-			return nil // nil child means "match all" - not pushable
+			return nil
 		}
 		dp, ok := child.(DictionaryPredicate)
 		if !ok {
@@ -83,7 +75,7 @@ func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 		}
 		keep := dp.KeepIndexes(dict)
 		if keep == nil {
-			return nil // child declined pushdown for this dictionary
+			return nil // child declined for this dictionary
 		}
 		if out == nil {
 			out = keep

--- a/pkg/parquetquery/predicates_dict.go
+++ b/pkg/parquetquery/predicates_dict.go
@@ -48,11 +48,18 @@ func (p ByteEqualPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 // so they resolve against the dictionary just like exact matches. This is an even
 // bigger win for them because the per-row cost (regex / bytes.Contains) is far
 // higher than a byte comparison.
+//
+// These predicates memoize per-value match results and rely on a per-chunk reset
+// to keep that memoization bounded. The dictionary fast path resolves the bitmap
+// via KeepIndexes instead of KeepColumnChunk, so the reset lives here too - one
+// KeepIndexes call per column chunk - keeping the cache bounded over a long scan.
 func (p *regexPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	p.matcher.Reset()
 	return dictionaryKeepIndexes(dict, p.KeepValue)
 }
 
 func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	p.matches = make(map[string]bool, len(p.matches))
 	return dictionaryKeepIndexes(dict, p.KeepValue)
 }
 
@@ -60,14 +67,31 @@ func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
 // dictionary-pushable. A nil child means "match all" and a non-dictionary child
 // (e.g. regex on a value the dictionary doesn't narrow) would require per-row
 // evaluation, so in both cases we return nil to disable the optimization.
+//
+// The bitmap is the OR of the children's bitmaps rather than a scan over the OR's
+// KeepValue, so each child's own KeepIndexes runs (resetting its memoization) and
+// the per-chunk bound is preserved for substring/regex children.
 func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	var out []bool
 	for _, child := range p.preds {
 		if child == nil {
+			return nil // nil child means "match all" - not pushable
+		}
+		dp, ok := child.(DictionaryPredicate)
+		if !ok {
 			return nil
 		}
-		if _, ok := child.(DictionaryPredicate); !ok {
-			return nil
+		keep := dp.KeepIndexes(dict)
+		if keep == nil {
+			return nil // child declined pushdown for this dictionary
+		}
+		if out == nil {
+			out = keep
+			continue
+		}
+		for i := range keep {
+			out[i] = out[i] || keep[i]
 		}
 	}
-	return dictionaryKeepIndexes(dict, p.KeepValue)
+	return out
 }

--- a/pkg/parquetquery/predicates_dict.go
+++ b/pkg/parquetquery/predicates_dict.go
@@ -1,0 +1,73 @@
+package parquetquery
+
+import pq "github.com/parquet-go/parquet-go"
+
+// DictionaryPredicate is an optional interface implemented by predicates that can
+// be evaluated directly against a column-chunk dictionary.
+//
+// When a column chunk is dictionary-encoded the iterator resolves the predicate
+// once over the (small) set of distinct dictionary values into a per-index keep
+// bitmap, then matches each row by its integer dictionary index. This avoids
+// materializing the value and running a byte comparison for every row, which
+// dominates CPU for exact-match string filters (service.name, span:name, etc.).
+//
+// Implementations must only advertise support when their KeepValue semantics over
+// present (non-null) values fully capture matching - i.e. the predicate does not
+// depend on null-ness beyond what KeepValue already returns for a present value.
+type DictionaryPredicate interface {
+	Predicate
+
+	// KeepIndexes resolves the predicate against dict and returns a bitmap of
+	// length dict.Len() where entry i is true iff dict.Index(i) satisfies the
+	// predicate. Returning nil signals that the predicate cannot be pushed down
+	// to the dictionary and the caller must fall back to per-row evaluation.
+	KeepIndexes(dict pq.Dictionary) []bool
+}
+
+// dictionaryKeepIndexes builds the keep bitmap by evaluating keep against every
+// distinct dictionary value once. The dictionary is small relative to the number
+// of rows, so this is paid once per column chunk rather than once per row.
+func dictionaryKeepIndexes(dict pq.Dictionary, keep func(pq.Value) bool) []bool {
+	n := dict.Len()
+	out := make([]bool, n)
+	for i := 0; i < n; i++ {
+		out[i] = keep(dict.Index(int32(i)))
+	}
+	return out
+}
+
+func (p *ByteInPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+func (p ByteEqualPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+// regex and substring matching are pure functions of the value and reject nulls,
+// so they resolve against the dictionary just like exact matches. This is an even
+// bigger win for them because the per-row cost (regex / bytes.Contains) is far
+// higher than a byte comparison.
+func (p *regexPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+func (p *SubstringPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}
+
+// KeepIndexes supports dictionary pushdown only when every child is itself
+// dictionary-pushable. A nil child means "match all" and a non-dictionary child
+// (e.g. regex on a value the dictionary doesn't narrow) would require per-row
+// evaluation, so in both cases we return nil to disable the optimization.
+func (p *OrPredicate) KeepIndexes(dict pq.Dictionary) []bool {
+	for _, child := range p.preds {
+		if child == nil {
+			return nil
+		}
+		if _, ok := child.(DictionaryPredicate); !ok {
+			return nil
+		}
+	}
+	return dictionaryKeepIndexes(dict, p.KeepValue)
+}

--- a/pkg/parquetquery/predicates_dict_test.go
+++ b/pkg/parquetquery/predicates_dict_test.go
@@ -1,0 +1,67 @@
+package parquetquery
+
+import (
+	"testing"
+
+	pq "github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+// byteArrayDict builds a real parquet byte-array dictionary containing the given
+// values in order, so tests exercise the same Dictionary implementation used at
+// query time.
+func byteArrayDict(t testing.TB, values ...string) pq.Dictionary {
+	t.Helper()
+	dict := pq.ByteArrayType.NewDictionary(0, 0, pq.ByteArrayType.NewValues(nil, nil))
+	vals := make([]pq.Value, len(values))
+	for i, v := range values {
+		vals[i] = pq.ByteArrayValue([]byte(v))
+	}
+	idx := make([]int32, len(vals))
+	dict.Insert(idx, vals)
+	return dict
+}
+
+func TestByteInPredicateKeepIndexes(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo", "charlie", "delta")
+
+	p := NewStringInPredicate([]string{"bravo", "delta", "missing"})
+	dp, ok := p.(DictionaryPredicate)
+	require.True(t, ok, "ByteInPredicate should implement DictionaryPredicate")
+
+	require.Equal(t, []bool{false, true, false, true}, dp.KeepIndexes(dict))
+}
+
+func TestByteEqualPredicateKeepIndexes(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo", "charlie")
+
+	p := NewByteEqualPredicate([]byte("charlie"))
+	dp, ok := any(p).(DictionaryPredicate)
+	require.True(t, ok, "ByteEqualPredicate should implement DictionaryPredicate")
+
+	require.Equal(t, []bool{false, false, true}, dp.KeepIndexes(dict))
+}
+
+func TestOrPredicateKeepIndexes(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo", "charlie", "delta")
+
+	// OR of exact matches -> union of matching indexes
+	p := NewOrPredicate(
+		NewByteEqualPredicate([]byte("alpha")),
+		NewByteEqualPredicate([]byte("delta")),
+	)
+	require.Equal(t, []bool{true, false, false, true}, p.KeepIndexes(dict))
+}
+
+func TestOrPredicateKeepIndexesUnsupportedChild(t *testing.T) {
+	dict := byteArrayDict(t, "alpha", "bravo")
+
+	// A child that is not dictionary-pushable (NOT IN keeps nulls, so it does not
+	// implement DictionaryPredicate) disables the optimization, signalled by a nil
+	// bitmap so the caller falls back to per-row evaluation.
+	p := NewOrPredicate(
+		NewByteEqualPredicate([]byte("alpha")),
+		NewStringNotInPredicate([]string{"bravo"}),
+	)
+	require.Nil(t, p.KeepIndexes(dict))
+}

--- a/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
+++ b/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
@@ -63,31 +63,37 @@ func BenchmarkBackendBlockMetricsQuery(b *testing.B) {
 		Exemplars: uint32(intEnv("VP5_BENCH_EXEMPLARS", 0)),
 	}
 
+	var em traceql.EvaluatorMetrics
 	b.ResetTimer()
 	for b.Loop() {
 		eval, err := e.CompileMetricsQueryRange(req, traceql.WithUnsafeHints(true))
 		require.NoError(b, err)
 		require.NoError(b, eval.Do(ctx, f, st, end, int(req.MaxSeries)))
 		_ = eval.Results()
-
-		em := eval.Metrics()
-		b.ReportMetric(float64(em.Bytes)/1024.0/1024.0, "MB_io/op")
-		b.ReportMetric(float64(em.SpansTotal), "spans/op")
+		em = eval.Metrics()
 	}
+	// Report once after the loop: ReportMetric overwrites, so calling it per
+	// iteration only adds overhead and keeps the last iteration's values anyway.
+	b.ReportMetric(float64(em.Bytes)/1024.0/1024.0, "MB_io/op")
+	b.ReportMetric(float64(em.SpansTotal), "spans/op")
 }
 
+// durationEnv reads a duration from name, falling back to def when unset, invalid,
+// or non-positive (a negative step would overflow the uint64 request field).
 func durationEnv(name string, def time.Duration) time.Duration {
 	if v := os.Getenv(name); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			return d
 		}
 	}
 	return def
 }
 
+// intEnv reads a non-negative int from name, falling back to def when unset,
+// invalid, or negative (a negative value would overflow the uint32 request field).
 func intEnv(name string, def int) int {
 	if v := os.Getenv(name); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			return n
 		}
 	}

--- a/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
+++ b/tempodb/encoding/vparquet5/block_metrics_query_bench_test.go
@@ -1,0 +1,95 @@
+package vparquet5
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/traceql"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkBackendBlockMetricsQuery runs an arbitrary metrics query_range against
+// a block on local disk. It is opt-in: the query and the block location are
+// supplied entirely via environment variables and the benchmark skips when they
+// are not set, so it never runs as part of a normal `go test`/CI run and embeds
+// no query or data in the source tree.
+//
+//	VP5_BENCH_PATH      backend root (block lives at <PATH>/<TENANTID>/<BLOCKID>)
+//	VP5_BENCH_TENANTID  tenant id (default "1")
+//	VP5_BENCH_BLOCKID   block guid
+//	VP5_BENCH_QUERY     TraceQL metrics query to run
+//	VP5_BENCH_STEP      step duration (default "1m")
+//	VP5_BENCH_EXEMPLARS exemplars per series (default 0)
+//
+// Example:
+//
+//	VP5_BENCH_PATH=/path/to/blocks VP5_BENCH_TENANTID=1 \
+//	VP5_BENCH_BLOCKID=<guid> VP5_BENCH_QUERY='{ name = "foo" } | rate()' \
+//	go test ./tempodb/encoding/vparquet5/ -run '^$' -bench BenchmarkBackendBlockMetricsQuery -cpuprofile cpu.out
+func BenchmarkBackendBlockMetricsQuery(b *testing.B) {
+	query := os.Getenv("VP5_BENCH_QUERY")
+	if query == "" || os.Getenv("VP5_BENCH_PATH") == "" || os.Getenv("VP5_BENCH_BLOCKID") == "" {
+		b.Skip("set VP5_BENCH_QUERY, VP5_BENCH_PATH and VP5_BENCH_BLOCKID to run this benchmark")
+	}
+
+	var (
+		e     = traceql.NewEngine()
+		ctx   = context.Background()
+		opts  = common.DefaultSearchOptions()
+		block = blockForBenchmarks(b)
+		st    = uint64(block.meta.StartTime.UnixNano())
+		end   = uint64(block.meta.EndTime.UnixNano())
+		f     = traceql.NewSpansetFetcherWrapperBoth(
+			func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
+				return block.Fetch(ctx, req, opts)
+			},
+			func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansOnlyResponse, error) {
+				return block.FetchSpans(ctx, req, opts)
+			},
+		)
+	)
+
+	req := &tempopb.QueryRangeRequest{
+		Query:     query,
+		Step:      uint64(durationEnv("VP5_BENCH_STEP", time.Minute)),
+		Start:     st,
+		End:       end,
+		MaxSeries: 1000,
+		Exemplars: uint32(intEnv("VP5_BENCH_EXEMPLARS", 0)),
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		eval, err := e.CompileMetricsQueryRange(req, traceql.WithUnsafeHints(true))
+		require.NoError(b, err)
+		require.NoError(b, eval.Do(ctx, f, st, end, int(req.MaxSeries)))
+		_ = eval.Results()
+
+		em := eval.Metrics()
+		b.ReportMetric(float64(em.Bytes)/1024.0/1024.0, "MB_io/op")
+		b.ReportMetric(float64(em.SpansTotal), "spans/op")
+	}
+}
+
+func durationEnv(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}
+
+func intEnv(name string, def int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}


### PR DESCRIPTION
> **Draft — stacked on #7536.** This is the follow-up refactor that lands *after* the dictionary-index pushdown PR. It targets `main` only because the base branch lives in a fork, so until #7536 merges this PR's diff includes #7536's commits too. Review #7536 first; the refactor itself is the last commit (`refactor(parquetquery): split SyncIterator into chunk + page readers`).

**What this PR does**

Pure refactor of `pkg/parquetquery.SyncIterator` to give its scattered state clear owners. Today one struct mixes iterator-, row-group-, chunk-, and page-level concerns with two interleaved scan strategies and seek/reslice logic. This splits it into three single-purpose units:

- **`SyncIterator`** — row-group navigation, the shared row number (`curr`), and result plumbing. Delegates a chunk at a time to a `chunkReader` (passing `&curr`).
- **`chunkReader`** — scans one column chunk: dictionary resolution (resolved once and reused for chunk-skip), page navigation, seek, and dispatch to a page reader.
- **`pageReader`** (interface) with two implementations: `bufferedPageReader` (per-row materialize + predicate, the existing path) and `dictPageReader` (match rows by integer dictionary index, the fast path).

`NilSyncIterator` drives the buffered reader via `peek`/`consume`, preserving its scope-aware nil logic. Page ownership and reslice move into the readers; `maxDef` is injected once instead of passed on every `next()`.

**No behavior change.** Results, bytes read, and performance are unchanged — the dict equivalence tests (`Required`/`OptionalWithNulls`/`Repeated`/`Regex`/`Substring`/`Or`/`FallsBack`/`SkipsChunkWithNoMatch`), the nil-iterator test, `-race`, and the micro-benchmark all pass with the same numbers. The diff is a relocation: `iters.go` sheds ~all of its `curr*`/`indexReader*` state and the per-row/dict/seek blocks, which become `chunk_reader.go` + `page_reader.go`.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (no user-facing change)
