### PR TITLE
enhancement: aggregate new stats metrics in missing querier methods

### DIFF
--- a/.chloggen/change-aggregate-new-metrics.yaml
+++ b/.chloggen/change-aggregate-new-metrics.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: querier
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Merge new stats metrics added in 7504 into missing querier methods
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolinar

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -211,7 +211,7 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 
 	maxBytes := q.limits.MaxBytesPerTrace(userID)
 	combiner := trace.NewCombiner(maxBytes, req.AllowPartialTrace)
-	var inspectedBytes uint64
+	metrics := &tempopb.TraceByIDMetrics{}
 
 	if req.QueryMode == QueryModeIngesters || req.QueryMode == QueryModeAll {
 		// Get responses from all live stores in parallel.
@@ -242,9 +242,7 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 
 			spanCountTotal += int64(spanCount)
 			traceCountTotal++
-			if resp.Metrics != nil {
-				inspectedBytes += resp.Metrics.InspectedBytes
-			}
+			tempopb.MergeTraceByIDMetrics(metrics, resp.Metrics)
 		}
 
 		span.AddEvent("done searching live-stores", oteltrace.WithAttributes(
@@ -286,9 +284,7 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 			if err != nil {
 				return nil, err
 			}
-			if partialTrace.Metrics != nil {
-				inspectedBytes += partialTrace.Metrics.InspectedBytes
-			}
+			tempopb.MergeTraceByIDMetrics(metrics, partialTrace.Metrics)
 		}
 	}
 
@@ -320,7 +316,7 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 	completeTrace, _ := combiner.Result()
 	resp := &tempopb.TraceByIDResponse{
 		Trace:   completeTrace,
-		Metrics: &tempopb.TraceByIDMetrics{InspectedBytes: inspectedBytes},
+		Metrics: metrics,
 	}
 
 	if combiner.IsPartialTrace() {
@@ -431,7 +427,7 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 
 	maxDataSize := q.limits.MaxBytesPerTagValuesQuery(userID)
 	distinctValues := collector.NewDistinctString(maxDataSize, req.MaxTagsPerScope, req.StaleValuesThreshold)
-	var inspectedBytes uint64
+	metrics := &tempopb.MetadataMetrics{}
 
 	results, err := q.forLiveStoreRing(ctx, func(ctx context.Context, client tempopb.QuerierClient) (any, error) {
 		return client.SearchTags(ctx, req)
@@ -443,9 +439,7 @@ func (q *Querier) SearchTags(ctx context.Context, req *tempopb.SearchTagsRequest
 outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagsResponse)
-		if resp.Metrics != nil {
-			inspectedBytes += resp.Metrics.InspectedBytes
-		}
+		tempopb.MergeMetadataMetrics(metrics, resp.Metrics)
 
 		for _, tag := range resp.TagNames {
 			distinctValues.Collect(tag)
@@ -461,7 +455,7 @@ outer:
 
 	return &tempopb.SearchTagsResponse{
 		TagNames: distinctValues.Strings(),
-		Metrics:  &tempopb.MetadataMetrics{InspectedBytes: inspectedBytes},
+		Metrics:  metrics,
 	}, nil
 }
 
@@ -473,7 +467,7 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 
 	maxBytesPerTag := q.limits.MaxBytesPerTagValuesQuery(orgID)
 	distinctValues := collector.NewScopedDistinctString(maxBytesPerTag, req.MaxTagsPerScope, req.StaleValuesThreshold)
-	var inspectedBytes uint64
+	metrics := &tempopb.MetadataMetrics{}
 
 	// Get results from all live stores.
 	results, err := q.forLiveStoreRing(ctx, func(ctx context.Context, client tempopb.QuerierClient) (any, error) {
@@ -486,9 +480,7 @@ func (q *Querier) SearchTagsV2(ctx context.Context, req *tempopb.SearchTagsReque
 outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagsV2Response)
-		if resp.Metrics != nil {
-			inspectedBytes += resp.Metrics.InspectedBytes
-		}
+		tempopb.MergeMetadataMetrics(metrics, resp.Metrics)
 
 		for _, res := range resp.Scopes {
 			for _, tag := range res.Tags {
@@ -506,7 +498,7 @@ outer:
 	collected := distinctValues.Strings()
 	resp := &tempopb.SearchTagsV2Response{
 		Scopes:  make([]*tempopb.SearchTagsV2Scope, 0, len(collected)),
-		Metrics: &tempopb.MetadataMetrics{InspectedBytes: inspectedBytes},
+		Metrics: metrics,
 	}
 	for scope, vals := range collected {
 		resp.Scopes = append(resp.Scopes, &tempopb.SearchTagsV2Scope{
@@ -526,7 +518,7 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 
 	maxDataSize := q.limits.MaxBytesPerTagValuesQuery(userID)
 	distinctValues := collector.NewDistinctString(maxDataSize, req.MaxTagValues, req.StaleValueThreshold)
-	var inspectedBytes uint64
+	metrics := &tempopb.MetadataMetrics{}
 
 	// Virtual tags values. Get these first.
 	for _, v := range search.GetVirtualTagValues(req.TagName) {
@@ -544,9 +536,7 @@ func (q *Querier) SearchTagValues(ctx context.Context, req *tempopb.SearchTagVal
 outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagValuesResponse)
-		if resp.Metrics != nil {
-			inspectedBytes += resp.Metrics.InspectedBytes
-		}
+		tempopb.MergeMetadataMetrics(metrics, resp.Metrics)
 
 		for _, res := range resp.TagValues {
 			distinctValues.Collect(res)
@@ -562,7 +552,7 @@ outer:
 
 	return &tempopb.SearchTagValuesResponse{
 		TagValues: distinctValues.Strings(),
-		Metrics:   &tempopb.MetadataMetrics{InspectedBytes: inspectedBytes},
+		Metrics:   metrics,
 	}, nil
 }
 
@@ -574,7 +564,7 @@ func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagV
 
 	maxDataSize := q.limits.MaxBytesPerTagValuesQuery(userID)
 	distinctValues := collector.NewDistinctValue(maxDataSize, req.MaxTagValues, req.StaleValueThreshold, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
-	var inspectedBytes uint64
+	metrics := &tempopb.MetadataMetrics{}
 
 	// Virtual tags values. Get these first.
 	virtualVals := search.GetVirtualTagValuesV2(req.TagName)
@@ -587,7 +577,7 @@ func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagV
 	// in v1 search b/c intrinsic tags like "status" are conflated with attributes named "status"
 	if virtualVals != nil {
 		// no data was read to collect virtual tags so 0 bytesRead
-		return valuesToV2Response(distinctValues, 0), nil
+		return valuesToV2Response(distinctValues, metrics), nil
 	}
 
 	results, err := q.forLiveStoreRing(ctx, func(ctx context.Context, client tempopb.QuerierClient) (any, error) {
@@ -600,9 +590,7 @@ func (q *Querier) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTagV
 outer:
 	for _, result := range results {
 		resp := result.(*tempopb.SearchTagValuesV2Response)
-		if resp.Metrics != nil {
-			inspectedBytes += resp.Metrics.InspectedBytes
-		}
+		tempopb.MergeMetadataMetrics(metrics, resp.Metrics)
 
 		for _, res := range resp.TagValues {
 			distinctValues.Collect(*res)
@@ -616,12 +604,16 @@ outer:
 		_ = level.Warn(log.Logger).Log("msg", "Search of tag values exceeded limit, reduce cardinality or size of tags", "tag", req.TagName, "orgID", userID, "stopReason", distinctValues.StopReason())
 	}
 
-	return valuesToV2Response(distinctValues, inspectedBytes), nil
+	return valuesToV2Response(distinctValues, metrics), nil
 }
 
-func valuesToV2Response(distinctValues *collector.DistinctValue[tempopb.TagValue], bytesRead uint64) *tempopb.SearchTagValuesV2Response {
+func valuesToV2Response(distinctValues *collector.DistinctValue[tempopb.TagValue], metrics *tempopb.MetadataMetrics) *tempopb.SearchTagValuesV2Response {
+	if metrics == nil {
+		metrics = &tempopb.MetadataMetrics{}
+	}
+
 	resp := &tempopb.SearchTagValuesV2Response{
-		Metrics: &tempopb.MetadataMetrics{InspectedBytes: bytesRead},
+		Metrics: metrics,
 	}
 	for _, v := range distinctValues.Values() {
 		v2 := v
@@ -881,7 +873,7 @@ func (q *Querier) internalTagValuesSearchBlockV2(ctx context.Context, req *tempo
 		level.Warn(log.Logger).Log("msg", "Search tags exceeded limit, reduce cardinality or size of tags", "orgID", tenantID, "stopReason", valueCollector.StopReason())
 	}
 
-	return valuesToV2Response(valueCollector, inspectedBytes), nil
+	return valuesToV2Response(valueCollector, &tempopb.MetadataMetrics{InspectedBytes: inspectedBytes}), nil
 }
 
 func (q *Querier) postProcessIngesterSearchResults(req *tempopb.SearchRequest, results []any) *tempopb.SearchResponse {
@@ -900,10 +892,7 @@ func (q *Querier) postProcessIngesterSearchResults(req *tempopb.SearchRequest, r
 				traces[t.TraceID] = t
 			}
 		}
-		if sr.Metrics != nil {
-			response.Metrics.InspectedBytes += sr.Metrics.InspectedBytes
-			response.Metrics.InspectedTraces += sr.Metrics.InspectedTraces
-		}
+		response.Metrics = tempopb.MergeSearchMetrics(response.Metrics, sr.Metrics)
 	}
 
 	for _, t := range traces {

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -112,6 +112,50 @@ func TestVirtualTagsDoesntHitBackend(t *testing.T) {
 	require.Nil(t, resp)
 }
 
+func TestPostProcessIngesterSearchResultsMergesReadMetrics(t *testing.T) {
+	q := &Querier{}
+
+	resp := q.postProcessIngesterSearchResults(&tempopb.SearchRequest{}, []any{
+		&tempopb.SearchResponse{
+			Metrics: &tempopb.SearchMetrics{
+				InspectedTraces: 1,
+				InspectedBytes:  2,
+				InspectedSpans:  3,
+				BackendReads:    4,
+				BackendBytes:    5,
+				AdditionalMetrics: map[string]int64{
+					tempopb.AdditionalMetricCacheHits: 6,
+				},
+			},
+		},
+		&tempopb.SearchResponse{
+			Metrics: &tempopb.SearchMetrics{
+				InspectedTraces: 7,
+				InspectedBytes:  8,
+				InspectedSpans:  9,
+				BackendReads:    10,
+				BackendBytes:    11,
+				AdditionalMetrics: map[string]int64{
+					tempopb.AdditionalMetricCacheHits:   12,
+					tempopb.AdditionalMetricCacheMisses: 13,
+				},
+			},
+		},
+	})
+
+	require.Equal(t, &tempopb.SearchMetrics{
+		InspectedTraces: 1 + 7,
+		InspectedBytes:  2 + 8,
+		InspectedSpans:  3 + 9,
+		BackendReads:    4 + 10,
+		BackendBytes:    5 + 11,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricCacheHits:   6 + 12,
+			tempopb.AdditionalMetricCacheMisses: 13,
+		},
+	}, resp.Metrics)
+}
+
 func TestFindTraceByID_ExternalMode(t *testing.T) {
 	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
 	userID := "test-tenant"

--- a/pkg/tempopb/metrics.go
+++ b/pkg/tempopb/metrics.go
@@ -1,0 +1,86 @@
+package tempopb
+
+// MergeSearchMetrics adds src into dst and returns dst. If src is nil, dst is returned unchanged.
+// If dst is nil and src is non-nil, dst is allocated.
+func MergeSearchMetrics(dst, src *SearchMetrics) *SearchMetrics {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		dst = &SearchMetrics{}
+	}
+
+	dst.InspectedTraces += src.InspectedTraces
+	dst.InspectedBytes += src.InspectedBytes
+	dst.TotalBlocks += src.TotalBlocks
+	dst.CompletedJobs += src.CompletedJobs
+	dst.TotalJobs += src.TotalJobs
+	dst.TotalBlockBytes += src.TotalBlockBytes
+	dst.InspectedSpans += src.InspectedSpans
+	dst.BackendReads += src.BackendReads
+	dst.BackendBytes += src.BackendBytes
+	if len(src.AdditionalMetrics) > 0 {
+		if dst.AdditionalMetrics == nil {
+			dst.AdditionalMetrics = make(map[string]int64, len(src.AdditionalMetrics))
+		}
+		for k, v := range src.AdditionalMetrics {
+			dst.AdditionalMetrics[k] += v
+		}
+	}
+
+	return dst
+}
+
+// MergeMetadataMetrics adds src into dst and returns dst. If src is nil, dst is returned unchanged.
+// If dst is nil and src is non-nil, dst is allocated.
+func MergeMetadataMetrics(dst, src *MetadataMetrics) *MetadataMetrics {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		dst = &MetadataMetrics{}
+	}
+
+	dst.InspectedBytes += src.InspectedBytes
+	dst.TotalJobs += src.TotalJobs
+	dst.CompletedJobs += src.CompletedJobs
+	dst.TotalBlocks += src.TotalBlocks
+	dst.TotalBlockBytes += src.TotalBlockBytes
+	dst.BackendReads += src.BackendReads
+	dst.BackendBytes += src.BackendBytes
+	if len(src.AdditionalMetrics) > 0 {
+		if dst.AdditionalMetrics == nil {
+			dst.AdditionalMetrics = make(map[string]int64, len(src.AdditionalMetrics))
+		}
+		for k, v := range src.AdditionalMetrics {
+			dst.AdditionalMetrics[k] += v
+		}
+	}
+
+	return dst
+}
+
+// MergeTraceByIDMetrics adds src into dst and returns dst. If src is nil, dst is returned unchanged.
+// If dst is nil and src is non-nil, dst is allocated.
+func MergeTraceByIDMetrics(dst, src *TraceByIDMetrics) *TraceByIDMetrics {
+	if src == nil {
+		return dst
+	}
+	if dst == nil {
+		dst = &TraceByIDMetrics{}
+	}
+
+	dst.InspectedBytes += src.InspectedBytes
+	dst.BackendReads += src.BackendReads
+	dst.BackendBytes += src.BackendBytes
+	if len(src.AdditionalMetrics) > 0 {
+		if dst.AdditionalMetrics == nil {
+			dst.AdditionalMetrics = make(map[string]int64, len(src.AdditionalMetrics))
+		}
+		for k, v := range src.AdditionalMetrics {
+			dst.AdditionalMetrics[k] += v
+		}
+	}
+
+	return dst
+}

--- a/pkg/tempopb/metrics_test.go
+++ b/pkg/tempopb/metrics_test.go
@@ -1,0 +1,116 @@
+package tempopb_test
+
+import (
+	"testing"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeMetricsWithNilSourceDoesNotAllocateDestination(t *testing.T) {
+	assert.Nil(t, tempopb.MergeSearchMetrics(nil, nil))
+	assert.Nil(t, tempopb.MergeMetadataMetrics(nil, nil))
+	assert.Nil(t, tempopb.MergeTraceByIDMetrics(nil, nil))
+}
+
+func TestMergeSearchMetrics(t *testing.T) {
+	dst := &tempopb.SearchMetrics{
+		InspectedTraces:   1,
+		InspectedBytes:    2,
+		TotalBlocks:       3,
+		CompletedJobs:     4,
+		TotalJobs:         5,
+		TotalBlockBytes:   6,
+		InspectedSpans:    7,
+		BackendReads:      8,
+		BackendBytes:      9,
+		AdditionalMetrics: map[string]int64{tempopb.AdditionalMetricCacheHits: 10},
+	}
+
+	got := tempopb.MergeSearchMetrics(dst, &tempopb.SearchMetrics{
+		InspectedTraces:   11,
+		InspectedBytes:    12,
+		TotalBlocks:       13,
+		CompletedJobs:     14,
+		TotalJobs:         15,
+		TotalBlockBytes:   16,
+		InspectedSpans:    17,
+		BackendReads:      18,
+		BackendBytes:      19,
+		AdditionalMetrics: map[string]int64{tempopb.AdditionalMetricCacheHits: 20, tempopb.AdditionalMetricCacheMisses: 21},
+	})
+
+	assert.Same(t, dst, got)
+	assert.Equal(t, &tempopb.SearchMetrics{
+		InspectedTraces: 1 + 11,
+		InspectedBytes:  2 + 12,
+		TotalBlocks:     3 + 13,
+		CompletedJobs:   4 + 14,
+		TotalJobs:       5 + 15,
+		TotalBlockBytes: 6 + 16,
+		InspectedSpans:  7 + 17,
+		BackendReads:    8 + 18,
+		BackendBytes:    9 + 19,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricCacheHits:   10 + 20,
+			tempopb.AdditionalMetricCacheMisses: 21,
+		},
+	}, got)
+}
+
+func TestMergeMetadataMetrics(t *testing.T) {
+	got := tempopb.MergeMetadataMetrics(nil, &tempopb.MetadataMetrics{
+		InspectedBytes:  1,
+		TotalJobs:       2,
+		CompletedJobs:   3,
+		TotalBlocks:     4,
+		TotalBlockBytes: 5,
+		BackendReads:    6,
+		BackendBytes:    7,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricPagesInspected: 8,
+		},
+	})
+
+	assert.Equal(t, &tempopb.MetadataMetrics{
+		InspectedBytes:  1,
+		TotalJobs:       2,
+		CompletedJobs:   3,
+		TotalBlocks:     4,
+		TotalBlockBytes: 5,
+		BackendReads:    6,
+		BackendBytes:    7,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricPagesInspected: 8,
+		},
+	}, got)
+}
+
+func TestMergeTraceByIDMetrics(t *testing.T) {
+	got := tempopb.MergeTraceByIDMetrics(&tempopb.TraceByIDMetrics{
+		InspectedBytes: 1,
+		BackendReads:   2,
+		BackendBytes:   3,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricRowGroupsSkipped: 4,
+		},
+	}, &tempopb.TraceByIDMetrics{
+		InspectedBytes: 5,
+		BackendReads:   6,
+		BackendBytes:   7,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricRowGroupsSkipped:   8,
+			tempopb.AdditionalMetricRowGroupsInspected: 9,
+		},
+	})
+
+	assert.Equal(t, &tempopb.TraceByIDMetrics{
+		InspectedBytes: 1 + 5,
+		BackendReads:   2 + 6,
+		BackendBytes:   3 + 7,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricRowGroupsSkipped:   4 + 8,
+			tempopb.AdditionalMetricRowGroupsInspected: 9,
+		},
+	}, got)
+}

--- a/pkg/traceql/combine.go
+++ b/pkg/traceql/combine.go
@@ -356,15 +356,7 @@ func (q *QueryRangeCombiner) Combine(resp *tempopb.QueryRangeResponse) {
 
 	// TODO: this is here only for the querier
 	// we want to use the metrics combiner from the frontend
-	if resp.Metrics != nil {
-		q.metrics.TotalJobs += resp.Metrics.TotalJobs
-		q.metrics.TotalBlocks += resp.Metrics.TotalBlocks
-		q.metrics.TotalBlockBytes += resp.Metrics.TotalBlockBytes
-		q.metrics.InspectedBytes += resp.Metrics.InspectedBytes
-		q.metrics.InspectedTraces += resp.Metrics.InspectedTraces
-		q.metrics.InspectedSpans += resp.Metrics.InspectedSpans
-		q.metrics.CompletedJobs += resp.Metrics.CompletedJobs
-	}
+	q.metrics = tempopb.MergeSearchMetrics(q.metrics, resp.Metrics)
 }
 
 func (q *QueryRangeCombiner) Response() *tempopb.QueryRangeResponse {

--- a/pkg/traceql/combine_test.go
+++ b/pkg/traceql/combine_test.go
@@ -269,6 +269,67 @@ func TestCombineResults(t *testing.T) {
 	}
 }
 
+func TestQueryRangeCombinerMergesReadMetrics(t *testing.T) {
+	combiner, err := QueryRangeCombinerFor(&tempopb.QueryRangeRequest{
+		Query: "{} | rate()",
+		Start: 1,
+		End:   2,
+		Step:  1,
+	}, AggregateModeSum, 0)
+	require.NoError(t, err)
+
+	combiner.Combine(&tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{
+			TotalJobs:       1,
+			CompletedJobs:   2,
+			TotalBlocks:     3,
+			TotalBlockBytes: 4,
+			InspectedBytes:  5,
+			InspectedTraces: 6,
+			InspectedSpans:  7,
+			BackendReads:    8,
+			BackendBytes:    9,
+			AdditionalMetrics: map[string]int64{
+				tempopb.AdditionalMetricCacheHits: 10,
+			},
+		},
+	})
+	combiner.Combine(&tempopb.QueryRangeResponse{
+		Metrics: &tempopb.SearchMetrics{
+			TotalJobs:       11,
+			CompletedJobs:   12,
+			TotalBlocks:     13,
+			TotalBlockBytes: 14,
+			InspectedBytes:  15,
+			InspectedTraces: 16,
+			InspectedSpans:  17,
+			BackendReads:    18,
+			BackendBytes:    19,
+			AdditionalMetrics: map[string]int64{
+				tempopb.AdditionalMetricCacheHits:   20,
+				tempopb.AdditionalMetricCacheMisses: 21,
+			},
+		},
+	})
+
+	resp := combiner.Response()
+	require.Equal(t, &tempopb.SearchMetrics{
+		TotalJobs:       1 + 11,
+		CompletedJobs:   2 + 12,
+		TotalBlocks:     3 + 13,
+		TotalBlockBytes: 4 + 14,
+		InspectedBytes:  5 + 15,
+		InspectedTraces: 6 + 16,
+		InspectedSpans:  7 + 17,
+		BackendReads:    8 + 18,
+		BackendBytes:    9 + 19,
+		AdditionalMetrics: map[string]int64{
+			tempopb.AdditionalMetricCacheHits:   10 + 20,
+			tempopb.AdditionalMetricCacheMisses: 21,
+		},
+	}, resp.Metrics)
+}
+
 func TestCombinerKeepsMostRecent(t *testing.T) {
 	totalTraces := 10
 	keepMostRecent := 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
New metrics are stats added in #7504 were not being aggregated to all the querier methods response. This PR adds them.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)