### PR TITLE
chore(renovate): drop release-v2.9 from base branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,6 @@
   ],
   baseBranchPatterns: [
     'main',
-    'release-v2.9',
     'release-v2.10',
     '/^release-v3.*/',
   ],


### PR DESCRIPTION
**What this PR does**:

Tempo 2.9 is no longer maintained now that 2.10 and 3.0 are the supported releases. This removes `release-v2.9` from Renovate's `baseBranchPatterns` in `.github/renovate.json5` so Renovate stops opening dependency-update PRs against that branch.

Follows the same pattern as #7347 (dropping `release-v2.8`).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated — N/A (CI config only)
- [ ] Documentation added — N/A
- [ ] Changelog entry added under `.chloggen/` — N/A (CI tooling change, no user-facing impact)
