### PR TITLE
Use SIMD for math operations in traceql metrics path

### DIFF
--- a/.chloggen/simd-amd64-ast-metrics-math.yaml
+++ b/.chloggen/simd-amd64-ast-metrics-math.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: traceql
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Vectorize arithmetic in the metrics second stage with SIMD, on amd64 binaries built with `GOEXPERIMENT=simd`. Other builds are unchanged.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7581]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mapno

--- a/pkg/traceql/ast_metrics_math.go
+++ b/pkg/traceql/ast_metrics_math.go
@@ -212,8 +212,10 @@ func applyBinaryOp(op Operator, lhs, rhs SeriesSet) SeriesSet {
 
 		n := min(len(r.Values), len(l.Values))
 		values := buf[offset : offset+n]
-		for j := 0; j < n; j++ {
-			values[j] = applyArithmeticOp(op, l.Values[j], r.Values[j])
+		if !applyArithmeticOpVec(op, l.Values, r.Values, values) {
+			for j := 0; j < n; j++ {
+				values[j] = applyArithmeticOp(op, l.Values[j], r.Values[j])
+			}
 		}
 
 		result[k] = TimeSeries{
@@ -337,16 +339,20 @@ func (m *MetricsScalarOp) process(input SeriesSet) SeriesSet {
 		values := make([]float64, len(series.Values))
 		exemplars := make([]Exemplar, len(series.Exemplars))
 		if m.scalarOnLeft {
-			for i, v := range series.Values {
-				values[i] = applyArithmeticOp(m.op, m.value, v)
+			if !applyArithmeticOpScalarVec(m.op, m.value, true, series.Values, values) {
+				for i, v := range series.Values {
+					values[i] = applyArithmeticOp(m.op, m.value, v)
+				}
 			}
 			for i, v := range series.Exemplars {
 				exemplars[i] = v
 				exemplars[i].Value = applyArithmeticOp(m.op, m.value, v.Value)
 			}
 		} else {
-			for i, v := range series.Values {
-				values[i] = applyArithmeticOp(m.op, v, m.value)
+			if !applyArithmeticOpScalarVec(m.op, m.value, false, series.Values, values) {
+				for i, v := range series.Values {
+					values[i] = applyArithmeticOp(m.op, v, m.value)
+				}
 			}
 			for i, v := range series.Exemplars {
 				exemplars[i] = v

--- a/pkg/traceql/ast_metrics_math_nosimd.go
+++ b/pkg/traceql/ast_metrics_math_nosimd.go
@@ -1,0 +1,10 @@
+//go:build !(goexperiment.simd && amd64)
+
+package traceql
+
+// SIMD fast paths exist only on amd64 with GOEXPERIMENT=simd. These stubs
+// make the callers fall back to the scalar loops.
+
+func applyArithmeticOpVec(Operator, []float64, []float64, []float64) bool { return false }
+
+func applyArithmeticOpScalarVec(Operator, float64, bool, []float64, []float64) bool { return false }

--- a/pkg/traceql/ast_metrics_math_simd.go
+++ b/pkg/traceql/ast_metrics_math_simd.go
@@ -1,0 +1,86 @@
+//go:build goexperiment.simd && amd64
+
+package traceql
+
+import (
+	"math"
+	"simd/archsimd"
+)
+
+// vecEnabled gates the vector paths on AVX2, required by Merge (used for the division-by-zero blend).
+var vecEnabled = archsimd.X86.AVX2()
+
+func vecSupportedOp(op Operator) bool {
+	switch op {
+	case OpAdd, OpSub, OpMult, OpDiv:
+		return true
+	}
+	return false
+}
+
+func vecArithmeticOp(op Operator, a, b archsimd.Float64x4) archsimd.Float64x4 {
+	switch op {
+	case OpAdd:
+		return a.Add(b)
+	case OpSub:
+		return a.Sub(b)
+	case OpMult:
+		return a.Mul(b)
+	default: // OpDiv; callers filter with vecSupportedOp
+		// Division by zero yields NaN, not ±Inf, matching applyArithmeticOp.
+		nan := archsimd.BroadcastFloat64x4(math.NaN())
+		zero := archsimd.BroadcastFloat64x4(0)
+		return nan.Merge(a.Div(b), b.Equal(zero))
+	}
+}
+
+// applyArithmeticOpVec computes out[i] = l[i] op r[i] with SIMD. l and r must
+// be at least len(out) long. It returns false when the op has no vector form
+// or the CPU lacks support, in which case the caller runs the scalar loop.
+func applyArithmeticOpVec(op Operator, l, r, out []float64) bool {
+	if !vecEnabled || !vecSupportedOp(op) {
+		return false
+	}
+
+	i := 0
+	for ; i+4 <= len(out); i += 4 {
+		a := archsimd.LoadFloat64x4Slice(l[i:])
+		b := archsimd.LoadFloat64x4Slice(r[i:])
+		vecArithmeticOp(op, a, b).StoreSlice(out[i:])
+	}
+	if i < len(out) {
+		a := archsimd.LoadFloat64x4SlicePart(l[i:])
+		b := archsimd.LoadFloat64x4SlicePart(r[i:])
+		vecArithmeticOp(op, a, b).StoreSlicePart(out[i:])
+	}
+	return true
+}
+
+// applyArithmeticOpScalarVec computes out[i] = scalar op in[i] (scalarOnLeft)
+// or out[i] = in[i] op scalar with SIMD. in must be at least len(out) long.
+// It returns false when the op has no vector form or the CPU lacks support.
+func applyArithmeticOpScalarVec(op Operator, scalar float64, scalarOnLeft bool, in, out []float64) bool {
+	if !vecEnabled || !vecSupportedOp(op) {
+		return false
+	}
+
+	s := archsimd.BroadcastFloat64x4(scalar)
+	i := 0
+	for ; i+4 <= len(out); i += 4 {
+		v := archsimd.LoadFloat64x4Slice(in[i:])
+		a, b := v, s
+		if scalarOnLeft {
+			a, b = s, v
+		}
+		vecArithmeticOp(op, a, b).StoreSlice(out[i:])
+	}
+	if i < len(out) {
+		v := archsimd.LoadFloat64x4SlicePart(in[i:])
+		a, b := v, s
+		if scalarOnLeft {
+			a, b = s, v
+		}
+		vecArithmeticOp(op, a, b).StoreSlicePart(out[i:])
+	}
+	return true
+}

--- a/pkg/traceql/ast_metrics_math_test.go
+++ b/pkg/traceql/ast_metrics_math_test.go
@@ -1,10 +1,151 @@
 package traceql
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// vecAvailable reports whether this build has a usable SIMD path
+// (GOEXPERIMENT=simd, amd64, AVX2). A zero-length call does no work but
+// still returns the availability check.
+func vecAvailable() bool {
+	return applyArithmeticOpVec(OpAdd, nil, nil, nil)
+}
+
+func TestApplyArithmeticOpVecMatchesScalar(t *testing.T) {
+	if !vecAvailable() {
+		t.Skip("SIMD path not available in this build")
+	}
+
+	// Values chosen to hit the special cases: zero divisors, NaN and ±Inf
+	// propagation, negative zero.
+	specials := []float64{0, math.Copysign(0, -1), 1, -1, 2.5, -3.75, math.NaN(), math.Inf(1), math.Inf(-1), 1e308, 5e-324}
+	val := func(i int) float64 { return specials[i%len(specials)] }
+
+	requireSameFloat := func(t *testing.T, want, got float64, i int) {
+		t.Helper()
+		if math.IsNaN(want) {
+			require.True(t, math.IsNaN(got), "index %d: want NaN, got %v", i, got)
+			return
+		}
+		// IEEE 754 basic ops are exact, so vector and scalar must agree bit-for-bit.
+		require.Equal(t, want, got, "index %d", i)
+	}
+
+	ops := []Operator{OpAdd, OpSub, OpMult, OpDiv}
+	sizes := []int{0, 1, 3, 4, 5, 7, 8, 33, 100}
+
+	for _, op := range ops {
+		for _, n := range sizes {
+			l := make([]float64, n)
+			r := make([]float64, n)
+			for i := range l {
+				l[i] = val(i)
+				r[i] = val(i + 3)
+			}
+
+			out := make([]float64, n)
+			require.True(t, applyArithmeticOpVec(op, l, r, out))
+			for i := range out {
+				requireSameFloat(t, applyArithmeticOp(op, l[i], r[i]), out[i], i)
+			}
+
+			for _, scalarOnLeft := range []bool{true, false} {
+				for _, scalar := range []float64{0, 100, -2.5} {
+					out := make([]float64, n)
+					require.True(t, applyArithmeticOpScalarVec(op, scalar, scalarOnLeft, l, out))
+					for i := range out {
+						want := applyArithmeticOp(op, l[i], scalar)
+						if scalarOnLeft {
+							want = applyArithmeticOp(op, scalar, l[i])
+						}
+						requireSameFloat(t, want, out[i], i)
+					}
+				}
+			}
+		}
+	}
+
+	// Unsupported ops must decline so callers run the scalar loop.
+	require.False(t, applyArithmeticOpVec(OpMod, []float64{1}, []float64{1}, []float64{0}))
+	require.False(t, applyArithmeticOpScalarVec(OpPower, 2, false, []float64{1}, []float64{0}))
+}
+
+func BenchmarkArithmeticOpKernel(b *testing.B) {
+	// 1440 = one day of 1-minute steps, the typical per-series size (cache
+	// resident). 100k exceeds L1/L2 to show the memory-bound ceiling.
+	for _, n := range []int{100, 1440, 100_000} {
+		l := make([]float64, n)
+		r := make([]float64, n)
+		out := make([]float64, n)
+		for i := range l {
+			l[i] = float64(i) * 1.5
+			r[i] = float64(n - i) // includes one zero divisor
+		}
+
+		for _, op := range []Operator{OpAdd, OpDiv} {
+			b.Run(fmt.Sprintf("scalar/%s/n=%d", op, n), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					for j := range n {
+						out[j] = applyArithmeticOp(op, l[j], r[j])
+					}
+				}
+			})
+			b.Run(fmt.Sprintf("vec/%s/n=%d", op, n), func(b *testing.B) {
+				if !vecAvailable() {
+					b.Skip("SIMD path not available in this build")
+				}
+				for i := 0; i < b.N; i++ {
+					applyArithmeticOpVec(op, l, r, out)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkApplyBinaryOp measures the full series ⊙ series path — map
+// iteration, label merging, and allocation included — to show what a real
+// ratio query gains end to end. Compare runs of a GOEXPERIMENT=simd build
+// against a default build; there is no in-binary scalar variant here.
+func BenchmarkApplyBinaryOp(b *testing.B) {
+	const (
+		numSeries = 1000
+		numSteps  = 1440
+	)
+
+	makeSet := func(seed float64) SeriesSet {
+		set := make(SeriesSet, numSeries)
+		for s := range numSeries {
+			lbls := Labels{{Name: "service.name", Value: NewStaticString(fmt.Sprintf("svc-%d", s))}}
+			values := make([]float64, numSteps)
+			for i := range values {
+				values[i] = seed * float64(s+i+1)
+			}
+			set[lbls.MapKey()] = TimeSeries{Labels: lbls, Values: values}
+		}
+		return set
+	}
+	lhs := makeSet(1.5)
+	rhs := makeSet(2.0)
+	// sprinkle zero divisors so OpDiv exercises the NaN rule
+	for _, ts := range rhs {
+		for i := 0; i < len(ts.Values); i += 97 {
+			ts.Values[i] = 0
+		}
+	}
+
+	for _, op := range []Operator{OpAdd, OpDiv} {
+		b.Run(op.String(), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				applyBinaryOp(op, lhs, rhs)
+			}
+		})
+	}
+}
 
 func TestApplyBinaryOp_Exemplars(t *testing.T) {
 	exemplar := func(id string) Exemplar {


### PR DESCRIPTION
**What this PR does**:

Adds SIMD fast paths for the arithmetic loops in the TraceQL metrics second stage, using the experimental [`simd/archsimd`](https://pkg.go.dev/simd/archsimd) package introduced in Go 1.26 behind `GOEXPERIMENT=simd`.

- `applyBinaryOp` (series ⊙ series) and `MetricsScalarOp` (series ⊙ scalar) now process 4 `float64` lanes per iteration with `Float64x4` (AVX2).
- Division-by-zero → `NaN` semantics are preserved branchlessly via a compare mask + blend. Results are bit-identical to the scalar loops, covered by an equivalence test across all ops, both scalar orientations, tail sizes, and special values (±0, NaN, ±Inf, zero divisors).
- The vector code is build-tagged `goexperiment.simd && amd64` and gated at runtime on AVX2. Every other build (arm64, or any build without the experiment) compiles stubs and keeps today's scalar loops, so **this PR is inert unless the binary is built with `GOEXPERIMENT=simd`**. It doesn't change Tempo's build flags; opting amd64 builds in can be a follow-up decision.

On amd64 hardware the kernel is **x2.2** faster for addition and **x5.1** faster for division — the op that dominates real usage, e.g. ratio queries like `rate of errors / rate of total`.

<details>
<summary>Benchmarks</summary>

Run on an amd64 Linux machine — Intel Core i7-1068NG7 @ 2.3 GHz (Ice Lake), kernel `7.0.3-arch1-Watanare-T2-1-t2` — Go 1.26, `GOEXPERIMENT=simd`. `BenchmarkArithmeticOpKernel` sweeps series lengths: n=1440 is the typical case (one day at 1-minute steps), n=100k stresses larger working sets (~2.4 MB, L3-resident — the speedup holds, it does not degrade with size in the realistic range).

| n | `+` scalar | `+` vec | speedup | `/` scalar | `/` vec | speedup |
|---|---|---|---|---|---|---|
| 100 | 127.9 ns | 68.2 ns | x1.9 | 554.6 ns | 111.2 ns | x5.0 |
| 1,440 | 1,833 ns | 848 ns | x2.2 | 8,446 ns | 1,657 ns | x5.1 |
| 100,000 | 127.9 µs | 56.5 µs | x2.3 | 590.2 µs | 117.0 µs | x5.0 |

Division benefits the most: `vdivpd` amortizes the expensive divide over 4 lanes and the per-element `rhs == 0` branch is replaced by a branchless mask + blend.

Raw output:

```
goos: linux
goarch: amd64
pkg: github.com/grafana/tempo/pkg/traceql
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkArithmeticOpKernel/scalar/+/n=100-8             8824831               127.9 ns/op
BenchmarkArithmeticOpKernel/vec/+/n=100-8               16893987                68.15 ns/op
BenchmarkArithmeticOpKernel/scalar///n=100-8             2194029               554.6 ns/op
BenchmarkArithmeticOpKernel/vec///n=100-8               10785914               111.2 ns/op
BenchmarkArithmeticOpKernel/scalar/+/n=1440-8             735352              1833 ns/op
BenchmarkArithmeticOpKernel/vec/+/n=1440-8               1442215               848.0 ns/op
BenchmarkArithmeticOpKernel/scalar///n=1440-8             451555              8446 ns/op
BenchmarkArithmeticOpKernel/vec///n=1440-8                689204              1657 ns/op
BenchmarkArithmeticOpKernel/scalar/+/n=100000-8            10000            127902 ns/op
BenchmarkArithmeticOpKernel/vec/+/n=100000-8               21192             56511 ns/op
BenchmarkArithmeticOpKernel/scalar///n=100000-8             9404            590181 ns/op
BenchmarkArithmeticOpKernel/vec///n=100000-8               10000            117037 ns/op
```

</details>

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
