### PR TITLE
distributor: add configurable Kafka SASL mechanism and TLS support

### DIFF
--- a/.chloggen/kafka-sasl-mechanism.yaml
+++ b/.chloggen/kafka-sasl-mechanism.yaml
@@ -1,0 +1,22 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: distributor
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Add Kafka SASL mechanism selection and TLS support. The `sasl_mechanism` option selects the SASL mechanism (`PLAIN` (default), `SCRAM-SHA-256`, `SCRAM-SHA-512`, `OAUTHBEARER`, or `AWS_MSK_IAM`), and `tls_enabled` with the `tls_*` options enables TLS transport and mutual-TLS for the Kafka client.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7580]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  OAUTHBEARER and AWS_MSK_IAM credentials can be supplied statically, from a JSON file, or fetched over a Unix domain socket. Existing configurations are unaffected because the default mechanism remains `PLAIN` with SASL disabled when no username or password is set.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: heytrav

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -463,11 +463,57 @@ ingest:
         # How long to wait for an incoming write request to be successfully committed to the Kafka backend.
         [write_timeout: <duration> | default = 10s]
 
-        # The SASL username for authentication.
+        # The SASL mechanism used to authenticate to Kafka. Supported values:
+        # PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, OAUTHBEARER, AWS_MSK_IAM.
+        # For backwards-compatibility, PLAIN with no username nor password disables SASL.
+        [sasl_mechanism: <string> | default = "PLAIN"]
+
+        # The username used to authenticate to Kafka using SASL (PLAIN and SCRAM-SHA-* mechanisms).
+        # To enable SASL, configure both the username and password.
         [sasl_username: <string>]
 
-        # The SASL password for authentication.
+        # The password used to authenticate to Kafka using SASL (PLAIN and SCRAM-SHA-* mechanisms).
         [sasl_password: <string>]
+
+        # OAUTHBEARER mechanism: exactly one token source must be configured.
+        # The OAuth token to use to authenticate to Kafka.
+        [sasl_oauthbearer_token: <string>]
+        # Optional authorization ID to use when authenticating.
+        [sasl_oauthbearer_zid: <string>]
+        # Optional additional OAuth extensions, as a map of string to string.
+        [sasl_oauthbearer_extensions: <map<string,string>>]
+        # Path to a file containing a JSON-encoded OAuth token (read on every reauthentication).
+        [sasl_oauthbearer_file_path: <string>]
+        # Path to a Unix domain socket to fetch a JSON-encoded OAuth token from via HTTP.
+        [sasl_oauthbearer_http_socket_path: <string>]
+        # Timeout for requesting the token from the HTTP socket.
+        [sasl_oauthbearer_http_socket_timeout: <duration> | default = 10s]
+
+        # AWS_MSK_IAM mechanism: exactly one credentials source must be configured.
+        # The AWS access key ID.
+        [sasl_msk_iam_access_key: <string>]
+        # The AWS secret access key.
+        [sasl_msk_iam_secret_key: <string>]
+        # Optional AWS session token.
+        [sasl_msk_iam_session_token: <string>]
+        # Optional user agent to send when authenticating.
+        [sasl_msk_iam_user_agent: <string>]
+        # Path to a file containing JSON-encoded AWS credentials (read on every reauthentication).
+        [sasl_msk_iam_file_path: <string>]
+        # Path to a Unix domain socket to fetch JSON-encoded AWS credentials from via HTTP.
+        [sasl_msk_iam_http_socket_path: <string>]
+        # Timeout for requesting AWS credentials from the HTTP socket.
+        [sasl_msk_iam_http_socket_timeout: <duration> | default = 10s]
+
+        # Enable TLS for the Kafka client connection. When enabled, the tls_* options below apply.
+        [tls_enabled: <bool> | default = false]
+        [tls_cert_path: <string>]
+        [tls_key_path: <string>]
+        [tls_ca_path: <string>]
+        [tls_server_name: <string>]
+        [tls_insecure_skip_verify: <bool> | default = false]
+        [tls_cipher_suites: <string>]
+        [tls_min_version: <string>]
 
         # Enable auto-creation of Kafka topic if it doesn't exist.
         [auto_create_topic_enabled: <bool> | default = true]

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -227,8 +227,30 @@ distributor:
         client_id: ""
         dial_timeout: 0s
         write_timeout: 0s
+        sasl_mechanism: ""
         sasl_username: ""
         sasl_password: ""
+        sasl_oauthbearer_token: ""
+        sasl_oauthbearer_zid: ""
+        sasl_oauthbearer_extensions: {}
+        sasl_oauthbearer_file_path: ""
+        sasl_oauthbearer_http_socket_path: ""
+        sasl_oauthbearer_http_socket_timeout: 0s
+        sasl_msk_iam_access_key: ""
+        sasl_msk_iam_secret_key: ""
+        sasl_msk_iam_session_token: ""
+        sasl_msk_iam_user_agent: ""
+        sasl_msk_iam_file_path: ""
+        sasl_msk_iam_http_socket_path: ""
+        sasl_msk_iam_http_socket_timeout: 0s
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        tls_cipher_suites: ""
+        tls_min_version: ""
         consumer_group: ""
         consumer_group_offset_commit_interval: 0s
         last_produced_offset_retry_timeout: 0s
@@ -504,8 +526,30 @@ ingest:
         client_id: ""
         dial_timeout: 2s
         write_timeout: 10s
+        sasl_mechanism: PLAIN
         sasl_username: ""
         sasl_password: ""
+        sasl_oauthbearer_token: ""
+        sasl_oauthbearer_zid: ""
+        sasl_oauthbearer_extensions: {}
+        sasl_oauthbearer_file_path: ""
+        sasl_oauthbearer_http_socket_path: ""
+        sasl_oauthbearer_http_socket_timeout: 10s
+        sasl_msk_iam_access_key: ""
+        sasl_msk_iam_secret_key: ""
+        sasl_msk_iam_session_token: ""
+        sasl_msk_iam_user_agent: ""
+        sasl_msk_iam_file_path: ""
+        sasl_msk_iam_http_socket_path: ""
+        sasl_msk_iam_http_socket_timeout: 10s
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        tls_cipher_suites: ""
+        tls_min_version: ""
         consumer_group: ""
         consumer_group_offset_commit_interval: 1s
         last_produced_offset_retry_timeout: 10s

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -223,8 +223,30 @@ distributor:
         client_id: ""
         dial_timeout: 0s
         write_timeout: 0s
+        sasl_mechanism: ""
         sasl_username: ""
         sasl_password: ""
+        sasl_oauthbearer_token: ""
+        sasl_oauthbearer_zid: ""
+        sasl_oauthbearer_extensions: {}
+        sasl_oauthbearer_file_path: ""
+        sasl_oauthbearer_http_socket_path: ""
+        sasl_oauthbearer_http_socket_timeout: 0s
+        sasl_msk_iam_access_key: ""
+        sasl_msk_iam_secret_key: ""
+        sasl_msk_iam_session_token: ""
+        sasl_msk_iam_user_agent: ""
+        sasl_msk_iam_file_path: ""
+        sasl_msk_iam_http_socket_path: ""
+        sasl_msk_iam_http_socket_timeout: 0s
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        tls_cipher_suites: ""
+        tls_min_version: ""
         consumer_group: ""
         consumer_group_offset_commit_interval: 0s
         last_produced_offset_retry_timeout: 0s
@@ -500,8 +522,30 @@ ingest:
         client_id: ""
         dial_timeout: 2s
         write_timeout: 10s
+        sasl_mechanism: PLAIN
         sasl_username: ""
         sasl_password: ""
+        sasl_oauthbearer_token: ""
+        sasl_oauthbearer_zid: ""
+        sasl_oauthbearer_extensions: {}
+        sasl_oauthbearer_file_path: ""
+        sasl_oauthbearer_http_socket_path: ""
+        sasl_oauthbearer_http_socket_timeout: 10s
+        sasl_msk_iam_access_key: ""
+        sasl_msk_iam_secret_key: ""
+        sasl_msk_iam_session_token: ""
+        sasl_msk_iam_user_agent: ""
+        sasl_msk_iam_file_path: ""
+        sasl_msk_iam_http_socket_path: ""
+        sasl_msk_iam_http_socket_timeout: 10s
+        tls_enabled: false
+        tls_cert_path: ""
+        tls_key_path: ""
+        tls_ca_path: ""
+        tls_server_name: ""
+        tls_insecure_skip_verify: false
+        tls_cipher_suites: ""
+        tls_min_version: ""
         consumer_group: ""
         consumer_group_offset_commit_interval: 1s
         last_produced_offset_retry_timeout: 10s

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -2,9 +2,11 @@ package ingest
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -12,10 +14,50 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/backoff"
+	dskittls "github.com/grafana/dskit/crypto/tls"
 	"github.com/grafana/dskit/flagext"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
+
+// SASLMechanism identifies the SASL authentication mechanism used to
+// authenticate with the Kafka backend.
+type SASLMechanism string
+
+// Set implements flag.Value.
+func (s *SASLMechanism) Set(v string) error {
+	if !slices.Contains(saslMechanismOptions, v) {
+		return ErrInvalidSASLMechanism
+	}
+	*s = SASLMechanism(v)
+	return nil
+}
+
+// String implements flag.Value.
+func (s *SASLMechanism) String() string {
+	return string(*s)
+}
+
+// FlagType implements flagext.Value so the generated docs describe the flag as a string.
+func (SASLMechanism) FlagType() string {
+	return "string"
+}
+
+const (
+	SASLMechanismPlain       SASLMechanism = "PLAIN"
+	SASLMechanismScramSHA256 SASLMechanism = "SCRAM-SHA-256"
+	SASLMechanismScramSHA512 SASLMechanism = "SCRAM-SHA-512"
+	SASLMechanismOauthbearer SASLMechanism = "OAUTHBEARER"
+	SASLMechanismMSKIAM      SASLMechanism = "AWS_MSK_IAM"
+)
+
+var saslMechanismOptions = []string{
+	string(SASLMechanismPlain),
+	string(SASLMechanismScramSHA256),
+	string(SASLMechanismScramSHA512),
+	string(SASLMechanismOauthbearer),
+	string(SASLMechanismMSKIAM),
+}
 
 const (
 	// writerRequestTimeoutOverhead is the overhead applied by the Writer to every Kafka timeout.
@@ -42,6 +84,9 @@ var (
 	ErrInvalidMaxConsumerLagAtStartup    = errors.New("the configured max consumer lag at startup must greater or equal than the configured target consumer lag")
 	ErrInvalidProducerMaxRecordSizeBytes = fmt.Errorf("the configured producer max record size bytes must be a value between %d and %d", minProducerRecordDataBytesLimit, maxProducerRecordDataBytesLimit)
 	ErrInconsistentSASLCredentials       = errors.New("the SASL username and password must be both configured to enable SASL authentication")
+	ErrInvalidSASLMechanism              = fmt.Errorf("the configured SASL mechanism is invalid, must be one of: %s", strings.Join(saslMechanismOptions, ", "))
+	ErrSASLMSKIAMBadConfig               = errors.New("exactly one of static credentials, file path, or HTTP socket path must be configured to enable SASL AWS_MSK_IAM authentication")
+	ErrSASLOauthbearerBadConfig          = errors.New("exactly one of OAuth token, file path, or HTTP socket path must be configured to enable SASL OAUTHBEARER authentication")
 )
 
 type Config struct {
@@ -64,8 +109,9 @@ type KafkaConfig struct {
 	DialTimeout  time.Duration `yaml:"dial_timeout"`
 	WriteTimeout time.Duration `yaml:"write_timeout"`
 
-	SASLUsername string         `yaml:"sasl_username"`
-	SASLPassword flagext.Secret `yaml:"sasl_password"`
+	SASL       KafkaAuthConfig `yaml:",inline"`
+	TLSEnabled bool            `yaml:"tls_enabled"`
+	TLS        TLSClientConfig `yaml:",inline"`
 
 	ConsumerGroup                     string        `yaml:"consumer_group"`
 	ConsumerGroupOffsetCommitInterval time.Duration `yaml:"consumer_group_offset_commit_interval"`
@@ -101,8 +147,9 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.DurationVar(&cfg.DialTimeout, prefix+".dial-timeout", 2*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
 	f.DurationVar(&cfg.WriteTimeout, prefix+".write-timeout", 10*time.Second, "How long to wait for an incoming write request to be successfully committed to the Kafka backend.")
 
-	f.StringVar(&cfg.SASLUsername, prefix+".sasl-username", "", "The SASL username for authentication.")
-	f.Var(&cfg.SASLPassword, prefix+".sasl-password", "The SASL password for authentication.")
+	cfg.SASL.RegisterFlagsWithPrefix(prefix+".sasl-", f)
+	f.BoolVar(&cfg.TLSEnabled, prefix+".tls-enabled", false, "Enable TLS for the Kafka client connection.")
+	cfg.TLS.RegisterFlagsWithPrefix(prefix, f)
 
 	f.StringVar(&cfg.ConsumerGroup, prefix+".consumer-group", "", "The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Tempo uses the ingester instance ID to guarantee uniqueness.")
 	f.DurationVar(&cfg.ConsumerGroupOffsetCommitInterval, prefix+".consumer-group-offset-commit-interval", time.Second, "How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left.")
@@ -141,8 +188,14 @@ func (cfg *KafkaConfig) Validate() error {
 		return ErrInvalidMaxConsumerLagAtStartup
 	}
 
-	if (cfg.SASLUsername == "") != (cfg.SASLPassword.String() == "") {
-		return ErrInconsistentSASLCredentials
+	if err := cfg.SASL.Validate(); err != nil {
+		return err
+	}
+
+	if cfg.TLSEnabled {
+		if _, err := cfg.TLS.GetTLSConfig(); err != nil {
+			return fmt.Errorf("invalid Kafka TLS config: %w", err)
+		}
 	}
 
 	return nil
@@ -164,7 +217,13 @@ func (cfg KafkaConfig) SetDefaultNumberOfPartitionsForAutocreatedTopics(logger l
 		return
 	}
 
-	cl, err := kgo.NewClient(commonKafkaClientOptions(cfg, nil, logger)...)
+	opts, err := commonKafkaClientOptions(cfg, nil, logger)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to build kafka client options", "err", err)
+		return
+	}
+
+	cl, err := kgo.NewClient(opts...)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to create kafka client", "err", err)
 		return
@@ -187,4 +246,250 @@ func (cfg KafkaConfig) SetDefaultNumberOfPartitionsForAutocreatedTopics(logger l
 	}
 
 	level.Info(logger).Log("msg", "configured Kafka-wide default number of partitions for auto-created topics (num.partitions)", "value", cfg.AutoCreateTopicDefaultPartitions)
+}
+
+// KafkaAuthConfig holds the SASL authentication config for the Kafka backend.
+type KafkaAuthConfig struct {
+	Mechanism SASLMechanism `yaml:"sasl_mechanism"`
+
+	// For PLAIN and SCRAM-SHA-* mechanisms.
+	Username string         `yaml:"sasl_username"`
+	Password flagext.Secret `yaml:"sasl_password"`
+
+	Oauthbearer KafkaAuthOauthbearerConfig `yaml:",inline"`
+
+	MSKIAM KafkaAuthMSKIAMConfig `yaml:",inline"`
+}
+
+func (cfg *KafkaAuthConfig) RegisterFlags(f *flag.FlagSet) {
+	cfg.RegisterFlagsWithPrefix("", f)
+}
+
+func (cfg *KafkaAuthConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.Mechanism = SASLMechanismPlain
+	f.Var(&cfg.Mechanism, prefix+"mechanism", fmt.Sprintf("The SASL mechanism used to authenticate to Kafka. Supported values: %s. For backwards-compatibility, PLAIN with no username nor password disables SASL.", strings.Join(saslMechanismOptions, ", ")))
+	f.StringVar(&cfg.Username, prefix+"username", "", "The username used to authenticate to Kafka using SASL. To enable SASL, configure both the username and password.")
+	f.Var(&cfg.Password, prefix+"password", "The password used to authenticate the username to Kafka using SASL. To enable SASL, configure both the username and password.")
+	cfg.Oauthbearer.RegisterFlagsWithPrefix(prefix+"oauthbearer-", f)
+	cfg.MSKIAM.RegisterFlagsWithPrefix(prefix+"msk-iam-", f)
+}
+
+func (cfg *KafkaAuthConfig) Validate() error {
+	if cfg.Mechanism == "" {
+		cfg.Mechanism = SASLMechanismPlain
+	}
+	switch cfg.Mechanism {
+	case SASLMechanismPlain:
+		if (cfg.Username == "") != (cfg.Password.String() == "") {
+			return ErrInconsistentSASLCredentials
+		}
+
+	case SASLMechanismScramSHA256, SASLMechanismScramSHA512:
+		if cfg.Username == "" || cfg.Password.String() == "" {
+			return ErrInconsistentSASLCredentials
+		}
+
+	case SASLMechanismOauthbearer:
+		return cfg.Oauthbearer.Validate()
+
+	case SASLMechanismMSKIAM:
+		return cfg.MSKIAM.Validate()
+
+	default:
+		return ErrInvalidSASLMechanism
+	}
+
+	return nil
+}
+
+// kafkaSASLConfig defines how to get a SASL secret: either from a static secret
+// provided in config, from a file, or with HTTP through a domain socket.
+//
+// Exactly one source must be configured; call Validate to enforce this.
+//
+// Because this struct is generic, it cannot have distinct YAML struct tags for
+// each kind of saslSecretConfig. Concrete structs with the same shape (so they
+// can be converted to kafkaSASLConfig) are used instead.
+type kafkaSASLConfig[T saslSecretConfig] struct {
+	Secret            T
+	FilePath          string
+	HTTPSocketPath    string
+	HTTPSocketTimeout time.Duration
+}
+
+var (
+	errNoSecret               = errors.New("no static credentials provided")
+	errIncompleteMSKIAMSecret = errors.New("both access key and secret key must be configured for static AWS_MSK_IAM credentials")
+)
+
+// Validate returns errNoSingleSource unless exactly one of the static secret,
+// file path, or HTTP socket path is configured.
+func (cfg kafkaSASLConfig[T]) Validate(errNoSingleSource error) error {
+	err := cfg.Secret.Validate()
+	if err != nil && !errors.Is(err, errNoSecret) {
+		return err
+	}
+	hasStaticSecret := err == nil
+	sourceFound := false
+	for _, source := range []bool{
+		hasStaticSecret,
+		cfg.FilePath != "",
+		cfg.HTTPSocketPath != "",
+	} {
+		if source {
+			if sourceFound {
+				return errNoSingleSource
+			}
+			sourceFound = true
+		}
+	}
+	if !sourceFound {
+		return errNoSingleSource
+	}
+	return nil
+}
+
+// KafkaAuthOauthbearerConfig holds OAUTHBEARER-specific SASL configuration.
+type KafkaAuthOauthbearerConfig struct {
+	Secret            KafkaOauthbearerStaticConfig `yaml:",inline"`
+	FilePath          string                       `yaml:"sasl_oauthbearer_file_path"`
+	HTTPSocketPath    string                       `yaml:"sasl_oauthbearer_http_socket_path"`
+	HTTPSocketTimeout time.Duration                `yaml:"sasl_oauthbearer_http_socket_timeout"`
+}
+
+func (cfg *KafkaAuthOauthbearerConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.Secret.RegisterFlagsWithPrefix(prefix, f)
+	f.StringVar(&cfg.FilePath, prefix+"file-path", "", `Path to a file containing an OAuth token to authenticate to Kafka. Mutually exclusive with `+prefix+`http-socket-path. The file is read anew on every reauthentication, so it can be updated with fresh tokens. The file must be in JSON format, adhering to this JSON schema: {"type": "object", "required": ["token"], "properties": {"token": {"type": "string"}, "zid": {"type": "string"}, "extensions": {"type": "object", "additionalProperties": {"type": "string"}}}}`)
+	f.StringVar(&cfg.HTTPSocketPath, prefix+"http-socket-path", "", `Path to a Unix domain socket to fetch an OAuth token from via HTTP. Mutually exclusive with `+prefix+`file-path. On every authentication or reauthentication, an HTTP GET / request is made to the socket and the response body is read as JSON. The JSON schema is the same as for `+prefix+`file-path.`)
+	f.DurationVar(&cfg.HTTPSocketTimeout, prefix+"http-socket-timeout", 10*time.Second, "Timeout for requesting the token from the HTTP socket. Effective when "+prefix+"http-socket-path is set.")
+}
+
+func (cfg *KafkaAuthOauthbearerConfig) Validate() error {
+	if cfg.HTTPSocketPath != "" && cfg.HTTPSocketTimeout == 0 {
+		cfg.HTTPSocketTimeout = 10 * time.Second
+	}
+	return kafkaSASLConfig[KafkaOauthbearerStaticConfig]{
+		Secret:            cfg.Secret,
+		FilePath:          cfg.FilePath,
+		HTTPSocketPath:    cfg.HTTPSocketPath,
+		HTTPSocketTimeout: cfg.HTTPSocketTimeout,
+	}.Validate(ErrSASLOauthbearerBadConfig)
+}
+
+// KafkaOauthbearerStaticConfig holds static OAUTHBEARER credentials.
+type KafkaOauthbearerStaticConfig struct {
+	Token      flagext.Secret        `yaml:"sasl_oauthbearer_token"`
+	Zid        string                `yaml:"sasl_oauthbearer_zid"`
+	Extensions oauthbearerExtensions `yaml:"sasl_oauthbearer_extensions"`
+}
+
+// oauthbearerExtensions wraps flagext.LimitsMap so it can be decoded by
+// Tempo's yaml.v2 config loader. flagext.LimitsMap only implements the
+// yaml.v3 Unmarshaler interface (UnmarshalYAML(*yaml.Node)), which yaml.v2
+// does not recognize; decoding sasl_oauthbearer_extensions directly into a
+// LimitsMap therefore fails ("field not found") or, for a zero-value map,
+// panics on assignment into its nil backing map. This wrapper provides a
+// yaml.v2 Unmarshaler that initializes the map before loading values.
+type oauthbearerExtensions struct {
+	flagext.LimitsMap[string]
+}
+
+// UnmarshalYAML implements the yaml.v2 Unmarshaler interface.
+func (e *oauthbearerExtensions) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	raw := map[string]string{}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	if !e.LimitsMap.IsInitialized() {
+		e.LimitsMap = flagext.NewLimitsMap[string](nil)
+	}
+	data := e.Read()
+	clear(data)
+	for k, v := range raw {
+		data[k] = v
+	}
+	return nil
+}
+
+// Validate returns errNoSecret when no token has been set.
+func (s KafkaOauthbearerStaticConfig) Validate() error {
+	if s.Token.String() == "" {
+		return errNoSecret
+	}
+	return nil
+}
+
+func (s *KafkaOauthbearerStaticConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.Var(&s.Token, prefix+"token", "The OAuth token to use to authenticate to Kafka. Consider "+prefix+"file-path instead.")
+	f.StringVar(&s.Zid, prefix+"zid", "", "Optional authorization ID to use when authenticating to Kafka using SASL OAUTHBEARER.")
+	if !s.Extensions.IsInitialized() {
+		s.Extensions.LimitsMap = flagext.NewLimitsMap[string](nil)
+	}
+	f.Var(&s.Extensions.LimitsMap, prefix+"extensions", "Optional additional OAuth extensions to include when authenticating to Kafka using SASL OAUTHBEARER as a JSON object.")
+}
+
+// KafkaAuthMSKIAMConfig holds AWS_MSK_IAM-specific SASL configuration.
+type KafkaAuthMSKIAMConfig struct {
+	Secret            KafkaMSKIAMStaticConfig `yaml:",inline"`
+	FilePath          string                  `yaml:"sasl_msk_iam_file_path"`
+	HTTPSocketPath    string                  `yaml:"sasl_msk_iam_http_socket_path"`
+	HTTPSocketTimeout time.Duration           `yaml:"sasl_msk_iam_http_socket_timeout"`
+}
+
+func (cfg *KafkaAuthMSKIAMConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	cfg.Secret.RegisterFlagsWithPrefix(prefix, f)
+	f.StringVar(&cfg.FilePath, prefix+"file-path", "", `Path to a file containing AWS credentials to authenticate to Kafka using SASL AWS_MSK_IAM. Mutually exclusive with `+prefix+`http-socket-path. The file is read anew on every reauthentication, so it can be updated with fresh credentials. The file must be in JSON format, adhering to this JSON schema: {"type": "object", "required": ["AccessKey", "SecretKey"], "properties": {"AccessKey": {"type": "string"}, "SecretKey": {"type": "string"}, "SessionToken": {"type": "string"}, "UserAgent": {"type": "string"}}}`)
+	f.StringVar(&cfg.HTTPSocketPath, prefix+"http-socket-path", "", `Path to a Unix domain socket to fetch AWS credentials from via HTTP. Mutually exclusive with `+prefix+`file-path. On every authentication or reauthentication, an HTTP GET / request is made to the socket and the response body is read as JSON. The JSON schema is the same as for `+prefix+`file-path.`)
+	f.DurationVar(&cfg.HTTPSocketTimeout, prefix+"http-socket-timeout", 10*time.Second, "Timeout for requesting AWS credentials from the HTTP socket. Effective when "+prefix+"http-socket-path is set.")
+}
+
+func (cfg *KafkaAuthMSKIAMConfig) Validate() error {
+	if cfg.HTTPSocketPath != "" && cfg.HTTPSocketTimeout == 0 {
+		cfg.HTTPSocketTimeout = 10 * time.Second
+	}
+	return kafkaSASLConfig[KafkaMSKIAMStaticConfig]{
+		Secret:            cfg.Secret,
+		FilePath:          cfg.FilePath,
+		HTTPSocketPath:    cfg.HTTPSocketPath,
+		HTTPSocketTimeout: cfg.HTTPSocketTimeout,
+	}.Validate(ErrSASLMSKIAMBadConfig)
+}
+
+// KafkaMSKIAMStaticConfig holds static AWS_MSK_IAM credentials.
+type KafkaMSKIAMStaticConfig struct {
+	AccessKey    flagext.Secret `yaml:"sasl_msk_iam_access_key"`
+	SecretKey    flagext.Secret `yaml:"sasl_msk_iam_secret_key"`
+	SessionToken flagext.Secret `yaml:"sasl_msk_iam_session_token"`
+	UserAgent    string         `yaml:"sasl_msk_iam_user_agent"`
+}
+
+// Validate returns errNoSecret when no access key and secret key have been set,
+// and errIncompleteMSKIAMSecret when only one of them is set.
+func (s KafkaMSKIAMStaticConfig) Validate() error {
+	hasAccessKey := s.AccessKey.String() != ""
+	hasSecretKey := s.SecretKey.String() != ""
+
+	if !hasAccessKey && !hasSecretKey {
+		return errNoSecret
+	}
+	if !hasAccessKey || !hasSecretKey {
+		return errIncompleteMSKIAMSecret
+	}
+	return nil
+}
+
+func (s *KafkaMSKIAMStaticConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.Var(&s.AccessKey, prefix+"access-key", "The AWS access key ID to authenticate to Kafka using SASL AWS_MSK_IAM. Consider "+prefix+"file-path instead.")
+	f.Var(&s.SecretKey, prefix+"secret-key", "The AWS secret access key to authenticate to Kafka using SASL AWS_MSK_IAM. Consider "+prefix+"file-path instead.")
+	f.Var(&s.SessionToken, prefix+"session-token", "Optional AWS session token to authenticate to Kafka using SASL AWS_MSK_IAM.")
+	f.StringVar(&s.UserAgent, prefix+"user-agent", "", "Optional user agent to use when authenticating to Kafka using SASL AWS_MSK_IAM.")
+}
+
+// TLSClientConfig holds the TLS configuration for the Kafka client.
+type TLSClientConfig struct {
+	dskittls.ClientConfig `yaml:",inline"`
+}
+
+func (c *TLSClientConfig) GetTLSConfig() (*tls.Config, error) {
+	return c.ClientConfig.GetTLSConfig()
 }

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -400,7 +400,7 @@ func (e *oauthbearerExtensions) UnmarshalYAML(unmarshal func(interface{}) error)
 	if err := unmarshal(&raw); err != nil {
 		return err
 	}
-	if !e.LimitsMap.IsInitialized() {
+	if !e.IsInitialized() {
 		e.LimitsMap = flagext.NewLimitsMap[string](nil)
 	}
 	data := e.Read()

--- a/pkg/ingest/config_sasl_test.go
+++ b/pkg/ingest/config_sasl_test.go
@@ -1,0 +1,566 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/flagext"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/sasl"
+	awssasl "github.com/twmb/franz-go/pkg/sasl/aws"
+	"github.com/twmb/franz-go/pkg/sasl/oauth"
+	yamlv2 "go.yaml.in/yaml/v2"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// validSASLBaseConfig returns a KafkaConfig with defaults applied and the
+// minimum required fields set so that Validate() passes. Individual tests
+// mutate the SASL fields to exercise the mechanism selection logic.
+func validSASLBaseConfig() KafkaConfig {
+	cfg := KafkaConfig{}
+	flagext.DefaultValues(&cfg)
+	cfg.Address = "localhost:9092"
+	cfg.Topic = "tempo"
+	return cfg
+}
+
+func TestKafkaConfig_RegisterFlags_DefaultSASLMechanism(t *testing.T) {
+	cfg := KafkaConfig{}
+	flagext.DefaultValues(&cfg)
+
+	require.Equal(t, SASLMechanismPlain, cfg.SASL.Mechanism)
+}
+
+func TestSASLMechanism_Set(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  SASLMechanism
+		err   bool
+	}{
+		{"plain", "PLAIN", SASLMechanismPlain, false},
+		{"scram sha256", "SCRAM-SHA-256", SASLMechanismScramSHA256, false},
+		{"scram sha512", "SCRAM-SHA-512", SASLMechanismScramSHA512, false},
+		{"oauthbearer", "OAUTHBEARER", SASLMechanismOauthbearer, false},
+		{"aws msk iam", "AWS_MSK_IAM", SASLMechanismMSKIAM, false},
+		{"unknown", "NOPE", "", true},
+		{"empty", "", "", true},
+		{"wrong case", "plain", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m SASLMechanism
+			err := m.Set(tt.value)
+			if tt.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, m)
+		})
+	}
+}
+
+// TestKafkaConfig_RegisterFlagsWithPrefix_SASLMechanism ensures the mechanism
+// can be configured through the CLI flag, that the flag uses the dotted
+// convention, and that invalid values are rejected at parse time.
+func TestKafkaConfig_RegisterFlagsWithPrefix_SASLMechanism(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want SASLMechanism
+		err  bool
+	}{
+		{"default when unset", nil, SASLMechanismPlain, false},
+		{"explicit scram", []string{"-kafka.sasl-mechanism", "SCRAM-SHA-512"}, SASLMechanismScramSHA512, false},
+		{"explicit msk iam", []string{"-kafka.sasl-mechanism", "AWS_MSK_IAM"}, SASLMechanismMSKIAM, false},
+		{"invalid value rejected", []string{"-kafka.sasl-mechanism", "NOPE"}, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := KafkaConfig{}
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			cfg.RegisterFlags(fs)
+
+			err := fs.Parse(tt.args)
+			if tt.err {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, cfg.SASL.Mechanism)
+		})
+	}
+}
+
+// TestKafkaConfig_RegisterFlagsWithPrefix_DottedFlags guards against the
+// flag-prefix regression where SASL/TLS flags were registered without the
+// leading dot (e.g. "kafkasasl-mechanism").
+func TestKafkaConfig_RegisterFlagsWithPrefix_DottedFlags(t *testing.T) {
+	cfg := KafkaConfig{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.RegisterFlags(fs)
+
+	for _, name := range []string{
+		"kafka.sasl-mechanism",
+		"kafka.sasl-username",
+		"kafka.sasl-password",
+		"kafka.sasl-oauthbearer-token",
+		"kafka.sasl-msk-iam-access-key",
+		"kafka.tls-enabled",
+	} {
+		require.NotNil(t, fs.Lookup(name), "expected flag %q to be registered", name)
+	}
+}
+
+func TestKafkaConfig_Validate_SASLMechanism(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*KafkaConfig)
+		wantErr error
+	}{
+		{
+			name:   "no sasl configured is valid",
+			mutate: func(_ *KafkaConfig) {},
+		},
+		{
+			name: "plain with credentials is valid",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismPlain
+				c.SASL.Username = "user"
+				c.SASL.Password = flagext.SecretWithValue("pass")
+			},
+		},
+		{
+			name: "scram with credentials is valid",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismScramSHA256
+				c.SASL.Username = "user"
+				c.SASL.Password = flagext.SecretWithValue("pass")
+			},
+		},
+		{
+			name: "username without password is inconsistent",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Username = "user"
+			},
+			wantErr: ErrInconsistentSASLCredentials,
+		},
+		{
+			name: "password without username is inconsistent",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Password = flagext.SecretWithValue("pass")
+			},
+			wantErr: ErrInconsistentSASLCredentials,
+		},
+		{
+			name: "scram without credentials is rejected",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismScramSHA512
+			},
+			wantErr: ErrInconsistentSASLCredentials,
+		},
+		{
+			name: "invalid mechanism value is rejected",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanism("NOPE")
+			},
+			wantErr: ErrInvalidSASLMechanism,
+		},
+		{
+			name: "oauthbearer with static token is valid",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismOauthbearer
+				c.SASL.Oauthbearer.Secret.Token = flagext.SecretWithValue("token")
+			},
+		},
+		{
+			name: "oauthbearer with no source is rejected",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismOauthbearer
+			},
+			wantErr: ErrSASLOauthbearerBadConfig,
+		},
+		{
+			name: "oauthbearer with two sources is rejected",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismOauthbearer
+				c.SASL.Oauthbearer.Secret.Token = flagext.SecretWithValue("token")
+				c.SASL.Oauthbearer.FilePath = "/tmp/token.json"
+			},
+			wantErr: ErrSASLOauthbearerBadConfig,
+		},
+		{
+			name: "msk iam with static credentials is valid",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismMSKIAM
+				c.SASL.MSKIAM.Secret.AccessKey = flagext.SecretWithValue("ak")
+				c.SASL.MSKIAM.Secret.SecretKey = flagext.SecretWithValue("sk")
+			},
+		},
+		{
+			name: "msk iam with incomplete static credentials is rejected",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismMSKIAM
+				c.SASL.MSKIAM.Secret.AccessKey = flagext.SecretWithValue("ak")
+			},
+			wantErr: errIncompleteMSKIAMSecret,
+		},
+		{
+			name: "msk iam with no source is rejected",
+			mutate: func(c *KafkaConfig) {
+				c.SASL.Mechanism = SASLMechanismMSKIAM
+			},
+			wantErr: ErrSASLMSKIAMBadConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validSASLBaseConfig()
+			tt.mutate(&cfg)
+
+			err := cfg.Validate()
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestKafkaAuthOptions verifies that kafkaAuthOptions selects the correct
+// franz-go SASL mechanism for each configured value. The mechanism name
+// reported by the franz-go client is used as the observable assertion.
+func TestKafkaAuthOptions(t *testing.T) {
+	tests := []struct {
+		name         string
+		mutate       func(*KafkaAuthConfig)
+		wantSASL     bool
+		wantSASLName string
+	}{
+		{
+			name:     "plain without credentials disables sasl",
+			mutate:   func(c *KafkaAuthConfig) { c.Mechanism = SASLMechanismPlain },
+			wantSASL: false,
+		},
+		{
+			name: "plain with credentials",
+			mutate: func(c *KafkaAuthConfig) {
+				c.Mechanism = SASLMechanismPlain
+				c.Username = "user"
+				c.Password = flagext.SecretWithValue("pass")
+			},
+			wantSASL:     true,
+			wantSASLName: "PLAIN",
+		},
+		{
+			name: "scram sha256",
+			mutate: func(c *KafkaAuthConfig) {
+				c.Mechanism = SASLMechanismScramSHA256
+				c.Username = "user"
+				c.Password = flagext.SecretWithValue("pass")
+			},
+			wantSASL:     true,
+			wantSASLName: "SCRAM-SHA-256",
+		},
+		{
+			name: "scram sha512",
+			mutate: func(c *KafkaAuthConfig) {
+				c.Mechanism = SASLMechanismScramSHA512
+				c.Username = "user"
+				c.Password = flagext.SecretWithValue("pass")
+			},
+			wantSASL:     true,
+			wantSASLName: "SCRAM-SHA-512",
+		},
+		{
+			name: "oauthbearer static token",
+			mutate: func(c *KafkaAuthConfig) {
+				c.Mechanism = SASLMechanismOauthbearer
+				c.Oauthbearer.Secret.Token = flagext.SecretWithValue("token")
+			},
+			wantSASL:     true,
+			wantSASLName: "OAUTHBEARER",
+		},
+		{
+			name: "aws msk iam static credentials",
+			mutate: func(c *KafkaAuthConfig) {
+				c.Mechanism = SASLMechanismMSKIAM
+				c.MSKIAM.Secret.AccessKey = flagext.SecretWithValue("ak")
+				c.MSKIAM.Secret.SecretKey = flagext.SecretWithValue("sk")
+			},
+			wantSASL:     true,
+			wantSASLName: "AWS_MSK_IAM",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := KafkaAuthConfig{}
+			cfg.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError))
+			tt.mutate(&cfg)
+
+			// The generated kgo option is opaque, so assert the selected
+			// mechanism through the helper it delegates to.
+			m, ok, err := saslMechanism(cfg)
+			require.NoError(t, err)
+			opts, err := kafkaAuthOptions(cfg)
+			require.NoError(t, err)
+
+			if !tt.wantSASL {
+				require.False(t, ok)
+				require.Nil(t, m)
+				require.Empty(t, opts)
+				return
+			}
+
+			require.True(t, ok)
+			require.NotNil(t, m)
+			require.Equal(t, tt.wantSASLName, m.Name())
+			require.Len(t, opts, 1)
+		})
+	}
+}
+
+// TestKafkaAuthOptions_UnknownMechanism verifies that an unknown SASL mechanism
+// is reported as an error rather than panicking, so a caller that skips
+// KafkaAuthConfig.Validate cannot crash the process.
+func TestKafkaAuthOptions_UnknownMechanism(t *testing.T) {
+	cfg := KafkaAuthConfig{
+		Mechanism: SASLMechanism("NOPE"),
+		Username:  "user",
+		Password:  flagext.SecretWithValue("pass"),
+	}
+
+	require.NotPanics(t, func() {
+		m, ok, err := saslMechanism(cfg)
+		require.Error(t, err)
+		require.False(t, ok)
+		require.Nil(t, m)
+
+		opts, err := kafkaAuthOptions(cfg)
+		require.Error(t, err)
+		require.Nil(t, opts)
+	})
+}
+
+// TestOauthbearerCredentialsFromSources verifies OAUTHBEARER tokens are read
+// from a file and from a Unix domain socket, and resolved lazily by the
+// mechanism callback.
+func TestOauthbearerCredentialsFromSources(t *testing.T) {
+	secret := oauth.Auth{Token: "some-oauth-token", Zid: "some-zid"}
+
+	setups := map[string]func(t *testing.T) kafkaSASLConfig[KafkaOauthbearerStaticConfig]{
+		"file-based": func(t *testing.T) kafkaSASLConfig[KafkaOauthbearerStaticConfig] {
+			var cfg KafkaAuthOauthbearerConfig
+			cfg.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError))
+			cfg.FilePath = writeSecretToFile(t, secret)
+			return kafkaSASLConfig[KafkaOauthbearerStaticConfig](cfg)
+		},
+		"socket-based": func(t *testing.T) kafkaSASLConfig[KafkaOauthbearerStaticConfig] {
+			var cfg KafkaAuthOauthbearerConfig
+			cfg.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError))
+			cfg.HTTPSocketPath = serveSecretFromSocket(t, secret)
+			return kafkaSASLConfig[KafkaOauthbearerStaticConfig](cfg)
+		},
+	}
+
+	for how, setUp := range setups {
+		t.Run(how, func(t *testing.T) {
+			cfg := setUp(t)
+
+			var gotCallback func(context.Context) (oauth.Auth, error)
+			gotMechanism := saslMechanismFromSources(cfg, func(cb func(context.Context) (oauth.Auth, error)) sasl.Mechanism {
+				gotCallback = cb
+				return oauth.Oauth(cb)
+			})
+			require.NotNil(t, gotCallback)
+			require.NotNil(t, gotMechanism)
+
+			gotSecret, err := gotCallback(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, secret, gotSecret)
+		})
+	}
+}
+
+// TestMSKIAMCredentialsFromSources verifies AWS_MSK_IAM credentials are read
+// from a file and from a Unix domain socket.
+func TestMSKIAMCredentialsFromSources(t *testing.T) {
+	secret := awssasl.Auth{
+		AccessKey:    "AKIDEXAMPLE",
+		SecretKey:    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		SessionToken: "AQoDYXdzEJr//some/session/token",
+	}
+
+	setups := map[string]func(t *testing.T) kafkaSASLConfig[KafkaMSKIAMStaticConfig]{
+		"file-based": func(t *testing.T) kafkaSASLConfig[KafkaMSKIAMStaticConfig] {
+			var cfg KafkaAuthMSKIAMConfig
+			cfg.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError))
+			cfg.FilePath = writeSecretToFile(t, secret)
+			return kafkaSASLConfig[KafkaMSKIAMStaticConfig](cfg)
+		},
+		"socket-based": func(t *testing.T) kafkaSASLConfig[KafkaMSKIAMStaticConfig] {
+			var cfg KafkaAuthMSKIAMConfig
+			cfg.RegisterFlagsWithPrefix("", flag.NewFlagSet("", flag.PanicOnError))
+			cfg.HTTPSocketPath = serveSecretFromSocket(t, secret)
+			return kafkaSASLConfig[KafkaMSKIAMStaticConfig](cfg)
+		},
+	}
+
+	for how, setUp := range setups {
+		t.Run(how, func(t *testing.T) {
+			cfg := setUp(t)
+
+			var gotCallback func(context.Context) (awssasl.Auth, error)
+			gotMechanism := saslMechanismFromSources(cfg, func(cb func(context.Context) (awssasl.Auth, error)) sasl.Mechanism {
+				gotCallback = cb
+				return awssasl.ManagedStreamingIAM(cb)
+			})
+			require.NotNil(t, gotCallback)
+			require.NotNil(t, gotMechanism)
+
+			gotSecret, err := gotCallback(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, secret, gotSecret)
+		})
+	}
+}
+
+// TestKafkaConfig_Validate_TLS ensures TLS misconfiguration is surfaced when
+// TLS is enabled and ignored when it is disabled.
+func TestKafkaConfig_Validate_TLS(t *testing.T) {
+	t.Run("enabled with bad cert path fails", func(t *testing.T) {
+		cfg := validSASLBaseConfig()
+		cfg.TLSEnabled = true
+		cfg.TLS.CertPath = "/does/not/exist.pem" // key missing -> invalid pair
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("disabled ignores TLS config", func(t *testing.T) {
+		cfg := validSASLBaseConfig()
+		cfg.TLSEnabled = false
+		cfg.TLS.CertPath = "/does/not/exist.pem"
+		require.NoError(t, cfg.Validate())
+	})
+}
+
+// TestKafkaClientConstructors_TLSError verifies that a failure building the TLS
+// config surfaces as an error from the client constructors rather than a panic.
+// This guards the error plumbing in commonKafkaClientOptions.
+func TestKafkaClientConstructors_TLSError(t *testing.T) {
+	badTLSConfig := func() KafkaConfig {
+		cfg := validSASLBaseConfig()
+		cfg.TLSEnabled = true
+		// A certificate without a key is an invalid pair, so GetTLSConfig fails
+		// without any network I/O.
+		cfg.TLS.CertPath = "/does/not/exist.pem"
+		return cfg
+	}
+
+	t.Run("NewWriterClient", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, err := NewWriterClient(badTLSConfig(), 1, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("NewReaderClient", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, err := NewReaderClient(badTLSConfig(), nil, log.NewNopLogger())
+			require.Error(t, err)
+		})
+	})
+}
+
+func writeSecretToFile(t *testing.T, secret any) string {
+	t.Helper()
+
+	js, err := json.Marshal(secret)
+	require.NoError(t, err)
+	filePath := filepath.Join(t.TempDir(), "secret.json")
+	require.NoError(t, os.WriteFile(filePath, js, 0o600))
+
+	return filePath
+}
+
+func serveSecretFromSocket(t *testing.T, secret any) string {
+	t.Helper()
+
+	js, err := json.Marshal(secret)
+	require.NoError(t, err)
+
+	// Unix socket paths have a low length limit (~104 bytes on macOS), so use a
+	// short base directory under /tmp rather than t.TempDir().
+	sockDir, err := os.MkdirTemp("/tmp", "tempo-kafka")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(sockDir) })
+
+	socketPath := filepath.Join(sockDir, "secret.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	server := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(js)
+		}),
+	}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	return socketPath
+}
+
+// TestOauthbearerExtensionsYAML verifies that sasl_oauthbearer_extensions
+// decodes correctly through Tempo's yaml.v2 config loader. flagext.LimitsMap
+// only implements the yaml.v3 Unmarshaler interface, so without the
+// oauthbearerExtensions wrapper this field either fails to decode or panics
+// on a nil backing map when no flags have been registered first.
+func TestOauthbearerExtensionsYAML(t *testing.T) {
+	t.Run("direct type", func(t *testing.T) {
+		var cfg KafkaOauthbearerStaticConfig
+		y := []byte("sasl_oauthbearer_token: tok\n" +
+			"sasl_oauthbearer_zid: zid\n" +
+			"sasl_oauthbearer_extensions:\n  foo: bar\n  baz: qux\n")
+
+		require.NotPanics(t, func() {
+			require.NoError(t, yamlv2.UnmarshalStrict(y, &cfg))
+		})
+		require.Equal(t, "tok", cfg.Token.String())
+		require.Equal(t, "zid", cfg.Zid)
+		require.Equal(t, map[string]string{"foo": "bar", "baz": "qux"}, cfg.Extensions.Read())
+	})
+
+	t.Run("inline chain via KafkaConfig", func(t *testing.T) {
+		var cfg KafkaConfig
+		y := []byte("sasl_oauthbearer_extensions:\n  a: b\n")
+
+		require.NotPanics(t, func() {
+			require.NoError(t, yamlv2.Unmarshal(y, &cfg))
+		})
+		require.Equal(t, map[string]string{"a": "b"}, cfg.SASL.Oauthbearer.Secret.Extensions.Read())
+	})
+
+	t.Run("extensions absent does not panic", func(t *testing.T) {
+		var cfg KafkaConfig
+		require.NotPanics(t, func() {
+			require.NoError(t, yamlv2.Unmarshal([]byte("sasl_oauthbearer_token: tok\n"), &cfg))
+		})
+	})
+}

--- a/pkg/ingest/kafka_tls_sasl_test.go
+++ b/pkg/ingest/kafka_tls_sasl_test.go
@@ -1,0 +1,284 @@
+package ingest_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/tempo/pkg/ingest"
+)
+
+// TestKafkaClient_MTLS_SCRAM_RoundTrip is an end-to-end test that exercises the
+// Kafka client authentication paths against a real (fake) broker configured for
+// mutual TLS and SASL/SCRAM-SHA-256. It produces a record with NewWriterClient
+// and consumes it back with NewReaderClient, proving that both the TLS transport
+// (including client-certificate mTLS) and the SCRAM mechanism are wired up
+// correctly.
+func TestKafkaClient_MTLS_SCRAM_RoundTrip(t *testing.T) {
+	const (
+		topic    = "mtls-scram-topic"
+		saslUser = "tempo"
+		saslPass = "tempo-secret"
+	)
+
+	certs := generateTestCerts(t)
+
+	// Server TLS config: present the server cert and require a client cert
+	// signed by our CA (mTLS).
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{certs.serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certs.caPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	fake, err := kfake.NewCluster(
+		kfake.NumBrokers(1),
+		kfake.SeedTopics(1, topic),
+		kfake.TLS(serverTLS),
+		kfake.EnableSASL(),
+		kfake.Superuser("SCRAM-SHA-256", saslUser, saslPass),
+	)
+	require.NoError(t, err)
+	t.Cleanup(fake.Close)
+
+	address := fake.ListenAddrs()[0]
+
+	cfg := mtlsScramKafkaConfig(t, address, topic, certs, saslUser, saslPass)
+	require.NoError(t, cfg.Validate())
+
+	logger := log.NewNopLogger()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Produce a record over mTLS + SCRAM.
+	writer, err := ingest.NewWriterClient(cfg, 1, logger, prometheus.NewPedanticRegistry())
+	require.NoError(t, err)
+	t.Cleanup(writer.Close)
+
+	want := []byte("hello over mtls and scram")
+	res := writer.ProduceSync(ctx, &kgo.Record{
+		Topic:     topic,
+		Partition: 0,
+		Value:     want,
+	})
+	require.NoError(t, res.FirstErr(), "producing over mTLS+SCRAM should succeed")
+
+	// Consume the record back with a fresh client that must independently
+	// authenticate over mTLS + SCRAM.
+	reader, err := ingest.NewReaderClient(
+		cfg,
+		ingest.NewReaderClientMetrics("test", prometheus.NewPedanticRegistry()),
+		logger,
+		kgo.ConsumeTopics(topic),
+		kgo.ConsumeResetOffset(kgo.NewOffset().AtStart()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(reader.Close)
+
+	var got []byte
+	require.Eventually(t, func() bool {
+		fetches := reader.PollFetches(ctx)
+		if err := fetches.Err(); err != nil {
+			return false
+		}
+		iter := fetches.RecordIter()
+		if iter.Done() {
+			return false
+		}
+		got = iter.Next().Value
+		return true
+	}, 20*time.Second, 100*time.Millisecond, "should consume the produced record")
+
+	require.Equal(t, want, got)
+}
+
+// TestKafkaClient_MTLS_MissingClientCert verifies that the broker rejects a
+// client that does not present a certificate when mTLS is required. This proves
+// the mTLS requirement is actually enforced end-to-end rather than TLS being a
+// no-op.
+func TestKafkaClient_MTLS_MissingClientCert(t *testing.T) {
+	const (
+		topic    = "mtls-required-topic"
+		saslUser = "tempo"
+		saslPass = "tempo-secret"
+	)
+
+	certs := generateTestCerts(t)
+
+	serverTLS := &tls.Config{
+		Certificates: []tls.Certificate{certs.serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    certs.caPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	fake, err := kfake.NewCluster(
+		kfake.NumBrokers(1),
+		kfake.SeedTopics(1, topic),
+		kfake.TLS(serverTLS),
+		kfake.EnableSASL(),
+		kfake.Superuser("SCRAM-SHA-256", saslUser, saslPass),
+	)
+	require.NoError(t, err)
+	t.Cleanup(fake.Close)
+
+	address := fake.ListenAddrs()[0]
+
+	// Configure a client that trusts the CA and has SCRAM credentials but does
+	// NOT present a client certificate.
+	cfg := mtlsScramKafkaConfig(t, address, topic, certs, saslUser, saslPass)
+	cfg.TLS.CertPath = ""
+	cfg.TLS.KeyPath = ""
+	// Fail fast: a rejected mTLS handshake should surface quickly rather than
+	// retrying up to the default write timeout.
+	cfg.WriteTimeout = 3 * time.Second
+	require.NoError(t, cfg.Validate())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	writer, err := ingest.NewWriterClient(cfg, 1, log.NewNopLogger(), prometheus.NewPedanticRegistry())
+	require.NoError(t, err)
+	t.Cleanup(writer.Close)
+
+	res := writer.ProduceSync(ctx, &kgo.Record{Topic: topic, Partition: 0, Value: []byte("nope")})
+	require.Error(t, res.FirstErr(), "producing without a client certificate must fail when mTLS is required")
+}
+
+func mtlsScramKafkaConfig(t *testing.T, address, topic string, certs testCerts, user, pass string) ingest.KafkaConfig {
+	t.Helper()
+
+	cfg := ingest.KafkaConfig{}
+	flagext.DefaultValues(&cfg)
+	cfg.Address = address
+	cfg.Topic = topic
+	cfg.WriteTimeout = 10 * time.Second
+
+	// SASL/SCRAM-SHA-256.
+	cfg.SASL.Mechanism = ingest.SASLMechanismScramSHA256
+	cfg.SASL.Username = user
+	cfg.SASL.Password = flagext.SecretWithValue(pass)
+
+	// mTLS: present our client cert and trust the CA that signed the broker.
+	cfg.TLSEnabled = true
+	cfg.TLS.CertPath = certs.clientCertPath
+	cfg.TLS.KeyPath = certs.clientKeyPath
+	cfg.TLS.CAPath = certs.caPath
+	cfg.TLS.ServerName = "localhost"
+
+	return cfg
+}
+
+type testCerts struct {
+	caPool *x509.CertPool
+	caPath string
+
+	serverCert tls.Certificate
+
+	clientCertPath string
+	clientKeyPath  string
+}
+
+// generateTestCerts creates a self-signed CA and issues a server and a client
+// certificate from it. The CA and client cert/key are written to files (as the
+// dskit TLS config loads them from disk); the server cert is returned in-memory
+// for the kfake broker.
+func generateTestCerts(t *testing.T) testCerts {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	// Certificate authority.
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tempo-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	caPath := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, caPEM, 0o600))
+
+	// issueCert signs a leaf certificate with the CA.
+	issueCert := func(cn string, isServer bool) (certPEM, keyPEM []byte) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		}
+		if isServer {
+			tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+			tmpl.DNSNames = []string{"localhost"}
+			tmpl.IPAddresses = []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+		} else {
+			tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+		}
+
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		require.NoError(t, err)
+
+		certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+		require.NoError(t, err)
+		keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+		return certPEM, keyPEM
+	}
+
+	// Server certificate (kept in-memory for the broker).
+	serverCertPEM, serverKeyPEM := issueCert("localhost", true)
+	serverCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	require.NoError(t, err)
+
+	// Client certificate (written to disk for the dskit TLS config).
+	clientCertPEM, clientKeyPEM := issueCert("tempo-client", false)
+	clientCertPath := filepath.Join(dir, "client.pem")
+	clientKeyPath := filepath.Join(dir, "client-key.pem")
+	require.NoError(t, os.WriteFile(clientCertPath, clientCertPEM, 0o600))
+	require.NoError(t, os.WriteFile(clientKeyPath, clientKeyPEM, 0o600))
+
+	return testCerts{
+		caPool:         caPool,
+		caPath:         caPath,
+		serverCert:     serverCert,
+		clientCertPath: clientCertPath,
+		clientKeyPath:  clientKeyPath,
+	}
+}

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -201,7 +201,8 @@ func createTestKafkaConfig(clusterAddr string) KafkaConfig {
 
 func createTestKafkaClient(t *testing.T, cfg KafkaConfig) *kgo.Client {
 	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
-	opts := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	opts, err := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	require.NoError(t, err)
 
 	// Use the manual partitioner because produceRecord() utility explicitly specifies
 	// the partition to write to in the kgo.Record itself.

--- a/pkg/ingest/reader_client.go
+++ b/pkg/ingest/reader_client.go
@@ -19,7 +19,11 @@ import (
 func NewReaderClient(kafkaCfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger, opts ...kgo.Opt) (*kgo.Client, error) {
 	const fetchMaxBytes = 100_000_000
 
-	opts = append(opts, commonKafkaClientOptions(kafkaCfg, metrics, logger)...)
+	commonOpts, err := commonKafkaClientOptions(kafkaCfg, metrics, logger)
+	if err != nil {
+		return nil, fmt.Errorf("creating kafka reader client options: %w", err)
+	}
+	opts = append(opts, commonOpts...)
 	opts = append(
 		opts,
 		kgo.FetchMinBytes(1),

--- a/pkg/ingest/sasl.go
+++ b/pkg/ingest/sasl.go
@@ -1,0 +1,186 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sasl"
+	awssasl "github.com/twmb/franz-go/pkg/sasl/aws"
+	"github.com/twmb/franz-go/pkg/sasl/oauth"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
+	"github.com/twmb/franz-go/pkg/sasl/scram"
+)
+
+// kafkaAuthOptions returns the kgo options needed to enable SASL authentication
+// for the configured mechanism. It returns nil options when SASL is disabled
+// (PLAIN with no username) and an error if the configured mechanism
+// or its credential sources are invalid.
+func kafkaAuthOptions(cfg KafkaAuthConfig) ([]kgo.Opt, error) {
+	m, ok, err := saslMechanism(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, nil
+	}
+	return []kgo.Opt{kgo.SASL(m)}, nil
+}
+
+// saslMechanism builds the franz-go SASL mechanism for the configured
+// authentication mechanism. It first validates the config (normalizing an unset
+// mechanism to PLAIN). The bool is false (with a nil mechanism and nil error)
+// when SASL is disabled, which is the case for the PLAIN mechanism with no
+// username configured. An invalid config returns an error.
+func saslMechanism(cfg KafkaAuthConfig) (sasl.Mechanism, bool, error) {
+	if err := (&cfg).Validate(); err != nil {
+		return nil, false, err
+	}
+	// For backwards compatibility, PLAIN with no username
+	// is treated as SASL disabled.
+	if cfg.Mechanism == SASLMechanismPlain && cfg.Username == "" {
+		return nil, false, nil
+	}
+
+	switch cfg.Mechanism {
+	case SASLMechanismScramSHA256:
+		return scram.Auth{
+			User: cfg.Username,
+			Pass: cfg.Password.String(),
+		}.AsSha256Mechanism(), true, nil
+	case SASLMechanismScramSHA512:
+		return scram.Auth{
+			User: cfg.Username,
+			Pass: cfg.Password.String(),
+		}.AsSha512Mechanism(), true, nil
+	case SASLMechanismPlain:
+		return plain.Auth{
+			User: cfg.Username,
+			Pass: cfg.Password.String(),
+		}.AsMechanism(), true, nil
+	case SASLMechanismOauthbearer:
+		return cfg.Oauthbearer.mechanism(), true, nil
+	case SASLMechanismMSKIAM:
+		return cfg.MSKIAM.mechanism(), true, nil
+	default:
+		return nil, false, fmt.Errorf("unknown SASL mechanism: %v", cfg.Mechanism)
+	}
+}
+
+// saslSecretConfig configures a static secret. It may be empty.
+type saslSecretConfig interface {
+	// Validate returns errNoSecret when no static secret is set. It may return
+	// other validation errors.
+	Validate() error
+	// mechanism constructs a sasl.Mechanism from the static secret, if one is set.
+	mechanism() (sasl.Mechanism, bool)
+}
+
+func (cfg KafkaAuthOauthbearerConfig) mechanism() sasl.Mechanism {
+	return saslMechanismFromSources(kafkaSASLConfig[KafkaOauthbearerStaticConfig](cfg), oauth.Oauth)
+}
+
+func (s KafkaOauthbearerStaticConfig) mechanism() (sasl.Mechanism, bool) {
+	if err := s.Validate(); err != nil {
+		return nil, false
+	}
+	return oauth.Auth{
+		Token:      s.Token.String(),
+		Zid:        s.Zid,
+		Extensions: s.Extensions.Read(),
+	}.AsMechanism(), true
+}
+
+func (cfg KafkaAuthMSKIAMConfig) mechanism() sasl.Mechanism {
+	return saslMechanismFromSources(kafkaSASLConfig[KafkaMSKIAMStaticConfig](cfg), awssasl.ManagedStreamingIAM)
+}
+
+func (s KafkaMSKIAMStaticConfig) mechanism() (sasl.Mechanism, bool) {
+	if err := s.Validate(); err != nil {
+		return nil, false
+	}
+	return awssasl.Auth{
+		AccessKey:    s.AccessKey.String(),
+		SecretKey:    s.SecretKey.String(),
+		SessionToken: s.SessionToken.String(),
+		UserAgent:    s.UserAgent,
+	}.AsManagedStreamingIAMMechanism(), true
+}
+
+// saslMechanismFromSources returns the sasl.Mechanism to be passed to the Kafka
+// client, resolving the secret from a static value, a file, or an HTTP socket.
+//
+// Validate must have been called on cfg beforehand: a config with no source
+// configured panics because it indicates a programmer error.
+func saslMechanismFromSources[T saslSecretConfig, A any](cfg kafkaSASLConfig[T], fromCallback func(func(context.Context) (A, error)) sasl.Mechanism) sasl.Mechanism {
+	if m, ok := cfg.Secret.mechanism(); ok {
+		return m
+	}
+	if cfg.FilePath != "" {
+		return fromCallback(func(_ context.Context) (A, error) {
+			f, err := os.ReadFile(cfg.FilePath)
+			if err != nil {
+				var zero A
+				return zero, err
+			}
+			var a A
+			err = json.Unmarshal(f, &a)
+			return a, err
+		})
+	}
+	if cfg.HTTPSocketPath != "" {
+		return fromCallback(func(ctx context.Context) (A, error) {
+			return requestJSONFromSocket[A](ctx, cfg.HTTPSocketPath, cfg.HTTPSocketTimeout)
+		})
+	}
+	panic("invalid kafkaSASLConfig: Validate must be called first")
+}
+
+// requestJSONFromSocket performs an HTTP GET against a Unix domain socket and
+// decodes the JSON response body into a value of type T.
+func requestJSONFromSocket[T any](ctx context.Context, socketPath string, timeout time.Duration) (T, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	transport := &http.Transport{
+		Proxy:             nil,
+		DisableKeepAlives: true,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+		},
+	}
+
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://credentials/", nil)
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("creating request for HTTP socket %s: %w", socketPath, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("requesting credentials from HTTP socket %s: %w", socketPath, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var zero T
+		return zero, fmt.Errorf("requesting credentials from HTTP socket %s: unexpected status %s", socketPath, resp.Status)
+	}
+
+	var a T
+	if err := json.NewDecoder(resp.Body).Decode(&a); err != nil {
+		var zero T
+		return zero, fmt.Errorf("parsing credentials from HTTP socket %s: %w", socketPath, err)
+	}
+	return a, nil
+}

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
-	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/plugin/kotel"
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.opentelemetry.io/otel/propagation"
@@ -36,8 +35,13 @@ func NewWriterClient(kafkaCfg KafkaConfig, maxInflightProduceRequests int, logge
 		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes),
 	)
 
+	commonOpts, err := commonKafkaClientOptions(kafkaCfg, metrics, logger)
+	if err != nil {
+		return nil, fmt.Errorf("creating kafka writer client options: %w", err)
+	}
+
 	opts := append(
-		commonKafkaClientOptions(kafkaCfg, metrics, logger),
+		commonOpts,
 		kgo.RequiredAcks(kgo.AllISRAcks()),
 		kgo.DefaultProduceTopic(kafkaCfg.Topic),
 
@@ -102,7 +106,7 @@ func (o onlySampledTraces) Inject(ctx context.Context, carrier propagation.TextM
 	o.TextMapPropagator.Inject(ctx, carrier)
 }
 
-func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger) []kgo.Opt {
+func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger) ([]kgo.Opt, error) {
 	opts := []kgo.Opt{
 		kgo.ClientID(cfg.ClientID),
 		kgo.SeedBrokers(cfg.Address),
@@ -150,14 +154,20 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		opts = append(opts, kgo.AllowAutoTopicCreation())
 	}
 
-	// SASL plain auth.
-	if cfg.SASLUsername != "" && cfg.SASLPassword.String() != "" {
-		opts = append(opts, kgo.SASL(plain.Plain(func(_ context.Context) (plain.Auth, error) {
-			return plain.Auth{
-				User: cfg.SASLUsername,
-				Pass: cfg.SASLPassword.String(),
-			}, nil
-		})))
+	// SASL auth. The configured mechanism determines how credentials are
+	// exchanged; kafkaAuthOptions returns nil options when SASL is disabled.
+	authOpts, err := kafkaAuthOptions(cfg.SASL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Kafka SASL config: %w", err)
+	}
+	opts = append(opts, authOpts...)
+
+	if cfg.TLSEnabled {
+		tlsConfig, err := cfg.TLS.GetTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build Kafka TLS config: %w", err)
+		}
+		opts = append(opts, kgo.DialTLSConfig(tlsConfig))
 	}
 
 	tracer := kotel.NewTracer(
@@ -172,7 +182,7 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		opts = append(opts, kgo.WithHooks(metrics))
 	}
 
-	return opts
+	return opts, nil
 }
 
 // Producer is a kgo.Client wrapper exposing some higher level features and metrics useful for producers.

--- a/vendor/github.com/twmb/franz-go/pkg/sasl/aws/aws.go
+++ b/vendor/github.com/twmb/franz-go/pkg/sasl/aws/aws.go
@@ -1,0 +1,281 @@
+// Package aws provides AWS_MSK_IAM sasl authentication as specified in the
+// Java source.
+//
+// The Java source can be found at https://github.com/aws/aws-msk-iam-auth.
+package aws
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/twmb/franz-go/pkg/sasl"
+)
+
+// Auth contains an AWS AccessKey and SecretKey for authentication.
+//
+// This client may add fields to this struct in the future if Kafka adds more
+// capabilities to MSK IAM.
+type Auth struct {
+	// AccessKey is an AWS AccessKey.
+	AccessKey string
+
+	// AccessKey is an AWS SecretKey.
+	SecretKey string
+
+	// SessionToken, if non-empty, is a session / security token to use for
+	// authentication.
+	//
+	// See the following link for more details:
+	//
+	//     https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html
+	//
+	SessionToken string
+
+	// UserAgent is the user agent to for the client to use when connecting
+	// to Kafka, overriding the default "franz-go/<runtime.Version()>/<hostname>".
+	//
+	// Setting a UserAgent allows authorizing based on the aws:UserAgent
+	// condition key; see the following link for more details:
+	//
+	//     https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-useragent
+	//
+	UserAgent string
+
+	_ struct{} // require explicit field initialization
+}
+
+var hostname, _ = os.Hostname()
+
+func init() {
+	if hostname == "" {
+		hostname = "unknown"
+	}
+}
+
+// AsManagedStreamingIAMMechanism returns a sasl mechanism that will use 'a' as
+// credentials for all sasl sessions.
+//
+// This is a shortcut for using the ManagedStreamingIAM function and is useful
+// when you do not need to live-rotate credentials.
+func (a Auth) AsManagedStreamingIAMMechanism() sasl.Mechanism {
+	return ManagedStreamingIAM(func(context.Context) (Auth, error) {
+		return a, nil
+	})
+}
+
+type mskiam func(context.Context) (Auth, error)
+
+// ManagedStreamingIAM returns a sasl mechanism that will call authFn whenever
+// sasl authentication is needed. The returned Auth is used for a single
+// session.
+func ManagedStreamingIAM(authFn func(context.Context) (Auth, error)) sasl.Mechanism {
+	return mskiam(authFn)
+}
+
+func (mskiam) Name() string { return "AWS_MSK_IAM" }
+
+func (fn mskiam) Authenticate(ctx context.Context, host string) (sasl.Session, []byte, error) {
+	auth, err := fn(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	challenge, err := challenge(auth, host)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return new(session), challenge, nil
+}
+
+type session struct{}
+
+func (session) Challenge(resp []byte) (bool, []byte, error) {
+	if len(resp) == 0 {
+		return false, nil, errors.New("empty challenge response: failed")
+	}
+	return true, nil, nil
+}
+
+const service = "kafka-cluster"
+
+func challenge(auth Auth, host string) ([]byte, error) {
+	host, _, err := net.SplitHostPort(host) // we do not need the port
+	if err != nil {
+		return nil, err
+	}
+	region, err := identifyRegion(host)
+	if err != nil {
+		region = os.Getenv("AWS_REGION")
+		if region == "" {
+			region = os.Getenv("AWS_DEFAULT_REGION")
+		}
+		if region == "" {
+			return nil, err
+		}
+	}
+
+	var (
+		timestamp = time.Now().UTC().Format("20060102T150405Z")
+		date      = timestamp[:8] // 20060102
+		scope     = scope(date, region)
+		v         = make(url.Values)
+	)
+
+	v.Set("Action", service+":Connect")
+	v.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	v.Set("X-Amz-Credential", auth.AccessKey+"/"+scope)
+	v.Set("X-Amz-Date", timestamp)
+	v.Set("X-Amz-Expires", "300") // 5 min
+	v.Set("X-Amz-SignedHeaders", "host")
+	if auth.SessionToken != "" {
+		v.Set("X-Amz-Security-Token", auth.SessionToken)
+	}
+
+	qps := strings.ReplaceAll(v.Encode(), "+", "%20")
+
+	canonicalRequest := task1(host, qps)
+	sts := task2(timestamp, scope, canonicalRequest)
+	signature := task3(auth.SecretKey, region, date, sts)
+
+	v.Set("X-Amz-Signature", signature) // task4
+
+	// According to the Java source and manual testing, all values in our
+	// challenge map must be lowercased, and we MUST have host, and we MUST
+	// have version, and version MUST be 2020_10_22.
+	keyvals := make(map[string]string)
+	for key, values := range v {
+		keyvals[strings.ToLower(key)] = values[0]
+	}
+	keyvals["host"] = host
+	keyvals["version"] = "2020_10_22"
+	ua := auth.UserAgent
+	if ua == "" {
+		ua = strings.Join([]string{"franz-go", runtime.Version(), hostname}, "/")
+	}
+	keyvals["user-agent"] = ua
+
+	marshaled, err := json.Marshal(keyvals)
+	if err != nil {
+		return nil, err
+	}
+	return marshaled, nil
+}
+
+// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+// "CredentialScope", Part 3
+func scope(date, region string) string {
+	return strings.Join([]string{date, region, service, "aws4_request"}, "/")
+}
+
+// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+func task1(host, qps string) []byte {
+	// We start with our defined method, "GET", and the defined empty path,
+	// "/". For query parameters, we have to escape +'s with %20, but we did
+	// that above when building our URL.
+	//
+	//   HTTPRequestMethod + '\n' +
+	//   CanonicalURI + '\n' +
+	//   CanonicalQueryString + '\n' +
+	canon := make([]byte, 0, 200)
+	canon = append(canon, "GET\n"...)
+	canon = append(canon, "/\n"...)
+	canon = append(canon, qps...)
+	canon = append(canon, '\n')
+
+	// We only sign one header, the host. Each signed header is followed by
+	// a newline, and then the canonical header block is followed itself by
+	// a newline.
+	//
+	//   CanonicalHeaders + '\n' +
+	//   SignedHeaders + '\n' +
+	canon = append(canon, "host:"...)
+	canon = append(canon, host...)
+	canon = append(canon, "\n\nhost\n"...)
+
+	// Finally, we add our empty body.
+	//
+	//   HexEncode(Hash(RequestPayload))
+	const emptyBody = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	return append(canon, emptyBody...)
+}
+
+// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+func task2(timestamp, scope string, canonicalRequest []byte) []byte {
+	toSign := make([]byte, 0, 512)
+	toSign = append(toSign, "AWS4-HMAC-SHA256\n"...)
+	toSign = append(toSign, timestamp...)
+	toSign = append(toSign, '\n')
+	toSign = append(toSign, scope...)
+	toSign = append(toSign, '\n')
+	canonHash := sha256.Sum256(canonicalRequest)
+	hexBuf := make([]byte, 64) // 32 bytes to 64
+	hex.Encode(hexBuf, canonHash[:])
+	toSign = append(toSign, hexBuf...)
+	return toSign
+}
+
+var aws4requestBytes = []byte("aws4_request")
+
+// https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+func task3(secretKey, region, date string, sts []byte) string {
+	key := make([]byte, 0, 100)
+	key = append(key, "AWS4"...)
+	key = append(key, secretKey...)
+
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(date)) // kDate
+
+	key = h.Sum(key[:0])
+	h = hmac.New(sha256.New, key)
+	h.Write([]byte(region)) // kRegion
+
+	key = h.Sum(key[:0])
+	h = hmac.New(sha256.New, key)
+	h.Write([]byte(service)) // kService
+
+	key = h.Sum(key[:0])
+	h = hmac.New(sha256.New, key)
+	h.Write(aws4requestBytes) // kSigning
+
+	key = h.Sum(key[:0])
+	h = hmac.New(sha256.New, key)
+	h.Write(sts)
+
+	return hex.EncodeToString(h.Sum(key[:0]))
+}
+
+// aws-java-sdk-core/src/main/resources/com/amazonaws/partitions/endpoints.json
+var suffixes = []string{
+	".amazonaws.com",
+	".amazonaws.com.cn",
+	".c2s.ic.gov",
+	".sc2s.sgov.gov",
+}
+
+// aws-java-sdk-core/src/main/java/com/amazonaws/partitions/PartitionMetadataProvider.java
+// tryGetRegionByEndpointDnsSuffix
+func identifyRegion(host string) (string, error) {
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(host, suffix) {
+			serviceRegion := strings.TrimSuffix(host, suffix)
+			regionDot := strings.LastIndexByte(serviceRegion, '.')
+			if regionDot == -1 {
+				break
+			}
+			return serviceRegion[regionDot+1:], nil
+		}
+	}
+	return "", fmt.Errorf("cannot determine the region in %+q", host)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1588,6 +1588,7 @@ github.com/twmb/franz-go/pkg/kgo/internal/sticky
 github.com/twmb/franz-go/pkg/kgo/internal/xsync
 github.com/twmb/franz-go/pkg/kversion
 github.com/twmb/franz-go/pkg/sasl
+github.com/twmb/franz-go/pkg/sasl/aws
 github.com/twmb/franz-go/pkg/sasl/oauth
 github.com/twmb/franz-go/pkg/sasl/plain
 github.com/twmb/franz-go/pkg/sasl/scram


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Wire up SASLMechanism option so operators can select a SASL mechanism other than PLAIN when authenticating with Kafka as well as enable TLS.


- Add a `sasl_mechanism` config field and `-kafka.sasl-mechanism` flag, defaulting to PLAIN to preserve existing behaviour.
- Support PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM, and OAUTHBEARER. 
- Validate the mechanism and require credentials when a non-default mechanism is set.

Refs  #7580

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)