### PR TITLE
test: fix flaky Unit and e2e tests

### DIFF
--- a/integration/api/query_range_test.go
+++ b/integration/api/query_range_test.go
@@ -652,13 +652,24 @@ func TestQueryRangeMaxSeriesDisabled(t *testing.T) {
 		// Wait for traces to be flushed to blocks. spanCount happens to make traces count
 		h.WaitTracesQueryable(t, spanCount)
 
-		callQueryRange(t, h, queryRangeRequest{
+		req := queryRangeRequest{
 			Query:     "{} | rate() by (span:id)",
 			Start:     time.Now().Add(-5 * time.Minute),
 			End:       time.Now(),
 			Step:      "5s",
 			Exemplars: 100,
-		}, func(queryRangeRes *tempopb.QueryRangeResponse, err error) {
+		}
+
+		// The traces_created_total barrier doesn't guarantee metrics-query
+		// visibility, so poll until every span:id series is returned.
+		apiClient := h.APIClientHTTP("")
+		require.Eventually(t, func() bool {
+			res, err := apiClient.MetricsQueryRange(req.Query, req.Start.UnixNano(), req.End.UnixNano(), req.Step, req.Exemplars)
+			require.NoError(t, err)
+			return len(res.GetSeries()) == spanCount
+		}, 30*time.Second, time.Second, "all %d series should become queryable", spanCount)
+
+		callQueryRange(t, h, req, func(queryRangeRes *tempopb.QueryRangeResponse, err error) {
 			require.NoError(t, err)
 			require.NotNil(t, queryRangeRes)
 			require.Equal(t, tempopb.PartialStatus_COMPLETE, queryRangeRes.GetStatus())

--- a/modules/backendworker/backendworker_test.go
+++ b/modules/backendworker/backendworker_test.go
@@ -40,15 +40,9 @@ func TestWorker(t *testing.T) {
 	limitCfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	workerCfg, schedulerClientCfg, overridesSvc, scheduler, store := setupDependencies(ctx, t, limitCfg)
-
-	defer func() {
-		cancel()
-		// Explicitly stop the store to avoid race condition on test fixture shutdown
-		store.StopAsync()
-		_ = store.AwaitTerminated(context.Background())
-	}()
 
 	w, err := New(workerCfg, schedulerClientCfg, store, overridesSvc, prometheus.DefaultRegisterer)
 	require.NoError(t, err)
@@ -198,11 +192,13 @@ func newStoreWithLogger(ctx context.Context, t testing.TB, log log.Logger, tmpDi
 	}, nil, log)
 	require.NoError(t, err)
 
+	// The store service is never started, so only cancel + Shutdown joins the poller.
+	ctx, cancel := context.WithCancel(ctx)
 	s.EnablePolling(ctx, &ownsEverythingSharder{}, false)
 
 	t.Cleanup(func() {
-		s.StopAsync()
-		require.NoError(t, s.AwaitTerminated(context.Background()))
+		cancel()
+		s.Shutdown()
 	})
 	return s
 }
@@ -260,12 +256,8 @@ func TestProcessRedactionJobMissingBlockObservable(t *testing.T) {
 	limitCfg.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	workerCfg, schedulerClientCfg, overridesSvc, _, store := setupDependencies(ctx, t, limitCfg)
-	defer func() {
-		cancel()
-		store.StopAsync()
-		_ = store.AwaitTerminated(context.Background())
-	}()
 
 	w, err := New(workerCfg, schedulerClientCfg, store, overridesSvc, prometheus.NewRegistry())
 	require.NoError(t, err)

--- a/modules/distributor/distributor_ring_mixed_test.go
+++ b/modules/distributor/distributor_ring_mixed_test.go
@@ -2,6 +2,7 @@ package distributor
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -196,9 +197,13 @@ func newRingReader(t *testing.T, store kv.Client, ringKey string, heartbeatTimeo
 
 func healthyIDs(t *testing.T, r *ring.Ring) map[string]bool {
 	t.Helper()
-	rs, err := r.GetAllHealthy(ringOp)
-	require.NoError(t, err)
 	out := map[string]bool{}
+	rs, err := r.GetAllHealthy(ringOp)
+	// Transiently empty until the reader syncs from KV. Let require.Eventually retry.
+	if errors.Is(err, ring.ErrEmptyRing) {
+		return out
+	}
+	require.NoError(t, err)
 	for _, ing := range rs.Instances {
 		out[ing.Id] = true
 	}


### PR DESCRIPTION
**What this PR does**:

- test: fix flaky TestDistributorRing_MixedLifecyclerRollout
- test: fix flaky backendworker TempDir cleanup race
- test: fix flaky TestQueryRangeMaxSeriesDisabled


**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)