### PR TITLE
docs: correct dedicated column type/capacity

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2031,14 +2031,14 @@ Defines re-used configuration blocks.
 
 # Configures attributes to be stored in dedicated columns within the parquet file, rather than in the
 # generic attribute key-value list. This allows for more efficient searching of these attributes.
-# Up to 10 span attributes and 10 resource attributes can be configured as dedicated columns.
+# Up to 20 string and 5 int attributes can be configured per scope (span, resource, event).
 # Requires vParquet4 or later.
 parquet_dedicated_columns: <list of columns>
 
       # name of the attribute
     - [name: <string>]
 
-      # type of the attribute. options: string
+      # type of the attribute. options: string, int
       [type: <string>]
 
       # scope of the attribute.
@@ -2581,12 +2581,12 @@ overrides:
     storage:
       # Configures attributes to be stored in dedicated columns within the parquet file, rather than in the
       # generic attribute key-value list. This allows for more efficient searching of these attributes.
-      # Up to 10 span attributes and 10 resource attributes can be configured as dedicated columns.
+      # Up to 20 string and 5 int attributes can be configured per scope (span, resource, event).
       # Requires vParquet4 or later.
       parquet_dedicated_columns:
         [
           name: <string>, # name of the attribute
-          type: <string>, # type of the attribute. options: string
+          type: <string>, # type of the attribute. options: string, int
           scope: <string> # scope of the attribute. options: resource, span
         ]
 

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/tempo/pkg/traceql"
 )
 
-// DedicatedColumnType is the type of the values in the dedicated attribute column. Only 'string' is supported.
+// DedicatedColumnType is the type of the values in the dedicated attribute column. Supported values are 'string' and 'int'.
 type DedicatedColumnType string
 
 // DedicatedColumnScope is the scope of the attribute that is stored in a dedicated column. Possible values are


### PR DESCRIPTION
I've hit the specific issue of declaring a string dedicated column (because the docs said that only strings are supported) for an int-valued attribute (`http.response.status_code`) and then had different query paths return different results. 
While I'm lookin into addressing the underlying issue I think it's worth updating the docs to reflect the current reality. 

## AI disclosure
I've used Claude Code to investigate the above issue, find the stale comment, and propose the changes version.