### PR TITLE
Tolerance-based numeric comparison for trace diffs

### DIFF
--- a/.chloggen/tracediff-numeric-tolerance.yaml
+++ b/.chloggen/tracediff-numeric-tolerance.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Trace diff reports span durations in nanoseconds and compares numeric values with a relative tolerance.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: stoewer

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -223,12 +223,16 @@ func valuesEqual(a, b any) bool {
 	case bool:
 		bv, ok := b.(bool)
 		return ok && av == bv
-	case int64:
-		bv, ok := b.(int64)
-		return ok && av == bv
-	case float64:
-		bv, ok := b.(float64)
-		return ok && av == bv
+	case int64, float64:
+		// if both a and b are int64 do exact comparison, otherwise use numericValue() to convert to float64
+		if ai, ok := a.(int64); ok {
+			if bi, ok := b.(int64); ok {
+				return ai == bi
+			}
+		}
+		af, _ := numericValue(a)
+		bf, ok := numericValue(b)
+		return ok && af == bf
 	case []byte:
 		bv, ok := b.([]byte)
 		if !ok || len(av) != len(bv) {

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -158,7 +158,7 @@ func mergeWarnings(warningGroups ...[]Warning) []Warning {
 
 func fieldChanges(base, compare normalizedSpan) []Change {
 	changes := make([]Change, 0, 2)
-	if !numericClose(float64(base.snapshot.DurationNanos), float64(compare.snapshot.DurationNanos), durationRelTol, durationAbsTolNano) {
+	if !numericClose(float64(base.snapshot.DurationNanos), float64(compare.snapshot.DurationNanos), durationRelTolerance, durationAbsTolerance) {
 		changes = append(changes, Change{
 			Op:     OperationModify,
 			Target: Target{Type: TargetField, Name: FieldDurationNanos},
@@ -204,10 +204,10 @@ func attributeChanges(base, compare normalizedSpan) []Change {
 // everything else is compared exactly.
 func attributeChanged(key string, before, after any) bool {
 	if isNumericFuzzyAttribute(key) {
-		if a, aok := numericValue(before); aok {
-			if b, bok := numericValue(after); bok {
-				return !numericClose(a, b, attrRelTol, attrAbsTol)
-			}
+		a, aOK := numericValue(before)
+		b, bOK := numericValue(after)
+		if aOK && bOK {
+			return !numericClose(a, b, attrRelTolerance, attrAbsTolerance)
 		}
 	}
 	return !valuesEqual(before, after)

--- a/pkg/model/tracediff/diff.go
+++ b/pkg/model/tracediff/diff.go
@@ -158,12 +158,12 @@ func mergeWarnings(warningGroups ...[]Warning) []Warning {
 
 func fieldChanges(base, compare normalizedSpan) []Change {
 	changes := make([]Change, 0, 2)
-	if base.snapshot.DurationMs != compare.snapshot.DurationMs {
+	if !numericClose(float64(base.snapshot.DurationNanos), float64(compare.snapshot.DurationNanos), durationRelTol, durationAbsTolNano) {
 		changes = append(changes, Change{
 			Op:     OperationModify,
-			Target: Target{Type: TargetField, Name: FieldDurationMs},
-			Before: base.snapshot.DurationMs,
-			After:  compare.snapshot.DurationMs,
+			Target: Target{Type: TargetField, Name: FieldDurationNanos},
+			Before: base.snapshot.DurationNanos,
+			After:  compare.snapshot.DurationNanos,
 		})
 	}
 	if base.snapshot.Status != compare.snapshot.Status {
@@ -192,11 +192,25 @@ func attributeChanges(base, compare normalizedSpan) []Change {
 			changes = append(changes, Change{Op: OperationAdd, Target: target, Before: nil, After: after})
 		case !inCompare:
 			changes = append(changes, Change{Op: OperationRemove, Target: target, Before: before, After: nil})
-		case !valuesEqual(before, after):
+		case attributeChanged(key, before, after):
 			changes = append(changes, Change{Op: OperationModify, Target: target, Before: before, After: after})
 		}
 	}
 	return changes
+}
+
+// attributeChanged reports whether before and after differ. Allow-listed numeric
+// magnitude attributes use a relative tolerance when both values are numeric;
+// everything else is compared exactly.
+func attributeChanged(key string, before, after any) bool {
+	if isNumericFuzzyAttribute(key) {
+		if a, aok := numericValue(before); aok {
+			if b, bok := numericValue(after); bok {
+				return !numericClose(a, b, attrRelTol, attrAbsTol)
+			}
+		}
+	}
+	return !valuesEqual(before, after)
 }
 
 func valuesEqual(a, b any) bool {

--- a/pkg/model/tracediff/diff_test.go
+++ b/pkg/model/tracediff/diff_test.go
@@ -264,10 +264,10 @@ func TestDiffMatchesDuplicateSpanIdentityByParent(t *testing.T) {
 	removedDBDurations := make([]int64, 0, 1)
 	for _, removed := range got.Removed {
 		if removed.Span.Service == "db" && removed.Span.Name == "SELECT users" {
-			removedDBDurations = append(removedDBDurations, removed.Span.DurationMs)
+			removedDBDurations = append(removedDBDurations, removed.Span.DurationNanos)
 		}
 	}
-	assert.Equal(t, []int64{10}, removedDBDurations)
+	assert.Equal(t, []int64{10_000_000}, removedDBDurations)
 }
 
 func TestDiffWarnsAndUsesRawHighCardinalitySpanName(t *testing.T) {
@@ -331,9 +331,9 @@ func TestDiffReportsModifiedSpanFields(t *testing.T) {
 	assert.Equal(t, []Change{
 		{
 			Op:     OperationModify,
-			Target: Target{Type: TargetField, Name: "duration_ms"},
-			Before: int64(100),
-			After:  int64(250),
+			Target: Target{Type: TargetField, Name: "duration_nanos"},
+			Before: int64(100_000_000),
+			After:  int64(250_000_000),
 		},
 		{
 			Op:     OperationModify,

--- a/pkg/model/tracediff/diff_test.go
+++ b/pkg/model/tracediff/diff_test.go
@@ -466,3 +466,42 @@ func stringArrayAttribute(key string, values ...string) *commonv1.KeyValue {
 		},
 	}
 }
+
+func TestValuesEqual(t *testing.T) {
+	// 2^53 is the largest integer float64 represents exactly; 2^53 and 2^53+1
+	// collapse to the same float64, so comparing int64s as float would miss the
+	// difference.
+	const maxExactFloat = int64(1) << 53
+
+	tests := []struct {
+		name string
+		a, b any
+		want bool
+	}{
+		{name: "nil equal", a: nil, b: nil, want: true},
+		{name: "nil vs value", a: nil, b: int64(0), want: false},
+		{name: "string equal", a: "x", b: "x", want: true},
+		{name: "string unequal", a: "x", b: "y", want: false},
+		{name: "bool equal", a: true, b: true, want: true},
+		{name: "int64 equal", a: int64(5), b: int64(5), want: true},
+		{name: "int64 unequal", a: int64(5), b: int64(6), want: false},
+		{name: "float64 equal", a: 2.5, b: 2.5, want: true},
+		{name: "float64 unequal", a: 2.5, b: 2.6, want: false},
+		{name: "int64 vs float64 same value", a: int64(80), b: 80.0, want: true},
+		{name: "float64 vs int64 same value", a: 80.0, b: int64(80), want: true},
+		{name: "int64 vs float64 different value", a: int64(80), b: 81.0, want: false},
+		{name: "large near-equal int64 stays exact", a: maxExactFloat, b: maxExactFloat + 1, want: false},
+		{name: "numeric vs string", a: int64(80), b: "80", want: false},
+		{name: "bytes equal", a: []byte{1, 2}, b: []byte{1, 2}, want: true},
+		{name: "bytes unequal", a: []byte{1, 2}, b: []byte{1, 3}, want: false},
+		{name: "array with cross-type numeric equal", a: []any{int64(1), "x"}, b: []any{1.0, "x"}, want: true},
+		{name: "array unequal", a: []any{int64(1)}, b: []any{int64(2)}, want: false},
+		{name: "map with cross-type numeric equal", a: map[string]any{"k": int64(3)}, b: map[string]any{"k": 3.0}, want: true},
+		{name: "map unequal", a: map[string]any{"k": int64(3)}, b: map[string]any{"k": int64(4)}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, valuesEqual(tt.a, tt.b))
+		})
+	}
+}

--- a/pkg/model/tracediff/normalize.go
+++ b/pkg/model/tracediff/normalize.go
@@ -130,12 +130,12 @@ func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey,
 		ref:            ref,
 		spanAttrs:      attributesMap(span.span.GetAttributes()),
 		snapshot: SpanSnapshot{
-			Path:       path,
-			Service:    ref.Service,
-			Name:       ref.Name,
-			Kind:       ref.Kind,
-			DurationMs: durationMs(span.span),
-			Status:     statusToString(span.span.GetStatus()),
+			Path:          path,
+			Service:       ref.Service,
+			Name:          ref.Name,
+			Kind:          ref.Kind,
+			DurationNanos: durationNanos(span.span),
+			Status:        statusToString(span.span.GetStatus()),
 		},
 	}
 }
@@ -242,11 +242,11 @@ func anyValue(value *commonv1.AnyValue) any {
 	}
 }
 
-func durationMs(span *tracev1.Span) int64 {
+func durationNanos(span *tracev1.Span) int64 {
 	if span.GetEndTimeUnixNano() < span.GetStartTimeUnixNano() {
 		return 0
 	}
-	return int64((span.GetEndTimeUnixNano() - span.GetStartTimeUnixNano()) / 1_000_000)
+	return int64(span.GetEndTimeUnixNano() - span.GetStartTimeUnixNano())
 }
 
 func statusToString(status *tracev1.Status) string {

--- a/pkg/model/tracediff/normalize_test.go
+++ b/pkg/model/tracediff/normalize_test.go
@@ -49,12 +49,12 @@ func TestNormalizeTraceBuildsSpanRefsAndSnapshots(t *testing.T) {
 		Kind:    "client",
 	}, reserve.ref)
 	assert.Equal(t, SpanSnapshot{
-		Path:       []int{0, 1, 0},
-		Service:    "inventory",
-		Name:       "reserve",
-		Kind:       "client",
-		DurationMs: 25,
-		Status:     "error",
+		Path:          []int{0, 1, 0},
+		Service:       "inventory",
+		Name:          "reserve",
+		Kind:          "client",
+		DurationNanos: 25_000_000,
+		Status:        "error",
 	}, reserve.snapshot)
 }
 

--- a/pkg/model/tracediff/numeric.go
+++ b/pkg/model/tracediff/numeric.go
@@ -2,38 +2,28 @@ package tracediff
 
 import "math"
 
-// Fixed tolerances for trace-patch-v0 numeric comparison. Two values are
+// Fixed tolerances for numeric comparisons in trace diffs. Two values are
 // considered unchanged when |a-b| <= absTol + relTol*max(|a|, |b|).
 const (
-	// durationRelTol is intentionally loose: a single pair of traces cannot
-	// separate a real regression from run-to-run jitter, so span duration diffs
-	// are advisory and only large (roughly first-significant-digit) changes are
-	// reported.
-	durationRelTol = 0.25
-	// durationAbsTolNano is a 1ms floor (in nanoseconds) that suppresses
-	// sub-millisecond jitter on short spans.
-	durationAbsTolNano = 1_000_000.0
+	// durationRelTolerance is intentionally loose in order to separate a real regression from run-to-run
+	// jitter, so span duration diffs only report large and significant changes.
+	durationRelTolerance = 0.20
+	// durationAbsTolerance is a 1ms floor (in nanoseconds) that suppresses
+	// sub-millisecond jitter on very short spans.
+	durationAbsTolerance = 1_000_000.0
 
-	// attrRelTol is stricter: allow-listed numeric attributes (sizes, token
-	// counts, durations) are usually deterministic for the same operation, so a
-	// roughly second-significant-digit change is reported.
-	attrRelTol = 0.05
-	// attrAbsTol is zero: allow-listed values are magnitudes where the relative
-	// term scales correctly. As a result any change to or from exactly zero is
-	// reported.
-	attrAbsTol = 0.0
+	// attrRelTolerance is the default relative tolerance for allow-listed numeric attributes
+	// like sizes, token counts, durations.
+	attrRelTolerance = 0.05
+	// attrAbsTolerance is zero: allow-listed values are magnitudes where the relative
+	// tolerance scales correctly.
+	attrAbsTolerance = 0.0
 )
 
 // numericFuzzyAttributes are OpenTelemetry semantic-convention numeric
 // attributes that represent magnitudes (byte sizes, token counts, durations)
 // where small relative differences are noise. Values for these keys are compared
 // with a relative tolerance; every other numeric attribute is compared exactly.
-//
-// Curated from open-telemetry/semantic-conventions (commit b51e2a6, 2026-06-25).
-// Deprecated attribute names are included alongside their current counterparts
-// because a trace carries only one. Identifiers, codes, ports, indices, epoch
-// timestamps, configuration parameters, small discrete counts, and vendor
-// product-specific attributes are intentionally excluded.
 var numericFuzzyAttributes = map[string]struct{}{
 	// Byte / payload sizes.
 	"http.request.body.size":                    {},

--- a/pkg/model/tracediff/numeric.go
+++ b/pkg/model/tracediff/numeric.go
@@ -1,0 +1,92 @@
+package tracediff
+
+import "math"
+
+// Fixed tolerances for trace-patch-v0 numeric comparison. Two values are
+// considered unchanged when |a-b| <= absTol + relTol*max(|a|, |b|).
+const (
+	// durationRelTol is intentionally loose: a single pair of traces cannot
+	// separate a real regression from run-to-run jitter, so span duration diffs
+	// are advisory and only large (roughly first-significant-digit) changes are
+	// reported.
+	durationRelTol = 0.25
+	// durationAbsTolNano is a 1ms floor (in nanoseconds) that suppresses
+	// sub-millisecond jitter on short spans.
+	durationAbsTolNano = 1_000_000.0
+
+	// attrRelTol is stricter: allow-listed numeric attributes (sizes, token
+	// counts, durations) are usually deterministic for the same operation, so a
+	// roughly second-significant-digit change is reported.
+	attrRelTol = 0.05
+	// attrAbsTol is zero: allow-listed values are magnitudes where the relative
+	// term scales correctly. As a result any change to or from exactly zero is
+	// reported.
+	attrAbsTol = 0.0
+)
+
+// numericFuzzyAttributes are OpenTelemetry semantic-convention numeric
+// attributes that represent magnitudes (byte sizes, token counts, durations)
+// where small relative differences are noise. Values for these keys are compared
+// with a relative tolerance; every other numeric attribute is compared exactly.
+//
+// Curated from open-telemetry/semantic-conventions (commit b51e2a6, 2026-06-25).
+// Deprecated attribute names are included alongside their current counterparts
+// because a trace carries only one. Identifiers, codes, ports, indices, epoch
+// timestamps, configuration parameters, small discrete counts, and vendor
+// product-specific attributes are intentionally excluded.
+var numericFuzzyAttributes = map[string]struct{}{
+	// Byte / payload sizes.
+	"http.request.body.size":                    {},
+	"http.request.size":                         {},
+	"http.response.body.size":                   {},
+	"http.response.size":                        {},
+	"http.request_content_length":               {}, // deprecated
+	"http.request_content_length_uncompressed":  {}, // deprecated
+	"http.response_content_length":              {}, // deprecated
+	"http.response_content_length_uncompressed": {}, // deprecated
+	"messaging.message.body.size":               {},
+	"messaging.message.envelope.size":           {},
+	"message.compressed_size":                   {}, // deprecated
+	"message.uncompressed_size":                 {}, // deprecated
+	"rpc.message.compressed_size":               {}, // deprecated
+	"rpc.message.uncompressed_size":             {}, // deprecated
+	"file.size":                                 {},
+
+	// Token counts.
+	"gen_ai.usage.input_tokens":                {},
+	"gen_ai.usage.output_tokens":               {},
+	"gen_ai.usage.prompt_tokens":               {}, // deprecated -> input_tokens
+	"gen_ai.usage.completion_tokens":           {}, // deprecated -> output_tokens
+	"gen_ai.usage.cache_creation.input_tokens": {},
+	"gen_ai.usage.cache_read.input_tokens":     {},
+	"gen_ai.usage.reasoning.output_tokens":     {},
+
+	// Durations.
+	"gen_ai.response.time_to_first_chunk": {}, // deprecated
+	"app.jank.period":                     {},
+}
+
+// numericClose reports whether a and b are equal within the given relative and
+// absolute tolerances: |a-b| <= absTol + relTol*max(|a|, |b|).
+func numericClose(a, b, relTol, absTol float64) bool {
+	return math.Abs(a-b) <= absTol+relTol*math.Max(math.Abs(a), math.Abs(b))
+}
+
+// isNumericFuzzyAttribute reports whether the attribute key is compared with a
+// relative tolerance instead of exact equality.
+func isNumericFuzzyAttribute(key string) bool {
+	_, ok := numericFuzzyAttributes[key]
+	return ok
+}
+
+// numericValue returns v as a float64 when it holds an int64 or float64.
+func numericValue(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return float64(n), true
+	case float64:
+		return n, true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/model/tracediff/numeric_test.go
+++ b/pkg/model/tracediff/numeric_test.go
@@ -100,6 +100,7 @@ func TestAttributeChanged(t *testing.T) {
 		{name: "allow-listed int vs float equal", key: testAttrInputTokens, before: int64(100), after: 100.0, want: false},
 		{name: "allow-listed non-numeric falls back to exact", key: testAttrBodySize, before: "a", after: "b", want: true},
 		{name: "non-allow-listed numeric compared exactly", key: "custom.count", before: int64(1000), after: int64(1001), want: true},
+		{name: "non-allow-listed int vs float equal value", key: "custom.count", before: int64(80), after: 80.0, want: false},
 		{name: "status code compared exactly", key: "http.response.status_code", before: int64(200), after: int64(201), want: true},
 	}
 	for _, tt := range tests {

--- a/pkg/model/tracediff/numeric_test.go
+++ b/pkg/model/tracediff/numeric_test.go
@@ -111,32 +111,44 @@ func TestAttributeChanged(t *testing.T) {
 
 func TestDiffDurationTolerance(t *testing.T) {
 	traceID := []byte("trace-id-0000001")
+	tests := []struct {
+		name       string
+		baseEnd    uint64
+		compareEnd uint64
+		wantChange bool
+	}{
+		{name: "below tolerance", baseEnd: 100, compareEnd: 110, wantChange: false},
+		{name: "just within relative tolerance", baseEnd: 100, compareEnd: 126, wantChange: false},
+		{name: "just beyond relative tolerance", baseEnd: 100, compareEnd: 127, wantChange: true},
+		{name: "well beyond tolerance", baseEnd: 100, compareEnd: 250, wantChange: true},
+		{name: "within absolute floor on short spans", baseEnd: 0, compareEnd: 1, wantChange: false},
+		{name: "beyond absolute floor on short spans", baseEnd: 0, compareEnd: 2, wantChange: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := traceWithNamedSpans(
+				spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, tt.baseEnd, tracev1.Status_STATUS_CODE_OK),
+			)
+			compare := traceWithNamedSpans(
+				spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, tt.compareEnd, tracev1.Status_STATUS_CODE_OK),
+			)
 
-	// 100ms vs 110ms: within tolerance, so no duration change is reported and
-	// the span is not modified.
-	base := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
-	)
-	compare := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 110, tracev1.Status_STATUS_CODE_OK),
-	)
+			got, err := Diff(base, compare, FormatTracePatchV0)
+			require.NoError(t, err)
+			require.Equal(t, 1, got.Stats.MatchedSpans)
 
-	got, err := Diff(base, compare, FormatTracePatchV0)
-	require.NoError(t, err)
-	assert.Equal(t, 1, got.Stats.MatchedSpans)
-	assert.Zero(t, got.Stats.FieldChanges)
-	assert.Empty(t, got.Modified)
+			if !tt.wantChange {
+				assert.Zero(t, got.Stats.FieldChanges)
+				assert.Empty(t, got.Modified)
+				return
+			}
 
-	// 100ms vs 250ms: beyond tolerance, duration change reported in raw ns.
-	compareBeyond := traceWithNamedSpans(
-		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 250, tracev1.Status_STATUS_CODE_OK),
-	)
-	got, err = Diff(base, compareBeyond, FormatTracePatchV0)
-	require.NoError(t, err)
-	require.Len(t, got.Modified, 1)
-	require.Len(t, got.Modified[0].Changes, 1)
-	change := got.Modified[0].Changes[0]
-	assert.Equal(t, FieldDurationNanos, change.Target.Name)
-	assert.Equal(t, int64(100_000_000), change.Before)
-	assert.Equal(t, int64(250_000_000), change.After)
+			require.Len(t, got.Modified, 1)
+			require.Len(t, got.Modified[0].Changes, 1)
+			change := got.Modified[0].Changes[0]
+			assert.Equal(t, FieldDurationNanos, change.Target.Name)
+			assert.Equal(t, int64(tt.baseEnd*1_000_000), change.Before)
+			assert.Equal(t, int64(tt.compareEnd*1_000_000), change.After)
+		})
+	}
 }

--- a/pkg/model/tracediff/numeric_test.go
+++ b/pkg/model/tracediff/numeric_test.go
@@ -1,0 +1,142 @@
+package tracediff
+
+import (
+	"testing"
+
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Allow-listed keys reused across the tests below.
+const (
+	testAttrBodySize    = "http.request.body.size"
+	testAttrFileSize    = "file.size"
+	testAttrInputTokens = "gen_ai.usage.input_tokens"
+)
+
+func TestNumericClose(t *testing.T) {
+	tests := []struct {
+		name           string
+		a, b           float64
+		relTol, absTol float64
+		want           bool
+	}{
+		{name: "equal", a: 5, b: 5, relTol: 0.05, want: true},
+		{name: "within relative", a: 1000, b: 1001, relTol: 0.05, want: true},
+		{name: "at relative boundary", a: 1000, b: 1050, relTol: 0.05, want: true},
+		{name: "beyond relative", a: 1000, b: 2000, relTol: 0.05, want: false},
+		{name: "within absolute floor", a: 0, b: 500_000, relTol: 0.25, absTol: 1_000_000, want: true},
+		{name: "beyond floor but within relative", a: 100e6, b: 110e6, relTol: 0.25, absTol: 1_000_000, want: true},
+		{name: "beyond both", a: 100e6, b: 250e6, relTol: 0.25, absTol: 1_000_000, want: false},
+		{name: "zero transition with no floor", a: 0, b: 1, relTol: 0.05, want: false},
+		{name: "both zero", a: 0, b: 0, relTol: 0.05, want: true},
+		{name: "negatives within tolerance", a: -100, b: -101, relTol: 0.05, want: true},
+		{name: "sign flip", a: -100, b: 100, relTol: 0.05, want: false},
+		{name: "zero tolerances reduce to exact equal", a: 5, b: 5, want: true},
+		{name: "zero tolerances reduce to exact unequal", a: 5, b: 6, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, numericClose(tt.a, tt.b, tt.relTol, tt.absTol))
+		})
+	}
+}
+
+func TestIsNumericFuzzyAttribute(t *testing.T) {
+	allowed := []string{
+		testAttrBodySize,
+		"http.response_content_length", // deprecated entry
+		testAttrInputTokens,
+		testAttrFileSize,
+		"app.jank.period",
+	}
+	for _, key := range allowed {
+		assert.Truef(t, isNumericFuzzyAttribute(key), "expected %q to be allow-listed", key)
+	}
+
+	excluded := []string{
+		"http.response.status_code", // status code
+		"server.port",               // port
+		"db.response.returned_rows", // intentionally excluded
+		"aws.dynamodb.count",        // vendor product-specific
+		"custom.app.counter",        // unknown -> exact
+	}
+	for _, key := range excluded {
+		assert.Falsef(t, isNumericFuzzyAttribute(key), "expected %q to be excluded", key)
+	}
+}
+
+func TestNumericValue(t *testing.T) {
+	v, ok := numericValue(int64(5))
+	assert.True(t, ok)
+	assert.Equal(t, 5.0, v)
+
+	v, ok = numericValue(2.5)
+	assert.True(t, ok)
+	assert.Equal(t, 2.5, v)
+
+	_, ok = numericValue("10")
+	assert.False(t, ok)
+
+	_, ok = numericValue(nil)
+	assert.False(t, ok)
+
+	_, ok = numericValue(true)
+	assert.False(t, ok)
+}
+
+func TestAttributeChanged(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		before, after any
+		want          bool
+	}{
+		{name: "allow-listed within tolerance", key: testAttrBodySize, before: int64(1000), after: int64(1001), want: false},
+		{name: "allow-listed beyond tolerance", key: testAttrBodySize, before: int64(1000), after: int64(2000), want: true},
+		{name: "allow-listed equal", key: testAttrFileSize, before: int64(500), after: int64(500), want: false},
+		{name: "allow-listed zero transition", key: testAttrFileSize, before: int64(0), after: int64(1), want: true},
+		{name: "allow-listed int vs float equal", key: testAttrInputTokens, before: int64(100), after: 100.0, want: false},
+		{name: "allow-listed non-numeric falls back to exact", key: testAttrBodySize, before: "a", after: "b", want: true},
+		{name: "non-allow-listed numeric compared exactly", key: "custom.count", before: int64(1000), after: int64(1001), want: true},
+		{name: "status code compared exactly", key: "http.response.status_code", before: int64(200), after: int64(201), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, attributeChanged(tt.key, tt.before, tt.after))
+		})
+	}
+}
+
+func TestDiffDurationTolerance(t *testing.T) {
+	traceID := []byte("trace-id-0000001")
+
+	// 100ms vs 110ms: within tolerance, so no duration change is reported and
+	// the span is not modified.
+	base := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK),
+	)
+	compare := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 110, tracev1.Status_STATUS_CODE_OK),
+	)
+
+	got, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Stats.MatchedSpans)
+	assert.Zero(t, got.Stats.FieldChanges)
+	assert.Empty(t, got.Modified)
+
+	// 100ms vs 250ms: beyond tolerance, duration change reported in raw ns.
+	compareBeyond := traceWithNamedSpans(
+		spanForNormalizeTest(traceID, "root", "", "checkout", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 250, tracev1.Status_STATUS_CODE_OK),
+	)
+	got, err = Diff(base, compareBeyond, FormatTracePatchV0)
+	require.NoError(t, err)
+	require.Len(t, got.Modified, 1)
+	require.Len(t, got.Modified[0].Changes, 1)
+	change := got.Modified[0].Changes[0]
+	assert.Equal(t, FieldDurationNanos, change.Target.Name)
+	assert.Equal(t, int64(100_000_000), change.Before)
+	assert.Equal(t, int64(250_000_000), change.After)
+}

--- a/pkg/model/tracediff/types.go
+++ b/pkg/model/tracediff/types.go
@@ -30,9 +30,9 @@ const (
 // Field names (Target.Name) and attribute scopes (Target.Scope) in the
 // trace-patch-v0 vocabulary.
 const (
-	FieldDurationMs = "duration_ms"
-	FieldStatus     = "status"
-	ScopeSpan       = "span"
+	FieldDurationNanos = "duration_nanos"
+	FieldStatus        = "status"
+	ScopeSpan          = "span"
 )
 
 // Warning codes in the trace-patch-v0 vocabulary.
@@ -119,12 +119,12 @@ type SpanTarget struct {
 
 // SpanSnapshot is the minimal span data needed to render an add/remove.
 type SpanSnapshot struct {
-	Path       []int  `json:"path"`
-	Service    string `json:"service"`
-	Name       string `json:"name"`
-	Kind       string `json:"kind"`
-	DurationMs int64  `json:"duration_ms"`
-	Status     string `json:"status"`
+	Path          []int  `json:"path"`
+	Service       string `json:"service"`
+	Name          string `json:"name"`
+	Kind          string `json:"kind"`
+	DurationNanos int64  `json:"duration_nanos"`
+	Status        string `json:"status"`
 }
 
 // Warning reports non-fatal limits or matcher caveats.

--- a/pkg/model/tracediff/types_test.go
+++ b/pkg/model/tracediff/types_test.go
@@ -45,10 +45,10 @@ func TestTracePatchV0JSONShape(t *testing.T) {
 						Op: OperationModify,
 						Target: Target{
 							Type: TargetField,
-							Name: "duration_ms",
+							Name: "duration_nanos",
 						},
-						Before: float64(80),
-						After:  float64(390),
+						Before: int64(80),
+						After:  int64(390),
 					},
 					{
 						Op: OperationModify,
@@ -100,12 +100,12 @@ func TestTracePatchV0JSONShape(t *testing.T) {
 					Index:      &idx,
 				},
 				Span: SpanSnapshot{
-					Path:       []int{0, 1, 0},
-					Service:    "inventory",
-					Name:       "retry reserve",
-					Kind:       "client",
-					DurationMs: 120,
-					Status:     "ok",
+					Path:          []int{0, 1, 0},
+					Service:       "inventory",
+					Name:          "retry reserve",
+					Kind:          "client",
+					DurationNanos: 120,
+					Status:        "ok",
 				},
 			},
 		},
@@ -116,12 +116,12 @@ func TestTracePatchV0JSONShape(t *testing.T) {
 					Path: []int{0, 2},
 				},
 				Span: SpanSnapshot{
-					Path:       []int{0, 2},
-					Service:    "fraud",
-					Name:       "check_risk",
-					Kind:       "client",
-					DurationMs: 35,
-					Status:     "ok",
+					Path:          []int{0, 2},
+					Service:       "fraud",
+					Name:          "check_risk",
+					Kind:          "client",
+					DurationNanos: 35,
+					Status:        "ok",
 				},
 			},
 		},
@@ -156,7 +156,7 @@ func TestTracePatchV0JSONShape(t *testing.T) {
 			{
 				"span": {"path": [0, 1], "service": "inventory", "name": "reserve", "kind": "client"},
 				"changes": [
-					{"op": "modify", "target": {"type": "field", "name": "duration_ms"}, "before": 80, "after": 390},
+					{"op": "modify", "target": {"type": "field", "name": "duration_nanos"}, "before": 80, "after": 390},
 					{"op": "modify", "target": {"type": "field", "name": "status"}, "before": "ok", "after": "error"},
 					{"op": "add", "target": {"type": "attribute", "scope": "span", "key": "error.type"}, "before": null, "after": "timeout"},
 					{"op": "modify", "target": {"type": "attribute", "scope": "span", "key": "http.request.header.accept"}, "before": ["text/html", "application/json"], "after": ["application/json", "image/webp"]},
@@ -167,13 +167,13 @@ func TestTracePatchV0JSONShape(t *testing.T) {
 		"added": [
 			{
 				"target": {"type": "span", "parentPath": [0, 1], "index": 0},
-				"span": {"path": [0, 1, 0], "service": "inventory", "name": "retry reserve", "kind": "client", "duration_ms": 120, "status": "ok"}
+				"span": {"path": [0, 1, 0], "service": "inventory", "name": "retry reserve", "kind": "client", "duration_nanos": 120, "status": "ok"}
 			}
 		],
 		"removed": [
 			{
 				"target": {"type": "span", "path": [0, 2]},
-				"span": {"path": [0, 2], "service": "fraud", "name": "check_risk", "kind": "client", "duration_ms": 35, "status": "ok"}
+				"span": {"path": [0, 2], "service": "fraud", "name": "check_risk", "kind": "client", "duration_nanos": 35, "status": "ok"}
 			}
 		],
 		"warnings": [


### PR DESCRIPTION
**What this PR does**:
The current trace diff normalizes span durations to milliseconds in order to avoid jitter. This produces good results for many cases. But the current approach also leaves some room for improvements because:
* It does not work well for very long or short duration
* It does address problems with jitter for other numerical attributes
* Diffs don't report the real values but only the truncated durations

This PR introduces a tolerance based approach. The new approach is applied to span duration and a selected list of safe attributes. Per default numeric values are still compared by without tolerance in order to avoid issues with numeric attributes where every change is significant e.g. port number, status codes etc.

**Which issue(s) this PR fixes**:
Fixes n.a.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)