### PR TITLE
generator borrowed labels followup

### DIFF
--- a/.chloggen/generator-native-histogram-empty-exemplar.yaml
+++ b/.chloggen/generator-native-histogram-empty-exemplar.yaml
@@ -12,7 +12,7 @@ note: Stop attaching empty traceID exemplars to native histograms for spans with
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.
-issues: [7124]
+issues: [7584]
 
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
 subtext: In `native` and `both` histogram modes, observations for spans with a missing or all-zero trace ID attached an exemplar with an empty traceID label; they now carry no exemplar, matching classic histograms.

--- a/.chloggen/generator-native-histogram-empty-exemplar.yaml
+++ b/.chloggen/generator-native-histogram-empty-exemplar.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: metrics-generator
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Stop attaching empty traceID exemplars to native histograms for spans without a trace ID.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7124]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: In `native` and `both` histogram modes, observations for spans with a missing or all-zero trace ID attached an exemplar with an empty traceID label; they now carry no exemplar, matching classic histograms.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: carles-grafana

--- a/.chloggen/generator-spanmetrics-borrowed-labels.yaml
+++ b/.chloggen/generator-spanmetrics-borrowed-labels.yaml
@@ -1,7 +1,7 @@
 change_type: enhancement
 component: metrics-generator
 note: Reduce per-span CPU and allocations in the span-metrics processor by building series labels through the registry's pooled borrowed-label path.
-issues: [7124]
+issues: [7584]
 subtext: |
   The span-metrics processor now builds series labels in registry-owned pooled buffers, updates metrics with a precomputed label hash, and builds target_info once per resource instead of once per span. Metric names, labels, and values are unchanged.
 user: carles-grafana

--- a/.chloggen/generator-spanmetrics-borrowed-labels.yaml
+++ b/.chloggen/generator-spanmetrics-borrowed-labels.yaml
@@ -1,6 +1,7 @@
 change_type: enhancement
 component: metrics-generator
-note: The span-metrics processor builds series labels through the registry's borrowed-label buffers and updates metrics with a precomputed hash, building target_info once per resource instead of once per span. This reduces per-span CPU and allocations on the generator hot path with no change to metric names, labels, or values for valid configurations. Histogram buckets (classic and native) are now normalized (sorted) when the histogram is built, which only affects misconfigured non-monotonic histogram_buckets — correcting classic exemplar bucket placement and avoiding a panic when native histograms are enabled. Label-builder pools are now owned per-tenant.
+note: Reduce per-span CPU and allocations in the span-metrics processor by building series labels through the registry's pooled borrowed-label path.
 issues: [7124]
-subtext:
+subtext: |
+  The span-metrics processor now builds series labels in registry-owned pooled buffers, updates metrics with a precomputed label hash, and builds target_info once per resource instead of once per span. Metric names, labels, and values are unchanged.
 user: carles-grafana

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -242,7 +242,7 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 	defer registryLabelValues.Release()
 
 	if p.Cfg.Subprocessors[Count] {
-		p.spanMetricsCallsTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, 1*spanMultiplier, updateTimeMs)
+		p.spanMetricsCallsTotal.IncBorrowed(registryLabelValues, 1*spanMultiplier, updateTimeMs)
 	}
 
 	if p.Cfg.Subprocessors[Latency] {
@@ -251,11 +251,11 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 		if start, end := span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano(); start < end {
 			latencySeconds = float64(end-start) / float64(time.Second.Nanoseconds())
 		}
-		p.spanMetricsDurationSeconds.ObserveWithExemplarTraceIDBytesWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, latencySeconds, span.TraceId, spanMultiplier, updateTimeMs)
+		p.spanMetricsDurationSeconds.ObserveBorrowed(registryLabelValues, latencySeconds, span.TraceId, spanMultiplier, updateTimeMs)
 	}
 
 	if p.Cfg.Subprocessors[Size] {
-		p.spanMetricsSizeTotal.IncWithHashAt(registryLabelValues.Labels, registryLabelValues.Hash, float64(span.Size()), updateTimeMs)
+		p.spanMetricsSizeTotal.IncBorrowed(registryLabelValues, float64(span.Size()), updateTimeMs)
 	}
 
 	return true
@@ -306,7 +306,7 @@ func (p *Processor) buildAndSetTargetInfoLabels(attributes []*v1_common.KeyValue
 	// resource attribute in the built label set. We count from the built set because
 	// the registry label builder drops empty-valued labels (Add(name, "") deletes name).
 	if identifyingLabels > 0 && targetInfoLabels.Labels.Len() > identifyingLabels {
-		p.spanMetricsTargetInfo.SetForTargetInfoWithHashAt(targetInfoLabels.Labels, targetInfoLabels.Hash, 1, updateTimeMs)
+		p.spanMetricsTargetInfo.SetForTargetInfoBorrowed(targetInfoLabels, 1, updateTimeMs)
 	}
 	return true
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 // BenchmarkSpanMetricsPushSpans measures the processor end to end against
-// registry.TestRegistry, which stringifies labels into a map and discards the
-// precomputed hash, so absolute numbers include test-registry scaffolding that
-// production does not pay. Treat results as before/after comparisons of
+// registry.TestRegistry, which stringifies labels into a map instead of using
+// the precomputed hash, so absolute numbers include test-registry scaffolding
+// that production does not pay. Treat results as before/after comparisons of
 // processor-side changes only; the production label-building path is measured
 // by BenchmarkManagedRegistryBorrowPath in the registry package.
 func BenchmarkSpanMetricsPushSpans(b *testing.B) {

--- a/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_benchmark_test.go
@@ -186,3 +186,47 @@ func benchmarkStringAttr(key, value string) *common_v1.KeyValue {
 		}},
 	}
 }
+
+// benchmarkEnumSink defeats dead-code elimination in the enum-string benchmarks.
+var benchmarkEnumSink int
+
+// BenchmarkEnumStringFastPaths quantifies why spanKindString / statusCodeString
+// exist: the generated proto String() resolves names through proto.EnumName's
+// map[int32]string on every call, which the hand-rolled switches avoid on the
+// per-span hot path (two lookups per span).
+func BenchmarkEnumStringFastPaths(b *testing.B) {
+	kinds := []trace_v1.Span_SpanKind{
+		trace_v1.Span_SPAN_KIND_UNSPECIFIED,
+		trace_v1.Span_SPAN_KIND_INTERNAL,
+		trace_v1.Span_SPAN_KIND_SERVER,
+		trace_v1.Span_SPAN_KIND_CLIENT,
+		trace_v1.Span_SPAN_KIND_PRODUCER,
+		trace_v1.Span_SPAN_KIND_CONSUMER,
+	}
+	codes := []trace_v1.Status_StatusCode{
+		trace_v1.Status_STATUS_CODE_UNSET,
+		trace_v1.Status_STATUS_CODE_OK,
+		trace_v1.Status_STATUS_CODE_ERROR,
+	}
+
+	b.Run("kind_switch", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkEnumSink += len(spanKindString(kinds[i%len(kinds)]))
+		}
+	})
+	b.Run("kind_proto_String", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkEnumSink += len(kinds[i%len(kinds)].String())
+		}
+	})
+	b.Run("code_switch", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkEnumSink += len(statusCodeString(codes[i%len(codes)]))
+		}
+	})
+	b.Run("code_proto_String", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchmarkEnumSink += len(codes[i%len(codes)].String())
+		}
+	})
+}

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -1912,9 +1912,9 @@ func (c *recordingCounter) Inc(lbls labels.Labels, value float64) {
 	c.Counter.Inc(lbls, value)
 }
 
-func (c *recordingCounter) IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+func (c *recordingCounter) IncBorrowed(lbls *registry.BorrowedLabels, value float64, timeMs int64) {
 	*c.calls = append(*c.calls, c.name)
-	c.Counter.IncWithHashAt(lbls, hash, value, timeMs)
+	c.Counter.IncBorrowed(lbls, value, timeMs)
 }
 
 type recordingGauge struct {
@@ -1938,9 +1938,9 @@ func (g *recordingGauge) SetForTargetInfo(lbls labels.Labels, value float64) {
 	g.Gauge.SetForTargetInfo(lbls, value)
 }
 
-func (g *recordingGauge) SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+func (g *recordingGauge) SetForTargetInfoBorrowed(lbls *registry.BorrowedLabels, value float64, timeMs int64) {
 	*g.calls = append(*g.calls, g.name)
-	g.Gauge.SetForTargetInfoWithHashAt(lbls, hash, value, timeMs)
+	g.Gauge.SetForTargetInfoBorrowed(lbls, value, timeMs)
 }
 
 type recordingHistogram struct {
@@ -1954,9 +1954,9 @@ func (h *recordingHistogram) ObserveWithExemplar(lbls labels.Labels, value float
 	h.Histogram.ObserveWithExemplar(lbls, value, traceID, multiplier)
 }
 
-func (h *recordingHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
+func (h *recordingHistogram) ObserveBorrowed(lbls *registry.BorrowedLabels, value float64, traceID []byte, multiplier float64, timeMs int64) {
 	*h.calls = append(*h.calls, h.name)
-	h.Histogram.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, value, traceID, multiplier, timeMs)
+	h.Histogram.ObserveBorrowed(lbls, value, traceID, multiplier, timeMs)
 }
 
 // TestSpanMetricsTargetInfoRegisteredAfterSpanMetrics pins the order in which

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -2124,3 +2124,30 @@ func TestSpanMetricsTargetInfoWithDisabledSubprocessors(t *testing.T) {
 	assert.NotContains(t, testRegistry.String(), "traces_spanmetrics_calls_total")
 	assert.Equal(t, 0.0, testutil.ToFloat64(invalidUTF8Counter))
 }
+
+// TestEnumStringFastPathsMatchProto guards the hand-rolled switches in
+// spanKindString / statusCodeString against enum drift: for every known value
+// they must return exactly what the generated proto String() returns, and
+// unknown values must fall back to the generated String(). Correctness cannot
+// drift for an added enum value — the switch's default returns String() — but
+// the new value would silently take the slow map-lookup path, so the Len pins
+// fail on any enum change to force the switches to be extended in step.
+func TestEnumStringFastPathsMatchProto(t *testing.T) {
+	require.Len(t, trace_v1.Span_SpanKind_name, 6, "Span_SpanKind enum changed: extend spanKindString and update this count")
+	require.Len(t, trace_v1.Status_StatusCode_name, 3, "Status_StatusCode enum changed: extend statusCodeString and update this count")
+
+	for value := range trace_v1.Span_SpanKind_name {
+		kind := trace_v1.Span_SpanKind(value)
+		require.Equal(t, kind.String(), spanKindString(kind))
+	}
+	for value := range trace_v1.Status_StatusCode_name {
+		code := trace_v1.Status_StatusCode(value)
+		require.Equal(t, code.String(), statusCodeString(code))
+	}
+
+	// Unknown values must fall back to the generated String().
+	unknownKind := trace_v1.Span_SpanKind(math.MaxInt32)
+	require.Equal(t, unknownKind.String(), spanKindString(unknownKind))
+	unknownCode := trace_v1.Status_StatusCode(math.MaxInt32)
+	require.Equal(t, unknownCode.String(), statusCodeString(unknownCode))
+}

--- a/modules/generator/registry/builder.go
+++ b/modules/generator/registry/builder.go
@@ -15,6 +15,11 @@ type labelBuilder struct {
 	labels          []labels.Label
 	pools           *labelBuilderPools
 
+	// borrowed is the value handed out by CloseAndBorrowLabels; it lives on
+	// the pooled builder so borrowing allocates nothing. Release clears it
+	// before the builder is returned to the pool.
+	borrowed BorrowedLabels
+
 	maxLabelNameLength  int
 	maxLabelValueLength int
 	closed              bool
@@ -31,15 +36,22 @@ type labelBuilderPools struct {
 	scratchBuilderPool sync.Pool
 }
 
+// initialLabelCapacity sizes pooled builders for the common case: the
+// intrinsic span-metrics labels (~9) plus a few configured dimensions fit
+// without growing. Builders that grow past it keep their larger capacity
+// when returned to the pool, so exceeding it costs one grow per builder,
+// not per series.
+const initialLabelCapacity = 16
+
 func newLabelBuilderPools() *labelBuilderPools {
 	p := &labelBuilderPools{}
 	p.labelBuilderPool.New = func() interface{} {
 		return &labelBuilder{
-			labels: make([]labels.Label, 0, 16),
+			labels: make([]labels.Label, 0, initialLabelCapacity),
 		}
 	}
 	p.scratchBuilderPool.New = func() interface{} {
-		b := labels.NewScratchBuilder(16)
+		b := labels.NewScratchBuilder(initialLabelCapacity)
 		return &b
 	}
 	return p
@@ -112,7 +124,7 @@ func (b *labelBuilder) CloseAndBuildLabels() (labels.Labels, bool) {
 	return lbls, lbls.IsValid(model.UTF8Validation)
 }
 
-func (b *labelBuilder) CloseAndBorrowLabels() (BorrowedLabels, bool) {
+func (b *labelBuilder) CloseAndBorrowLabels() (*BorrowedLabels, bool) {
 	if b.closed {
 		// Closing twice would borrow a second value backed by this same builder
 		// and scratch, and releasing both double-Puts them into the pools
@@ -132,15 +144,14 @@ func (b *labelBuilder) CloseAndBorrowLabels() (BorrowedLabels, bool) {
 	lbls = b.perLabelLimiter.Limit(lbls)
 	if !lbls.IsValid(model.UTF8Validation) {
 		b.releaseBorrowedLabels(scratch)
-		return BorrowedLabels{}, false
+		return nil, false
 	}
 
-	return BorrowedLabels{
-		Labels:  lbls,
-		Hash:    lbls.Hash(),
-		builder: b,
-		scratch: scratch,
-	}, true
+	b.borrowed.Labels = lbls
+	b.borrowed.Hash = lbls.Hash()
+	b.borrowed.builder = b
+	b.borrowed.scratch = scratch
+	return &b.borrowed, true
 }
 
 // releaseBorrowedLabels resets the builder and returns it and the scratch

--- a/modules/generator/registry/builder_test.go
+++ b/modules/generator/registry/builder_test.go
@@ -96,10 +96,9 @@ func TestBorrowedLabels_AppliesSanitizerAndLimiter(t *testing.T) {
 	borrowed, ok := builder.CloseAndBorrowLabels()
 	assert.True(t, ok)
 	assert.Equal(t, "sanitized", borrowed.Labels.Get("name"))
-	// Hash must be computed on the post-sanitize/post-limit labels — it is the
-	// documented precondition for every *WithHash* metric method. A regression
-	// that hashed the pre-transform labels would silently split or collide
-	// series.
+	// Hash must be computed on the post-sanitize/post-limit labels — the
+	// *Borrowed metric methods trust it as the series key. A regression that
+	// hashed the pre-transform labels would silently split or collide series.
 	assert.Equal(t, borrowed.Labels.Hash(), borrowed.Hash, "Hash must match the transformed labels")
 	borrowed.Release()
 }
@@ -125,13 +124,16 @@ func TestBorrowedLabels_SequentialReuseDoesNotLeak(t *testing.T) {
 	}
 }
 
-func TestBorrowedLabels_ReleaseIsIdempotent(t *testing.T) {
+func TestBorrowedLabels_DoubleReleaseBeforeReuseIsNoOp(t *testing.T) {
 	// Release must not double-Put the builder/scratch into their pools when
-	// called more than once on the same struct value. This only protects
-	// repeated Release on the same value — Release on a copy of BorrowedLabels
-	// is documented as forbidden because each copy retains independent
-	// non-nil builder/scratch pointers and the second Release on the copy
-	// would still double-Put.
+	// called twice through the same pointer. This is best-effort misuse
+	// mitigation, not a guarantee: it only holds until the pooled builder is
+	// re-issued by a future CloseAndBorrowLabels — the same *BorrowedLabels is
+	// then live again, and a stale Release would clear the new borrower's
+	// fields and still double-Put. Release is documented as call-exactly-once.
+	// Release on a dereferenced copy of BorrowedLabels is likewise forbidden:
+	// the copy retains independent non-nil builder/scratch pointers, so
+	// releasing both double-Puts.
 	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
 	builder.Add("name", "value")
 
@@ -143,6 +145,20 @@ func TestBorrowedLabels_ReleaseIsIdempotent(t *testing.T) {
 	// second release is a no-op; would otherwise corrupt the sync.Pool.
 	borrowed.Release()
 	assert.Equal(t, labels.EmptyLabels(), borrowed.Labels)
+}
+
+func TestBorrowedLabels_ReleaseOnFailedBorrowIsNoOp(t *testing.T) {
+	// CloseAndBorrowLabels returns (nil, false) for an invalid label set.
+	// Release on that nil must be a no-op so a caller that defers Release
+	// before checking ok cannot be panicked by remote-controlled input (span
+	// attributes with invalid UTF-8).
+	builder := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())
+	builder.Add("name", "svc-\xc3\x28") // invalid UTF-8
+
+	borrowed, ok := builder.CloseAndBorrowLabels()
+	require.False(t, ok)
+	require.Nil(t, borrowed)
+	require.NotPanics(t, func() { borrowed.Release() })
 }
 
 func TestLabelBuilder_Sanitizer(t *testing.T) {
@@ -198,7 +214,7 @@ func TestBorrowedLabels_CollapsedLabelsProduceSingleSeries(t *testing.T) {
 		borrowed, ok := builder.CloseAndBorrowLabels()
 		require.True(t, ok)
 		require.Equal(t, borrowed.Labels.Hash(), borrowed.Hash)
-		c.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, time.Now().UnixMilli())
+		c.IncBorrowed(borrowed, 1, time.Now().UnixMilli())
 		borrowed.Release()
 	}
 
@@ -206,9 +222,10 @@ func TestBorrowedLabels_CollapsedLabelsProduceSingleSeries(t *testing.T) {
 }
 
 // TestLabelBuilder_DoubleClosePanics verifies both close methods reject a second
-// close on the same builder. Without the guard the second close would build a
-// value backed by the same pooled builder/scratch, and releasing both would
-// double-Put them into the pools, handing one instance to two future callers.
+// close on the same builder. Without the guard the second close would hand out
+// a second borrow backed by the same pooled builder/scratch, and releasing both
+// would double-Put them into the pools, handing one instance to two future
+// callers.
 func TestLabelBuilder_DoubleClosePanics(t *testing.T) {
 	t.Run("CloseAndBuildLabels", func(t *testing.T) {
 		b := NewLabelBuilder(0, 0, newTestDrainSanitizer(SpanNameSanitizationDisabled), newTestLabelLimiter())

--- a/modules/generator/registry/counter.go
+++ b/modules/generator/registry/counter.go
@@ -59,10 +59,14 @@ func newCounter(name string, lifecycler Limiter, externalLabels map[string]strin
 }
 
 func (c *counter) Inc(lbls labels.Labels, value float64) {
-	c.IncWithHashAt(lbls, lbls.Hash(), value, time.Now().UnixMilli())
+	c.incAt(lbls, lbls.Hash(), value, time.Now().UnixMilli())
 }
 
-func (c *counter) IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
+func (c *counter) IncBorrowed(lbls *BorrowedLabels, value float64, timeMs int64) {
+	c.incAt(lbls.Labels, lbls.Hash, value, timeMs)
+}
+
+func (c *counter) incAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
 	if value < 0 {
 		panic("counter can only increase")
 	}

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -63,11 +63,11 @@ func (g *gauge) Inc(lbls labels.Labels, value float64) {
 }
 
 func (g *gauge) SetForTargetInfo(lbls labels.Labels, value float64) {
-	g.SetForTargetInfoWithHashAt(lbls, lbls.Hash(), value, time.Now().UnixMilli())
+	g.updateSeries(lbls, lbls.Hash(), value, set, false, time.Now().UnixMilli())
 }
 
-func (g *gauge) SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64) {
-	g.updateSeries(lbls, hash, value, set, false, timeMs)
+func (g *gauge) SetForTargetInfoBorrowed(lbls *BorrowedLabels, value float64, timeMs int64) {
+	g.updateSeries(lbls.Labels, lbls.Hash, value, set, false, timeMs)
 }
 
 func (g *gauge) updateSeries(lbls labels.Labels, hash uint64, value float64, operation string, updateIfAlreadyExist bool, timeMs int64) {

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -145,8 +145,8 @@ func (h *histogram) ObserveWithExemplar(lbls labels.Labels, value float64, trace
 	h.observeWithExemplarWithHashAt(lbls, lbls.Hash(), value, newHistogramStringExemplar(traceID), multiplier, time.Now().UnixMilli())
 }
 
-func (h *histogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
-	h.observeWithExemplarWithHashAt(lbls, hash, value, newHistogramTraceIDBytesExemplar(traceID), multiplier, timeMs)
+func (h *histogram) ObserveBorrowed(lbls *BorrowedLabels, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls.Labels, lbls.Hash, value, newHistogramTraceIDBytesExemplar(traceID), multiplier, timeMs)
 }
 
 func (h *histogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, ex histogramExemplar, multiplier float64, timeMs int64) {

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	"go.uber.org/atomic"
 
 	tempo_util "github.com/grafana/tempo/pkg/util"
 )
@@ -37,21 +36,22 @@ type histogram struct {
 }
 
 // histogramSeries state is serialized by histogram.seriesMtx: the observe,
-// collect, and stale-removal paths all take the full mutex.
+// collect, and stale-removal paths all take the full mutex, so all fields are
+// plain values.
 type histogramSeries struct {
 	countLabels  labels.Labels
 	sumLabels    labels.Labels
 	bucketLabels []labels.Labels
 
-	count *atomic.Float64
-	sum   *atomic.Float64
+	count float64
+	sum   float64
 	// buckets includes the +Inf bucket
-	buckets []*atomic.Float64
+	buckets []float64
 	// exemplars stores either a hex-encoded string traceID or a raw <=16 byte
 	// traceID per bucket.
 	exemplars      []histogramExemplar
 	exemplarValues []float64
-	lastUpdated    *atomic.Int64
+	lastUpdated    int64
 	// firstSeries is used to track if this series is new to the counter.  This
 	// is used to ensure that new counters being with 0, and then are incremented
 	// to the desired value.  This avoids Prometheus throwing away the first
@@ -165,16 +165,10 @@ func (h *histogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint6
 
 func (h *histogram) newSeries(lbls labels.Labels, hash uint64, value float64, ex histogramExemplar, multiplier float64, timeMs int64) *histogramSeries {
 	newSeries := &histogramSeries{
-		count:          atomic.NewFloat64(0),
-		sum:            atomic.NewFloat64(0),
-		buckets:        make([]*atomic.Float64, 0, len(h.buckets)),
+		buckets:        make([]float64, len(h.buckets)),
 		exemplars:      make([]histogramExemplar, len(h.buckets)),
 		exemplarValues: make([]float64, len(h.buckets)),
-		lastUpdated:    atomic.NewInt64(0),
 		firstSeries:    true,
-	}
-	for i := 0; i < len(h.buckets); i++ {
-		newSeries.buckets = append(newSeries.buckets, atomic.NewFloat64(0))
 	}
 
 	// Precompute all labels for all sub-metrics upfront
@@ -203,18 +197,18 @@ func (h *histogram) newSeries(lbls labels.Labels, hash uint64, value float64, ex
 }
 
 func (h *histogram) updateSeries(hash uint64, s *histogramSeries, value float64, ex histogramExemplar, multiplier float64, timeMs int64) {
-	s.count.Add(multiplier)
-	s.sum.Add(value * multiplier)
+	s.count += multiplier
+	s.sum += value * multiplier
 
 	bucket := sort.SearchFloat64s(h.buckets, value)
 	for i := bucket; i < len(h.buckets); i++ {
-		s.buckets[i].Add(multiplier)
+		s.buckets[i] += multiplier
 	}
 
 	s.exemplars[bucket] = ex
 	s.exemplarValues[bucket] = value
 
-	s.lastUpdated.Store(timeMs)
+	s.lastUpdated = timeMs
 	h.lifecycler.OnUpdate(hash, h.activeSeriesPerHistogramSerie())
 }
 
@@ -240,13 +234,13 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) erro
 		}
 
 		// sum
-		_, err := appender.Append(0, s.sumLabels, timeMs, s.sum.Load())
+		_, err := appender.Append(0, s.sumLabels, timeMs, s.sum)
 		if err != nil {
 			return err
 		}
 
 		// count
-		_, err = appender.Append(0, s.countLabels, timeMs, s.count.Load())
+		_, err = appender.Append(0, s.countLabels, timeMs, s.count)
 		if err != nil {
 			return err
 		}
@@ -260,7 +254,7 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) erro
 					return err
 				}
 			}
-			ref, err := appender.Append(0, s.bucketLabels[i], timeMs, s.buckets[i].Load())
+			ref, err := appender.Append(0, s.bucketLabels[i], timeMs, s.buckets[i])
 			if err != nil {
 				return err
 			}
@@ -312,7 +306,7 @@ func (h *histogram) removeStaleSeries(staleTimeMs int64) {
 	defer h.seriesMtx.Unlock()
 
 	for hash, s := range h.series {
-		if s.lastUpdated.Load() < staleTimeMs {
+		if s.lastUpdated < staleTimeMs {
 			delete(h.series, hash)
 			h.lifecycler.OnDelete(hash, h.activeSeriesPerHistogramSerie())
 		}

--- a/modules/generator/registry/histogram_benchmark_test.go
+++ b/modules/generator/registry/histogram_benchmark_test.go
@@ -22,18 +22,22 @@ func BenchmarkRegistryHistogramObserve(b *testing.B) {
 	})
 
 	// The path spanmetrics uses on the hot path: raw trace ID bytes plus a
-	// precomputed label hash.
+	// precomputed label hash carried by BorrowedLabels (hand-constructed here
+	// from owned labels, as documented on the type). This differs from
+	// classic_low_bucket in several variables at once (trace ID form, hash
+	// source, timestamp source), so compare the pair as a whole-path
+	// before/after; don't attribute a delta to any single variable.
 	b.Run("classic_trace_id_bytes_with_hash", func(b *testing.B) {
 		h := newHistogram("bench_histogram", []float64{0.01, 0.05, 0.1, 0.5, 1, 5}, noopLimiter, "trace_id", nil, 15*time.Minute)
 		traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-		hash := lbls.Hash()
+		borrowed := &BorrowedLabels{Labels: lbls, Hash: lbls.Hash()}
 		timeMs := time.Now().UnixMilli()
-		h.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, 0.001, traceID, 1, timeMs)
+		h.ObserveBorrowed(borrowed, 0.001, traceID, 1, timeMs)
 
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			h.ObserveWithExemplarTraceIDBytesWithHashAt(lbls, hash, 0.001, traceID, 1, timeMs)
+			h.ObserveBorrowed(borrowed, 0.001, traceID, 1, timeMs)
 		}
 	})
 

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -542,9 +542,5 @@ func TestNewHistogram_SortsUnsortedBuckets(t *testing.T) {
 	if s == nil {
 		t.Fatalf("series not found for %s", lbls.String())
 	}
-	got := make([]float64, len(s.buckets))
-	for i := range s.buckets {
-		got[i] = s.buckets[i].Load()
-	}
-	assert.Equal(t, []float64{0, 1, 1, 1, 1}, got)
+	assert.Equal(t, []float64{0, 1, 1, 1, 1}, s.buckets)
 }

--- a/modules/generator/registry/interface.go
+++ b/modules/generator/registry/interface.go
@@ -19,25 +19,33 @@ type Registry interface {
 type LabelBuilder interface {
 	Add(name, value string)
 	CloseAndBuildLabels() (labels.Labels, bool)
-	CloseAndBorrowLabels() (BorrowedLabels, bool)
+	CloseAndBorrowLabels() (*BorrowedLabels, bool)
 }
 
 // BorrowedLabels holds a label set whose backing memory is owned by a pooled
-// scratch builder. The Labels and Hash are only valid between
-// CloseAndBorrowLabels and Release. Callers MUST NOT retain Labels (or substrings
-// of any Label.Name or Label.Value — in the default stringlabels build both
-// alias the pooled buffer) past Release, store BorrowedLabels in a long-lived field,
-// copy the value across goroutines, or copy the value at all and call Release
-// on more than one copy — the underlying scratch and builder are returned to
-// pools by Release, and a second Release on a copy double-Puts them and lets
-// later callers receive the same instance concurrently. Metric methods that
-// accept BorrowedLabels.Labels copy what they need synchronously before
-// returning.
+// scratch builder, together with the precomputed Hash of Labels. Hash is
+// computed by CloseAndBorrowLabels, so the pair cannot disagree; the metric
+// *Borrowed methods trust it as the series key. The pointer returned by
+// CloseAndBorrowLabels points into the pooled builder itself, so borrowing
+// allocates nothing.
+//
+// Labels and Hash are only valid between CloseAndBorrowLabels and Release.
+// Callers MUST NOT retain the pointer or Labels (or substrings of any
+// Label.Name or Label.Value — in the default stringlabels build both alias
+// the pooled buffer) past Release, store them in a long-lived field, or share
+// them across goroutines — Release returns the underlying scratch and builder
+// to pools, and the same BorrowedLabels is re-issued to future borrowers.
+// Metric methods that accept *BorrowedLabels copy what they need synchronously
+// before returning.
+//
+// Tests with owned labels may hand-construct a BorrowedLabels, setting Hash to
+// Labels.Hash(); Release on such a value is a no-op.
 type BorrowedLabels struct {
-	// noCopy makes `go vet` copylocks flag accidental copies of BorrowedLabels,
-	// which are unsafe: a copy retains independent non-nil builder/scratch
-	// pointers, so releasing both copies double-Puts them into the pools (see
-	// the Release/copy warning above).
+	// noCopy makes `go vet` copylocks flag accidental copies of the
+	// dereferenced value, which are unsafe: a copy retains independent
+	// non-nil builder/scratch pointers, so releasing both the original and
+	// the copy double-Puts them into the pools (handing one to two future
+	// callers concurrently).
 	noCopy noCopy
 
 	Labels labels.Labels
@@ -57,17 +65,35 @@ func (*noCopy) Lock()   {}
 func (*noCopy) Unlock() {}
 
 // Release returns the underlying builder and scratch buffer to their pools.
-// It is safe to call multiple times: subsequent calls are no-ops.
-// After Release, Labels and Hash are no longer valid.
+// After Release, Labels and Hash are no longer valid. The fields are cleared
+// before the builder is pooled: once it is Put, another goroutine may Get it,
+// so writing to them afterwards would race with the next borrower.
+//
+// Treat Release as call-exactly-once per successful CloseAndBorrowLabels.
+// Calling it again through the same pointer is a no-op only until the pooled
+// builder is re-issued to a future borrower; after that the same
+// *BorrowedLabels is live again, and a stale Release would clear the new
+// borrower's fields and double-Put the builder and scratch into their pools.
+// The no-op softens misuse — it does not license early or repeated Release.
+//
+// Release on a nil *BorrowedLabels is a no-op, so the nil returned by a
+// failed CloseAndBorrowLabels is safe to Release (e.g. via a defer set up
+// before checking ok).
 func (b *BorrowedLabels) Release() {
-	if b.builder == nil {
+	if b == nil {
+		// CloseAndBorrowLabels returns nil when the label set is invalid.
 		return
 	}
-	b.builder.releaseBorrowedLabels(b.scratch)
+	builder := b.builder
+	if builder == nil {
+		return
+	}
+	scratch := b.scratch
 	b.builder = nil
 	b.scratch = nil
 	b.Labels = labels.EmptyLabels()
 	b.Hash = 0
+	builder.releaseBorrowedLabels(scratch)
 }
 
 // Counter
@@ -76,11 +102,10 @@ type Counter interface {
 	metric
 
 	Inc(lbls labels.Labels, value float64)
-	// IncWithHashAt is like Inc but uses the supplied hash as the series key
-	// and timeMs as the lastUpdated stamp. Precondition: hash MUST equal
-	// lbls.Hash(). Supplying any other value silently maps to a different
-	// series and corrupts metrics.
-	IncWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64)
+	// IncBorrowed is like Inc but keys the series by the precomputed
+	// lbls.Hash and uses timeMs as the lastUpdated stamp. It copies what it
+	// needs before returning, so the caller may Release lbls afterwards.
+	IncBorrowed(lbls *BorrowedLabels, value float64, timeMs int64)
 }
 
 // Histogram
@@ -90,13 +115,12 @@ type Histogram interface {
 
 	// ObserveWithExemplar observes a datapoint with the given values. traceID will be added as exemplar.
 	ObserveWithExemplar(lbls labels.Labels, value float64, traceID string, multiplier float64)
-	// ObserveWithExemplarTraceIDBytesWithHashAt is like ObserveWithExemplar but
-	// accepts the traceID as raw bytes, uses the supplied hash as the series key,
-	// and uses timeMs as the lastUpdated stamp. The histogram copies the traceID
-	// bytes synchronously, so the slice may be reused after the call.
-	// Precondition: hash MUST equal lbls.Hash(). Supplying any other value
-	// silently maps to a different series and corrupts metrics.
-	ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64)
+	// ObserveBorrowed is like ObserveWithExemplar but keys the series by the
+	// precomputed lbls.Hash, uses timeMs as the lastUpdated stamp, and takes
+	// the exemplar trace ID as raw bytes (empty = no exemplar). It copies the
+	// trace ID bytes and label data it needs before returning, so the caller
+	// may Release lbls and reuse the slice afterwards.
+	ObserveBorrowed(lbls *BorrowedLabels, value float64, traceID []byte, multiplier float64, timeMs int64)
 }
 
 // Gauge
@@ -109,11 +133,11 @@ type Gauge interface {
 	Set(lbls labels.Labels, value float64)
 	Inc(lbls labels.Labels, value float64)
 	SetForTargetInfo(lbls labels.Labels, value float64)
-	// SetForTargetInfoWithHashAt is like SetForTargetInfo but uses the supplied
-	// hash as the series key and timeMs as the lastUpdated stamp.
-	// Precondition: hash MUST equal lbls.Hash(). Supplying any other value
-	// silently maps to a different series and corrupts metrics.
-	SetForTargetInfoWithHashAt(lbls labels.Labels, hash uint64, value float64, timeMs int64)
+	// SetForTargetInfoBorrowed is like SetForTargetInfo but keys the series by
+	// the precomputed lbls.Hash and uses timeMs as the lastUpdated stamp. It
+	// copies what it needs before returning, so the caller may Release lbls
+	// afterwards.
+	SetForTargetInfoBorrowed(lbls *BorrowedLabels, value float64, timeMs int64)
 }
 
 type HistogramMode int

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -214,16 +214,23 @@ func (h *nativeHistogram) newSeries(lbls labels.Labels, hash uint64, value float
 }
 
 func (h *nativeHistogram) updateSeries(hash uint64, s *nativeHistogramSeries, value float64, traceID string, multiplier float64, timeMs int64) {
-	// Use Prometheus native exemplar handling
-	exemplarObserver := s.promHistogram.(prometheus.ExemplarObserver)
-
-	// ObserveWithExemplar copies the labels synchronously; seriesMtx serializes reuse.
-	h.exemplarLabels[h.traceIDLabelName] = traceID
-
-	// multiplier is 1 on the common path, so this loop runs exactly once.
-	for i := 0.0; i < multiplier; i++ {
-		// Let Prometheus handle exemplars natively
-		exemplarObserver.ObserveWithExemplar(value, h.exemplarLabels)
+	// multiplier is 1 on the common path, so these loops run exactly once.
+	if traceID == "" {
+		// Interface contract: empty trace ID (including all-zero IDs, which
+		// hex-encode to "") means no exemplar. Observing with an empty label
+		// value would attach a junk traceID="" exemplar; the classic histogram
+		// instead drops empty exemplars at collect time.
+		for i := 0.0; i < multiplier; i++ {
+			s.promHistogram.Observe(value)
+		}
+	} else {
+		// Use Prometheus native exemplar handling.
+		exemplarObserver := s.promHistogram.(prometheus.ExemplarObserver)
+		// ObserveWithExemplar copies the labels synchronously; seriesMtx serializes reuse.
+		h.exemplarLabels[h.traceIDLabelName] = traceID
+		for i := 0.0; i < multiplier; i++ {
+			exemplarObserver.ObserveWithExemplar(value, h.exemplarLabels)
+		}
 	}
 
 	// lastUpdated rides the observation call (timeMs is supplied by the

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -132,8 +132,8 @@ func (h *nativeHistogram) ObserveWithExemplar(lbls labels.Labels, value float64,
 	h.observeWithExemplarWithHashAt(lbls, lbls.Hash(), value, traceID, multiplier, time.Now().UnixMilli())
 }
 
-func (h *nativeHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID []byte, multiplier float64, timeMs int64) {
-	h.observeWithExemplarWithHashAt(lbls, hash, value, tempo_util.TraceIDToHexString(traceID), multiplier, timeMs)
+func (h *nativeHistogram) ObserveBorrowed(lbls *BorrowedLabels, value float64, traceID []byte, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls.Labels, lbls.Hash, value, tempo_util.TraceIDToHexString(traceID), multiplier, timeMs)
 }
 
 func (h *nativeHistogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) {
@@ -226,6 +226,10 @@ func (h *nativeHistogram) updateSeries(hash uint64, s *nativeHistogramSeries, va
 		exemplarObserver.ObserveWithExemplar(value, h.exemplarLabels)
 	}
 
+	// lastUpdated rides the observation call (timeMs is supplied by the
+	// caller: the batch timestamp on the borrowed path, time.Now() on the
+	// owned path) instead of a per-observation time.Now(); removeStaleSeries
+	// compares against it under the same seriesMtx.
 	s.lastUpdated = timeMs
 	h.lifecycler.OnUpdate(hash, h.activeSeriesPerHistogramSerie())
 }

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -979,3 +979,37 @@ func TestNewNativeHistogram_SortsUnsortedBuckets(t *testing.T) {
 		h.ObserveWithExemplar(lbls, 1.5, "trace-1", 1.0)
 	})
 }
+
+// TestNativeHistogram_EmptyTraceIDEmitsNoExemplar verifies the Histogram
+// interface contract (empty trace ID = no exemplar) on the native
+// implementation: spans without a trace ID — or with an all-zero one, which
+// TraceIDToHexString renders as "" — must not attach a traceID="" exemplar to
+// the observation, matching the classic histogram, which drops empty
+// exemplars at collect time.
+func TestNativeHistogram_EmptyTraceIDEmitsNoExemplar(t *testing.T) {
+	for _, mode := range []HistogramMode{HistogramModeNative, HistogramModeBoth} {
+		t.Run(HistogramModeToString[mode], func(t *testing.T) {
+			overrides := &mockOverrides{
+				nativeHistogramBucketFactor:     1.5,
+				nativeHistogramMaxBucketNumber:  100,
+				nativeHistogramMinResetDuration: 15 * time.Minute,
+			}
+			h := newNativeHistogram("test_histogram", []float64{1, 2}, noopLimiter, "trace_id", mode, nil, testTenant, overrides, 15*time.Minute)
+
+			// Owned path: empty trace ID string.
+			h.ObserveWithExemplar(buildTestLabels([]string{"label"}, []string{"value-1"}), 1.0, "", 1.0)
+
+			// Borrowed path: an all-zero trace ID hex-encodes to "" and must
+			// behave the same. Hand-constructed BorrowedLabels from owned
+			// labels, as documented on the type.
+			lbls := buildTestLabels([]string{"label"}, []string{"value-2"})
+			borrowed := &BorrowedLabels{Labels: lbls, Hash: lbls.Hash()}
+			h.ObserveBorrowed(borrowed, 1.0, make([]byte, 16), 1.0, time.Now().UnixMilli())
+
+			appender := &capturingAppender{}
+			require.NoError(t, h.collectMetrics(appender, time.Now().UnixMilli()))
+			require.NotEmpty(t, appender.histograms, "observations must still be collected")
+			require.Empty(t, appender.exemplars, "empty trace IDs must not produce exemplars")
+		})
+	}
+}

--- a/modules/generator/registry/registry_benchmark_test.go
+++ b/modules/generator/registry/registry_benchmark_test.go
@@ -12,7 +12,7 @@ import (
 // sanitize + per-label limit + hash + utf8 check) -> hash-keyed metric update
 // -> Release, against a real ManagedRegistry with its per-tenant pools. This is
 // the path spanmetrics drives per span and the one the borrow API optimizes.
-// BenchmarkSpanMetricsPushSpans uses registry.TestRegistry, which discards the
+// BenchmarkSpanMetricsPushSpans uses registry.TestRegistry, which ignores the
 // precomputed hash and stringifies labels, so it does not exercise this path.
 //
 // The variants toggle the sanitizer and per-label limiter so their per-span
@@ -61,8 +61,8 @@ func BenchmarkManagedRegistryBorrowPath(b *testing.B) {
 				if !ok {
 					b.Fatal("expected valid labels")
 				}
-				counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, ts)
-				histogram.ObserveWithExemplarTraceIDBytesWithHashAt(borrowed.Labels, borrowed.Hash, 0.42, traceID, 1, ts)
+				counter.IncBorrowed(borrowed, 1, ts)
+				histogram.ObserveBorrowed(borrowed, 0.42, traceID, 1, ts)
 				borrowed.Release()
 			}
 		})

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"os"
 	"sort"
+	"sync"
 	"testing"
 	"time"
 
@@ -1069,9 +1070,9 @@ func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
 
 	timeMs := time.Now().UnixMilli()
 	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-	counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, timeMs)
-	histogram.ObserveWithExemplarTraceIDBytesWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, traceID, 1.0, timeMs)
-	gauge.SetForTargetInfoWithHashAt(borrowed.Labels, borrowed.Hash, 1.0, timeMs)
+	counter.IncBorrowed(borrowed, 1.0, timeMs)
+	histogram.ObserveBorrowed(borrowed, 1.0, traceID, 1.0, timeMs)
+	gauge.SetForTargetInfoBorrowed(borrowed, 1.0, timeMs)
 	borrowed.Release()
 
 	// Overwrite the caller-owned trace ID slice: the histogram must have
@@ -1145,7 +1146,7 @@ func TestManagedRegistry_borrowedLabelsSurviveSanitizerAndLimiter(t *testing.T) 
 		builder.Add("route", fmt.Sprintf("/u/%0*d", i%37, i))
 		borrowed, ok := builder.CloseAndBorrowLabels()
 		require.True(t, ok)
-		counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, time.Now().UnixMilli())
+		counter.IncBorrowed(borrowed, 1, time.Now().UnixMilli())
 		borrowed.Release()
 	}
 
@@ -1188,7 +1189,7 @@ func TestManagedRegistry_retainingLimiterDoesNotCorruptSeries(t *testing.T) {
 	builder.Add("label", "value-1")
 	borrowed, ok := builder.CloseAndBorrowLabels()
 	require.True(t, ok)
-	counter.IncWithHashAt(borrowed.Labels, borrowed.Hash, 1, time.Now().UnixMilli())
+	counter.IncBorrowed(borrowed, 1, time.Now().UnixMilli())
 	borrowed.Release()
 
 	// Churn the pools so anything the limiter wrongly retained is overwritten.
@@ -1242,7 +1243,7 @@ func TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse(t *testing.T) {
 			builder.Add("label", "value-1")
 			borrowed, valid := builder.CloseAndBorrowLabels()
 			require.True(t, valid)
-			histogram.ObserveWithExemplarTraceIDBytesWithHashAt(borrowed.Labels, borrowed.Hash, 1.5, traceID, 1.0, time.Now().UnixMilli())
+			histogram.ObserveBorrowed(borrowed, 1.5, traceID, 1.0, time.Now().UnixMilli())
 			borrowed.Release()
 
 			// Churn the pooled builders/scratch so any retained borrowed label
@@ -1314,4 +1315,53 @@ func TestManagedRegistryPerTenantPools(t *testing.T) {
 		assert.Equal(t, "b", lb.Labels.Get("k"))
 		lb.Release()
 	}
+}
+
+// TestManagedRegistry_concurrentBorrowRelease exercises the full borrow path —
+// NewLabelBuilder → Add → CloseAndBorrowLabels → *Borrowed update → Release —
+// from many goroutines sharing one registry, as production does (a tenant's
+// pools are shared across ingest_concurrency consumers). Run under -race it
+// pins the Release ordering invariant that fields are cleared before the
+// builder is pooled: a regression that Puts the builder first would let the
+// next borrower's writes race Release's clears across goroutines.
+func TestManagedRegistry_concurrentBorrowRelease(t *testing.T) {
+	registry := New(&Config{}, &mockOverrides{}, "test", &noopAppender{}, log.NewNopLogger(), noopLimiter)
+	defer registry.Close()
+
+	counter := registry.NewCounter("my_counter")
+	histogram := registry.NewHistogram("my_histogram", []float64{1}, HistogramModeClassic)
+	gauge := registry.NewGauge("my_gauge")
+
+	const (
+		goroutines = 8
+		iterations = 500
+	)
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				timeMs := time.Now().UnixMilli()
+
+				builder := registry.NewLabelBuilder()
+				builder.Add("service", "svc")
+				// A small set of distinct values keeps the series count
+				// bounded while still churning the pooled scratch buffers
+				// with different content between borrows.
+				builder.Add("span_name", fmt.Sprintf("GET /g/%d/%d", g, i%5))
+				borrowed, ok := builder.CloseAndBorrowLabels()
+				if !assert.True(t, ok) {
+					continue
+				}
+				counter.IncBorrowed(borrowed, 1, timeMs)
+				histogram.ObserveBorrowed(borrowed, 0.5, traceID, 1, timeMs)
+				gauge.SetForTargetInfoBorrowed(borrowed, 1, timeMs)
+				borrowed.Release()
+			}
+		}(g)
+	}
+	wg.Wait()
 }

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -121,8 +121,8 @@ func (t *testCounter) Inc(lbls labels.Labels, value float64) {
 	t.registry.addToMetric(t.n, lbls, value)
 }
 
-func (t *testCounter) IncWithHashAt(lbls labels.Labels, _ uint64, value float64, _ int64) {
-	t.Inc(lbls, value)
+func (t *testCounter) IncBorrowed(lbls *BorrowedLabels, value float64, _ int64) {
+	t.Inc(lbls.Labels, value)
 }
 
 func (t *testCounter) name() string {
@@ -168,8 +168,8 @@ func (t *testGauge) SetForTargetInfo(lbls labels.Labels, value float64) {
 	t.Set(lbls, value)
 }
 
-func (t *testGauge) SetForTargetInfoWithHashAt(lbls labels.Labels, _ uint64, value float64, _ int64) {
-	t.SetForTargetInfo(lbls, value)
+func (t *testGauge) SetForTargetInfoBorrowed(lbls *BorrowedLabels, value float64, _ int64) {
+	t.SetForTargetInfo(lbls.Labels, value)
 }
 
 func (t *testGauge) name() string {
@@ -218,10 +218,10 @@ func (t *testHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, _
 	t.registry.addToMetric(t.nameBucket, withLe(lbls, math.Inf(1)), 1*multiplier)
 }
 
-func (t *testHistogram) ObserveWithExemplarTraceIDBytesWithHashAt(lbls labels.Labels, _ uint64, value float64, _ []byte, multiplier float64, _ int64) {
+func (t *testHistogram) ObserveBorrowed(lbls *BorrowedLabels, value float64, _ []byte, multiplier float64, _ int64) {
 	// testHistogram discards the trace ID (ObserveWithExemplar ignores it), so
 	// skip hex-encoding it — that allocation only inflated benchmark allocs.
-	t.ObserveWithExemplar(lbls, value, "", multiplier)
+	t.ObserveWithExemplar(lbls.Labels, value, "", multiplier)
 }
 
 func (t *testHistogram) name() string {


### PR DESCRIPTION
**What this PR does**:

Follow-ups to #7498 (zero-copy borrowed-label path), scoped strictly to improving that refactor:

- **registry: remove redundant histogram atomics** — finishes the de-atomicization #7498 started; every `histogramSeries` access is serialized by `seriesMtx`, counter/gauge keep their atomics for the `RLock` fast path.
- **registry: pass borrowed labels as a handle** — replaces the `*WithHashAt(lbls, hash)` APIs with `*Borrowed(*BorrowedLabels)`, making the "hash must equal lbls.Hash()" precondition unrepresentable. `Release` is safe on the nil returned by a failed borrow, documented as call-exactly-once, and covered by a new `-race` concurrent borrow/release test.
- **spanmetrics: pin enum fast paths** — drift test + benchmark for the enum-name switches #7498 introduced.
- **registry: skip empty native exemplars** — native histograms honor the documented "(empty = no exemplar)" contract for missing/all-zero trace IDs, matching classic histograms.


**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added (n/a — internal API)
- [x] Changelog entry added under `.chloggen/`
