### PR TITLE
enhancement: add simple hard input protection to the diff handler

### DIFF
--- a/.chloggen/feat-diff-proctention.yaml
+++ b/.chloggen/feat-diff-proctention.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Added a hard imput protection for the diff handler. The sum in bytes of both traces cannot be bigger than the MaxBytesPerTrace
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolinar

--- a/.chloggen/feat-diff-proctention.yaml
+++ b/.chloggen/feat-diff-proctention.yaml
@@ -8,7 +8,7 @@ change_type: enhancement
 component: query-frontend
 
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
-note: Added hard input protection for the trace diff handler: the combined size of both traces must not exceed MaxBytesPerTrace.
+note: Added hard input protection for the trace diff handler, the combined size of both traces must not exceed MaxBytesPerTrace.
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.

--- a/.chloggen/feat-diff-proctention.yaml
+++ b/.chloggen/feat-diff-proctention.yaml
@@ -8,7 +8,7 @@ change_type: enhancement
 component: query-frontend
 
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
-note: Added a hard imput protection for the diff handler. The sum in bytes of both traces cannot be bigger than the MaxBytesPerTrace
+note: Added hard input protection for the trace diff handler: the combined size of both traces must not exceed MaxBytesPerTrace.
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.

--- a/modules/frontend/tracediff_handler.go
+++ b/modules/frontend/tracediff_handler.go
@@ -79,6 +79,9 @@ func newTraceDiffHandler(_ Config, apiPrefix string, tracePipeline pipeline.Asyn
 		if err != nil {
 			return traceDiffErrorResponse(err), nil
 		}
+		// Trace diff intentionally uses the single-trace limit as a combined input budget.
+		// Diffing holds both traces plus normalized/indexed structures in memory, so allowing
+		// two max-sized traces would preserve the worst case this guard is meant to avoid.
 		if err := validateTraceDiffInputSize(baseResp.Trace, compareResp.Trace, o.MaxBytesPerTrace(tenant)); err != nil {
 			return traceDiffErrorResponse(err), nil
 		}
@@ -108,19 +111,20 @@ func validateTraceDiffInputSize(base, compare *tempopb.Trace, maxBytes int) erro
 		return nil
 	}
 
+	maxBytes64 := int64(maxBytes)
 	inputBytes := traceDiffInputSize(base) + traceDiffInputSize(compare)
-	if inputBytes <= maxBytes {
+	if inputBytes <= maxBytes64 {
 		return nil
 	}
 
-	return status.Errorf(codes.ResourceExhausted, "trace diff input too large: combined trace size %d bytes exceeds limit %d bytes; reduce the time range", inputBytes, maxBytes)
+	return status.Errorf(codes.ResourceExhausted, "trace diff input too large: combined trace size %d bytes exceeds limit %d bytes; reduce the time range", inputBytes, maxBytes64)
 }
 
-func traceDiffInputSize(trace *tempopb.Trace) int {
+func traceDiffInputSize(trace *tempopb.Trace) int64 {
 	if trace == nil {
 		return 0
 	}
-	return trace.Size()
+	return int64(trace.Size())
 }
 
 // It builds an http request to pass to the TraceByIdHandler

--- a/modules/frontend/tracediff_handler.go
+++ b/modules/frontend/tracediff_handler.go
@@ -79,6 +79,9 @@ func newTraceDiffHandler(_ Config, apiPrefix string, tracePipeline pipeline.Asyn
 		if err != nil {
 			return traceDiffErrorResponse(err), nil
 		}
+		if err := validateTraceDiffInputSize(baseResp.Trace, compareResp.Trace, o.MaxBytesPerTrace(tenant)); err != nil {
+			return traceDiffErrorResponse(err), nil
+		}
 
 		result, err := tracediff.Diff(baseResp.Trace, compareResp.Trace, tracediff.Format(diffReq.Format))
 		if err != nil {
@@ -98,6 +101,26 @@ func traceDiffTimeParam(v *int64) any {
 		return ""
 	}
 	return *v
+}
+
+func validateTraceDiffInputSize(base, compare *tempopb.Trace, maxBytes int) error {
+	if maxBytes <= 0 {
+		return nil
+	}
+
+	inputBytes := traceDiffInputSize(base) + traceDiffInputSize(compare)
+	if inputBytes <= maxBytes {
+		return nil
+	}
+
+	return status.Errorf(codes.ResourceExhausted, "trace diff input too large: combined trace size %d bytes exceeds limit %d bytes; reduce the time range", inputBytes, maxBytes)
+}
+
+func traceDiffInputSize(trace *tempopb.Trace) int {
+	if trace == nil {
+		return 0
+	}
+	return trace.Size()
 }
 
 // It builds an http request to pass to the TraceByIdHandler

--- a/modules/frontend/tracediff_handler.go
+++ b/modules/frontend/tracediff_handler.go
@@ -117,7 +117,7 @@ func validateTraceDiffInputSize(base, compare *tempopb.Trace, maxBytes int) erro
 		return nil
 	}
 
-	return status.Errorf(codes.ResourceExhausted, "trace diff input too large: combined trace size %d bytes exceeds limit %d bytes; reduce the time range", inputBytes, maxBytes64)
+	return status.Errorf(codes.ResourceExhausted, "trace diff input too large: combined trace size %d bytes exceeds limit %d bytes", inputBytes, maxBytes64)
 }
 
 func traceDiffInputSize(trace *tempopb.Trace) int64 {

--- a/modules/frontend/tracediff_handler_test.go
+++ b/modules/frontend/tracediff_handler_test.go
@@ -202,6 +202,39 @@ func TestTraceDiffHandlerReturnsDiff(t *testing.T) {
 	require.Contains(t, resp.Body.String(), `"version":"trace-patch-v0"`)
 }
 
+func TestTraceDiffHandlerRejectsOversizedCombinedInput(t *testing.T) {
+	baseTrace := tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})
+	compareTrace := tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})
+	maxBytes := baseTrace.Size()
+	if compareTrace.Size() > maxBytes {
+		maxBytes = compareTrace.Size()
+	}
+	require.Less(t, maxBytes, baseTrace.Size()+compareTrace.Size())
+
+	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": {Trace: baseTrace},
+		"def456": {Trace: compareTrace},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{
+		Defaults: overrides.Overrides{
+			Global: overrides.GlobalOverrides{
+				MaxBytesPerTrace: maxBytes,
+			},
+		},
+	}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(`{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`))
+	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusTooManyRequests, resp.Code)
+	require.Contains(t, resp.Body.String(), "trace diff input too large")
+}
+
 func TestTraceDiffHandlerAppliesTraceRedactor(t *testing.T) {
 	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
 		"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
It implements  a simple hard input protection. After fetching both full traces, validates:
      
`base.Trace.Size() + compare.Trace.Size() <= o.MaxBytesPerTrace(tenant)`


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)