### PR TITLE
cache: evict compacted-away block entries from Redis by key prefix

### DIFF
--- a/.chloggen/redis-evict-compacted-block-keys.yaml
+++ b/.chloggen/redis-evict-compacted-block-keys.yaml
@@ -1,0 +1,20 @@
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: cache
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: evict a compacted-away block's parquet footer, index, and page entries from Redis by key prefix, instead of leaving them to expire via TTL or LRU.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  Applies to Redis-backed caches, which can enumerate keys by prefix; memcached is unchanged and continues to rely on TTL or LRU for these entries. Bloom filter and trace-id index entries were already removed on block deletion.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: oleg-kozlyuk-grafana

--- a/.chloggen/redis-evict-compacted-block-keys.yaml
+++ b/.chloggen/redis-evict-compacted-block-keys.yaml
@@ -6,7 +6,7 @@ change_type: enhancement
 component: cache
 
 # A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
-note: evict a compacted-away block's parquet footer, index, and page entries from Redis by key prefix, instead of leaving them to expire via TTL or LRU.
+note: on block deletion, optionally evict the block's parquet footer, index, and page entries from Redis by key prefix. Opt-in via the `prefix_cache_eviction` compaction option, disabled by default.
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.
@@ -14,7 +14,7 @@ issues: []
 
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
 subtext: |
-  Applies to Redis-backed caches, which can enumerate keys by prefix; memcached is unchanged and continues to rely on TTL or LRU for these entries. Bloom filter and trace-id index entries were already removed on block deletion.
+  Previously only bloom filter and trace-id index entries were removed when the backend worker deleted a block; the offset-keyed parquet entries were left to expire via TTL or LRU. Applies to Redis-backed caches, which can enumerate keys by prefix; memcached is unaffected.
 
 # The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
 user: oleg-kozlyuk-grafana

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2083,6 +2083,12 @@ The `compaction` configuration block is used by the scheduler and worker.
 # The time between compaction cycles.
 # Note: The default will be used if the value is set to 0.
 [compaction_cycle: <duration> | default=30s]
+
+# Optional
+# On block deletion, scan the caches and remove every entry sharing the block's key prefix.
+# Reclaims offset-keyed parquet cache entries (footer, indexes, pages) that cannot be removed by
+# exact key. Only caches that can enumerate keys (Redis) honor it; others rely on TTL or LRU.
+[prefix_cache_eviction: <bool> | default=false]
 ```
 
 ### Filter policies

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -867,6 +867,7 @@ backend_scheduler:
                 retention_concurrency: 10
                 max_time_per_tenant: 5m0s
                 compaction_cycle: 30s
+                prefix_cache_eviction: false
             max_jobs_per_tenant: 1000
             min_input_blocks: 2
             max_input_blocks: 4
@@ -920,6 +921,7 @@ backend_worker:
         retention_concurrency: 10
         max_time_per_tenant: 5m0s
         compaction_cycle: 30s
+        prefix_cache_eviction: false
     override_ring_key: backend-worker
     ring:
         kvstore:

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -863,6 +863,7 @@ backend_scheduler:
                 retention_concurrency: 10
                 max_time_per_tenant: 5m0s
                 compaction_cycle: 30s
+                prefix_cache_eviction: false
             max_jobs_per_tenant: 1000
             min_input_blocks: 2
             max_input_blocks: 4
@@ -916,6 +917,7 @@ backend_worker:
         retention_concurrency: 10
         max_time_per_tenant: 5m0s
         compaction_cycle: 30s
+        prefix_cache_eviction: false
     override_ring_key: backend-worker
     ring:
         kvstore:

--- a/pkg/cache/background.go
+++ b/pkg/cache/background.go
@@ -108,6 +108,18 @@ func (c *backgroundCache) Store(ctx context.Context, keys []string, bufs [][]byt
 	}
 }
 
+// RemoveByPrefix forwards prefix eviction to the wrapped cache when it supports
+// it (Redis), and is a no-op otherwise (e.g. memcached). It runs synchronously
+// rather than through the write-back queue: it is a low-frequency,
+// compaction-driven operation, not on the read/write hot path. This makes
+// *backgroundCache satisfy PrefixEvictor regardless of the underlying backend, so
+// callers can assert the capability once against the wrapper.
+func (c *backgroundCache) RemoveByPrefix(ctx context.Context, prefix string) {
+	if e, ok := c.Cache.(PrefixEvictor); ok {
+		e.RemoveByPrefix(ctx, prefix)
+	}
+}
+
 func (c *backgroundCache) writeBackLoop() {
 	defer c.wg.Done()
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -53,6 +53,17 @@ type Cache interface {
 	Stop()
 }
 
+// PrefixEvictor is an optional capability a Cache may implement: deleting every
+// key that shares a given prefix. The compactor uses it to evict all cache
+// entries for a block that has been compacted away, including the offset-keyed
+// parquet entries whose exact keys are not tracked in the block meta and so
+// cannot be reconstructed for a targeted Remove. Backends that cannot enumerate
+// keys (e.g. memcached) do not implement it, and such entries there continue to
+// rely on TTL or LRU eviction.
+type PrefixEvictor interface {
+	RemoveByPrefix(ctx context.Context, prefix string)
+}
+
 func measureRequest(ctx context.Context, method string, col instr.Collector, toStatusCode func(error) string, f func(context.Context) error) error {
 	start := time.Now()
 	col.Before(ctx, method, start)

--- a/pkg/cache/redis_cache.go
+++ b/pkg/cache/redis_cache.go
@@ -146,6 +146,20 @@ func (c *RedisCache) Remove(ctx context.Context, keys []string) {
 	})
 }
 
+// RemoveByPrefix evicts every cached key beginning with prefix. Like the other
+// mutating operations it is best-effort: failures are logged, not returned.
+func (c *RedisCache) RemoveByPrefix(ctx context.Context, prefix string) {
+	_ = measureRequest(ctx, "RedisCache.RemoveByPrefix", c.requestDuration, redisStatusCode, func(ctx context.Context) error {
+		deleted, err := c.redis.RemoveByPrefix(ctx, prefix)
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to remove keys by prefix from redis", "name", c.name, "prefix", prefix, "err", err)
+			return err
+		}
+		level.Debug(c.logger).Log("msg", "removed keys by prefix from redis", "name", c.name, "prefix", prefix, "deleted", deleted)
+		return nil
+	})
+}
+
 // Stop stops the redis client.
 func (c *RedisCache) Stop() {
 	_ = c.redis.Close()

--- a/pkg/cache/redis_client.go
+++ b/pkg/cache/redis_client.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -15,6 +16,37 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/redis/go-redis/v9"
 )
+
+const (
+	// redisScanCount is the COUNT hint passed to SCAN while evicting a block's
+	// keys by prefix. A large value minimizes the number of round trips; SCAN
+	// only ever does O(count) work per call, so it never blocks the server.
+	redisScanCount = 20000
+	// redisDeleteBatch caps how many keys are sent in a single DEL while draining
+	// a scan, bounding command size on large blocks.
+	redisDeleteBatch = 1000
+)
+
+// globPrefixReplacer escapes the glob metacharacters that Redis SCAN MATCH
+// interprets (* ? [ ] and the \ escape itself), so a prefix built from a tenant
+// ID is matched literally rather than as a pattern. strings.Replacer performs a
+// single non-overlapping pass, so the backslashes it inserts are not re-escaped.
+var globPrefixReplacer = strings.NewReplacer(
+	`\`, `\\`,
+	`*`, `\*`,
+	`?`, `\?`,
+	`[`, `\[`,
+	`]`, `\]`,
+)
+
+// redisScanner is the subset of redis commands needed to enumerate and delete
+// keys. It is satisfied by *redis.Client, *redis.ClusterClient, and the wrapped
+// UniversalClient, so the same loop runs per-node on a cluster and directly on a
+// single node.
+type redisScanner interface {
+	Scan(ctx context.Context, cursor uint64, match string, count int64) *redis.ScanCmd
+	Del(ctx context.Context, keys ...string) *redis.IntCmd
+}
 
 // RedisConfig defines how a RedisCache should be constructed.
 type RedisConfig struct {
@@ -260,6 +292,88 @@ func (c *RedisClient) Del(ctx context.Context, keys []string) error {
 	}
 
 	return c.rdb.Del(ctx, keys...).Err()
+}
+
+// RemoveByPrefix deletes every key whose name begins with prefix and returns the
+// number of keys deleted. On a Redis Cluster the scan runs on each master node —
+// a block's keys are spread across slots because the whole key (not just the
+// block ID) is hashed — so ForEachMaster covers the entire keyspace; on a single
+// node it runs once. Unlike the other operations this is not bounded by
+// c.timeout as a whole (a scan may legitimately take much longer than a single
+// request); each underlying SCAN/DEL is still bounded by the client's socket
+// timeouts, and the caller's context cancels the loop.
+func (c *RedisClient) RemoveByPrefix(ctx context.Context, prefix string) (int, error) {
+	pattern := globPrefixReplacer.Replace(prefix) + "*"
+
+	if cc, ok := c.rdb.(*redis.ClusterClient); ok {
+		var total atomic.Int64
+		// ForEachMaster runs the callback concurrently across masters.
+		err := cc.ForEachMaster(ctx, func(ctx context.Context, node *redis.Client) error {
+			n, err := scanAndDelete(ctx, node, pattern)
+			total.Add(int64(n))
+			return err
+		})
+		return int(total.Load()), err
+	}
+
+	return scanAndDelete(ctx, c.rdb, pattern)
+}
+
+// scanAndDelete iterates a single node's keyspace with SCAN and deletes every key
+// matching pattern. It always drives the cursor to completion: SCAN returns an
+// opaque cursor alongside a best-effort batch, so an empty batch paired with a
+// non-zero cursor is normal (MATCH filters after COUNT elements are examined) and
+// iteration must continue until the cursor returns to 0.
+func scanAndDelete(ctx context.Context, s redisScanner, pattern string) (int, error) {
+	var (
+		cursor  uint64
+		pending []string
+		deleted int
+	)
+
+	// flush drains pending in DEL commands of at most redisDeleteBatch keys, so a
+	// block with many cached ranges does not produce one oversized command.
+	flush := func() error {
+		for len(pending) > 0 {
+			n := min(redisDeleteBatch, len(pending))
+			cnt, err := s.Del(ctx, pending[:n]...).Result()
+			deleted += int(cnt)
+			pending = pending[n:]
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return deleted, err
+		}
+
+		var (
+			keys []string
+			err  error
+		)
+		keys, cursor, err = s.Scan(ctx, cursor, pattern, redisScanCount).Result()
+		if err != nil {
+			return deleted, err
+		}
+
+		pending = append(pending, keys...)
+		if len(pending) >= redisDeleteBatch {
+			if err := flush(); err != nil {
+				return deleted, err
+			}
+		}
+
+		// Only a zero cursor signals the end of iteration; an empty batch does not.
+		if cursor == 0 {
+			break
+		}
+	}
+
+	return deleted, flush()
 }
 
 func (c *RedisClient) Close() error {

--- a/pkg/cache/redis_client.go
+++ b/pkg/cache/redis_client.go
@@ -19,8 +19,11 @@ import (
 
 const (
 	// redisScanCount is the COUNT hint passed to SCAN while evicting a block's
-	// keys by prefix. A large value minimizes the number of round trips; SCAN
-	// only ever does O(count) work per call, so it never blocks the server.
+	// keys by prefix. COUNT is only a hint for how many keys SCAN examines per
+	// call, not a cap on the result; a larger value trades fewer round trips for
+	// more work — and, since Redis is single-threaded, higher latency for other
+	// clients — per call. 20000 favors throughput for this low-frequency,
+	// compaction-driven scan.
 	redisScanCount = 20000
 	// redisDeleteBatch caps how many keys are sent in a single DEL while draining
 	// a scan, bounding command size on large blocks.
@@ -357,11 +360,11 @@ func scanAndDelete(ctx context.Context, scanner redisScanner, deleter redisDelet
 		for len(pending) > 0 {
 			n := min(redisDeleteBatch, len(pending))
 			cnt, err := deleter.Del(ctx, pending[:n]...).Result()
-			deleted += int(cnt)
-			pending = pending[n:]
 			if err != nil {
 				return err
 			}
+			deleted += int(cnt)
+			pending = pending[n:]
 		}
 		return nil
 	}

--- a/pkg/cache/redis_client.go
+++ b/pkg/cache/redis_client.go
@@ -39,12 +39,24 @@ var globPrefixReplacer = strings.NewReplacer(
 	`]`, `\]`,
 )
 
-// redisScanner is the subset of redis commands needed to enumerate and delete
-// keys. It is satisfied by *redis.Client, *redis.ClusterClient, and the wrapped
-// UniversalClient, so the same loop runs per-node on a cluster and directly on a
-// single node.
+// redisScanner enumerates keys with SCAN. On a cluster it is a single master node
+// (SCAN has no cluster-wide form); on a single node it is the client itself.
+// Satisfied by *redis.Client, *redis.ClusterClient, and the wrapped
+// UniversalClient.
 type redisScanner interface {
 	Scan(ctx context.Context, cursor uint64, match string, count int64) *redis.ScanCmd
+}
+
+// redisDeleter deletes keys with DEL. On a cluster this MUST be the
+// *redis.ClusterClient, never a per-master node client: DEL is a multi-key
+// command and a Redis Cluster node rejects a single DEL whose keys span more than
+// one hash slot with CROSSSLOT. The cluster client splits a multi-key DEL into
+// per-slot subcommands (osscluster: executeMultiShard); a node client sends it
+// as-is. A block's keys are spread across every slot a master owns — the whole
+// key, not just the block ID, is hashed — so deleting a scanned batch through a
+// node client would fail. Satisfied by both *redis.Client and
+// *redis.ClusterClient.
+type redisDeleter interface {
 	Del(ctx context.Context, keys ...string) *redis.IntCmd
 }
 
@@ -295,36 +307,44 @@ func (c *RedisClient) Del(ctx context.Context, keys []string) error {
 }
 
 // RemoveByPrefix deletes every key whose name begins with prefix and returns the
-// number of keys deleted. On a Redis Cluster the scan runs on each master node —
-// a block's keys are spread across slots because the whole key (not just the
-// block ID) is hashed — so ForEachMaster covers the entire keyspace; on a single
-// node it runs once. Unlike the other operations this is not bounded by
-// c.timeout as a whole (a scan may legitimately take much longer than a single
-// request); each underlying SCAN/DEL is still bounded by the client's socket
-// timeouts, and the caller's context cancels the loop.
+// number of keys deleted. On a Redis Cluster the keyspace is enumerated on each
+// master (SCAN has no cluster-wide form, and a block's keys are spread across
+// slots because the whole key — not just the block ID — is hashed, so
+// ForEachMaster covers the entire keyspace), while deletion is routed through the
+// cluster client, which splits each multi-key DEL across slots; deleting through
+// the per-master node client instead would fail with CROSSSLOT (see
+// redisDeleter). On a single node both run on the one client. Unlike the other
+// operations this is not bounded by c.timeout as a whole (a scan may legitimately
+// take much longer than a single request); each underlying SCAN/DEL is still
+// bounded by the client's socket timeouts, and the caller's context cancels the
+// loop.
 func (c *RedisClient) RemoveByPrefix(ctx context.Context, prefix string) (int, error) {
 	pattern := globPrefixReplacer.Replace(prefix) + "*"
 
 	if cc, ok := c.rdb.(*redis.ClusterClient); ok {
 		var total atomic.Int64
-		// ForEachMaster runs the callback concurrently across masters.
+		// ForEachMaster runs the callback concurrently across masters. Enumerate
+		// on the node, but delete through cc so each DEL is split per slot.
 		err := cc.ForEachMaster(ctx, func(ctx context.Context, node *redis.Client) error {
-			n, err := scanAndDelete(ctx, node, pattern)
+			n, err := scanAndDelete(ctx, node, cc, pattern)
 			total.Add(int64(n))
 			return err
 		})
 		return int(total.Load()), err
 	}
 
-	return scanAndDelete(ctx, c.rdb, pattern)
+	return scanAndDelete(ctx, c.rdb, c.rdb, pattern)
 }
 
-// scanAndDelete iterates a single node's keyspace with SCAN and deletes every key
-// matching pattern. It always drives the cursor to completion: SCAN returns an
-// opaque cursor alongside a best-effort batch, so an empty batch paired with a
-// non-zero cursor is normal (MATCH filters after COUNT elements are examined) and
-// iteration must continue until the cursor returns to 0.
-func scanAndDelete(ctx context.Context, s redisScanner, pattern string) (int, error) {
+// scanAndDelete iterates a single node's keyspace with SCAN (via scanner) and
+// deletes every key matching pattern (via deleter). It always drives the cursor
+// to completion: SCAN returns an opaque cursor alongside a best-effort batch, so
+// an empty batch paired with a non-zero cursor is normal (MATCH filters after
+// COUNT elements are examined) and iteration must continue until the cursor
+// returns to 0. Scanning and deletion are separate interfaces because on a
+// cluster the scanner is a single master node while the deleter must be the
+// slot-splitting cluster client (see redisDeleter).
+func scanAndDelete(ctx context.Context, scanner redisScanner, deleter redisDeleter, pattern string) (int, error) {
 	var (
 		cursor  uint64
 		pending []string
@@ -336,7 +356,7 @@ func scanAndDelete(ctx context.Context, s redisScanner, pattern string) (int, er
 	flush := func() error {
 		for len(pending) > 0 {
 			n := min(redisDeleteBatch, len(pending))
-			cnt, err := s.Del(ctx, pending[:n]...).Result()
+			cnt, err := deleter.Del(ctx, pending[:n]...).Result()
 			deleted += int(cnt)
 			pending = pending[n:]
 			if err != nil {
@@ -355,7 +375,7 @@ func scanAndDelete(ctx context.Context, s redisScanner, pattern string) (int, er
 			keys []string
 			err  error
 		)
-		keys, cursor, err = s.Scan(ctx, cursor, pattern, redisScanCount).Result()
+		keys, cursor, err = scanner.Scan(ctx, cursor, pattern, redisScanCount).Result()
 		if err != nil {
 			return deleted, err
 		}

--- a/pkg/cache/redis_client_prefix_test.go
+++ b/pkg/cache/redis_client_prefix_test.go
@@ -4,8 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +66,7 @@ func TestScanAndDelete_DrivesCursorThroughEmptyBatches(t *testing.T) {
 		{"d"}, // final batch reports cursor 0
 	}}
 
-	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	deleted, err := scanAndDelete(context.Background(), f, f, "p*")
 	require.NoError(t, err)
 	require.Equal(t, 4, deleted)
 	require.Equal(t, []string{"a", "b", "c", "d"}, f.deleted)
@@ -72,7 +77,7 @@ func TestScanAndDelete_EmptyKeyspace(t *testing.T) {
 	// A single empty batch with cursor 0 (nothing matched the prefix).
 	f := &fakeScanner{batches: [][]string{{}}}
 
-	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	deleted, err := scanAndDelete(context.Background(), f, f, "p*")
 	require.NoError(t, err)
 	require.Equal(t, 0, deleted)
 	require.Empty(t, f.deleted)
@@ -86,7 +91,7 @@ func TestScanAndDelete_CapsDeleteBatchSize(t *testing.T) {
 	}
 	f := &fakeScanner{batches: [][]string{big, {"tail"}}}
 
-	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	deleted, err := scanAndDelete(context.Background(), f, f, "p*")
 	require.NoError(t, err)
 	require.Equal(t, len(big)+1, deleted)
 
@@ -101,7 +106,7 @@ func TestScanAndDelete_PropagatesScanError(t *testing.T) {
 	sentinel := errors.New("scan boom")
 	f := &fakeScanner{scanErr: sentinel}
 
-	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	deleted, err := scanAndDelete(context.Background(), f, f, "p*")
 	require.ErrorIs(t, err, sentinel)
 	require.Zero(t, deleted)
 }
@@ -110,7 +115,7 @@ func TestScanAndDelete_PropagatesDeleteError(t *testing.T) {
 	sentinel := errors.New("del boom")
 	f := &fakeScanner{batches: [][]string{{"a"}}, delErr: sentinel}
 
-	_, err := scanAndDelete(context.Background(), f, "p*")
+	_, err := scanAndDelete(context.Background(), f, f, "p*")
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -119,7 +124,7 @@ func TestScanAndDelete_RespectsContextCancellation(t *testing.T) {
 	cancel()
 
 	f := &fakeScanner{batches: [][]string{{"a"}}}
-	deleted, err := scanAndDelete(ctx, f, "p*")
+	deleted, err := scanAndDelete(ctx, f, f, "p*")
 	require.ErrorIs(t, err, context.Canceled)
 	require.Zero(t, deleted)
 	require.Zero(t, f.call, "a cancelled context must stop before the first SCAN")
@@ -170,6 +175,181 @@ func TestRedisClient_RemoveByPrefix(t *testing.T) {
 	deleted, err := client.RemoveByPrefix(ctx, "tenantA:block1:")
 	require.NoError(t, err)
 	require.Equal(t, len(target), deleted)
+
+	got, err := client.MGet(ctx, target)
+	require.NoError(t, err)
+	for i, key := range target {
+		require.Nil(t, got[i], "key %q must be evicted", key)
+	}
+
+	got, err = client.MGet(ctx, survivors)
+	require.NoError(t, err)
+	for i, key := range survivors {
+		require.NotNil(t, got[i], "unrelated key %q must survive", key)
+	}
+}
+
+// testSlot stands in for Redis's CRC16-based slot assignment. The exact value
+// does not matter — only that distinct keys can land in distinct slots, so a
+// multi-key DEL can span slots the way it does on a real cluster (and the way
+// miniredis, which ignores slots, never reproduces).
+func testSlot(key string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	return int(h.Sum32() % 16384)
+}
+
+// crossSlotNode models a single Redis Cluster master: a DEL whose keys span more
+// than one hash slot is rejected with CROSSSLOT, exactly as a real node rejects
+// it. A per-master node client (redis.ClusterClient.ForEachMaster) behaves this
+// way — which is why deleting a scanned batch through it is a bug.
+type crossSlotNode struct {
+	store map[string]struct{}
+	dels  [][]string
+}
+
+func newCrossSlotNode(keys []string) *crossSlotNode {
+	n := &crossSlotNode{store: make(map[string]struct{}, len(keys))}
+	for _, k := range keys {
+		n.store[k] = struct{}{}
+	}
+	return n
+}
+
+func (n *crossSlotNode) Del(_ context.Context, keys ...string) *redis.IntCmd {
+	n.dels = append(n.dels, append([]string(nil), keys...))
+
+	slot := -1
+	for _, k := range keys {
+		if s := testSlot(k); slot == -1 {
+			slot = s
+		} else if s != slot {
+			return redis.NewIntResult(0, errors.New("CROSSSLOT Keys in request don't hash to the same slot"))
+		}
+	}
+
+	var deleted int64
+	for _, k := range keys {
+		if _, ok := n.store[k]; ok {
+			delete(n.store, k)
+			deleted++
+		}
+	}
+	return redis.NewIntResult(deleted, nil)
+}
+
+// slotSplittingDeleter models redis.ClusterClient.Del: it groups keys by slot and
+// issues one single-slot DEL per group, so a cross-slot batch never reaches the
+// node as one command. This is the deleter the cluster path now passes.
+type slotSplittingDeleter struct{ node *crossSlotNode }
+
+func (d slotSplittingDeleter) Del(ctx context.Context, keys ...string) *redis.IntCmd {
+	bySlot := map[int][]string{}
+	for _, k := range keys {
+		s := testSlot(k)
+		bySlot[s] = append(bySlot[s], k)
+	}
+	var total int64
+	for _, group := range bySlot {
+		cnt, err := d.node.Del(ctx, group...).Result()
+		total += cnt
+		if err != nil {
+			return redis.NewIntResult(total, err)
+		}
+	}
+	return redis.NewIntResult(total, nil)
+}
+
+// TestScanAndDelete_ClusterDeletionMustSplitBySlot pins the reason the cluster
+// path deletes through the cluster client rather than the per-master node client.
+// A batch scanned from one master spans many slots, so a single multi-key DEL to
+// the node fails with CROSSSLOT (the original bug); routing the same batch through
+// a slot-splitting deleter removes every key.
+func TestScanAndDelete_ClusterDeletionMustSplitBySlot(t *testing.T) {
+	ctx := context.Background()
+
+	// Keys chosen so they hash to more than one slot under testSlot.
+	keys := []string{"tenant:block:footer", "tenant:block:col", "tenant:block:page:0:100", "tenant:block:page:100:250"}
+	slots := map[int]struct{}{}
+	for _, k := range keys {
+		slots[testSlot(k)] = struct{}{}
+	}
+	require.Greater(t, len(slots), 1, "test keys must span >1 slot to exercise CROSSSLOT")
+
+	// Deleting a cross-slot batch straight to the node fails — this is what the
+	// old code did by handing ForEachMaster's node client to the delete loop.
+	node := newCrossSlotNode(keys)
+	_, err := scanAndDelete(ctx, &fakeScanner{batches: [][]string{keys}}, node, "tenant:block:*")
+	require.ErrorContains(t, err, "CROSSSLOT")
+
+	// Deleting through the slot-splitting deleter (what redis.ClusterClient does)
+	// removes every key and never sends a cross-slot DEL to the node.
+	node = newCrossSlotNode(keys)
+	deleted, err := scanAndDelete(ctx, &fakeScanner{batches: [][]string{keys}}, slotSplittingDeleter{node: node}, "tenant:block:*")
+	require.NoError(t, err)
+	require.Equal(t, len(keys), deleted)
+	require.Empty(t, node.store, "all keys must be evicted")
+	for _, del := range node.dels {
+		gotSlots := map[int]struct{}{}
+		for _, k := range del {
+			gotSlots[testSlot(k)] = struct{}{}
+		}
+		require.LessOrEqual(t, len(gotSlots), 1, "no DEL reaching a node may span slots")
+	}
+}
+
+// TestRedisClient_RemoveByPrefix_Cluster exercises prefix eviction against a real
+// Redis Cluster, the default topology. A block's keys spread across every
+// master/slot must all be removed without the CROSSSLOT error a per-node multi-key
+// DEL would hit — which miniredis cannot model, so this is skipped unless
+// TEMPO_REDIS_CLUSTER_ADDRS points at a running cluster. Bring one up with:
+//
+//	docker run --rm -d --name c -p 7000-7005:7000-7005 -e IP=0.0.0.0 grokzen/redis-cluster:7.2.4
+//	TEMPO_REDIS_CLUSTER_ADDRS=127.0.0.1:7000,127.0.0.1:7001,127.0.0.1:7002 \
+//	  go test ./pkg/cache -run TestRedisClient_RemoveByPrefix_Cluster -v
+func TestRedisClient_RemoveByPrefix_Cluster(t *testing.T) {
+	addrs := os.Getenv("TEMPO_REDIS_CLUSTER_ADDRS")
+	if addrs == "" {
+		t.Skip("set TEMPO_REDIS_CLUSTER_ADDRS to a running Redis Cluster to run this test")
+	}
+
+	cfg := &RedisConfig{
+		Endpoint:   addrs,
+		Timeout:    5 * time.Second,
+		Expiration: time.Minute,
+		// SingleNode defaults to false: exercise the cluster path.
+	}
+	client, err := NewRedisClient(cfg, "test-cluster", prometheus.NewRegistry())
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	// A fresh block ID per run keeps the test isolated on a shared cluster.
+	blockID := uuid.New()
+	prefix := fmt.Sprintf("tenantA:%s:", blockID)
+	// Enough offset-keyed range entries that they spread across masters and slots.
+	var target []string
+	for i := 0; i < 200; i++ {
+		target = append(target, fmt.Sprintf("%sdata.parquet:%d:%d", prefix, i*100, i*100+100))
+	}
+	target = append(target, prefix+"bloom-0", prefix+"index")
+
+	survivors := []string{
+		fmt.Sprintf("tenantA:%s:data.parquet:0:100", uuid.New()), // different block, same tenant
+		fmt.Sprintf("tenantB:%s:data.parquet:0:100", blockID),    // different tenant, same block id
+	}
+
+	all := append(append([]string{}, target...), survivors...)
+	vals := make([][]byte, len(all))
+	for i := range all {
+		vals[i] = []byte("v")
+	}
+	require.NoError(t, client.MSet(ctx, all, vals))
+
+	deleted, err := client.RemoveByPrefix(ctx, prefix)
+	require.NoError(t, err, "cross-slot prefix eviction must not fail with CROSSSLOT")
+	require.Equal(t, len(target), deleted, "every entry under the prefix must be deleted exactly once")
 
 	got, err := client.MGet(ctx, target)
 	require.NoError(t, err)

--- a/pkg/cache/redis_client_prefix_test.go
+++ b/pkg/cache/redis_client_prefix_test.go
@@ -1,0 +1,185 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeScanner drives scanAndDelete through scripted SCAN batches so we can
+// reproduce the real Redis semantics that miniredis does not: multiple
+// iterations, empty batches paired with a non-zero cursor, and termination only
+// when the cursor returns to 0.
+type fakeScanner struct {
+	batches [][]string
+	call    int
+	deleted []string
+	delSize []int // number of keys per Del call, in order
+	scanErr error
+	delErr  error
+}
+
+func (f *fakeScanner) Scan(_ context.Context, _ uint64, _ string, _ int64) *redis.ScanCmd {
+	if f.scanErr != nil {
+		return redis.NewScanCmdResult(nil, 0, f.scanErr)
+	}
+
+	var keys []string
+	if f.call < len(f.batches) {
+		keys = f.batches[f.call]
+	}
+	f.call++
+
+	// The cursor stays non-zero while scripted batches remain, so the loop must
+	// keep going even across empty batches; only the final batch reports 0.
+	var cursor uint64
+	if f.call < len(f.batches) {
+		cursor = uint64(f.call)
+	}
+	return redis.NewScanCmdResult(keys, cursor, nil)
+}
+
+func (f *fakeScanner) Del(_ context.Context, keys ...string) *redis.IntCmd {
+	if f.delErr != nil {
+		return redis.NewIntResult(0, f.delErr)
+	}
+	f.deleted = append(f.deleted, keys...)
+	f.delSize = append(f.delSize, len(keys))
+	return redis.NewIntResult(int64(len(keys)), nil)
+}
+
+func TestScanAndDelete_DrivesCursorThroughEmptyBatches(t *testing.T) {
+	f := &fakeScanner{batches: [][]string{
+		{"a", "b"},
+		{}, // empty batch with a non-zero cursor: iteration must continue
+		{"c"},
+		{},    // and again
+		{"d"}, // final batch reports cursor 0
+	}}
+
+	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	require.NoError(t, err)
+	require.Equal(t, 4, deleted)
+	require.Equal(t, []string{"a", "b", "c", "d"}, f.deleted)
+	require.Equal(t, len(f.batches), f.call, "must SCAN through every batch, including the empty ones")
+}
+
+func TestScanAndDelete_EmptyKeyspace(t *testing.T) {
+	// A single empty batch with cursor 0 (nothing matched the prefix).
+	f := &fakeScanner{batches: [][]string{{}}}
+
+	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	require.NoError(t, err)
+	require.Equal(t, 0, deleted)
+	require.Empty(t, f.deleted)
+	require.Empty(t, f.delSize, "no DEL should be issued when nothing matched")
+}
+
+func TestScanAndDelete_CapsDeleteBatchSize(t *testing.T) {
+	big := make([]string, redisDeleteBatch+redisDeleteBatch/2) // 1.5x the batch cap
+	for i := range big {
+		big[i] = fmt.Sprintf("k%d", i)
+	}
+	f := &fakeScanner{batches: [][]string{big, {"tail"}}}
+
+	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	require.NoError(t, err)
+	require.Equal(t, len(big)+1, deleted)
+
+	want := append(append([]string{}, big...), "tail")
+	require.Equal(t, want, f.deleted)
+	for _, n := range f.delSize {
+		require.LessOrEqual(t, n, redisDeleteBatch, "no DEL command may exceed the batch cap")
+	}
+}
+
+func TestScanAndDelete_PropagatesScanError(t *testing.T) {
+	sentinel := errors.New("scan boom")
+	f := &fakeScanner{scanErr: sentinel}
+
+	deleted, err := scanAndDelete(context.Background(), f, "p*")
+	require.ErrorIs(t, err, sentinel)
+	require.Zero(t, deleted)
+}
+
+func TestScanAndDelete_PropagatesDeleteError(t *testing.T) {
+	sentinel := errors.New("del boom")
+	f := &fakeScanner{batches: [][]string{{"a"}}, delErr: sentinel}
+
+	_, err := scanAndDelete(context.Background(), f, "p*")
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestScanAndDelete_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	f := &fakeScanner{batches: [][]string{{"a"}}}
+	deleted, err := scanAndDelete(ctx, f, "p*")
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, deleted)
+	require.Zero(t, f.call, "a cancelled context must stop before the first SCAN")
+}
+
+func TestGlobPrefixReplacer(t *testing.T) {
+	cases := map[string]string{
+		"tenant:block:": "tenant:block:",
+		`a*b:block:`:    `a\*b:block:`,
+		`a?b:block:`:    `a\?b:block:`,
+		`a[b]:block:`:   `a\[b\]:block:`,
+		`a\b:block:`:    `a\\b:block:`,
+		`*?[]\`:         `\*\?\[\]\\`,
+	}
+	for in, want := range cases {
+		require.Equal(t, want, globPrefixReplacer.Replace(in), "input %q", in)
+	}
+}
+
+// TestRedisClient_RemoveByPrefix exercises the real SCAN MATCH + DEL path against
+// miniredis (single node): only keys under the requested prefix are removed, and
+// offset-keyed range entries are covered like whole-object ones.
+func TestRedisClient_RemoveByPrefix(t *testing.T) {
+	client, err := mockRedisClientSingle()
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	ctx := context.Background()
+
+	target := []string{
+		"tenantA:block1:bloom-0",
+		"tenantA:block1:index",
+		"tenantA:block1:data.parquet:0:100",
+		"tenantA:block1:data.parquet:100:250",
+	}
+	survivors := []string{
+		"tenantA:block2:data.parquet:0:100", // different block, same tenant
+		"tenantB:block1:data.parquet:0:100", // different tenant, same block id
+	}
+
+	all := append(append([]string{}, target...), survivors...)
+	vals := make([][]byte, len(all))
+	for i := range all {
+		vals[i] = []byte("v")
+	}
+	require.NoError(t, client.MSet(ctx, all, vals))
+
+	deleted, err := client.RemoveByPrefix(ctx, "tenantA:block1:")
+	require.NoError(t, err)
+	require.Equal(t, len(target), deleted)
+
+	got, err := client.MGet(ctx, target)
+	require.NoError(t, err)
+	for i, key := range target {
+		require.Nil(t, got[i], "key %q must be evicted", key)
+	}
+
+	got, err = client.MGet(ctx, survivors)
+	require.NoError(t, err)
+	for i, key := range survivors {
+		require.NotNil(t, got[i], "unrelated key %q must survive", key)
+	}
+}

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -133,6 +133,13 @@ type CompactorConfig struct {
 	RetentionConcurrency    uint          `yaml:"retention_concurrency"`
 	MaxTimePerTenant        time.Duration `yaml:"max_time_per_tenant"`
 	CompactionCycle         time.Duration `yaml:"compaction_cycle"`
+
+	// PrefixCacheEviction, when enabled, makes the compactor scan the configured
+	// caches on block deletion and remove every entry sharing the block's key
+	// prefix. This reclaims the offset-keyed parquet entries (footer, indexes,
+	// pages) that cannot be removed by exact key; when disabled they are left to
+	// expire via TTL or LRU. Only caches that can enumerate keys (Redis) honor it.
+	PrefixCacheEviction bool `yaml:"prefix_cache_eviction"`
 }
 
 func (cfg *CompactorConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet) {
@@ -146,6 +153,7 @@ func (cfg *CompactorConfig) RegisterFlagsAndApplyDefaults(prefix string, f *flag
 	f.IntVar(&cfg.MaxCompactionObjects, util.PrefixConfig(prefix, "max-objects-per-block"), 6000000, "Maximum number of traces in a compacted block.")
 	f.Uint64Var(&cfg.MaxBlockBytes, util.PrefixConfig(prefix, "max-block-bytes"), 100*1024*1024*1024 /* 100GB */, "Maximum size of a compacted block.")
 	f.DurationVar(&cfg.MaxCompactionRange, util.PrefixConfig(prefix, "compaction-window"), time.Hour, "Maximum time window across which to compact blocks.")
+	f.BoolVar(&cfg.PrefixCacheEviction, util.PrefixConfig(prefix, "prefix-cache-eviction"), false, "On block deletion, scan the caches and remove every entry sharing the block's key prefix. Reclaims offset-keyed parquet cache entries that cannot be removed by exact key; only caches that can enumerate keys (Redis) honor it. Disabled by default.")
 }
 
 func (cfg *CompactorConfig) validate() error {

--- a/tempodb/retention.go
+++ b/tempodb/retention.go
@@ -124,7 +124,7 @@ func (rw *readerWriter) retainTenant(ctx context.Context, tenantID string, compa
 					metricRetentionErrors.Inc()
 				} else {
 					metricDeleted.Inc()
-					rw.removeCachedBlock(ctx, tenantID, (uuid.UUID)(b.BlockID), int(b.BloomShardCount))
+					rw.removeCachedBlock(ctx, tenantID, (uuid.UUID)(b.BlockID), int(b.BloomShardCount), compactorCfg.PrefixCacheEviction)
 					rw.blocklist.Update(tenantID, nil, nil, nil, []*backend.CompactedBlockMeta{b})
 				}
 			}
@@ -139,13 +139,15 @@ func (rw *readerWriter) retainTenant(ctx context.Context, tenantID string, compa
 // the only eviction path available on caches that cannot enumerate keys
 // (e.g. memcached).
 //
-// The parquet roles (footer, column index, offset index, pages) are read via
-// offset-keyed range requests whose keys embed byte offsets not tracked in the
-// block meta, so they cannot be reconstructed. They are evicted by prefix on
-// caches that support it (Redis); a single prefix covers every role sharing an
-// instance, so the backing caches are deduplicated and each is scanned at most
-// once. On caches without prefix eviction these entries still rely on TTL or LRU.
-func (rw *readerWriter) removeCachedBlock(ctx context.Context, tenantID string, blockID uuid.UUID, bloomShardCount int) {
+// When prefixEviction is enabled, the parquet roles (footer, column index, offset
+// index, pages) are also evicted. They are read via offset-keyed range requests
+// whose keys embed byte offsets not tracked in the block meta, so they cannot be
+// reconstructed; instead they are removed by prefix on caches that support it
+// (Redis). A single prefix covers every role sharing an instance, so the backing
+// caches are deduplicated and each is scanned at most once. When prefixEviction is
+// disabled, or on caches that cannot enumerate keys, these entries rely on TTL or
+// LRU.
+func (rw *readerWriter) removeCachedBlock(ctx context.Context, tenantID string, blockID uuid.UUID, bloomShardCount int, prefixEviction bool) {
 	if rw.cacheProvider == nil {
 		return
 	}
@@ -162,6 +164,10 @@ func (rw *readerWriter) removeCachedBlock(ctx context.Context, tenantID string, 
 
 	if c := rw.cacheProvider.CacheFor(cache.RoleTraceIDIdx); c != nil {
 		c.Remove(ctx, []string{keyPrefix + common.NameIndex})
+	}
+
+	if !prefixEviction {
+		return
 	}
 
 	seen := map[cache.Cache]struct{}{}

--- a/tempodb/retention.go
+++ b/tempodb/retention.go
@@ -132,10 +132,19 @@ func (rw *readerWriter) retainTenant(ctx context.Context, tenantID string, compa
 	}
 }
 
-// removeCachedBlock evicts bloom filter shards and the trace-id index for a deleted block
-// from all configured caches. Cache entries for other roles (parquet pages, footer, etc.)
-// use byte offsets in their keys that are not tracked in the block meta, so those are left
-// to expire via TTL or LRU eviction.
+// removeCachedBlock evicts a deleted block's entries from all configured caches.
+//
+// Bloom filter shards and the trace-id index have whole-object keys that can be
+// reconstructed from the block meta, so they are removed exactly. This is also
+// the only eviction path available on caches that cannot enumerate keys
+// (e.g. memcached).
+//
+// The parquet roles (footer, column index, offset index, pages) are read via
+// offset-keyed range requests whose keys embed byte offsets not tracked in the
+// block meta, so they cannot be reconstructed. They are evicted by prefix on
+// caches that support it (Redis); a single prefix covers every role sharing an
+// instance, so the backing caches are deduplicated and each is scanned at most
+// once. On caches without prefix eviction these entries still rely on TTL or LRU.
 func (rw *readerWriter) removeCachedBlock(ctx context.Context, tenantID string, blockID uuid.UUID, bloomShardCount int) {
 	if rw.cacheProvider == nil {
 		return
@@ -153,5 +162,26 @@ func (rw *readerWriter) removeCachedBlock(ctx context.Context, tenantID string, 
 
 	if c := rw.cacheProvider.CacheFor(cache.RoleTraceIDIdx); c != nil {
 		c.Remove(ctx, []string{keyPrefix + common.NameIndex})
+	}
+
+	seen := map[cache.Cache]struct{}{}
+	for _, role := range []cache.Role{
+		cache.RoleParquetFooter,
+		cache.RoleParquetColumnIdx,
+		cache.RoleParquetOffsetIdx,
+		cache.RoleParquetPage,
+	} {
+		c := rw.cacheProvider.CacheFor(role)
+		if c == nil {
+			continue
+		}
+		if _, ok := seen[c]; ok {
+			continue
+		}
+		seen[c] = struct{}{}
+
+		if e, ok := c.(cache.PrefixEvictor); ok {
+			e.RemoveByPrefix(ctx, keyPrefix)
+		}
 	}
 }

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -587,7 +587,7 @@ func TestRemoveCachedBlockEvictsParquetRolesByPrefix(t *testing.T) {
 	cacheA.Store(ctx, []string{footerKey, pageKey, decoyKey}, [][]byte{{3}, {4}, {5}})
 	cacheB.Store(ctx, []string{colKey}, [][]byte{{6}})
 
-	rw.removeCachedBlock(ctx, testTenantID, blockID, 1)
+	rw.removeCachedBlock(ctx, testTenantID, blockID, 1, true)
 
 	// Exact-key roles evicted.
 	_, found := bloom.FetchKey(ctx, bloomKey)
@@ -610,4 +610,40 @@ func TestRemoveCachedBlockEvictsParquetRolesByPrefix(t *testing.T) {
 	// Each distinct backing cache is scanned exactly once (dedup).
 	require.Equal(t, []string{prefix}, cacheA.recordedPrefixes())
 	require.Equal(t, []string{prefix}, cacheB.recordedPrefixes())
+}
+
+// TestRemoveCachedBlockPrefixEvictionDisabled verifies that with prefix eviction
+// off (the default), bloom and trace-id index entries are still removed exactly
+// but the parquet roles are left in place and no prefix scan is issued.
+func TestRemoveCachedBlockPrefixEvictionDisabled(t *testing.T) {
+	parquet := newRecordingPrefixCache()
+	bloom := testutil.NewMockClient()
+
+	provider := &perRoleMockProvider{caches: map[cache.Role]cache.Cache{
+		cache.RoleBloom:         bloom,
+		cache.RoleParquetFooter: parquet,
+		cache.RoleParquetPage:   parquet,
+	}}
+
+	rw := &readerWriter{cacheProvider: provider}
+
+	ctx := context.Background()
+	blockID := uuid.New()
+	prefix := backend_cache.BlockKeyPrefix(blockID, testTenantID)
+
+	bloomKey := prefix + common.BloomName(0)
+	parquetKey := prefix + "data.parquet:0:100"
+	bloom.Store(ctx, []string{bloomKey}, [][]byte{{1}})
+	parquet.Store(ctx, []string{parquetKey}, [][]byte{{2}})
+
+	rw.removeCachedBlock(ctx, testTenantID, blockID, 1, false)
+
+	// Exact-key removal still happens regardless of the flag.
+	_, found := bloom.FetchKey(ctx, bloomKey)
+	require.False(t, found, "bloom key must still be removed exactly when prefix eviction is disabled")
+
+	// The parquet entry survives and no prefix scan was issued.
+	_, found = parquet.FetchKey(ctx, parquetKey)
+	require.True(t, found, "parquet key must be left to TTL/LRU when prefix eviction is disabled")
+	require.Empty(t, parquet.recordedPrefixes(), "no prefix eviction should be issued when disabled")
 }

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -468,4 +470,144 @@ func TestRetentionCacheEviction(t *testing.T) {
 	require.False(t, found, "bloom key should be evicted from bloom cache after block deletion")
 	_, found = idxCache.FetchKey(ctx, idxKey)
 	require.False(t, found, "index key should be evicted from trace-id-index cache after block deletion")
+}
+
+// recordingPrefixCache is a map-backed mock cache that also implements
+// cache.PrefixEvictor, like a Redis-backed cache. It records RemoveByPrefix calls
+// so tests can assert the compactor issues exactly one prefix eviction per
+// distinct backing cache instance.
+type recordingPrefixCache struct {
+	mu       sync.Mutex
+	data     map[string][]byte
+	prefixes []string
+}
+
+func newRecordingPrefixCache() *recordingPrefixCache {
+	return &recordingPrefixCache{data: map[string][]byte{}}
+}
+
+func (c *recordingPrefixCache) Store(_ context.Context, keys []string, bufs [][]byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i := range keys {
+		c.data[keys[i]] = bufs[i]
+	}
+}
+
+func (c *recordingPrefixCache) FetchKey(_ context.Context, key string) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	b, ok := c.data[key]
+	return b, ok
+}
+
+func (c *recordingPrefixCache) Fetch(_ context.Context, keys []string) (found []string, bufs [][]byte, missing []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, k := range keys {
+		if b, ok := c.data[k]; ok {
+			found = append(found, k)
+			bufs = append(bufs, b)
+		} else {
+			missing = append(missing, k)
+		}
+	}
+	return
+}
+
+func (c *recordingPrefixCache) Remove(_ context.Context, keys []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, k := range keys {
+		delete(c.data, k)
+	}
+}
+
+func (c *recordingPrefixCache) RemoveByPrefix(_ context.Context, prefix string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.prefixes = append(c.prefixes, prefix)
+	for k := range c.data {
+		if strings.HasPrefix(k, prefix) {
+			delete(c.data, k)
+		}
+	}
+}
+
+func (c *recordingPrefixCache) recordedPrefixes() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.prefixes...)
+}
+
+func (c *recordingPrefixCache) MaxItemSize() int { return 0 }
+func (c *recordingPrefixCache) Stop()            {}
+func (c *recordingPrefixCache) Release([]byte)   {}
+
+// TestRemoveCachedBlockEvictsParquetRolesByPrefix verifies that deleting a block
+// evicts the offset-keyed parquet roles by prefix (on caches that support it),
+// scans each distinct backing cache at most once, still removes bloom and
+// trace-id-index entries exactly (covering prefix-incapable backends), and
+// leaves other blocks' entries intact.
+func TestRemoveCachedBlockEvictsParquetRolesByPrefix(t *testing.T) {
+	// footer+page share cacheA and column+offset share cacheB, so each must be
+	// evicted by prefix exactly once despite backing two roles.
+	cacheA := newRecordingPrefixCache()
+	cacheB := newRecordingPrefixCache()
+	// bloom and trace-id index use a prefix-incapable mock (like memcached).
+	bloom := testutil.NewMockClient()
+	idx := testutil.NewMockClient()
+
+	provider := &perRoleMockProvider{caches: map[cache.Role]cache.Cache{
+		cache.RoleBloom:            bloom,
+		cache.RoleTraceIDIdx:       idx,
+		cache.RoleParquetFooter:    cacheA,
+		cache.RoleParquetPage:      cacheA,
+		cache.RoleParquetColumnIdx: cacheB,
+		cache.RoleParquetOffsetIdx: cacheB,
+	}}
+
+	rw := &readerWriter{cacheProvider: provider}
+
+	ctx := context.Background()
+	blockID := uuid.New()
+	prefix := backend_cache.BlockKeyPrefix(blockID, testTenantID)
+	decoy := backend_cache.BlockKeyPrefix(uuid.New(), testTenantID)
+
+	bloomKey := prefix + common.BloomName(0)
+	idxKey := prefix + common.NameIndex
+	bloom.Store(ctx, []string{bloomKey}, [][]byte{{1}})
+	idx.Store(ctx, []string{idxKey}, [][]byte{{2}})
+
+	// Offset-keyed parquet entries (not reconstructable) plus a decoy block's key.
+	footerKey := prefix + "data.parquet:0:100"
+	pageKey := prefix + "data.parquet:100:250"
+	colKey := prefix + "data.parquet:250:300"
+	decoyKey := decoy + "data.parquet:0:100"
+	cacheA.Store(ctx, []string{footerKey, pageKey, decoyKey}, [][]byte{{3}, {4}, {5}})
+	cacheB.Store(ctx, []string{colKey}, [][]byte{{6}})
+
+	rw.removeCachedBlock(ctx, testTenantID, blockID, 1)
+
+	// Exact-key roles evicted.
+	_, found := bloom.FetchKey(ctx, bloomKey)
+	require.False(t, found, "bloom key must be removed exactly")
+	_, found = idx.FetchKey(ctx, idxKey)
+	require.False(t, found, "trace-id index key must be removed exactly")
+
+	// Parquet roles evicted by prefix on both instances.
+	for _, k := range []string{footerKey, pageKey} {
+		_, found = cacheA.FetchKey(ctx, k)
+		require.False(t, found, "parquet key %q must be evicted by prefix", k)
+	}
+	_, found = cacheB.FetchKey(ctx, colKey)
+	require.False(t, found, "parquet key %q must be evicted by prefix", colKey)
+
+	// Another block's entry in the same cache is untouched.
+	_, found = cacheA.FetchKey(ctx, decoyKey)
+	require.True(t, found, "a different block's key must not be evicted")
+
+	// Each distinct backing cache is scanned exactly once (dedup).
+	require.Equal(t, []string{prefix}, cacheA.recordedPrefixes())
+	require.Equal(t, []string{prefix}, cacheB.recordedPrefixes())
 }


### PR DESCRIPTION
**What this PR does**:

When the backend worker deletes a compacted-away block it evicted only the bloom filter and trace-id index cache entries, by exact key. The parquet roles (footer, column/offset index, pages) are read via offset-keyed range requests whose keys aren't tracked in the block meta, so they couldn't be reconstructed and were left to expire via TTL or LRU — accumulating indefinitely in Redis when no TTL is set.

This adds opt-in prefix eviction: with `compaction.prefix_cache_eviction` enabled (default off), all of a block's entries share the `tenantID:blockID:` key prefix, so one `SCAN … MATCH <prefix>* COUNT 20000` per backing Redis instance (fanned out across masters on a cluster) removes every role. Exposed as an optional `cache.PrefixEvictor`, implemented only by Redis; memcached is unaffected and still relies on TTL/LRU.

Note: when enabled, this issues one keyspace `SCAN` per deleted block, per master, per retention cycle.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
