### PR TITLE
chore: add module frontend docs to CODEOWNERS for docs reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,3 +25,4 @@
 /docs/make-docs                 @jdbaldry @knylander-grafana @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
 /docs/Makefile                  @jdbaldry @knylander-grafana @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
 /docs/variables.mk              @jdbaldry @knylander-grafana @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
+/modules/frontend/docs/         @knylander-grafana @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @oleg-kozlyuk-grafana @zhxiaogg


### PR DESCRIPTION
## What this PR does

Adds `/modules/frontend/docs/` to CODEOWNERS so the docs writer (@knylander-grafana) is an owner of these in-tree docs.

## Why

These files live outside the top-level `/docs/` tree, so today they fall through to the `*` catch-all owners. A docs-only PR/backport touching them cannot be satisfied by a docs-writer review alone (e.g. grafana/tempo#7546). The engineer owners are preserved; this only adds the docs writer.

`/.chloggen/` already includes the docs writer on `main`; the release-branch backports of this change also add it there.