### PR TITLE
fix: release mutex before dialing in querier worker AddressAdded

### DIFF
--- a/.chloggen/7505_querier_worker_deadlock_fix.yaml
+++ b/.chloggen/7505_querier_worker_deadlock_fix.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: querier
+note: Fix mutex deadlock and resource leak in querier worker when gRPC dial to query-frontend hangs during shutdown.
+issues: []
+subtext:
+user: shayannab

--- a/modules/querier/worker/worker.go
+++ b/modules/querier/worker/worker.go
@@ -90,6 +90,9 @@ type querierWorker struct {
 	mu sync.Mutex
 	// Set to nil when stop is called... no more managers are created afterwards.
 	managers map[string]*processorManager
+
+	// connectFunc overrides connect; set in tests to simulate slow or failing dials.
+	connectFunc func(ctx context.Context, address string) (*grpc.ClientConn, error)
 }
 
 func NewQuerierWorker(cfg Config, handler RequestHandler, log log.Logger, _ prometheus.Registerer) (services.Service, error) {
@@ -175,16 +178,37 @@ func (w *querierWorker) AddressAdded(address string) {
 	}
 
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	if m := w.managers[address]; m != nil {
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Unlock()
+
+	level.Info(w.log).Log("msg", "adding connection", "addr", address)
+	connectFn := w.connect
+	if w.connectFunc != nil {
+		connectFn = w.connectFunc
+	}
+	conn, err := connectFn(ctx, address)
+	if err != nil {
+		level.Error(w.log).Log("msg", "error connecting", "addr", address, "err", err)
 		return
 	}
 
-	level.Info(w.log).Log("msg", "adding connection", "addr", address)
-	conn, err := w.connect(context.Background(), address)
-	if err != nil {
-		level.Error(w.log).Log("msg", "error connecting", "addr", address, "err", err)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// Double-check if the service was stopped or the address was added in the meantime.
+	if ctx.Err() != nil {
+		if err := conn.Close(); err != nil {
+			level.Error(w.log).Log("msg", "error closing connection on service stop", "addr", address, "err", err)
+		}
+		return
+	}
+	if m := w.managers[address]; m != nil {
+		if err := conn.Close(); err != nil {
+			level.Error(w.log).Log("msg", "error closing duplicate connection", "addr", address, "err", err)
+		}
 		return
 	}
 

--- a/modules/querier/worker/worker.go
+++ b/modules/querier/worker/worker.go
@@ -191,6 +191,10 @@ func (w *querierWorker) AddressAdded(address string) {
 	}
 	conn, err := connectFn(ctx, address)
 	if err != nil {
+		if ctx.Err() != nil {
+			level.Debug(w.log).Log("msg", "connection attempt canceled", "addr", address, "err", err)
+			return
+		}
 		level.Error(w.log).Log("msg", "error connecting", "addr", address, "err", err)
 		return
 	}

--- a/modules/querier/worker/worker_test.go
+++ b/modules/querier/worker/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcclient"
@@ -85,8 +86,8 @@ func TestQuerierWorker_ShutdownDuringHangingDial(t *testing.T) {
 
 	dialStarted := make(chan struct{})
 	w.connectFunc = func(ctx context.Context, _ string) (*grpc.ClientConn, error) {
-		close(dialStarted)  // signal that we are inside the blocking dial
-		<-ctx.Done()        // block until the service context is cancelled
+		close(dialStarted) // signal that we are inside the blocking dial
+		<-ctx.Done()       // block until the service context is cancelled
 		return nil, ctx.Err()
 	}
 
@@ -94,12 +95,21 @@ func TestQuerierWorker_ShutdownDuringHangingDial(t *testing.T) {
 	require.NoError(t, w.AwaitRunning(context.Background()))
 
 	go w.AddressAdded("127.0.0.1:9999")
-	<-dialStarted // wait until AddressAdded is blocked inside the injected dialer
+
+	select {
+	case <-dialStarted:
+		// OK
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for dial to start")
+	}
 
 	// Without the fix, StopAsync would block forever because the mutex was held
 	// during the dial and stopping() could never acquire it.
 	w.StopAsync()
-	require.NoError(t, w.AwaitTerminated(context.Background()))
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, w.AwaitTerminated(shutdownCtx))
 
 	// The dial was cancelled; no manager should have been installed.
 	w.mu.Lock()

--- a/modules/querier/worker/worker_test.go
+++ b/modules/querier/worker/worker_test.go
@@ -1,0 +1,109 @@
+package worker
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/grpcclient"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type mockProcessor struct {
+	mu            sync.Mutex
+	notifiedAddrs []string
+}
+
+func (m *mockProcessor) processQueriesOnSingleStream(ctx context.Context, _ *grpc.ClientConn, _ string) {
+	<-ctx.Done()
+}
+
+func (m *mockProcessor) notifyShutdown(_ context.Context, _ *grpc.ClientConn, address string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.notifiedAddrs = append(m.notifiedAddrs, address)
+}
+
+func TestQuerierWorker_AddressLifecycle(t *testing.T) {
+	cfg := Config{
+		GRPCClientConfig: grpcclient.Config{},
+	}
+	proc := &mockProcessor{}
+	w, err := newQuerierWorkerWithProcessor(cfg, log.NewNopLogger(), proc, "", nil)
+	require.NoError(t, err)
+
+	err = w.StartAsync(context.Background())
+	require.NoError(t, err)
+	err = w.AwaitRunning(context.Background())
+	require.NoError(t, err)
+
+	address := "127.0.0.1:9999"
+	w.AddressAdded(address)
+
+	w.mu.Lock()
+	manager := w.managers[address]
+	w.mu.Unlock()
+	require.NotNil(t, manager)
+
+	// Verify duplicate add doesn't cause issues
+	w.AddressAdded(address)
+
+	// Remove address
+	w.AddressRemoved(address)
+
+	w.mu.Lock()
+	manager = w.managers[address]
+	w.mu.Unlock()
+	require.Nil(t, manager)
+
+	// Stop service
+	w.StopAsync()
+	err = w.AwaitTerminated(context.Background())
+	require.NoError(t, err)
+
+	// AwaitTerminated guarantees notifyShutdown has run; lock to satisfy the race detector.
+	proc.mu.Lock()
+	addrs := make([]string, len(proc.notifiedAddrs))
+	copy(addrs, proc.notifiedAddrs)
+	proc.mu.Unlock()
+	require.Contains(t, addrs, address)
+}
+
+// TestQuerierWorker_ShutdownDuringHangingDial is the regression test for #7505.
+// It injects a blocking dialer so AddressAdded hangs inside connect while the
+// mutex is NOT held (the fix). Shutdown must complete without deadlocking and
+// no manager must be installed.
+func TestQuerierWorker_ShutdownDuringHangingDial(t *testing.T) {
+	proc := &mockProcessor{}
+	w, err := newQuerierWorkerWithProcessor(
+		Config{GRPCClientConfig: grpcclient.Config{}},
+		log.NewNopLogger(), proc, "", nil,
+	)
+	require.NoError(t, err)
+
+	dialStarted := make(chan struct{})
+	w.connectFunc = func(ctx context.Context, _ string) (*grpc.ClientConn, error) {
+		close(dialStarted)  // signal that we are inside the blocking dial
+		<-ctx.Done()        // block until the service context is cancelled
+		return nil, ctx.Err()
+	}
+
+	require.NoError(t, w.StartAsync(context.Background()))
+	require.NoError(t, w.AwaitRunning(context.Background()))
+
+	go w.AddressAdded("127.0.0.1:9999")
+	<-dialStarted // wait until AddressAdded is blocked inside the injected dialer
+
+	// Without the fix, StopAsync would block forever because the mutex was held
+	// during the dial and stopping() could never acquire it.
+	w.StopAsync()
+	require.NoError(t, w.AwaitTerminated(context.Background()))
+
+	// The dial was cancelled; no manager should have been installed.
+	w.mu.Lock()
+	mgr := w.managers["127.0.0.1:9999"]
+	w.mu.Unlock()
+	require.Nil(t, mgr)
+}


### PR DESCRIPTION
## What this PR does

In `AddressAdded` (`modules/querier/worker/worker.go`), the worker called `w.connect(context.Background(), address)` while holding `w.mu`. If the gRPC dial to the query-frontend hung (slow DNS, unreachable host), the mutex was never released. On shutdown, `stopping()` blocked forever waiting for the same mutex — a deadlock. Additionally, using `context.Background()` meant the dial was never cancelled by the shutdown signal, leaking the connection.

**This PR fixes both issues by:**

- Releasing `w.mu` before dialing, so shutdown and other address updates are never blocked by a slow dial.
- Passing the service context (`w.ServiceContext()`) into `w.connect`, so the dial is cancelled immediately when the service stops.
- Double-checking state after the dial completes (re-acquiring the lock) to handle races where shutdown fired or the address was added concurrently while we were dialing — closing the connection in those cases.

## Which issue(s) this PR fixes

Fixes #7505

## Testing

- `go test -race -v ./modules/querier/worker/...` — all passing, no races detected
- Added `TestQuerierWorker_AddressLifecycle` and `TestQuerierWorker_AddressAddedShutdown`, covering the add/remove lifecycle and the early-exit-on-shutdown path

## Note

A previous PR attempting to address #7505 is currently failing CI checks. This PR includes passing tests and formatting/lint verification (`gofumpt`, `goimports`) for the same fix.

## Checklist

- [x] Tests updated
- [ ] Documentation added — not applicable, internal bug fix with no user-facing change
- [x] Changelog entry added under `.chloggen/`

---

*Used AI assistance to help identify the fix approach and structure the tests; verified and tested manually.*