### PR TITLE
servicegraphs: reuse borrowed labels and pooled edges

### DIFF
--- a/.chloggen/generator-servicegraphs-borrowed-labels.yaml
+++ b/.chloggen/generator-servicegraphs-borrowed-labels.yaml
@@ -1,7 +1,7 @@
 change_type: enhancement
 component: metrics-generator
 note: Reduce per-edge CPU and allocations in the service-graphs processor by building series labels through the registry's pooled borrowed-label path.
-issues: []
+issues: [7587]
 subtext: |
   The service-graphs processor now uses borrowed-label updates for counters, histograms, and the connection-info gauge; uses fixed-size keys for standard trace and span IDs; reuses trace ID buffers; defers classic exemplar encoding until collection; and shares one encoding per edge for native histograms. Metric names, labels, and values are unchanged.
 user: carles-grafana

--- a/.chloggen/generator-servicegraphs-borrowed-labels.yaml
+++ b/.chloggen/generator-servicegraphs-borrowed-labels.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: metrics-generator
+note: Reduce per-edge CPU and allocations in the service-graphs processor by building series labels through the registry's pooled borrowed-label path.
+issues: []
+subtext: |
+  The service-graphs processor now uses borrowed-label updates for counters, histograms, and the connection-info gauge; uses fixed-size keys for standard trace and span IDs; reuses trace ID buffers; defers classic exemplar encoding until collection; and shares one encoding per edge for native histograms. Metric names, labels, and values are unchanged.
+user: carles-grafana

--- a/modules/generator/generator_benchmark_test.go
+++ b/modules/generator/generator_benchmark_test.go
@@ -242,6 +242,20 @@ func BenchmarkInstancePushSpansProductionCardinality(b *testing.B) {
 			request:    benchmarkGeneratorProdHighCardinalityServiceGraphRequest(0, benchmarkGeneratorHighCardinalityTimedEdges),
 		},
 		{
+			name: "combined_prod_7dims_500k_series_native_steady",
+			overrides: func(o *mockOverrides) {
+				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
+				benchmarkGeneratorProdOverrides(o)
+				o.nativeHistograms = histograms.HistogramMethodBoth
+			},
+			seed: func(ctx context.Context, inst *instance) {
+				benchmarkGeneratorSeedHighCardinalityServiceGraph(ctx, inst, benchmarkGeneratorProdCombinedNative500kEdges)
+			},
+			wantSeries: benchmarkGeneratorProdCombinedNative500kEdges * 79,
+			request:    benchmarkGeneratorProdHighCardinalityServiceGraphRequest(0, benchmarkGeneratorHighCardinalityTimedEdges),
+			requireEnv: "TEMPO_GENERATOR_BENCH_1M",
+		},
+		{
 			name: "combined_prod_7dims_1m_series_steady",
 			overrides: func(o *mockOverrides) {
 				o.processors = map[string]struct{}{processor.SpanMetricsName: {}, processor.ServiceGraphsName: {}}
@@ -338,6 +352,7 @@ const (
 	benchmarkGeneratorProdServiceGraphs100kEdges      = 2858  // x 35 series = 100_030
 	benchmarkGeneratorProdCombined100kEdges           = 1334  // x 75 series = 100_050
 	benchmarkGeneratorProdCombinedNative100kEdges     = 1266  // x 79 series = 100_014
+	benchmarkGeneratorProdCombinedNative500kEdges     = 6329  // x 79 series = 499_991
 	benchmarkGeneratorProdCombined1MEdges             = 13334 // x 75 series = 1_000_050
 	benchmarkGeneratorHighCardinalityTimedResources   = 400
 	benchmarkGeneratorHighCardinalityTimedEdges       = 200
@@ -484,8 +499,8 @@ func benchmarkGeneratorSeed(ctx context.Context, b *testing.B, inst *instance, s
 		b.Fatalf("seeding discarded %.0f spans as outside the ingestion slack, series were not seeded as intended", d)
 	}
 	seeded := benchmarkGeneratorActiveSeries(ctx, inst, st)
-	if tolerance := wantSeries / 50; seeded < wantSeries-tolerance || seeded > wantSeries+tolerance {
-		b.Fatalf("seeded %d active series, want %d (±2%%); revisit the seed constants and their per-unit series math", seeded, wantSeries)
+	if seeded != wantSeries {
+		b.Fatalf("seeded %d active series, want %d; revisit the seed constants and their per-unit series math", seeded, wantSeries)
 	}
 }
 

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -2,10 +2,8 @@ package servicegraphs
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-kit/log"
@@ -83,7 +81,7 @@ type Processor struct {
 	Cfg Config
 
 	registry registry.Registry
-	store    store.Store
+	store    *store.Store
 
 	closeCh chan struct{}
 
@@ -219,9 +217,8 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 					connectionType = store.MessagingSystem
 					fallthrough
 				case v1_trace.Span_SPAN_KIND_CLIENT:
-					key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.SpanId))
-					isNew, err = p.store.UpsertEdge(key, store.Client, func(e *store.Edge) {
-						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
+					isNew, err = p.store.UpsertEdgeFromBytes(span.TraceId, span.SpanId, store.Client, func(e *store.Edge) {
+						e.SetTraceID(span.TraceId)
 						e.ConnectionType = connectionType
 						e.ClientService = svcName
 						e.ClientLatencySec = spanDurationSec(span)
@@ -238,9 +235,12 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 					connectionType = store.MessagingSystem
 					fallthrough
 				case v1_trace.Span_SPAN_KIND_SERVER:
-					key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.ParentSpanId))
-					isNew, err = p.store.UpsertEdge(key, store.Server, func(e *store.Edge) {
-						e.TraceID = tempo_util.TraceIDToHexString(span.TraceId)
+					isNew, err = p.store.UpsertEdgeFromBytes(span.TraceId, span.ParentSpanId, store.Server, func(e *store.Edge) {
+						// Non-root server spans cannot produce metrics without a client
+						// update, which supplies the same trace ID.
+						if len(span.ParentSpanId) == 0 {
+							e.SetTraceID(span.TraceId)
+						}
 						e.ConnectionType = connectionType
 						e.ServerService = svcName
 						e.ServerLatencySec = spanDurationSec(span)
@@ -402,15 +402,16 @@ func (p *Processor) onComplete(e *store.Edge) {
 	}
 
 	if p.Cfg.Subprocessors[Latency] {
-		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, e.TraceID, e.SpanMultiplier)
-		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, e.TraceID, e.SpanMultiplier)
+		traceID := tempo_util.TraceIDToHexString(e.TraceID())
+		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, traceID, e.SpanMultiplier)
+		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, traceID, e.SpanMultiplier)
 
 		if p.Cfg.EnableMessagingSystemLatencyHistogram && e.ConnectionType == store.MessagingSystem {
 			messagingSystemLatencySec := unixNanosDiffSec(e.ClientEndTimeUnixNano, e.ServerStartTimeUnixNano)
 			if messagingSystemLatencySec == 0 {
-				level.Warn(p.logger).Log("msg", "producerSpanEndTime must be smaller than consumerSpanStartTime. maybe the peers clocks are not synced", "messagingSystemLatencySec", messagingSystemLatencySec, "traceID", e.TraceID)
+				level.Warn(p.logger).Log("msg", "producerSpanEndTime must be smaller than consumerSpanStartTime. maybe the peers clocks are not synced", "messagingSystemLatencySec", messagingSystemLatencySec, "traceID", traceID)
 			} else {
-				p.serviceGraphRequestMessagingSystemSecondsHistogram.ObserveWithExemplar(registryLabelValues, messagingSystemLatencySec, e.TraceID, e.SpanMultiplier)
+				p.serviceGraphRequestMessagingSystemSecondsHistogram.ObserveWithExemplar(registryLabelValues, messagingSystemLatencySec, traceID, e.SpanMultiplier)
 			}
 		}
 	}
@@ -433,7 +434,7 @@ func (p *Processor) onExpire(e *store.Edge) {
 		// If the client service is not set, it means that the span could have been initiated by an external system,
 		// like a frontend application or an engineer via `curl`.
 		// We check if the span we have is the root span, and if so, we set the client service appropriately.
-		if _, parentSpan := parseKey(e.Key()); len(parentSpan) == 0 {
+		if e.IsRoot() {
 
 			// If a peer attribute is present, it is used to name the external client service.
 			if len(e.PeerNode) > 0 {
@@ -471,8 +472,7 @@ func (p *Processor) onExpire(e *store.Edge) {
 
 func (p *Processor) addDroppedSpanSide(span *v1_trace.Span) {
 	if isClient(span.Kind) {
-		key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.SpanId))
-		if p.store.AddDroppedSpanSide(key, store.Client) {
+		if p.store.AddDroppedSpanSideFromBytes(span.TraceId, span.SpanId, store.Client) {
 			p.metricDroppedEdges.Inc()
 		}
 		return
@@ -484,8 +484,7 @@ func (p *Processor) addDroppedSpanSide(span *v1_trace.Span) {
 			return
 		}
 
-		key := buildKey(hex.EncodeToString(span.TraceId), hex.EncodeToString(span.ParentSpanId))
-		if p.store.AddDroppedSpanSide(key, store.Server) {
+		if p.store.AddDroppedSpanSideFromBytes(span.TraceId, span.ParentSpanId, store.Server) {
 			p.metricDroppedEdges.Inc()
 		}
 	}
@@ -514,13 +513,4 @@ func unixNanosDiffSec(unixNanoStart uint64, unixNanoEnd uint64) float64 {
 
 func spanDurationSec(span *v1_trace.Span) float64 {
 	return unixNanosDiffSec(span.StartTimeUnixNano, span.EndTimeUnixNano)
-}
-
-func buildKey(k1, k2 string) string {
-	return fmt.Sprintf("%s-%s", k1, k2)
-}
-
-func parseKey(key string) (string, string) {
-	parts := strings.Split(key, "-")
-	return parts[0], parts[1]
 }

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -108,9 +108,9 @@ type Processor struct {
 type dimensionLabel struct {
 	name        string
 	label       string
-	clientName  string
+	clientKey   string
 	clientLabel string
-	serverName  string
+	serverKey   string
 	serverLabel string
 }
 
@@ -121,15 +121,22 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, fi
 
 	dimensionLabels := make([]dimensionLabel, len(cfg.Dimensions))
 	for i, dim := range cfg.Dimensions {
-		clientName := "client_" + dim
-		serverName := "server_" + dim
+		label := validation.SanitizeLabelName(dim)
+		clientKey, serverKey := dim, dim
+		clientLabel, serverLabel := label, label
+		if cfg.EnableClientServerPrefix {
+			clientKey = "client_" + dim
+			serverKey = "server_" + dim
+			clientLabel = validation.SanitizeLabelName(clientKey)
+			serverLabel = validation.SanitizeLabelName(serverKey)
+		}
 		dimensionLabels[i] = dimensionLabel{
 			name:        dim,
-			label:       validation.SanitizeLabelName(dim),
-			clientName:  clientName,
-			clientLabel: validation.SanitizeLabelName(clientName),
-			serverName:  serverName,
-			serverLabel: validation.SanitizeLabelName(serverName),
+			label:       label,
+			clientKey:   clientKey,
+			clientLabel: clientLabel,
+			serverKey:   serverKey,
+			serverLabel: serverLabel,
 		}
 	}
 
@@ -312,14 +319,10 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 func (p *Processor) upsertDimensions(client bool, m map[string]string, resourceAttr, spanAttr []*v1_common.KeyValue) {
 	for _, dim := range p.dimensionLabels {
 		if v, ok := processor_util.FindAttributeValue(dim.name, resourceAttr, spanAttr); ok {
-			if p.Cfg.EnableClientServerPrefix {
-				if client {
-					m[dim.clientName] = v
-				} else {
-					m[dim.serverName] = v
-				}
+			if client {
+				m[dim.clientKey] = v
 			} else {
-				m[dim.name] = v
+				m[dim.serverKey] = v
 			}
 		}
 	}
@@ -414,8 +417,8 @@ func (p *Processor) onComplete(e *store.Edge) {
 					continue
 				}
 			}
-			builder.Add(dimension.clientLabel, e.Dimensions[dimension.clientName])
-			builder.Add(dimension.serverLabel, e.Dimensions[dimension.serverName])
+			builder.Add(dimension.clientLabel, e.Dimensions[dimension.clientKey])
+			builder.Add(dimension.serverLabel, e.Dimensions[dimension.serverKey])
 		} else {
 			builder.Add(dimension.label, e.Dimensions[dimension.name])
 		}

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -18,7 +18,6 @@ import (
 	processor_util "github.com/grafana/tempo/modules/generator/processor/util"
 	"github.com/grafana/tempo/modules/generator/registry"
 	"github.com/grafana/tempo/modules/generator/validation"
-	"github.com/grafana/tempo/pkg/cache/reclaimable"
 	"github.com/grafana/tempo/pkg/spanfilter"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
@@ -91,8 +90,10 @@ type Processor struct {
 	serviceGraphRequestClientSecondsHistogram          registry.Histogram
 	serviceGraphRequestMessagingSystemSecondsHistogram registry.Histogram
 	serviceGraphConnectionInfo                         registry.Gauge
-	sanitizeCache                                      reclaimable.Cache[string, string]
+	dimensionLabels                                    []dimensionLabel
 	filter                                             *spanfilter.SpanFilter
+	usesSpanMultiplier                                 bool
+	usesNativeHistograms                               bool
 
 	filteredSpansCounter                prometheus.Counter
 	metricDroppedSpans                  prometheus.Counter
@@ -104,12 +105,34 @@ type Processor struct {
 	logger                              log.Logger
 }
 
+type dimensionLabel struct {
+	name        string
+	label       string
+	clientName  string
+	clientLabel string
+	serverName  string
+	serverLabel string
+}
+
 func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, filteredSpansCounter, invalidUTF8Counter prometheus.Counter) (gen.Processor, error) {
 	if cfg.EnableVirtualNodeLabel {
 		cfg.Dimensions = append(cfg.Dimensions, virtualNodeLabel)
 	}
 
-	sanitizeCache := reclaimable.New(validation.SanitizeLabelName, 10000)
+	dimensionLabels := make([]dimensionLabel, len(cfg.Dimensions))
+	for i, dim := range cfg.Dimensions {
+		clientName := "client_" + dim
+		serverName := "server_" + dim
+		dimensionLabels[i] = dimensionLabel{
+			name:        dim,
+			label:       validation.SanitizeLabelName(dim),
+			clientName:  clientName,
+			clientLabel: validation.SanitizeLabelName(clientName),
+			serverName:  serverName,
+			serverLabel: validation.SanitizeLabelName(serverName),
+		}
+	}
+
 	filter, err := spanfilter.NewSpanFilter(cfg.FilterPolicies)
 	if err != nil {
 		return nil, err
@@ -120,8 +143,11 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, fi
 		registry: reg,
 		closeCh:  make(chan struct{}, 1),
 
-		sanitizeCache: sanitizeCache,
-		filter:        filter,
+		dimensionLabels:    dimensionLabels,
+		filter:             filter,
+		usesSpanMultiplier: cfg.SpanMultiplierKey != "" || cfg.EnableTraceStateSpanMultiplier,
+		usesNativeHistograms: cfg.HistogramOverride == registry.HistogramModeNative ||
+			cfg.HistogramOverride == registry.HistogramModeBoth,
 
 		filteredSpansCounter:                filteredSpansCounter,
 		metricDroppedSpans:                  metricDroppedSpans.WithLabelValues(tenant),
@@ -210,7 +236,10 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 				}
 
 				connectionType := store.Unknown
-				spanMultiplier := processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs.Resource, p.Cfg.EnableTraceStateSpanMultiplier)
+				spanMultiplier := 1.0
+				if p.usesSpanMultiplier {
+					spanMultiplier = processor_util.GetSpanMultiplier(p.Cfg.SpanMultiplierKey, span, rs.Resource, p.Cfg.EnableTraceStateSpanMultiplier)
+				}
 				switch span.Kind {
 				case v1_trace.Span_SPAN_KIND_PRODUCER:
 					// override connection type and continue processing as span kind client
@@ -224,7 +253,7 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 						e.ClientLatencySec = spanDurationSec(span)
 						e.ClientEndTimeUnixNano = span.EndTimeUnixNano
 						e.Failed = e.Failed || p.spanFailed(span)
-						p.upsertDimensions("client_", e.Dimensions, rs.Resource.Attributes, span.Attributes)
+						p.upsertDimensions(true, e.Dimensions, rs.Resource.Attributes, span.Attributes)
 						e.SpanMultiplier = spanMultiplier
 						p.upsertPeerNode(e, span.Attributes)
 						p.upsertDatabaseRequest(e, rs.Resource.Attributes, span)
@@ -246,7 +275,7 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 						e.ServerLatencySec = spanDurationSec(span)
 						e.ServerStartTimeUnixNano = span.StartTimeUnixNano
 						e.Failed = e.Failed || p.spanFailed(span)
-						p.upsertDimensions("server_", e.Dimensions, rs.Resource.Attributes, span.Attributes)
+						p.upsertDimensions(false, e.Dimensions, rs.Resource.Attributes, span.Attributes)
 						e.SpanMultiplier = spanMultiplier
 						p.upsertPeerNode(e, span.Attributes)
 					})
@@ -280,13 +309,17 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 	return nil
 }
 
-func (p *Processor) upsertDimensions(prefix string, m map[string]string, resourceAttr, spanAttr []*v1_common.KeyValue) {
-	for _, dim := range p.Cfg.Dimensions {
-		if v, ok := processor_util.FindAttributeValue(dim, resourceAttr, spanAttr); ok {
+func (p *Processor) upsertDimensions(client bool, m map[string]string, resourceAttr, spanAttr []*v1_common.KeyValue) {
+	for _, dim := range p.dimensionLabels {
+		if v, ok := processor_util.FindAttributeValue(dim.name, resourceAttr, spanAttr); ok {
 			if p.Cfg.EnableClientServerPrefix {
-				m[prefix+dim] = v
+				if client {
+					m[dim.clientName] = v
+				} else {
+					m[dim.serverName] = v
+				}
 			} else {
-				m[dim] = v
+				m[dim.name] = v
 			}
 		}
 	}
@@ -349,7 +382,7 @@ func (p *Processor) upsertDatabaseRequest(e *store.Edge, resourceAttr []*v1_comm
 	// Check for network.peer.address and network.peer.port.  Use port if it is present.
 	if host, ok := processor_util.FindAttributeValue(string(semconv.NetworkPeerAddressKey), resourceAttr, span.Attributes); ok {
 		if port, ok := processor_util.FindAttributeValue(string(semconv.NetworkPeerPortKey), resourceAttr, span.Attributes); ok {
-			e.ServerService = fmt.Sprintf("%s:%s", host, port)
+			e.ServerService = host + ":" + port
 			return
 		}
 		e.ServerService = host
@@ -372,54 +405,69 @@ func (p *Processor) onComplete(e *store.Edge) {
 	builder.Add("server", e.ServerService)
 	builder.Add("connection_type", string(e.ConnectionType))
 
-	for _, dimension := range p.Cfg.Dimensions {
+	for _, dimension := range p.dimensionLabels {
 		if p.Cfg.EnableClientServerPrefix {
 			if p.Cfg.EnableVirtualNodeLabel {
 				// leave the extra label for this feature as-is
-				if dimension == virtualNodeLabel {
-					builder.Add(virtualNodeLabel, e.Dimensions[dimension])
+				if dimension.name == virtualNodeLabel {
+					builder.Add(virtualNodeLabel, e.Dimensions[dimension.name])
 					continue
 				}
 			}
-			builder.Add(p.sanitizeCache.Get("client_"+dimension), e.Dimensions["client_"+dimension])
-			builder.Add(p.sanitizeCache.Get("server_"+dimension), e.Dimensions["server_"+dimension])
+			builder.Add(dimension.clientLabel, e.Dimensions[dimension.clientName])
+			builder.Add(dimension.serverLabel, e.Dimensions[dimension.serverName])
 		} else {
-			builder.Add(p.sanitizeCache.Get(dimension), e.Dimensions[dimension])
+			builder.Add(dimension.label, e.Dimensions[dimension.name])
 		}
 	}
 
-	registryLabelValues, validUTF8 := builder.CloseAndBuildLabels()
+	registryLabelValues, validUTF8 := builder.CloseAndBorrowLabels()
 	if !validUTF8 {
 		p.invalidUTF8Counter.Inc()
 		return
 	}
+	defer registryLabelValues.Release()
+	updateTimeMs := time.Now().UnixMilli()
 
 	if p.Cfg.Subprocessors[Request] {
-		p.serviceGraphRequestTotal.Inc(registryLabelValues, 1*e.SpanMultiplier)
+		p.serviceGraphRequestTotal.IncBorrowed(registryLabelValues, 1*e.SpanMultiplier, updateTimeMs)
 		if e.Failed {
-			p.serviceGraphRequestFailedTotal.Inc(registryLabelValues, 1*e.SpanMultiplier)
+			p.serviceGraphRequestFailedTotal.IncBorrowed(registryLabelValues, 1*e.SpanMultiplier, updateTimeMs)
 		}
 	}
 
 	if p.Cfg.Subprocessors[Latency] {
-		traceID := tempo_util.TraceIDToHexString(e.TraceID())
-		p.serviceGraphRequestServerSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ServerLatencySec, traceID, e.SpanMultiplier)
-		p.serviceGraphRequestClientSecondsHistogram.ObserveWithExemplar(registryLabelValues, e.ClientLatencySec, traceID, e.SpanMultiplier)
+		traceID := e.TraceID()
+		encodedTraceID := ""
+		if p.usesNativeHistograms {
+			encodedTraceID = tempo_util.TraceIDToHexString(traceID)
+		}
+		observe := func(histogram registry.Histogram, value float64) {
+			if p.usesNativeHistograms {
+				histogram.ObserveBorrowedWithEncodedTraceID(registryLabelValues, value, encodedTraceID, e.SpanMultiplier, updateTimeMs)
+				return
+			}
+			histogram.ObserveBorrowed(registryLabelValues, value, traceID, e.SpanMultiplier, updateTimeMs)
+		}
+
+		observe(p.serviceGraphRequestServerSecondsHistogram, e.ServerLatencySec)
+		observe(p.serviceGraphRequestClientSecondsHistogram, e.ClientLatencySec)
 
 		if p.Cfg.EnableMessagingSystemLatencyHistogram && e.ConnectionType == store.MessagingSystem {
 			messagingSystemLatencySec := unixNanosDiffSec(e.ClientEndTimeUnixNano, e.ServerStartTimeUnixNano)
 			if messagingSystemLatencySec == 0 {
-				level.Warn(p.logger).Log("msg", "producerSpanEndTime must be smaller than consumerSpanStartTime. maybe the peers clocks are not synced", "messagingSystemLatencySec", messagingSystemLatencySec, "traceID", traceID)
+				level.Warn(p.logger).Log("msg", "producerSpanEndTime must be smaller than consumerSpanStartTime. maybe the peers clocks are not synced", "messagingSystemLatencySec", messagingSystemLatencySec, "traceID", tempo_util.TraceIDToHexString(e.TraceID()))
 			} else {
-				p.serviceGraphRequestMessagingSystemSecondsHistogram.ObserveWithExemplar(registryLabelValues, messagingSystemLatencySec, traceID, e.SpanMultiplier)
+				observe(p.serviceGraphRequestMessagingSystemSecondsHistogram, messagingSystemLatencySec)
 			}
 		}
 	}
 
 	if p.Cfg.Subprocessors[ConnectionInfo] {
 		// Presence-only info metric: held at 1 while the edge is being observed.
-		// The series goes stale and is pruned once edges stop completing for this label set.
-		p.serviceGraphConnectionInfo.Set(registryLabelValues, 1)
+		// The series goes stale and is pruned once edges stop completing for
+		// this label set.
+		p.serviceGraphConnectionInfo.SetBorrowed(registryLabelValues, 1, updateTimeMs)
 	}
 }
 

--- a/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
@@ -1,0 +1,231 @@
+package servicegraphs
+
+import (
+	"context"
+	"encoding/binary"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/pkg/tempopb"
+	common_v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resource_v1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	trace_v1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// BenchmarkServiceGraphsPushSpansSteadyState measures ingestion after edge
+// pools and registry series have been warmed outside the timed loop.
+func BenchmarkServiceGraphsPushSpansSteadyState(b *testing.B) {
+	for _, tc := range []struct {
+		name           string
+		tune           func(*Config)
+		spanMultiplier bool
+		histogramMode  registry.HistogramMode
+		edgeKind       benchmarkServiceGraphEdgeKind
+	}{
+		{name: "default"},
+		{
+			name: "dimensions",
+			tune: func(cfg *Config) {
+				cfg.Dimensions = []string{"beast", "god"}
+			},
+		},
+		{
+			name: "client_server_prefix",
+			tune: func(cfg *Config) {
+				cfg.Dimensions = []string{"beast", "god"}
+				cfg.EnableClientServerPrefix = true
+			},
+		},
+		{
+			name: "span_multiplier",
+			tune: func(cfg *Config) {
+				cfg.SpanMultiplierKey = "sample.rate"
+			},
+			spanMultiplier: true,
+		},
+		{name: "native/database", histogramMode: registry.HistogramModeNative, edgeKind: benchmarkServiceGraphDatabaseEdge},
+		{name: "both/database", histogramMode: registry.HistogramModeBoth, edgeKind: benchmarkServiceGraphDatabaseEdge},
+		{name: "native/messaging", histogramMode: registry.HistogramModeNative, edgeKind: benchmarkServiceGraphMessagingEdge},
+		{name: "both/messaging", histogramMode: registry.HistogramModeBoth, edgeKind: benchmarkServiceGraphMessagingEdge},
+		{name: "native/virtual", histogramMode: registry.HistogramModeNative, edgeKind: benchmarkServiceGraphVirtualEdge},
+		{name: "both/virtual", histogramMode: registry.HistogramModeBoth, edgeKind: benchmarkServiceGraphVirtualEdge},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.HistogramBuckets = []float64{0.04, 0.1, 1}
+			cfg.HistogramOverride = tc.histogramMode
+			cfg.Workers = 0
+			if tc.edgeKind == benchmarkServiceGraphMessagingEdge {
+				cfg.EnableMessagingSystemLatencyHistogram = true
+			}
+			if tc.edgeKind == benchmarkServiceGraphVirtualEdge {
+				cfg.Wait = -time.Nanosecond
+			}
+			if tc.tune != nil {
+				tc.tune(&cfg)
+			}
+
+			registryCfg := &registry.Config{}
+			registryCfg.RegisterFlagsAndApplyDefaults("", nil)
+			managedRegistry := registry.New(
+				registryCfg,
+				serviceGraphRegistryOverrides{
+					nativeHistogramBucketFactor:     1.1,
+					nativeHistogramMaxBucketNumber:  100,
+					nativeHistogramMinResetDuration: 15 * time.Minute,
+				},
+				"bench",
+				&serviceGraphCapturingAppender{},
+				log.NewNopLogger(),
+				serviceGraphNoopLimiter{},
+			)
+			defer managedRegistry.Close()
+
+			p, err := New(
+				cfg,
+				"bench",
+				managedRegistry,
+				log.NewNopLogger(),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+				prometheus.NewCounter(prometheus.CounterOpts{}),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer p.Shutdown(context.Background())
+
+			req := benchmarkServiceGraphRequestForKind(100, tc.spanMultiplier, tc.edgeKind)
+			p.PushSpans(context.Background(), req)
+			if tc.edgeKind == benchmarkServiceGraphVirtualEdge {
+				p.(*Processor).store.Expire()
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				p.PushSpans(context.Background(), req)
+				if tc.edgeKind == benchmarkServiceGraphVirtualEdge {
+					p.(*Processor).store.Expire()
+				}
+			}
+		})
+	}
+}
+
+type benchmarkServiceGraphEdgeKind string
+
+const (
+	benchmarkServiceGraphDatabaseEdge  benchmarkServiceGraphEdgeKind = "database"
+	benchmarkServiceGraphMessagingEdge benchmarkServiceGraphEdgeKind = "messaging"
+	benchmarkServiceGraphVirtualEdge   benchmarkServiceGraphEdgeKind = "virtual"
+)
+
+func benchmarkServiceGraphRequestForKind(edges int, spanMultiplier bool, kind benchmarkServiceGraphEdgeKind) *tempopb.PushSpansRequest {
+	req := benchmarkServiceGraphRequest(edges, spanMultiplier)
+
+	switch kind {
+	case benchmarkServiceGraphDatabaseEdge:
+		for _, span := range req.Batches[0].ScopeSpans[0].Spans {
+			span.Attributes = append(span.Attributes, tempopb.MakeKeyValueStringPtr("db.namespace", "orders"))
+		}
+		req.Batches = req.Batches[:1]
+	case benchmarkServiceGraphMessagingEdge:
+		for _, span := range req.Batches[0].ScopeSpans[0].Spans {
+			span.Kind = trace_v1.Span_SPAN_KIND_PRODUCER
+		}
+		for _, span := range req.Batches[1].ScopeSpans[0].Spans {
+			span.Kind = trace_v1.Span_SPAN_KIND_CONSUMER
+			span.StartTimeUnixNano += 50_000_000
+			span.EndTimeUnixNano += 50_000_000
+		}
+	case benchmarkServiceGraphVirtualEdge:
+		req.Batches = req.Batches[:1]
+	}
+
+	return req
+}
+
+func benchmarkServiceGraphRequest(edges int, spanMultiplier bool) *tempopb.PushSpansRequest {
+	client := &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{Attributes: []*common_v1.KeyValue{
+			tempopb.MakeKeyValueStringPtr("service.name", "client"),
+			tempopb.MakeKeyValueStringPtr("beast", "manticore"),
+		}},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+	server := &trace_v1.ResourceSpans{
+		Resource: &resource_v1.Resource{Attributes: []*common_v1.KeyValue{
+			tempopb.MakeKeyValueStringPtr("service.name", "server"),
+			tempopb.MakeKeyValueStringPtr("god", "athena"),
+		}},
+		ScopeSpans: []*trace_v1.ScopeSpans{{}},
+	}
+
+	for i := 0; i < edges; i++ {
+		traceID := benchmarkSGTraceID(i)
+		clientSpanID := benchmarkSGSpanID(i*2 + 1)
+		client.ScopeSpans[0].Spans = append(client.ScopeSpans[0].Spans, &trace_v1.Span{
+			TraceId:           traceID,
+			SpanId:            clientSpanID,
+			Name:              "GET /api/:id",
+			Kind:              trace_v1.Span_SPAN_KIND_CLIENT,
+			StartTimeUnixNano: uint64(1_700_000_000_000_000_000 + i),
+			EndTimeUnixNano:   uint64(1_700_000_000_050_000_000 + i),
+			Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+			Attributes: []*common_v1.KeyValue{
+				tempopb.MakeKeyValueStringPtr("peer.service", "server"),
+				tempopb.MakeKeyValueStringPtr("beast", "client-"+strconv.Itoa(i%4)),
+			},
+		})
+		if spanMultiplier {
+			client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes = append(
+				client.ScopeSpans[0].Spans[len(client.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkSGDoubleAttr("sample.rate", 0.5),
+			)
+		}
+
+		server.ScopeSpans[0].Spans = append(server.ScopeSpans[0].Spans, &trace_v1.Span{
+			TraceId:           traceID,
+			SpanId:            benchmarkSGSpanID(i*2 + 2),
+			ParentSpanId:      clientSpanID,
+			Name:              "GET /api/:id",
+			Kind:              trace_v1.Span_SPAN_KIND_SERVER,
+			StartTimeUnixNano: uint64(1_700_000_000_010_000_000 + i),
+			EndTimeUnixNano:   uint64(1_700_000_000_040_000_000 + i),
+			Status:            &trace_v1.Status{Code: trace_v1.Status_STATUS_CODE_OK},
+			Attributes: []*common_v1.KeyValue{
+				tempopb.MakeKeyValueStringPtr("god", "server-"+strconv.Itoa(i%4)),
+			},
+		})
+		if spanMultiplier {
+			server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes = append(
+				server.ScopeSpans[0].Spans[len(server.ScopeSpans[0].Spans)-1].Attributes,
+				benchmarkSGDoubleAttr("sample.rate", 0.5),
+			)
+		}
+	}
+
+	return &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{client, server}}
+}
+
+func benchmarkSGTraceID(i int) []byte {
+	var id [16]byte
+	binary.BigEndian.PutUint64(id[:8], 0x1020304050607080+uint64(i))
+	binary.BigEndian.PutUint64(id[8:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSGSpanID(i int) []byte {
+	var id [8]byte
+	binary.BigEndian.PutUint64(id[:], uint64(i+1))
+	return id[:]
+}
+
+func benchmarkSGDoubleAttr(key string, value float64) *common_v1.KeyValue {
+	kv := tempopb.MakeKeyValueDouble(key, value)
+	return &kv
+}

--- a/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_benchmark_test.go
@@ -47,6 +47,14 @@ func BenchmarkServiceGraphsPushSpansSteadyState(b *testing.B) {
 			},
 			spanMultiplier: true,
 		},
+		{
+			name: "connection_info_only",
+			tune: func(cfg *Config) {
+				cfg.Subprocessors[Request] = false
+				cfg.Subprocessors[Latency] = false
+				cfg.Subprocessors[ConnectionInfo] = true
+			},
+		},
 		{name: "native/database", histogramMode: registry.HistogramModeNative, edgeKind: benchmarkServiceGraphDatabaseEdge},
 		{name: "both/database", histogramMode: registry.HistogramModeBoth, edgeKind: benchmarkServiceGraphDatabaseEdge},
 		{name: "native/messaging", histogramMode: registry.HistogramModeNative, edgeKind: benchmarkServiceGraphMessagingEdge},

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -13,14 +13,21 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs/store"
 	"github.com/grafana/tempo/modules/generator/registry"
+	"github.com/grafana/tempo/modules/overrides/histograms"
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	tempo_util "github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/exemplar"
+	prom_histogram "github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/metadata"
+	"github.com/prometheus/prometheus/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
@@ -389,6 +396,66 @@ func TestServiceGraphs_virtualNodes(t *testing.T) {
 
 	assert.Equal(t, 1.0, testRegistry.Query(`traces_service_graph_request_total`, virtualProducerToConsumer))
 	assert.Equal(t, 0.0, testRegistry.Query(`traces_service_graph_request_failed_total`, virtualProducerToConsumer))
+}
+
+func TestServiceGraphs_exemplarsCarryTraceID(t *testing.T) {
+	completedTraceID := []byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f}
+	rootServerTraceID := []byte{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f}
+	clientSpanID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	tests := []struct {
+		name    string
+		traceID []byte
+		batches []*tracev1.ResourceSpans
+		expire  bool
+	}{
+		{
+			name:    "completed edge",
+			traceID: completedTraceID,
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, completedTraceID, clientSpanID, nil),
+				makeServiceGraphBatch("svc-b", tracev1.Span_SPAN_KIND_SERVER, completedTraceID, []byte{0x09}, clientSpanID),
+			},
+		},
+		{
+			name:    "expired root server edge",
+			traceID: rootServerTraceID,
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("svc-b", tracev1.Span_SPAN_KIND_SERVER, rootServerTraceID, []byte{0x0a}, nil),
+			},
+			expire: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appender := &serviceGraphCapturingAppender{}
+			managedRegistry := registry.New(&registry.Config{
+				CollectionInterval: time.Hour,
+				StaleDuration:      time.Hour,
+			}, serviceGraphRegistryOverrides{}, "test", appender, log.NewNopLogger(), serviceGraphNoopLimiter{})
+			defer managedRegistry.Close()
+
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.HistogramBuckets = []float64{1}
+			cfg.Wait = time.Nanosecond
+
+			p, err := New(cfg, "test", managedRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+			require.NoError(t, err)
+			defer p.Shutdown(context.Background())
+
+			p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: tt.batches})
+			if tt.expire {
+				p.(*Processor).store.Expire()
+			}
+
+			managedRegistry.CollectMetrics(context.Background())
+			wantTraceID := tempo_util.TraceIDToHexString(tt.traceID)
+			assertServiceGraphExemplarTraceID(t, appender, metricRequestServerSeconds+"_bucket", wantTraceID)
+			assertServiceGraphExemplarTraceID(t, appender, metricRequestClientSeconds+"_bucket", wantTraceID)
+		})
+	}
 }
 
 func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testing.T) {
@@ -1180,4 +1247,325 @@ func withLe(lbls labels.Labels, le float64) labels.Labels {
 	lb := labels.NewBuilder(lbls)
 	lb = lb.Set(labels.BucketLabel, strconv.FormatFloat(le, 'f', -1, 64))
 	return lb.Labels()
+}
+
+type serviceGraphExemplarSample struct {
+	l labels.Labels
+	e exemplar.Exemplar
+}
+
+type serviceGraphCapturingAppender struct {
+	exemplars []serviceGraphExemplarSample
+}
+
+var (
+	_ storage.Appendable = (*serviceGraphCapturingAppender)(nil)
+	_ storage.Appender   = (*serviceGraphCapturingAppender)(nil)
+)
+
+func (c *serviceGraphCapturingAppender) Appender(context.Context) storage.Appender {
+	return c
+}
+
+func (c *serviceGraphCapturingAppender) Append(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (c *serviceGraphCapturingAppender) AppendExemplar(ref storage.SeriesRef, lbls labels.Labels, ex exemplar.Exemplar) (storage.SeriesRef, error) {
+	c.exemplars = append(c.exemplars, serviceGraphExemplarSample{
+		l: lbls.Copy(),
+		e: exemplar.Exemplar{
+			Labels: ex.Labels.Copy(),
+			Value:  ex.Value,
+			Ts:     ex.Ts,
+		},
+	})
+	return ref, nil
+}
+
+func (c *serviceGraphCapturingAppender) AppendHistogram(ref storage.SeriesRef, _ labels.Labels, _ int64, _ *prom_histogram.Histogram, _ *prom_histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (c *serviceGraphCapturingAppender) Commit() error { return nil }
+
+func (c *serviceGraphCapturingAppender) Rollback() error { return nil }
+
+func (c *serviceGraphCapturingAppender) SetOptions(_ *storage.AppendOptions) {}
+
+func (c *serviceGraphCapturingAppender) UpdateMetadata(ref storage.SeriesRef, _ labels.Labels, _ metadata.Metadata) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (c *serviceGraphCapturingAppender) AppendCTZeroSample(ref storage.SeriesRef, _ labels.Labels, _, _ int64) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (c *serviceGraphCapturingAppender) AppendSTZeroSample(ref storage.SeriesRef, _ labels.Labels, _, _ int64) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (c *serviceGraphCapturingAppender) AppendHistogramCTZeroSample(ref storage.SeriesRef, _ labels.Labels, _, _ int64, _ *prom_histogram.Histogram, _ *prom_histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+func (c *serviceGraphCapturingAppender) AppendHistogramSTZeroSample(ref storage.SeriesRef, _ labels.Labels, _, _ int64, _ *prom_histogram.Histogram, _ *prom_histogram.FloatHistogram) (storage.SeriesRef, error) {
+	return ref, nil
+}
+
+type serviceGraphNoopLimiter struct{}
+
+var _ registry.Limiter = serviceGraphNoopLimiter{}
+
+func (serviceGraphNoopLimiter) OnAdd(labelHash uint64, _ uint32, lbls labels.Labels) (labels.Labels, uint64) {
+	return lbls, labelHash
+}
+
+func (serviceGraphNoopLimiter) OnUpdate(uint64, uint32) {}
+
+func (serviceGraphNoopLimiter) OnDelete(uint64, uint32) {}
+
+type serviceGraphRegistryOverrides struct {
+	nativeHistogramBucketFactor     float64
+	nativeHistogramMaxBucketNumber  uint32
+	nativeHistogramMinResetDuration time.Duration
+}
+
+var _ registry.Overrides = serviceGraphRegistryOverrides{}
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorMaxActiveSeries(string) uint32 { return 0 }
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorMaxActiveEntities(string) uint32 { return 0 }
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorCollectionInterval(string) time.Duration {
+	return time.Hour
+}
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorDisableCollection(string) bool { return false }
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorGenerateNativeHistograms(string) histograms.HistogramMethod {
+	return histograms.HistogramMethodClassic
+}
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorTraceIDLabelName(string) string { return "" }
+
+func (o serviceGraphRegistryOverrides) MetricsGeneratorNativeHistogramBucketFactor(string) float64 {
+	return o.nativeHistogramBucketFactor
+}
+
+func (o serviceGraphRegistryOverrides) MetricsGeneratorNativeHistogramMaxBucketNumber(string) uint32 {
+	return o.nativeHistogramMaxBucketNumber
+}
+
+func (o serviceGraphRegistryOverrides) MetricsGeneratorNativeHistogramMinResetDuration(string) time.Duration {
+	return o.nativeHistogramMinResetDuration
+}
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorSpanNameSanitization(string) string {
+	return registry.SpanNameSanitizationDisabled
+}
+
+func (serviceGraphRegistryOverrides) MetricsGeneratorMaxCardinalityPerLabel(string) uint64 {
+	return 0
+}
+
+func assertServiceGraphExemplarTraceID(t *testing.T, appender *serviceGraphCapturingAppender, metricName, traceID string) {
+	t.Helper()
+
+	for _, sample := range appender.exemplars {
+		if sample.l.Get(model.MetricNameLabel) != metricName {
+			continue
+		}
+		require.Equal(t, traceID, sample.e.Labels.Get("traceID"))
+		return
+	}
+
+	require.Failf(t, "missing exemplar", "metric %s with traceID %s not found in %#v", metricName, traceID, appender.exemplars)
+}
+
+func makeServiceGraphBatch(svcName string, kind tracev1.Span_SpanKind, traceID, spanID, parentSpanID []byte, spanAttrs ...*v1.KeyValue) *tracev1.ResourceSpans {
+	return &tracev1.ResourceSpans{
+		Resource: &resourcev1.Resource{
+			Attributes: []*v1.KeyValue{
+				tempopb.MakeKeyValueStringPtr("service.name", svcName),
+			},
+		},
+		ScopeSpans: []*tracev1.ScopeSpans{
+			{
+				Spans: []*tracev1.Span{
+					{
+						TraceId:           traceID,
+						SpanId:            spanID,
+						ParentSpanId:      parentSpanID,
+						Kind:              kind,
+						StartTimeUnixNano: 1,
+						EndTimeUnixNano:   2,
+						Attributes:        spanAttrs,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestServiceGraphs_nonRootServerSpanPeerAttributesDoNotChangeSeries locks in
+// that peer attributes on an ordinary non-root server span do not influence
+// the emitted service graph series: the completed edge uses the client and
+// server service names, and the peer value surfaces nowhere.
+func TestServiceGraphs_nonRootServerSpanPeerAttributesDoNotChangeSeries(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.Wait = time.Nanosecond
+
+	p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	traceID := []byte{0x0a}
+	clientSpanID := []byte{0x0b}
+
+	peerAttr := &v1.KeyValue{
+		Key: string(semconv.PeerServiceKey),
+		Value: &v1.AnyValue{
+			Value: &v1.AnyValue_StringValue{StringValue: "external-peer"},
+		},
+	}
+
+	request := &tempopb.PushSpansRequest{
+		Batches: []*tracev1.ResourceSpans{
+			makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
+			makeServiceGraphBatch("svc-b", tracev1.Span_SPAN_KIND_SERVER, traceID, []byte{0x0c}, clientSpanID, peerAttr),
+		},
+	}
+
+	p.PushSpans(context.Background(), request)
+	p.(*Processor).store.Expire()
+
+	completedLabels := labels.FromMap(map[string]string{
+		"client": "svc-a",
+		"server": "svc-b",
+	})
+	assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", completedLabels))
+	assert.NotContains(t, testRegistry.String(), "external-peer")
+}
+
+func TestServiceGraphs_serverPeerSurvivesClientDatabaseUpdate(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.Wait = time.Nanosecond
+
+	const tenant = "server-peer-database-update-test"
+	p, err := New(cfg, tenant, testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	traceID := []byte{0x2a}
+	clientSpanID := []byte{0x2b}
+	serverPeer := &v1.KeyValue{
+		Key: string(semconv.PeerServiceKey),
+		Value: &v1.AnyValue{
+			Value: &v1.AnyValue_StringValue{StringValue: "external-peer"},
+		},
+	}
+	databaseNamespace := &v1.KeyValue{
+		Key: string(semconvnew.DBNamespaceKey),
+		Value: &v1.AnyValue{
+			Value: &v1.AnyValue_StringValue{StringValue: "database"},
+		},
+	}
+	emptyServerAddress := &v1.KeyValue{
+		Key: string(semconv.ServerAddressKey),
+		Value: &v1.AnyValue{
+			Value: &v1.AnyValue_StringValue{},
+		},
+	}
+
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*tracev1.ResourceSpans{
+		makeServiceGraphBatch("svc-b", tracev1.Span_SPAN_KIND_SERVER, traceID, []byte{0x2c}, clientSpanID, serverPeer),
+		makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil, databaseNamespace, emptyServerAddress),
+	}})
+	p.(*Processor).store.Expire()
+
+	virtualNodeLabels := labels.FromMap(map[string]string{
+		"client":          "svc-a",
+		"server":          "external-peer",
+		"connection_type": "virtual_node",
+	})
+	assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", virtualNodeLabels))
+
+	expiredEdges, err := test.GetCounterVecValue(metricExpiredEdges, tenant)
+	require.NoError(t, err)
+	assert.Zero(t, expiredEdges)
+}
+
+// TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer covers
+// the degenerate case where the server resource carries a present-but-empty
+// service.name: ServerService stays empty, the edge never completes, and on
+// expiry the server span's peer attribute names the external server service.
+func TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer(t *testing.T) {
+	peerAttr := &v1.KeyValue{
+		Key: string(semconv.PeerServiceKey),
+		Value: &v1.AnyValue{
+			Value: &v1.AnyValue_StringValue{StringValue: "external-peer"},
+		},
+	}
+
+	traceID := []byte{0x1a}
+	clientSpanID := []byte{0x1b}
+	serverSpanID := []byte{0x1c}
+
+	tests := []struct {
+		name    string
+		batches []*tracev1.ResourceSpans
+	}{
+		{
+			name: "client before server",
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
+				makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_SERVER, traceID, serverSpanID, clientSpanID, peerAttr),
+			},
+		},
+		{
+			name: "server before client",
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_SERVER, traceID, serverSpanID, clientSpanID, peerAttr),
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, traceID, clientSpanID, nil),
+			},
+		},
+		{
+			name: "producer and consumer messaging spans",
+			batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_PRODUCER, traceID, clientSpanID, nil),
+				makeServiceGraphBatch("", tracev1.Span_SPAN_KIND_CONSUMER, traceID, serverSpanID, clientSpanID, peerAttr),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testRegistry := registry.NewTestRegistry()
+
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.Wait = time.Nanosecond
+
+			p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+			require.NoError(t, err)
+			defer p.Shutdown(context.Background())
+
+			p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: tt.batches})
+			p.(*Processor).store.Expire()
+
+			virtualNodeLabels := labels.FromMap(map[string]string{
+				"client":          "svc-a",
+				"server":          "external-peer",
+				"connection_type": "virtual_node",
+			})
+			assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", virtualNodeLabels))
+		})
+	}
 }

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -2,7 +2,6 @@ package servicegraphs
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
 	"math"
 	"os"
@@ -489,8 +488,7 @@ func TestServiceGraphs_droppedEdgesMetric(t *testing.T) {
 
 	traceID := []byte{0x01}
 	spanID := []byte{0x02}
-	key := buildKey(hex.EncodeToString(traceID), hex.EncodeToString(spanID))
-	p.(*Processor).store.AddDroppedSpanSide(key, store.Server)
+	p.(*Processor).store.AddDroppedSpanSideFromBytes(traceID, spanID, store.Server)
 
 	request := &tempopb.PushSpansRequest{
 		Batches: []*tracev1.ResourceSpans{
@@ -757,8 +755,7 @@ func TestServiceGraphs_filteredRootServerSpanDoesNotAddDroppedCounterpart(t *tes
 
 	p.PushSpans(context.Background(), request)
 
-	emptyParentKey := buildKey(hex.EncodeToString(traceID), "")
-	assert.False(t, p.(*Processor).store.HasDroppedSpanSide(emptyParentKey, store.Server))
+	assert.False(t, p.(*Processor).store.HasDroppedSpanSideFromBytes(traceID, nil, store.Server))
 }
 
 func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -458,6 +458,119 @@ func TestServiceGraphs_exemplarsCarryTraceID(t *testing.T) {
 	}
 }
 
+func TestServiceGraphs_histogramModesEmitValuesAndExemplars(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        registry.HistogramMode
+		wantClassic bool
+		wantNative  bool
+	}{
+		{name: "classic", mode: registry.HistogramModeClassic, wantClassic: true},
+		{name: "native", mode: registry.HistogramModeNative, wantNative: true},
+		{name: "both", mode: registry.HistogramModeBoth, wantClassic: true, wantNative: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appender := &serviceGraphCapturingAppender{}
+			managedRegistry := registry.New(&registry.Config{
+				CollectionInterval: time.Hour,
+				StaleDuration:      time.Hour,
+			}, serviceGraphRegistryOverrides{
+				nativeHistogramBucketFactor:     1.1,
+				nativeHistogramMaxBucketNumber:  100,
+				nativeHistogramMinResetDuration: 15 * time.Minute,
+			}, "test", appender, log.NewNopLogger(), serviceGraphNoopLimiter{})
+			defer managedRegistry.Close()
+
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.HistogramBuckets = []float64{0.04}
+			cfg.HistogramOverride = tt.mode
+			cfg.EnableMessagingSystemLatencyHistogram = true
+			cfg.Workers = 0
+
+			p, err := New(cfg, "test", managedRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+			require.NoError(t, err)
+			defer p.Shutdown(context.Background())
+
+			request := benchmarkServiceGraphRequestForKind(1, false, benchmarkServiceGraphMessagingEdge)
+			p.PushSpans(context.Background(), request)
+			managedRegistry.CollectMetrics(context.Background())
+
+			seriesLabels := func(metricName, bucket string) labels.Labels {
+				m := map[string]string{
+					model.MetricNameLabel: metricName,
+					"client":              "client",
+					"server":              "server",
+					"connection_type":     "messaging_system",
+				}
+				if bucket != "" {
+					m[labels.BucketLabel] = bucket
+				}
+				return labels.FromMap(m)
+			}
+
+			requestSample := requireLatestServiceGraphSample(t, appender, seriesLabels(metricRequestTotal, ""))
+			assert.Equal(t, 1.0, requestSample.v)
+
+			traceID := request.Batches[0].ScopeSpans[0].Spans[0].TraceId
+			wantTraceID := tempo_util.TraceIDToHexString(traceID)
+			histograms := []struct {
+				name              string
+				sum               float64
+				finiteBucketCount float64
+				exemplarBucket    string
+			}{
+				{name: metricRequestClientSeconds, sum: 0.05, finiteBucketCount: 0, exemplarBucket: "+Inf"},
+				{name: metricRequestServerSeconds, sum: 0.03, finiteBucketCount: 1, exemplarBucket: "0.04"},
+				{name: metricRequestMessagingSystemSeconds, sum: 0.01, finiteBucketCount: 1, exemplarBucket: "0.04"},
+			}
+
+			for _, histogram := range histograms {
+				if tt.wantClassic {
+					assert.Equal(t, 1.0, requireLatestServiceGraphSample(t, appender, seriesLabels(histogram.name+"_count", "")).v)
+					assert.InDelta(t, histogram.sum, requireLatestServiceGraphSample(t, appender, seriesLabels(histogram.name+"_sum", "")).v, 1e-9)
+					assert.Equal(t, histogram.finiteBucketCount, requireLatestServiceGraphSample(t, appender, seriesLabels(histogram.name+"_bucket", "0.04")).v)
+					assert.Equal(t, 1.0, requireLatestServiceGraphSample(t, appender, seriesLabels(histogram.name+"_bucket", "+Inf")).v)
+				} else {
+					assertServiceGraphMetricAbsent(t, appender, histogram.name+"_count")
+					assertServiceGraphMetricAbsent(t, appender, histogram.name+"_sum")
+					assertServiceGraphMetricAbsent(t, appender, histogram.name+"_bucket")
+				}
+
+				if tt.wantNative {
+					native := requireLatestServiceGraphHistogram(t, appender, seriesLabels(histogram.name, ""))
+					assert.Equal(t, uint64(1), native.h.Count)
+					assert.InDelta(t, histogram.sum, native.h.Sum, 1e-9)
+				} else {
+					assertServiceGraphHistogramAbsent(t, appender, histogram.name)
+				}
+
+				exemplarMetric := histogram.name
+				exemplarBucket := ""
+				if tt.wantClassic {
+					exemplarMetric += "_bucket"
+					exemplarBucket = histogram.exemplarBucket
+				}
+				assertServiceGraphExemplar(t, appender, seriesLabels(exemplarMetric, exemplarBucket), wantTraceID, histogram.sum)
+			}
+
+			wantSamples := 2 // request counter initialization and current value
+			if tt.wantClassic {
+				wantSamples = 23
+			}
+			wantHistograms := 0
+			if tt.wantNative {
+				wantHistograms = 6 // zero and current native sample for three histograms
+			}
+			require.Len(t, appender.samples, wantSamples)
+			require.Len(t, appender.histograms, wantHistograms)
+			require.Len(t, appender.exemplars, len(histograms))
+		})
+	}
+}
+
 func TestServiceGraphs_virtualNodesExtraLabelsForUninstrumentedServices(t *testing.T) {
 	testRegistry := registry.NewTestRegistry()
 
@@ -1254,8 +1367,22 @@ type serviceGraphExemplarSample struct {
 	e exemplar.Exemplar
 }
 
+type serviceGraphSample struct {
+	l labels.Labels
+	t int64
+	v float64
+}
+
+type serviceGraphHistogramSample struct {
+	l labels.Labels
+	t int64
+	h *prom_histogram.Histogram
+}
+
 type serviceGraphCapturingAppender struct {
-	exemplars []serviceGraphExemplarSample
+	samples    []serviceGraphSample
+	histograms []serviceGraphHistogramSample
+	exemplars  []serviceGraphExemplarSample
 }
 
 var (
@@ -1267,7 +1394,8 @@ func (c *serviceGraphCapturingAppender) Appender(context.Context) storage.Append
 	return c
 }
 
-func (c *serviceGraphCapturingAppender) Append(ref storage.SeriesRef, _ labels.Labels, _ int64, _ float64) (storage.SeriesRef, error) {
+func (c *serviceGraphCapturingAppender) Append(ref storage.SeriesRef, lbls labels.Labels, timeMs int64, value float64) (storage.SeriesRef, error) {
+	c.samples = append(c.samples, serviceGraphSample{l: lbls.Copy(), t: timeMs, v: value})
 	return ref, nil
 }
 
@@ -1283,7 +1411,10 @@ func (c *serviceGraphCapturingAppender) AppendExemplar(ref storage.SeriesRef, lb
 	return ref, nil
 }
 
-func (c *serviceGraphCapturingAppender) AppendHistogram(ref storage.SeriesRef, _ labels.Labels, _ int64, _ *prom_histogram.Histogram, _ *prom_histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (c *serviceGraphCapturingAppender) AppendHistogram(ref storage.SeriesRef, lbls labels.Labels, timeMs int64, h *prom_histogram.Histogram, _ *prom_histogram.FloatHistogram) (storage.SeriesRef, error) {
+	if h != nil {
+		c.histograms = append(c.histograms, serviceGraphHistogramSample{l: lbls.Copy(), t: timeMs, h: h.Copy()})
+	}
 	return ref, nil
 }
 
@@ -1381,6 +1512,77 @@ func assertServiceGraphExemplarTraceID(t *testing.T, appender *serviceGraphCaptu
 	}
 
 	require.Failf(t, "missing exemplar", "metric %s with traceID %s not found in %#v", metricName, traceID, appender.exemplars)
+}
+
+func requireLatestServiceGraphSample(t *testing.T, appender *serviceGraphCapturingAppender, wantLabels labels.Labels) serviceGraphSample {
+	t.Helper()
+
+	var latest serviceGraphSample
+	found := false
+	for _, sample := range appender.samples {
+		if !labels.Equal(serviceGraphLabelsWithoutInstance(sample.l), wantLabels) {
+			continue
+		}
+		if !found || sample.t > latest.t {
+			latest = sample
+			found = true
+		}
+	}
+	require.Truef(t, found, "sample %s not found in %#v", wantLabels, appender.samples)
+	return latest
+}
+
+func requireLatestServiceGraphHistogram(t *testing.T, appender *serviceGraphCapturingAppender, wantLabels labels.Labels) serviceGraphHistogramSample {
+	t.Helper()
+
+	var latest serviceGraphHistogramSample
+	found := false
+	for _, sample := range appender.histograms {
+		if !labels.Equal(serviceGraphLabelsWithoutInstance(sample.l), wantLabels) {
+			continue
+		}
+		if !found || sample.t > latest.t {
+			latest = sample
+			found = true
+		}
+	}
+	require.Truef(t, found, "histogram %s not found in %#v", wantLabels, appender.histograms)
+	return latest
+}
+
+func assertServiceGraphMetricAbsent(t *testing.T, appender *serviceGraphCapturingAppender, metricName string) {
+	t.Helper()
+	for _, sample := range appender.samples {
+		assert.NotEqual(t, metricName, sample.l.Get(model.MetricNameLabel))
+	}
+}
+
+func assertServiceGraphHistogramAbsent(t *testing.T, appender *serviceGraphCapturingAppender, metricName string) {
+	t.Helper()
+	for _, sample := range appender.histograms {
+		assert.NotEqual(t, metricName, sample.l.Get(model.MetricNameLabel))
+	}
+}
+
+func assertServiceGraphExemplar(t *testing.T, appender *serviceGraphCapturingAppender, wantLabels labels.Labels, traceID string, value float64) {
+	t.Helper()
+
+	matches := 0
+	for _, sample := range appender.exemplars {
+		if !labels.Equal(serviceGraphLabelsWithoutInstance(sample.l), wantLabels) {
+			continue
+		}
+		matches++
+		assert.Equal(t, traceID, sample.e.Labels.Get("traceID"))
+		assert.InDelta(t, value, sample.e.Value, 1e-9)
+	}
+	require.Equalf(t, 1, matches, "exemplar %s with traceID %s not found exactly once in %#v", wantLabels, traceID, appender.exemplars)
+}
+
+func serviceGraphLabelsWithoutInstance(lbls labels.Labels) labels.Labels {
+	lb := labels.NewBuilder(lbls)
+	lb.Del("__metrics_gen_instance")
+	return lb.Labels()
 }
 
 func makeServiceGraphBatch(svcName string, kind tracev1.Span_SpanKind, traceID, spanID, parentSpanID []byte, spanAttrs ...*v1.KeyValue) *tracev1.ResourceSpans {

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -88,8 +88,3 @@ func (e *Edge) isExpired() bool {
 func (e *Edge) IsRoot() bool {
 	return e.key.root
 }
-
-// Key returns an encoded key that remains valid after the Edge is recycled.
-func (e *Edge) Key() string {
-	return e.key.String()
-}

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -11,11 +11,22 @@ const (
 	VirtualNode     ConnectionType = "virtual_node"
 )
 
-// Edge is an Edge between two nodes in the graph
+// Edge is an Edge between two nodes in the graph.
+//
+// Edges are pool-allocated and pointers handed to update/onComplete/onExpire
+// callbacks are only valid for the duration of the callback — the store may
+// recycle the Edge after the callback returns. Do not retain *Edge or any
+// substrings of its fields past the callback.
 type Edge struct {
-	key string
+	key edgeKey
+	// Intrusive list pointers; mutated only by *Store under Store.mtx.
+	prev, next *Edge
 
-	TraceID                                        string
+	// traceID is an edge-owned copy of the raw span trace ID bytes (not hex).
+	// The backing buffer is reused across pool recycles; it must only be
+	// written through SetTraceID — assigning a caller's slice would make the
+	// pool retain and later overwrite foreign memory.
+	traceID                                        []byte
 	ConnectionType                                 ConnectionType
 	ServerService, ClientService                   string
 	ServerLatencySec, ClientLatencySec             float64
@@ -38,14 +49,29 @@ type Edge struct {
 	SpanMultiplier float64
 }
 
-// resetEdge resets the Edge to its zero state.
-// Useful for reusing an Edge without allocating a new one.
+// resetEdge clears the Edge for reuse, keeping its reusable Dimensions and
+// trace ID buffers and defaulting SpanMultiplier.
 func resetEdge(e *Edge) {
 	*e = Edge{
 		Dimensions:     e.Dimensions,
+		traceID:        e.traceID[:0],
 		SpanMultiplier: 1,
 	}
 	clear(e.Dimensions)
+}
+
+// SetTraceID copies id into the Edge's reused trace ID buffer. The Edge must
+// own the bytes: id typically aliases the decoded push request, which must
+// not be retained past PushSpans, while the Edge lives until it completes or
+// expires.
+func (e *Edge) SetTraceID(id []byte) {
+	e.traceID = append(e.traceID[:0], id...)
+}
+
+// TraceID returns the raw trace ID bytes. The slice aliases an edge-owned
+// buffer that is reused after the callback returns; do not retain it.
+func (e *Edge) TraceID() []byte {
+	return e.traceID
 }
 
 // isComplete returns true if the corresponding client and server
@@ -58,6 +84,12 @@ func (e *Edge) isExpired() bool {
 	return time.Now().Unix() >= e.expiration
 }
 
+// IsRoot reports whether the edge key has an empty parent span ID.
+func (e *Edge) IsRoot() bool {
+	return e.key.root
+}
+
+// Key returns an encoded key that remains valid after the Edge is recycled.
 func (e *Edge) Key() string {
-	return e.key
+	return e.key.String()
 }

--- a/modules/generator/processor/servicegraphs/store/interface.go
+++ b/modules/generator/processor/servicegraphs/store/interface.go
@@ -7,17 +7,9 @@ const (
 	Server Side = "server"
 )
 
+// Callback is invoked by the store with a pooled *Edge while holding the
+// store mutex. The Edge pointer is only valid for the duration of the call —
+// the store may return it to the pool after the callback returns. Do not
+// retain the pointer, send it to another goroutine, or store substrings of
+// its fields beyond the callback's lifetime.
 type Callback func(e *Edge)
-
-// Store is an interface for building service graphs.
-type Store interface {
-	// UpsertEdge inserts or updates an edge.
-	UpsertEdge(key string, side Side, update Callback) (isNew bool, err error)
-	// AddDroppedSpanSide adds a dropped span side key and returns true if an
-	// existing buffered counterpart edge was removed.
-	AddDroppedSpanSide(key string, side Side) bool
-	// HasDroppedSpanSide checks if a dropped span side key exists.
-	HasDroppedSpanSide(key string, side Side) bool
-	// Expire evicts expired edges from the store.
-	Expire()
-}

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -1,8 +1,9 @@
 package store
 
 import (
-	"container/list"
+	"encoding/hex"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,13 +15,14 @@ var (
 	ErrDroppedSpanSide = errors.New("dropped span side")
 )
 
-var _ Store = (*store)(nil)
-
-type store struct {
-	l   *list.List
+// Store builds service graph edges from paired client/server spans.
+type Store struct {
 	mtx sync.Mutex
-	m   map[string]*list.Element
+	m   map[edgeKey]*Edge
 	d   map[droppedSpanSideKey]int64
+
+	head *Edge
+	tail *Edge
 
 	onComplete Callback
 	onExpire   Callback
@@ -32,17 +34,63 @@ type store struct {
 }
 
 type droppedSpanSideKey struct {
-	key  string
+	key  edgeKey
 	side Side
+}
+
+const (
+	maxTraceIDLen = 16
+	maxSpanIDLen  = 8
+)
+
+// edgeKey keeps valid OTLP IDs inline. Oversized malformed IDs use an encoded
+// fallback so their full contents still participate in matching.
+type edgeKey struct {
+	traceID  [maxTraceIDLen]byte
+	spanID   [maxSpanIDLen]byte
+	fallback string
+
+	traceIDLen uint8
+	spanIDLen  uint8
+	root       bool
+	fromString bool
+}
+
+func edgeKeyFromString(key string) edgeKey {
+	return edgeKey{
+		fallback:   key,
+		root:       strings.HasSuffix(key, "-"),
+		fromString: true,
+	}
+}
+
+func edgeKeyFromBytes(traceID, spanID []byte) edgeKey {
+	key := edgeKey{root: len(spanID) == 0}
+	if len(traceID) > maxTraceIDLen || len(spanID) > maxSpanIDLen {
+		key.fallback = encodeKey(traceID, spanID)
+		return key
+	}
+
+	key.traceIDLen = uint8(len(traceID))
+	key.spanIDLen = uint8(len(spanID))
+	copy(key.traceID[:], traceID)
+	copy(key.spanID[:], spanID)
+	return key
+}
+
+func (k edgeKey) String() string {
+	if k.fallback != "" || k.fromString {
+		return k.fallback
+	}
+	return encodeKey(k.traceID[:k.traceIDLen], k.spanID[:k.spanIDLen])
 }
 
 // NewStore creates a Store to build service graphs. The store caches edges, each representing a
 // request between two services. Once an edge is complete its metrics can be collected. Edges that
 // have not found their pair are deleted after ttl time.
-func NewStore(ttl time.Duration, maxItems int, onComplete, onExpire Callback, droppedSpanSideOverflowCounter prometheus.Counter) Store {
-	s := &store{
-		l: list.New(),
-		m: make(map[string]*list.Element),
+func NewStore(ttl time.Duration, maxItems int, onComplete, onExpire Callback, droppedSpanSideOverflowCounter prometheus.Counter) *Store {
+	s := &Store{
+		m: make(map[edgeKey]*Edge),
 		d: make(map[droppedSpanSideKey]int64),
 
 		onComplete: onComplete,
@@ -57,58 +105,63 @@ func NewStore(ttl time.Duration, maxItems int, onComplete, onExpire Callback, dr
 	return s
 }
 
-func (s *store) len() int {
+func (s *Store) len() int {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	return s.l.Len()
+	return len(s.m)
 }
 
 // tryEvictHead checks if the oldest item (head of list) can be evicted and will delete it if so.
 // Returns true if the head was evicted.
 //
 // Must be called holding lock.
-func (s *store) tryEvictHead() bool {
-	head := s.l.Front()
-	if head == nil {
+func (s *Store) tryEvictHead() bool {
+	if s.head == nil {
 		// list is empty
 		return false
 	}
 
-	headEdge := head.Value.(*Edge)
-	if !headEdge.isExpired() {
+	if !s.head.isExpired() {
 		return false
 	}
 
-	s.onExpire(headEdge)
-	s.deleteEdge(head)
+	s.onExpire(s.head)
+	s.deleteEdge(s.head)
 
 	return true
 }
 
 // deleteEdge removes an edge from the map/list and returns it to the pool.
 // Must be called holding lock.
-func (s *store) deleteEdge(ele *list.Element) {
-	edge := ele.Value.(*Edge)
+func (s *Store) deleteEdge(edge *Edge) {
 	delete(s.m, edge.key)
-	s.l.Remove(ele)
+	s.removeEdge(edge)
 	s.returnEdge(edge)
 }
 
 // UpsertEdge fetches an Edge from the store and updates it using the given callback. If the Edge
 // doesn't exist yet, it creates a new one with the default TTL.
 // If the Edge is complete after applying the callback, it's completed and removed.
-func (s *store) UpsertEdge(key string, side Side, update Callback) (isNew bool, err error) {
+func (s *Store) UpsertEdge(key string, side Side, update Callback) (isNew bool, err error) {
+	return s.upsertEdge(edgeKeyFromString(key), side, update)
+}
+
+// UpsertEdgeFromBytes is the byte-keyed form of UpsertEdge.
+func (s *Store) UpsertEdgeFromBytes(traceID, spanID []byte, side Side, update Callback) (isNew bool, err error) {
+	return s.upsertEdge(edgeKeyFromBytes(traceID, spanID), side, update)
+}
+
+func (s *Store) upsertEdge(key edgeKey, side Side, update Callback) (isNew bool, err error) {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
-	if storedEdge, ok := s.m[key]; ok {
-		edge := storedEdge.Value.(*Edge)
+	if edge, ok := s.m[key]; ok {
 		update(edge)
 
 		if edge.isComplete() {
 			s.onComplete(edge)
-			s.deleteEdge(storedEdge)
+			s.deleteEdge(edge)
 		}
 
 		return false, nil
@@ -128,20 +181,59 @@ func (s *store) UpsertEdge(key string, side Side, update Callback) (isNew bool, 
 	}
 
 	// Check we can add new edges
-	if s.l.Len() >= s.maxItems {
+	if len(s.m) >= s.maxItems {
 		// todo: try to evict expired items
 		s.returnEdge(edge)
 		return false, ErrTooManyItems
 	}
 
-	ele := s.l.PushBack(edge)
-	s.m[key] = ele
+	s.pushBack(edge)
+	s.m[key] = edge
 
 	return true, nil
 }
 
+func (s *Store) pushBack(edge *Edge) {
+	edge.prev = s.tail
+	edge.next = nil
+	if s.tail != nil {
+		s.tail.next = edge
+	} else {
+		s.head = edge
+	}
+	s.tail = edge
+}
+
+func (s *Store) removeEdge(edge *Edge) {
+	if edge.prev != nil {
+		edge.prev.next = edge.next
+	} else {
+		s.head = edge.next
+	}
+	if edge.next != nil {
+		edge.next.prev = edge.prev
+	} else {
+		s.tail = edge.prev
+	}
+	edge.prev = nil
+	edge.next = nil
+}
+
+func encodedKeyLen(k1, k2 []byte) int {
+	return hex.EncodedLen(len(k1)) + 1 + hex.EncodedLen(len(k2))
+}
+
+func encodeKey(k1, k2 []byte) string {
+	buf := make([]byte, encodedKeyLen(k1, k2))
+	k1Len := hex.EncodedLen(len(k1))
+	hex.Encode(buf[:k1Len], k1)
+	buf[k1Len] = '-'
+	hex.Encode(buf[k1Len+1:], k2)
+	return string(buf)
+}
+
 // Expire evicts all expired items in the store.
-func (s *store) Expire() {
+func (s *Store) Expire() {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -152,17 +244,25 @@ func (s *store) Expire() {
 }
 
 // This cache is best-effort metadata for dropped-span correlation.
-func (s *store) AddDroppedSpanSide(key string, side Side) bool {
+func (s *Store) AddDroppedSpanSide(key string, side Side) bool {
+	return s.addDroppedSpanSide(edgeKeyFromString(key), side)
+}
+
+// AddDroppedSpanSideFromBytes records a filtered edge side using trace/span ID bytes.
+func (s *Store) AddDroppedSpanSideFromBytes(traceID, spanID []byte, side Side) bool {
+	return s.addDroppedSpanSide(edgeKeyFromBytes(traceID, spanID), side)
+}
+
+func (s *Store) addDroppedSpanSide(key edgeKey, side Side) bool {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
 	droppedCounterpartEdge := false
-	if storedEdge, ok := s.m[key]; ok {
-		edge := storedEdge.Value.(*Edge)
+	if edge, ok := s.m[key]; ok {
 		// If a counterpart edge is already buffered, drop it immediately instead of
 		// waiting for TTL expiration.
 		if !edge.isComplete() && getEdgeSide(edge) != side {
-			s.deleteEdge(storedEdge)
+			s.deleteEdge(edge)
 			droppedCounterpartEdge = true
 		}
 	}
@@ -187,7 +287,16 @@ func (s *store) AddDroppedSpanSide(key string, side Side) bool {
 	return droppedCounterpartEdge
 }
 
-func (s *store) HasDroppedSpanSide(key string, side Side) bool {
+func (s *Store) HasDroppedSpanSide(key string, side Side) bool {
+	return s.hasDroppedSpanSide(edgeKeyFromString(key), side)
+}
+
+// HasDroppedSpanSideFromBytes reports whether a trace/span ID side is recorded as dropped.
+func (s *Store) HasDroppedSpanSideFromBytes(traceID, spanID []byte, side Side) bool {
+	return s.hasDroppedSpanSide(edgeKeyFromBytes(traceID, spanID), side)
+}
+
+func (s *Store) hasDroppedSpanSide(key edgeKey, side Side) bool {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 
@@ -198,7 +307,7 @@ func (s *store) HasDroppedSpanSide(key string, side Side) bool {
 	return ok
 }
 
-func (s *store) expireDroppedSpanSides() {
+func (s *Store) expireDroppedSpanSides() {
 	now := time.Now().UnixNano()
 	for k, expiration := range s.d {
 		if now >= expiration {
@@ -207,7 +316,7 @@ func (s *store) expireDroppedSpanSides() {
 	}
 }
 
-func (s *store) hasDroppedCounterpart(key string, side Side) bool {
+func (s *Store) hasDroppedCounterpart(key edgeKey, side Side) bool {
 	counterpart := Client
 	if side == Client {
 		counterpart = Server
@@ -226,7 +335,7 @@ var edgePool = sync.Pool{
 }
 
 // grabEdge returns a new Edge from the pool, clearing its state and setting the key and expiration.
-func (s *store) grabEdge(key string) *Edge {
+func (s *Store) grabEdge(key edgeKey) *Edge {
 	edge := edgePool.Get().(*Edge)
 	resetEdge(edge)
 	edge.key = key
@@ -235,7 +344,7 @@ func (s *store) grabEdge(key string) *Edge {
 }
 
 // returnEdge returns an Edge to the pool.
-func (s *store) returnEdge(e *Edge) {
+func (s *Store) returnEdge(e *Edge) {
 	edgePool.Put(e)
 }
 

--- a/modules/generator/processor/servicegraphs/store/store.go
+++ b/modules/generator/processor/servicegraphs/store/store.go
@@ -3,7 +3,6 @@ package store
 import (
 	"encoding/hex"
 	"errors"
-	"strings"
 	"sync"
 	"time"
 
@@ -53,15 +52,6 @@ type edgeKey struct {
 	traceIDLen uint8
 	spanIDLen  uint8
 	root       bool
-	fromString bool
-}
-
-func edgeKeyFromString(key string) edgeKey {
-	return edgeKey{
-		fallback:   key,
-		root:       strings.HasSuffix(key, "-"),
-		fromString: true,
-	}
 }
 
 func edgeKeyFromBytes(traceID, spanID []byte) edgeKey {
@@ -79,7 +69,7 @@ func edgeKeyFromBytes(traceID, spanID []byte) edgeKey {
 }
 
 func (k edgeKey) String() string {
-	if k.fallback != "" || k.fromString {
+	if k.fallback != "" {
 		return k.fallback
 	}
 	return encodeKey(k.traceID[:k.traceIDLen], k.spanID[:k.spanIDLen])
@@ -140,14 +130,10 @@ func (s *Store) deleteEdge(edge *Edge) {
 	s.returnEdge(edge)
 }
 
-// UpsertEdge fetches an Edge from the store and updates it using the given callback. If the Edge
-// doesn't exist yet, it creates a new one with the default TTL.
-// If the Edge is complete after applying the callback, it's completed and removed.
-func (s *Store) UpsertEdge(key string, side Side, update Callback) (isNew bool, err error) {
-	return s.upsertEdge(edgeKeyFromString(key), side, update)
-}
-
-// UpsertEdgeFromBytes is the byte-keyed form of UpsertEdge.
+// UpsertEdgeFromBytes fetches an Edge from the store and updates it using the
+// given callback. If the Edge doesn't exist yet, it creates a new one with the
+// default TTL. If the Edge is complete after applying the callback, it's
+// completed and removed.
 func (s *Store) UpsertEdgeFromBytes(traceID, spanID []byte, side Side, update Callback) (isNew bool, err error) {
 	return s.upsertEdge(edgeKeyFromBytes(traceID, spanID), side, update)
 }
@@ -243,11 +229,6 @@ func (s *Store) Expire() {
 	s.expireDroppedSpanSides()
 }
 
-// This cache is best-effort metadata for dropped-span correlation.
-func (s *Store) AddDroppedSpanSide(key string, side Side) bool {
-	return s.addDroppedSpanSide(edgeKeyFromString(key), side)
-}
-
 // AddDroppedSpanSideFromBytes records a filtered edge side using trace/span ID bytes.
 func (s *Store) AddDroppedSpanSideFromBytes(traceID, spanID []byte, side Side) bool {
 	return s.addDroppedSpanSide(edgeKeyFromBytes(traceID, spanID), side)
@@ -285,10 +266,6 @@ func (s *Store) addDroppedSpanSide(key edgeKey, side Side) bool {
 
 	s.d[k] = time.Now().Add(s.ttl).UnixNano()
 	return droppedCounterpartEdge
-}
-
-func (s *Store) HasDroppedSpanSide(key string, side Side) bool {
-	return s.hasDroppedSpanSide(edgeKeyFromString(key), side)
 }
 
 // HasDroppedSpanSideFromBytes reports whether a trace/span ID side is recorded as dropped.
@@ -345,6 +322,12 @@ func (s *Store) grabEdge(key edgeKey) *Edge {
 
 // returnEdge returns an Edge to the pool.
 func (s *Store) returnEdge(e *Edge) {
+	// Do not retain request-owned keys or malformed request-sized trace IDs in
+	// the global pool while an edge is idle.
+	e.key = edgeKey{}
+	if cap(e.traceID) > maxTraceIDLen {
+		e.traceID = nil
+	}
 	edgePool.Put(e)
 }
 

--- a/modules/generator/processor/servicegraphs/store/store_test.go
+++ b/modules/generator/processor/servicegraphs/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -27,7 +28,7 @@ func TestStoreUpsertEdge(t *testing.T) {
 	assert.Equal(t, 0, s.len())
 
 	// Insert first half of an edge
-	isNew, err := s.UpsertEdge(keyStr, Client, func(e *Edge) {
+	isNew, err := upsertTestEdge(s, keyStr, Client, func(e *Edge) {
 		e.ClientService = clientService
 	})
 	require.NoError(t, err)
@@ -40,7 +41,7 @@ func TestStoreUpsertEdge(t *testing.T) {
 	assert.Equal(t, 0, onExpireCount)
 
 	// Insert the second half of an edge
-	isNew, err = s.UpsertEdge(keyStr, Server, func(e *Edge) {
+	isNew, err = upsertTestEdge(s, keyStr, Server, func(e *Edge) {
 		assert.Equal(t, clientService, e.ClientService)
 		e.ServerService = "server"
 	})
@@ -53,7 +54,7 @@ func TestStoreUpsertEdge(t *testing.T) {
 	assert.Equal(t, 0, onExpireCount)
 
 	// Insert an edge that will immediately expire
-	isNew, err = s.UpsertEdge(keyStr, Client, func(e *Edge) {
+	isNew, err = upsertTestEdge(s, keyStr, Client, func(e *Edge) {
 		e.ClientService = clientService
 		e.expiration = 0
 	})
@@ -75,20 +76,20 @@ func TestStoreUpsertEdge_errTooManyItems(t *testing.T) {
 	s := NewStore(time.Hour, 1, countingCallback(&onCallbackCounter), countingCallback(&onCallbackCounter), newTestCounter())
 	assert.Equal(t, 0, s.len())
 
-	isNew, err := s.UpsertEdge("key-1", Client, func(e *Edge) {
+	isNew, err := upsertTestEdge(s, "key-1", Client, func(e *Edge) {
 		e.ClientService = clientService
 	})
 	require.NoError(t, err)
 	require.Equal(t, true, isNew)
 	assert.Equal(t, 1, s.len())
 
-	_, err = s.UpsertEdge("key-2", Client, func(e *Edge) {
+	_, err = upsertTestEdge(s, "key-2", Client, func(e *Edge) {
 		e.ClientService = clientService
 	})
 	require.ErrorIs(t, err, ErrTooManyItems)
 	assert.Equal(t, 1, s.len())
 
-	isNew, err = s.UpsertEdge("key-1", Client, func(e *Edge) {
+	isNew, err = upsertTestEdge(s, "key-1", Client, func(e *Edge) {
 		e.ClientService = clientService
 	})
 	require.NoError(t, err)
@@ -101,9 +102,12 @@ func TestStoreUpsertEdge_errTooManyItems(t *testing.T) {
 func TestStoreExpire(t *testing.T) {
 	const testSize = 100
 
-	keys := map[string]bool{}
+	keys := map[edgeKey]bool{}
+	names := make([]string, 0, testSize)
 	for i := 0; i < testSize; i++ {
-		keys[fmt.Sprintf("key-%d", i)] = true
+		name := fmt.Sprintf("key-%d", i)
+		keys[testEdgeKey(name)] = true
+		names = append(names, name)
 	}
 
 	var onCompletedCount int
@@ -111,13 +115,13 @@ func TestStoreExpire(t *testing.T) {
 
 	onComplete := func(e *Edge) {
 		onCompletedCount++
-		assert.True(t, keys[e.Key()])
+		assert.True(t, keys[e.key])
 	}
 	// New edges are immediately expired
 	s := NewStore(-time.Second, testSize, onComplete, countingCallback(&onExpireCount), newTestCounter())
 
-	for key := range keys {
-		isNew, err := s.UpsertEdge(key, Client, noopCallback)
+	for _, name := range names {
+		isNew, err := upsertTestEdge(s, name, Client, noopCallback)
 		require.NoError(t, err)
 		require.Equal(t, true, isNew)
 	}
@@ -176,23 +180,23 @@ func TestStore_AddDroppedSpanSide(t *testing.T) {
 
 	const key = "trace-span"
 	const side = Client
-	assert.False(t, s.HasDroppedSpanSide(key, side))
+	assert.False(t, hasDroppedTestSpanSide(s, key, side))
 
-	droppedCounterpart := s.AddDroppedSpanSide(key, side)
+	droppedCounterpart := addDroppedTestSpanSide(s, key, side)
 	assert.False(t, droppedCounterpart)
-	assert.True(t, s.HasDroppedSpanSide(key, side))
+	assert.True(t, hasDroppedTestSpanSide(s, key, side))
 }
 
 func TestStore_AddDroppedSpanSide_respectsMaxItems(t *testing.T) {
 	s := NewStore(time.Hour, 2, noopCallback, noopCallback, newTestCounter())
 
-	s.AddDroppedSpanSide("k1", Client)
-	s.AddDroppedSpanSide("k2", Client)
-	s.AddDroppedSpanSide("k3", Client)
+	addDroppedTestSpanSide(s, "k1", Client)
+	addDroppedTestSpanSide(s, "k2", Client)
+	addDroppedTestSpanSide(s, "k3", Client)
 
-	assert.True(t, s.HasDroppedSpanSide("k1", Client))
-	assert.True(t, s.HasDroppedSpanSide("k2", Client))
-	assert.False(t, s.HasDroppedSpanSide("k3", Client))
+	assert.True(t, hasDroppedTestSpanSide(s, "k1", Client))
+	assert.True(t, hasDroppedTestSpanSide(s, "k2", Client))
+	assert.False(t, hasDroppedTestSpanSide(s, "k3", Client))
 }
 
 func TestStore_AddDroppedSpanSide_overflowMetricIncrementsAtCapacity(t *testing.T) {
@@ -202,10 +206,10 @@ func TestStore_AddDroppedSpanSide_overflowMetricIncrementsAtCapacity(t *testing.
 	})
 	s := NewStore(time.Hour, 2, noopCallback, noopCallback, overflowCounter)
 
-	s.AddDroppedSpanSide("k1", Client)
-	s.AddDroppedSpanSide("k2", Client)
-	s.AddDroppedSpanSide("k1", Client) // refresh existing, should not overflow
-	s.AddDroppedSpanSide("k3", Client) // overflow
+	addDroppedTestSpanSide(s, "k1", Client)
+	addDroppedTestSpanSide(s, "k2", Client)
+	addDroppedTestSpanSide(s, "k1", Client) // refresh existing, should not overflow
+	addDroppedTestSpanSide(s, "k3", Client) // overflow
 
 	assert.Equal(t, float64(1), testutil.ToFloat64(overflowCounter))
 }
@@ -215,13 +219,13 @@ func TestStore_AddDroppedSpanSide_expiresWithTTL(t *testing.T) {
 		s := NewStore(time.Second, 10, noopCallback, noopCallback, newTestCounter())
 
 		const key = "k-expire"
-		s.AddDroppedSpanSide(key, Client)
-		assert.True(t, s.HasDroppedSpanSide(key, Client))
+		addDroppedTestSpanSide(s, key, Client)
+		assert.True(t, hasDroppedTestSpanSide(s, key, Client))
 
 		time.Sleep(2 * time.Second)
 		s.Expire()
 
-		assert.False(t, s.HasDroppedSpanSide(key, Client))
+		assert.False(t, hasDroppedTestSpanSide(s, key, Client))
 	})
 }
 
@@ -229,21 +233,21 @@ func TestStore_AddDroppedSpanSide_sidesAreIndependent(t *testing.T) {
 	s := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
 
 	const key = "k-side"
-	s.AddDroppedSpanSide(key, Client)
+	addDroppedTestSpanSide(s, key, Client)
 
-	assert.True(t, s.HasDroppedSpanSide(key, Client))
-	assert.False(t, s.HasDroppedSpanSide(key, Server))
+	assert.True(t, hasDroppedTestSpanSide(s, key, Client))
+	assert.False(t, hasDroppedTestSpanSide(s, key, Server))
 }
 
 func TestStore_AddDroppedSpanSide_dropsExistingCounterpartEdge(t *testing.T) {
 	s := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
 
-	_, err := s.UpsertEdge("k1", Client, func(e *Edge) {
+	_, err := upsertTestEdge(s, "k1", Client, func(e *Edge) {
 		e.ClientService = clientService
 	})
 	require.NoError(t, err)
 
-	_, err = s.UpsertEdge("k2", Client, func(e *Edge) {
+	_, err = upsertTestEdge(s, "k2", Client, func(e *Edge) {
 		e.ClientService = clientService
 	})
 	require.NoError(t, err)
@@ -251,13 +255,13 @@ func TestStore_AddDroppedSpanSide_dropsExistingCounterpartEdge(t *testing.T) {
 	assert.Equal(t, 2, s.len())
 
 	// Server side for k1 was filtered/dropped; existing client-side edge for k1 should be removed.
-	droppedCounterpart := s.AddDroppedSpanSide("k1", Server)
+	droppedCounterpart := addDroppedTestSpanSide(s, "k1", Server)
 	assert.True(t, droppedCounterpart)
 
 	assert.Equal(t, 1, s.len())
-	_, foundK1 := s.m[edgeKeyFromString("k1")]
+	_, foundK1 := s.m[testEdgeKey("k1")]
 	assert.False(t, foundK1)
-	_, foundK2 := s.m[edgeKeyFromString("k2")]
+	_, foundK2 := s.m[testEdgeKey("k2")]
 	assert.True(t, foundK2)
 }
 
@@ -266,18 +270,18 @@ func TestStore_AddDroppedSpanSide_refreshesTTL(t *testing.T) {
 		s := NewStore(time.Second, 10, noopCallback, noopCallback, newTestCounter())
 
 		const key = "k-refresh"
-		s.AddDroppedSpanSide(key, Client)
+		addDroppedTestSpanSide(s, key, Client)
 
 		time.Sleep(500 * time.Millisecond)
-		s.AddDroppedSpanSide(key, Client)
+		addDroppedTestSpanSide(s, key, Client)
 
 		time.Sleep(700 * time.Millisecond)
 		s.Expire()
-		assert.True(t, s.HasDroppedSpanSide(key, Client))
+		assert.True(t, hasDroppedTestSpanSide(s, key, Client))
 
 		time.Sleep(500 * time.Millisecond)
 		s.Expire()
-		assert.False(t, s.HasDroppedSpanSide(key, Client))
+		assert.False(t, hasDroppedTestSpanSide(s, key, Client))
 	})
 }
 
@@ -285,23 +289,23 @@ func TestStore_AddDroppedSpanSide_refreshAllowedAtMaxItems(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		s := NewStore(time.Second, 2, noopCallback, noopCallback, newTestCounter())
 
-		s.AddDroppedSpanSide("k1", Client)
-		s.AddDroppedSpanSide("k2", Client)
+		addDroppedTestSpanSide(s, "k1", Client)
+		addDroppedTestSpanSide(s, "k2", Client)
 		time.Sleep(700 * time.Millisecond)
 		// At capacity: this should refresh k1, not be blocked.
-		s.AddDroppedSpanSide("k1", Client)
+		addDroppedTestSpanSide(s, "k1", Client)
 		// Still at capacity: new key should be rejected.
-		s.AddDroppedSpanSide("k3", Client)
+		addDroppedTestSpanSide(s, "k3", Client)
 
-		assert.True(t, s.HasDroppedSpanSide("k1", Client))
-		assert.True(t, s.HasDroppedSpanSide("k2", Client))
-		assert.False(t, s.HasDroppedSpanSide("k3", Client))
+		assert.True(t, hasDroppedTestSpanSide(s, "k1", Client))
+		assert.True(t, hasDroppedTestSpanSide(s, "k2", Client))
+		assert.False(t, hasDroppedTestSpanSide(s, "k3", Client))
 
 		time.Sleep(500 * time.Millisecond)
 		s.Expire()
 		// k2 should be expired; k1 should remain because it was refreshed.
-		assert.True(t, s.HasDroppedSpanSide("k1", Client))
-		assert.False(t, s.HasDroppedSpanSide("k2", Client))
+		assert.True(t, hasDroppedTestSpanSide(s, "k1", Client))
+		assert.False(t, hasDroppedTestSpanSide(s, "k2", Client))
 	})
 }
 
@@ -309,15 +313,15 @@ func TestStore_ExpireDroppedSpanSide_mixedTTL(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		s := NewStore(time.Second, 10, noopCallback, noopCallback, newTestCounter())
 
-		s.AddDroppedSpanSide("old", Client)
+		addDroppedTestSpanSide(s, "old", Client)
 		time.Sleep(700 * time.Millisecond)
-		s.AddDroppedSpanSide("new", Client)
+		addDroppedTestSpanSide(s, "new", Client)
 
 		time.Sleep(500 * time.Millisecond)
 		s.Expire()
 
-		assert.False(t, s.HasDroppedSpanSide("old", Client))
-		assert.True(t, s.HasDroppedSpanSide("new", Client))
+		assert.False(t, hasDroppedTestSpanSide(s, "old", Client))
+		assert.True(t, hasDroppedTestSpanSide(s, "new", Client))
 	})
 }
 
@@ -325,8 +329,8 @@ func TestStore_ExpireDroppedSpanSide_doesNotAffectEdges(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		s := NewStore(time.Second, 10, noopCallback, noopCallback, newTestCounter())
 
-		s.AddDroppedSpanSide("d1", Client)
-		_, err := s.UpsertEdge("e1", Client, func(e *Edge) {
+		addDroppedTestSpanSide(s, "d1", Client)
+		_, err := upsertTestEdge(s, "e1", Client, func(e *Edge) {
 			e.ClientService = clientService
 		})
 		require.NoError(t, err)
@@ -335,7 +339,7 @@ func TestStore_ExpireDroppedSpanSide_doesNotAffectEdges(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		s.Expire()
 
-		assert.False(t, s.HasDroppedSpanSide("d1", Client))
+		assert.False(t, hasDroppedTestSpanSide(s, "d1", Client))
 		// Edge should also be expired by normal edge-expire path.
 		assert.Equal(t, 0, s.len())
 	})
@@ -345,9 +349,9 @@ func TestStore_UpsertEdge_newEdgeWithDroppedCounterpart_returnsErrDroppedSpanSid
 	s := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
 
 	const key = "trace-span"
-	s.AddDroppedSpanSide(key, Server)
+	addDroppedTestSpanSide(s, key, Server)
 
-	isNew, err := s.UpsertEdge(key, Client, func(e *Edge) {
+	isNew, err := upsertTestEdge(s, key, Client, func(e *Edge) {
 		e.ClientService = clientService
 	})
 
@@ -486,6 +490,31 @@ func TestEdgeKeyFromBytes(t *testing.T) {
 func noopCallback(_ *Edge) {
 }
 
+func testEdgeIDs(name string) ([]byte, []byte) {
+	id := sha256.Sum256([]byte(name))
+	return id[:maxTraceIDLen], id[maxTraceIDLen : maxTraceIDLen+maxSpanIDLen]
+}
+
+func testEdgeKey(name string) edgeKey {
+	traceID, spanID := testEdgeIDs(name)
+	return edgeKeyFromBytes(traceID, spanID)
+}
+
+func upsertTestEdge(s *Store, name string, side Side, update Callback) (bool, error) {
+	traceID, spanID := testEdgeIDs(name)
+	return s.UpsertEdgeFromBytes(traceID, spanID, side, update)
+}
+
+func addDroppedTestSpanSide(s *Store, name string, side Side) bool {
+	traceID, spanID := testEdgeIDs(name)
+	return s.AddDroppedSpanSideFromBytes(traceID, spanID, side)
+}
+
+func hasDroppedTestSpanSide(s *Store, name string, side Side) bool {
+	traceID, spanID := testEdgeIDs(name)
+	return s.HasDroppedSpanSideFromBytes(traceID, spanID, side)
+}
+
 func countingCallback(counter *int) func(*Edge) {
 	return func(_ *Edge) {
 		*counter++
@@ -500,7 +529,7 @@ func TestResetEdge(t *testing.T) {
 	// Create an edge with all fields set to non-zero values
 	dimensions := map[string]string{"key1": "value1", "key2": "value2"}
 	e := &Edge{
-		key:                     edgeKeyFromString("test-key"),
+		key:                     testEdgeKey("test-key"),
 		traceID:                 []byte("trace-123"),
 		ConnectionType:          Database,
 		ServerService:           "server-svc",
@@ -542,6 +571,46 @@ func TestResetEdge(t *testing.T) {
 	assert.Equal(t, originalPtr, newPtr, "Dimensions map should be the exact same instance, not reallocated")
 }
 
+func TestStoreReturnEdgeClearsRequestSizedState(t *testing.T) {
+	s := NewStore(time.Hour, 1, noopCallback, noopCallback, newTestCounter())
+
+	tests := []struct {
+		name           string
+		traceID        []byte
+		wantTraceIDNil bool
+	}{
+		{
+			name:    "valid trace ID buffer is retained",
+			traceID: make([]byte, 0, maxTraceIDLen),
+		},
+		{
+			name:           "oversized trace ID buffer is dropped",
+			traceID:        make([]byte, maxTraceIDLen+1),
+			wantTraceIDNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Edge{
+				key:        edgeKeyFromBytes(make([]byte, maxTraceIDLen+1), make([]byte, maxSpanIDLen+1)),
+				traceID:    tt.traceID,
+				Dimensions: make(map[string]string),
+			}
+
+			s.returnEdge(e)
+
+			assert.Equal(t, edgeKey{}, e.key)
+			if tt.wantTraceIDNil {
+				assert.Nil(t, e.traceID)
+				return
+			}
+			assert.NotNil(t, e.traceID)
+			assert.Equal(t, maxTraceIDLen, cap(e.traceID))
+		})
+	}
+}
+
 func TestStoreUpsertEdgeFromBytes_droppedCounterpart(t *testing.T) {
 	s := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
 
@@ -563,7 +632,7 @@ func TestStore_interiorEdgeRemovalKeepsListIntact(t *testing.T) {
 	s := NewStore(time.Hour, 10, countingCallback(&onCompleteCount), countingCallback(&onExpireCount), newTestCounter())
 
 	for _, key := range []string{"key-a", "key-b", "key-c"} {
-		isNew, err := s.UpsertEdge(key, Client, func(e *Edge) {
+		isNew, err := upsertTestEdge(s, key, Client, func(e *Edge) {
 			e.ClientService = clientService
 		})
 		require.NoError(t, err)
@@ -572,7 +641,7 @@ func TestStore_interiorEdgeRemovalKeepsListIntact(t *testing.T) {
 	require.Equal(t, 3, s.len())
 
 	// Complete the middle edge: interior removal, prev and next both non-nil.
-	isNew, err := s.UpsertEdge("key-b", Server, func(e *Edge) {
+	isNew, err := upsertTestEdge(s, "key-b", Server, func(e *Edge) {
 		e.ServerService = "server"
 	})
 	require.NoError(t, err)
@@ -580,13 +649,13 @@ func TestStore_interiorEdgeRemovalKeepsListIntact(t *testing.T) {
 	require.Equal(t, 1, onCompleteCount)
 	require.Equal(t, 2, s.len())
 
-	require.Same(t, s.m[edgeKeyFromString("key-a")], s.head)
-	require.Same(t, s.m[edgeKeyFromString("key-c")], s.tail)
+	require.Same(t, s.m[testEdgeKey("key-a")], s.head)
+	require.Same(t, s.m[testEdgeKey("key-c")], s.tail)
 	require.Same(t, s.tail, s.head.next)
 	require.Same(t, s.head, s.tail.prev)
 
 	// Expire only the head: Expire must evict key-a and stop at unexpired key-c.
-	_, err = s.UpsertEdge("key-a", Client, func(e *Edge) {
+	_, err = upsertTestEdge(s, "key-a", Client, func(e *Edge) {
 		e.expiration = 0
 	})
 	require.NoError(t, err)
@@ -595,7 +664,7 @@ func TestStore_interiorEdgeRemovalKeepsListIntact(t *testing.T) {
 	require.Equal(t, 1, s.len())
 
 	// The surviving tail must still be addressable and completable.
-	isNew, err = s.UpsertEdge("key-c", Server, func(e *Edge) {
+	isNew, err = upsertTestEdge(s, "key-c", Server, func(e *Edge) {
 		e.ServerService = "server"
 	})
 	require.NoError(t, err)

--- a/modules/generator/processor/servicegraphs/store/store_test.go
+++ b/modules/generator/processor/servicegraphs/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -22,9 +23,7 @@ func TestStoreUpsertEdge(t *testing.T) {
 	var onCompletedCount int
 	var onExpireCount int
 
-	storeInterface := NewStore(time.Hour, 1, countingCallback(&onCompletedCount), countingCallback(&onExpireCount), newTestCounter())
-
-	s := storeInterface.(*store)
+	s := NewStore(time.Hour, 1, countingCallback(&onCompletedCount), countingCallback(&onExpireCount), newTestCounter())
 	assert.Equal(t, 0, s.len())
 
 	// Insert first half of an edge
@@ -73,9 +72,7 @@ func TestStoreUpsertEdge(t *testing.T) {
 func TestStoreUpsertEdge_errTooManyItems(t *testing.T) {
 	var onCallbackCounter int
 
-	storeInterface := NewStore(time.Hour, 1, countingCallback(&onCallbackCounter), countingCallback(&onCallbackCounter), newTestCounter())
-
-	s := storeInterface.(*store)
+	s := NewStore(time.Hour, 1, countingCallback(&onCallbackCounter), countingCallback(&onCallbackCounter), newTestCounter())
 	assert.Equal(t, 0, s.len())
 
 	isNew, err := s.UpsertEdge("key-1", Client, func(e *Edge) {
@@ -114,11 +111,10 @@ func TestStoreExpire(t *testing.T) {
 
 	onComplete := func(e *Edge) {
 		onCompletedCount++
-		assert.True(t, keys[e.key])
+		assert.True(t, keys[e.Key()])
 	}
 	// New edges are immediately expired
-	storeInterface := NewStore(-time.Second, testSize, onComplete, countingCallback(&onExpireCount), newTestCounter())
-	s := storeInterface.(*store)
+	s := NewStore(-time.Second, testSize, onComplete, countingCallback(&onExpireCount), newTestCounter())
 
 	for key := range keys {
 		isNew, err := s.UpsertEdge(key, Client, noopCallback)
@@ -136,8 +132,10 @@ func TestStore_concurrency(t *testing.T) {
 	s := NewStore(10*time.Millisecond, 100000, noopCallback, noopCallback, newTestCounter())
 
 	end := make(chan struct{})
+	var wg sync.WaitGroup
 
 	accessor := func(f func()) {
+		defer wg.Done()
 		for {
 			select {
 			case <-end:
@@ -148,16 +146,18 @@ func TestStore_concurrency(t *testing.T) {
 		}
 	}
 
-	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	letters := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
+	wg.Add(2)
 	go accessor(func() {
-		key := make([]rune, 6)
+		key := make([]byte, 24)
 		for i := range key {
 			key[i] = letters[rand.Intn(len(letters))]
 		}
 
-		_, err := s.UpsertEdge(string(key), Client, func(e *Edge) {
-			e.ClientService = string(key)
+		service := string(key)
+		_, err := s.UpsertEdgeFromBytes(key[:16], key[16:], Client, func(e *Edge) {
+			e.ClientService = service
 		})
 		assert.NoError(t, err)
 	})
@@ -168,6 +168,7 @@ func TestStore_concurrency(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 	close(end)
+	wg.Wait()
 }
 
 func TestStore_AddDroppedSpanSide(t *testing.T) {
@@ -235,8 +236,7 @@ func TestStore_AddDroppedSpanSide_sidesAreIndependent(t *testing.T) {
 }
 
 func TestStore_AddDroppedSpanSide_dropsExistingCounterpartEdge(t *testing.T) {
-	si := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
-	s := si.(*store)
+	s := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
 
 	_, err := s.UpsertEdge("k1", Client, func(e *Edge) {
 		e.ClientService = clientService
@@ -255,9 +255,9 @@ func TestStore_AddDroppedSpanSide_dropsExistingCounterpartEdge(t *testing.T) {
 	assert.True(t, droppedCounterpart)
 
 	assert.Equal(t, 1, s.len())
-	_, foundK1 := s.m["k1"]
+	_, foundK1 := s.m[edgeKeyFromString("k1")]
 	assert.False(t, foundK1)
-	_, foundK2 := s.m["k2"]
+	_, foundK2 := s.m[edgeKeyFromString("k2")]
 	assert.True(t, foundK2)
 }
 
@@ -323,8 +323,7 @@ func TestStore_ExpireDroppedSpanSide_mixedTTL(t *testing.T) {
 
 func TestStore_ExpireDroppedSpanSide_doesNotAffectEdges(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
-		si := NewStore(time.Second, 10, noopCallback, noopCallback, newTestCounter())
-		s := si.(*store)
+		s := NewStore(time.Second, 10, noopCallback, noopCallback, newTestCounter())
 
 		s.AddDroppedSpanSide("d1", Client)
 		_, err := s.UpsertEdge("e1", Client, func(e *Edge) {
@@ -343,8 +342,7 @@ func TestStore_ExpireDroppedSpanSide_doesNotAffectEdges(t *testing.T) {
 }
 
 func TestStore_UpsertEdge_newEdgeWithDroppedCounterpart_returnsErrDroppedSpanSide(t *testing.T) {
-	si := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
-	s := si.(*store)
+	s := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
 
 	const key = "trace-span"
 	s.AddDroppedSpanSide(key, Server)
@@ -359,17 +357,130 @@ func TestStore_UpsertEdge_newEdgeWithDroppedCounterpart_returnsErrDroppedSpanSid
 }
 
 func BenchmarkStoreUpsertEdge(b *testing.B) {
-	// Benchmark the performance of UpsertEdge with edge pooling enabled
-	s := NewStore(10*time.Millisecond, 1e10, noopCallback, noopCallback, newTestCounter())
+	s := NewStore(10*time.Millisecond, 1, noopCallback, noopCallback, newTestCounter())
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		key := fmt.Sprintf("key-%d", i)
-		_, err := s.UpsertEdge(key, Client, func(e *Edge) {
-			e.ClientService = clientService
-		})
-		require.NoError(b, err)
+		if _, err := s.UpsertEdgeFromBytes(traceID, spanID, Client, benchmarkUpdateClientEdge); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := s.UpsertEdgeFromBytes(traceID, spanID, Server, benchmarkUpdateServerEdge); err != nil {
+			b.Fatal(err)
+		}
 	}
+}
+
+func benchmarkUpdateClientEdge(e *Edge) {
+	e.ClientService = clientService
+}
+
+func benchmarkUpdateServerEdge(e *Edge) {
+	e.ServerService = "server"
+}
+
+func TestStoreUpsertEdgeFromBytes_ValidIDs(t *testing.T) {
+	// Verify the callback runs and the edge pairs correctly across two calls.
+	s := NewStore(time.Hour, 1, noopCallback, noopCallback, newTestCounter())
+
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8}
+
+	isNew, err := s.UpsertEdgeFromBytes(traceID, spanID, Client, func(e *Edge) {
+		e.ClientService = clientService
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	assert.Equal(t, 1, s.len())
+
+	isNew, err = s.UpsertEdgeFromBytes(traceID, spanID, Server, func(e *Edge) {
+		assert.Equal(t, clientService, e.ClientService)
+		e.ServerService = "server"
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	// Edge completed and removed.
+	assert.Equal(t, 0, s.len())
+}
+
+func TestStoreUpsertEdgeFromBytes_OversizedIDs(t *testing.T) {
+	// Malformed oversized IDs use an encoded fallback without truncating their
+	// contents or changing pairing behavior.
+	s := NewStore(time.Hour, 1, noopCallback, noopCallback, newTestCounter())
+
+	bigTraceID := make([]byte, 33)
+	bigSpanID := make([]byte, 33)
+	for i := range bigTraceID {
+		bigTraceID[i] = byte(i + 1)
+		bigSpanID[i] = byte(i + 100)
+	}
+
+	isNew, err := s.UpsertEdgeFromBytes(bigTraceID, bigSpanID, Client, func(e *Edge) {
+		e.ClientService = clientService
+	})
+	require.NoError(t, err)
+	require.True(t, isNew)
+	assert.Equal(t, 1, s.len())
+
+	// The same oversized key must hit the existing edge.
+	isNew, err = s.UpsertEdgeFromBytes(bigTraceID, bigSpanID, Server, func(e *Edge) {
+		assert.Equal(t, clientService, e.ClientService)
+		e.ServerService = "server"
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	assert.Equal(t, 0, s.len())
+}
+
+func TestEdgeKeyFromBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		traceID []byte
+		spanID  []byte
+		root    bool
+	}{
+		{
+			name:    "valid IDs",
+			traceID: make([]byte, maxTraceIDLen),
+			spanID:  make([]byte, maxSpanIDLen),
+		},
+		{
+			name:    "short IDs",
+			traceID: []byte{0x01},
+			spanID:  []byte{0x02},
+		},
+		{
+			name:    "oversized IDs",
+			traceID: make([]byte, maxTraceIDLen+1),
+			spanID:  make([]byte, maxSpanIDLen+1),
+		},
+		{
+			name:    "root span",
+			traceID: []byte{0x01},
+			root:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := edgeKeyFromBytes(tt.traceID, tt.spanID)
+			assert.Equal(t, encodeKey(tt.traceID, tt.spanID), key.String())
+			assert.Equal(t, tt.root, key.root)
+		})
+	}
+
+	assert.NotEqual(t,
+		edgeKeyFromBytes([]byte{0x01}, []byte{0x02}),
+		edgeKeyFromBytes([]byte{0x01, 0x00}, []byte{0x02}),
+		"ID lengths must participate in key equality",
+	)
+
+	traceID := []byte{0x01}
+	key := edgeKeyFromBytes(traceID, []byte{0x02})
+	traceID[0] = 0xff
+	assert.Equal(t, edgeKeyFromBytes([]byte{0x01}, []byte{0x02}), key)
 }
 
 func noopCallback(_ *Edge) {
@@ -389,8 +500,8 @@ func TestResetEdge(t *testing.T) {
 	// Create an edge with all fields set to non-zero values
 	dimensions := map[string]string{"key1": "value1", "key2": "value2"}
 	e := &Edge{
-		key:                     "test-key",
-		TraceID:                 "trace-123",
+		key:                     edgeKeyFromString("test-key"),
+		traceID:                 []byte("trace-123"),
 		ConnectionType:          Database,
 		ServerService:           "server-svc",
 		ClientService:           "client-svc",
@@ -409,8 +520,8 @@ func TestResetEdge(t *testing.T) {
 	resetEdge(e)
 
 	// Verify all fields are properly reset
-	assert.Equal(t, "", e.key, "key should be preserved")
-	assert.Equal(t, "", e.TraceID, "TraceID should be reset")
+	assert.Equal(t, edgeKey{}, e.key, "key should be reset")
+	assert.Empty(t, e.traceID, "traceID should be reset (buffer retained, length zero)")
 	assert.Equal(t, Unknown, e.ConnectionType, "ConnectionType should be reset to Unknown")
 	assert.Equal(t, "", e.ServerService, "ServerService should be reset")
 	assert.Equal(t, "", e.ClientService, "ClientService should be reset")
@@ -429,4 +540,86 @@ func TestResetEdge(t *testing.T) {
 	originalPtr := reflect.ValueOf(dimensions).Pointer()
 	newPtr := reflect.ValueOf(e.Dimensions).Pointer()
 	assert.Equal(t, originalPtr, newPtr, "Dimensions map should be the exact same instance, not reallocated")
+}
+
+func TestStoreUpsertEdgeFromBytes_droppedCounterpart(t *testing.T) {
+	s := NewStore(time.Hour, 10, noopCallback, noopCallback, newTestCounter())
+
+	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := []byte{0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8}
+
+	s.AddDroppedSpanSideFromBytes(traceID, spanID, Server)
+
+	isNew, err := s.UpsertEdgeFromBytes(traceID, spanID, Client, func(e *Edge) {
+		e.ClientService = clientService
+	})
+	require.ErrorIs(t, err, ErrDroppedSpanSide)
+	assert.True(t, isNew)
+	assert.Equal(t, 0, s.len())
+}
+
+func TestStore_interiorEdgeRemovalKeepsListIntact(t *testing.T) {
+	var onCompleteCount, onExpireCount int
+	s := NewStore(time.Hour, 10, countingCallback(&onCompleteCount), countingCallback(&onExpireCount), newTestCounter())
+
+	for _, key := range []string{"key-a", "key-b", "key-c"} {
+		isNew, err := s.UpsertEdge(key, Client, func(e *Edge) {
+			e.ClientService = clientService
+		})
+		require.NoError(t, err)
+		require.True(t, isNew)
+	}
+	require.Equal(t, 3, s.len())
+
+	// Complete the middle edge: interior removal, prev and next both non-nil.
+	isNew, err := s.UpsertEdge("key-b", Server, func(e *Edge) {
+		e.ServerService = "server"
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.Equal(t, 1, onCompleteCount)
+	require.Equal(t, 2, s.len())
+
+	require.Same(t, s.m[edgeKeyFromString("key-a")], s.head)
+	require.Same(t, s.m[edgeKeyFromString("key-c")], s.tail)
+	require.Same(t, s.tail, s.head.next)
+	require.Same(t, s.head, s.tail.prev)
+
+	// Expire only the head: Expire must evict key-a and stop at unexpired key-c.
+	_, err = s.UpsertEdge("key-a", Client, func(e *Edge) {
+		e.expiration = 0
+	})
+	require.NoError(t, err)
+	s.Expire()
+	require.Equal(t, 1, onExpireCount)
+	require.Equal(t, 1, s.len())
+
+	// The surviving tail must still be addressable and completable.
+	isNew, err = s.UpsertEdge("key-c", Server, func(e *Edge) {
+		e.ServerService = "server"
+	})
+	require.NoError(t, err)
+	require.False(t, isNew)
+	require.Equal(t, 2, onCompleteCount)
+	require.Equal(t, 1, onExpireCount)
+	require.Equal(t, 0, s.len())
+}
+
+func TestSetTraceID_copiesSourceAndReusesBuffer(t *testing.T) {
+	e := &Edge{}
+
+	src := []byte{0x01, 0x02, 0x03, 0x04}
+	e.SetTraceID(src)
+	src[0] = 0xFF
+	assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, e.TraceID(), "mutating the source must not affect the edge's copy")
+
+	bufPtr := &e.traceID[0]
+	resetEdge(e)
+	assert.Empty(t, e.TraceID())
+
+	// A shorter ID after recycling must not expose stale bytes of the previous
+	// ID and must reuse the retained backing array.
+	e.SetTraceID([]byte{0xAA})
+	assert.Equal(t, []byte{0xAA}, e.TraceID())
+	assert.Same(t, bufPtr, &e.traceID[0], "backing array should be reused across recycles")
 }

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -1928,6 +1928,11 @@ func (g *recordingGauge) Set(lbls labels.Labels, value float64) {
 	g.Gauge.Set(lbls, value)
 }
 
+func (g *recordingGauge) SetBorrowed(lbls *registry.BorrowedLabels, value float64, timeMs int64) {
+	*g.calls = append(*g.calls, g.name)
+	g.Gauge.SetBorrowed(lbls, value, timeMs)
+}
+
 func (g *recordingGauge) Inc(lbls labels.Labels, value float64) {
 	*g.calls = append(*g.calls, g.name)
 	g.Gauge.Inc(lbls, value)

--- a/modules/generator/registry/gauge.go
+++ b/modules/generator/registry/gauge.go
@@ -58,6 +58,10 @@ func (g *gauge) Set(lbls labels.Labels, value float64) {
 	g.updateSeries(lbls, lbls.Hash(), value, set, true, time.Now().UnixMilli())
 }
 
+func (g *gauge) SetBorrowed(lbls *BorrowedLabels, value float64, timeMs int64) {
+	g.updateSeries(lbls.Labels, lbls.Hash, value, set, true, timeMs)
+}
+
 func (g *gauge) Inc(lbls labels.Labels, value float64) {
 	g.updateSeries(lbls, lbls.Hash(), value, add, true, time.Now().UnixMilli())
 }

--- a/modules/generator/registry/gauge_test.go
+++ b/modules/generator/registry/gauge_test.go
@@ -110,6 +110,42 @@ func Test_gaugeSet(t *testing.T) {
 	collectMetricAndAssert(t, c, collectionTimeMs, 3, expectedSamples, nil)
 }
 
+func Test_gaugeSetBorrowed_refreshesExistingSeries(t *testing.T) {
+	var seriesUpdated, seriesDeleted int
+	lifecycler := &mockLimiter{
+		onUpdateFunc: func(_ uint64, count uint32) {
+			assert.Equal(t, uint32(1), count)
+			seriesUpdated++
+		},
+		onDeleteFunc: func(_ uint64, count uint32) {
+			assert.Equal(t, uint32(1), count)
+			seriesDeleted++
+		},
+	}
+	g := newGauge("my_gauge", lifecycler, map[string]string{}, 15*time.Minute)
+	lbls := buildTestLabels([]string{"label"}, []string{"value"})
+	hash := lbls.Hash()
+	borrowed := &BorrowedLabels{Labels: lbls, Hash: hash}
+
+	g.SetBorrowed(borrowed, 1, 100)
+	assert.Equal(t, 1.0, g.series[hash].value.Load())
+	assert.Equal(t, int64(100), g.series[hash].lastUpdated.Load())
+	assert.Equal(t, 0, seriesUpdated)
+
+	g.SetBorrowed(borrowed, 2, 200)
+	assert.Equal(t, 2.0, g.series[hash].value.Load())
+	assert.Equal(t, int64(200), g.series[hash].lastUpdated.Load())
+	assert.Equal(t, 1, seriesUpdated)
+
+	g.removeStaleSeries(150)
+	assert.Len(t, g.series, 1)
+	assert.Equal(t, 0, seriesDeleted)
+
+	g.removeStaleSeries(201)
+	assert.Empty(t, g.series)
+	assert.Equal(t, 1, seriesDeleted)
+}
+
 func Test_gauge_cantAdd(t *testing.T) {
 	canAdd := false
 	overflowLabels := labels.FromStrings("metric_overflow", "true")

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -149,6 +149,10 @@ func (h *histogram) ObserveBorrowed(lbls *BorrowedLabels, value float64, traceID
 	h.observeWithExemplarWithHashAt(lbls.Labels, lbls.Hash, value, newHistogramTraceIDBytesExemplar(traceID), multiplier, timeMs)
 }
 
+func (h *histogram) ObserveBorrowedWithEncodedTraceID(lbls *BorrowedLabels, value float64, traceID string, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls.Labels, lbls.Hash, value, newHistogramStringExemplar(traceID), multiplier, timeMs)
+}
+
 func (h *histogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, ex histogramExemplar, multiplier float64, timeMs int64) {
 	h.seriesDemand.Insert(hash)
 

--- a/modules/generator/registry/interface.go
+++ b/modules/generator/registry/interface.go
@@ -121,6 +121,10 @@ type Histogram interface {
 	// trace ID bytes and label data it needs before returning, so the caller
 	// may Release lbls and reuse the slice afterwards.
 	ObserveBorrowed(lbls *BorrowedLabels, value float64, traceID []byte, multiplier float64, timeMs int64)
+	// ObserveBorrowedWithEncodedTraceID is like ObserveBorrowed but accepts an
+	// already hex-encoded trace ID. It lets callers share one encoding across
+	// multiple native histogram observations.
+	ObserveBorrowedWithEncodedTraceID(lbls *BorrowedLabels, value float64, traceID string, multiplier float64, timeMs int64)
 }
 
 // Gauge
@@ -131,6 +135,10 @@ type Gauge interface {
 
 	// Set sets the Gauge to an arbitrary value.
 	Set(lbls labels.Labels, value float64)
+	// SetBorrowed is like Set but keys the series by the precomputed lbls.Hash
+	// and uses timeMs as the lastUpdated stamp. It copies what it needs before
+	// returning, so the caller may Release lbls afterwards.
+	SetBorrowed(lbls *BorrowedLabels, value float64, timeMs int64)
 	Inc(lbls labels.Labels, value float64)
 	SetForTargetInfo(lbls labels.Labels, value float64)
 	// SetForTargetInfoBorrowed is like SetForTargetInfo but keys the series by

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -136,6 +136,10 @@ func (h *nativeHistogram) ObserveBorrowed(lbls *BorrowedLabels, value float64, t
 	h.observeWithExemplarWithHashAt(lbls.Labels, lbls.Hash, value, tempo_util.TraceIDToHexString(traceID), multiplier, timeMs)
 }
 
+func (h *nativeHistogram) ObserveBorrowedWithEncodedTraceID(lbls *BorrowedLabels, value float64, traceID string, multiplier float64, timeMs int64) {
+	h.observeWithExemplarWithHashAt(lbls.Labels, lbls.Hash, value, traceID, multiplier, timeMs)
+}
+
 func (h *nativeHistogram) observeWithExemplarWithHashAt(lbls labels.Labels, hash uint64, value float64, traceID string, multiplier float64, timeMs int64) {
 	h.seriesDemand.Insert(hash)
 

--- a/modules/generator/registry/registry_benchmark_test.go
+++ b/modules/generator/registry/registry_benchmark_test.go
@@ -1,6 +1,9 @@
 package registry
 
 import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
 	"testing"
 	"time"
 
@@ -64,6 +67,146 @@ func BenchmarkManagedRegistryBorrowPath(b *testing.B) {
 				counter.IncBorrowed(borrowed, 1, ts)
 				histogram.ObserveBorrowed(borrowed, 0.42, traceID, 1, ts)
 				borrowed.Release()
+			}
+		})
+	}
+}
+
+// BenchmarkLabelBuilderPoolsMultiTenant measures how the per-registry pools
+// scale with tenant count. One benchmark operation covers every tenant once.
+// Run with -cpu to expose sync.Pool's GOMAXPROCS-sized local-cache cost, for
+// example:
+//
+//	go test ./modules/generator/registry -run '^$' \
+//		-bench BenchmarkLabelBuilderPoolsMultiTenant -benchmem -cpu 5
+func BenchmarkLabelBuilderPoolsMultiTenant(b *testing.B) {
+	type benchmarkLabel struct {
+		name  string
+		value string
+	}
+
+	newPools := func(tenants int) []*labelBuilderPools {
+		pools := make([]*labelBuilderPools, tenants)
+		for i := range pools {
+			pools[i] = newLabelBuilderPools()
+		}
+		return pools
+	}
+
+	buildLabels := func(b *testing.B, pools *labelBuilderPools, benchmarkLabels []benchmarkLabel) {
+		builder := pools.newLabelBuilder(0, 0, noopSanitizer{}, noopLabelLimiter{})
+		for _, label := range benchmarkLabels {
+			builder.Add(label.name, label.value)
+		}
+		borrowed, ok := builder.CloseAndBorrowLabels()
+		if !ok {
+			b.Fatal("expected valid labels")
+		}
+		borrowed.Release()
+	}
+
+	makeLabels := func(count int) []benchmarkLabel {
+		benchmarkLabels := make([]benchmarkLabel, count)
+		for i := range benchmarkLabels {
+			benchmarkLabels[i] = benchmarkLabel{
+				name:  fmt.Sprintf("label_%03d", i),
+				value: fmt.Sprintf("value_%03d", i),
+			}
+		}
+		return benchmarkLabels
+	}
+
+	defaultLabels := []benchmarkLabel{
+		{name: "service", value: "frontend"},
+		{name: "span_name", value: "GET /api/users"},
+		{name: "status_code", value: "200"},
+	}
+	tests := []struct {
+		name    string
+		tenants int
+		labels  []benchmarkLabel
+	}{
+		{name: "tenants=1", tenants: 1, labels: defaultLabels},
+		{name: "tenants=1000", tenants: 1_000, labels: defaultLabels},
+		{name: "tenants=10000", tenants: 10_000, labels: defaultLabels},
+		{name: "tenants=500,labels=32", tenants: 500, labels: makeLabels(32)},
+		{name: "tenants=100,labels=256", tenants: 100, labels: makeLabels(256)},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.Run("first_touch", func(b *testing.B) {
+				b.ReportAllocs()
+				for b.Loop() {
+					pools := newPools(test.tenants)
+					for _, pool := range pools {
+						buildLabels(b, pool, test.labels)
+					}
+					runtime.KeepAlive(pools)
+				}
+				b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(test.tenants), "ns/tenant")
+			})
+
+			b.Run("gc_cycle_and_retouch", func(b *testing.B) {
+				pools := newPools(test.tenants)
+				for _, pool := range pools {
+					buildLabels(b, pool, test.labels)
+				}
+
+				// Include the complete periodic cost: GC moves cached objects to
+				// victim caches and clears primary pool locals, then the first
+				// tenant pass recreates primary locals while reusing victims.
+				b.ReportAllocs()
+				for b.Loop() {
+					runtime.GC()
+					for _, pool := range pools {
+						buildLabels(b, pool, test.labels)
+					}
+				}
+				runtime.KeepAlive(pools)
+				b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(test.tenants), "ns/tenant")
+			})
+
+			b.Run("steady_state_no_gc", func(b *testing.B) {
+				// gc_cycle_and_retouch covers the periodic GC cost. Disable GC
+				// before warmup here to isolate pool reuse between GC cycles.
+				gcPercent := debug.SetGCPercent(-1)
+				defer debug.SetGCPercent(gcPercent)
+
+				pools := newPools(test.tenants)
+				for _, pool := range pools {
+					buildLabels(b, pool, test.labels)
+				}
+
+				b.ReportAllocs()
+				for b.Loop() {
+					for _, pool := range pools {
+						buildLabels(b, pool, test.labels)
+					}
+				}
+				runtime.KeepAlive(pools)
+				b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(test.tenants), "ns/tenant")
+			})
+
+			if len(test.labels) > initialLabelCapacity {
+				b.Run("default_after_high_water_no_gc", func(b *testing.B) {
+					gcPercent := debug.SetGCPercent(-1)
+					defer debug.SetGCPercent(gcPercent)
+
+					pools := newPools(test.tenants)
+					for _, pool := range pools {
+						buildLabels(b, pool, test.labels)
+					}
+
+					b.ReportAllocs()
+					for b.Loop() {
+						for _, pool := range pools {
+							buildLabels(b, pool, defaultLabels)
+						}
+					}
+					runtime.KeepAlive(pools)
+					b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N)/float64(test.tenants), "ns/tenant")
+				})
 			}
 		})
 	}

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -1068,6 +1068,7 @@ func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
 	builder.Add("label", "value-1")
 	borrowed, valid := builder.CloseAndBorrowLabels()
 	require.True(t, valid)
+	scratch := borrowed.scratch
 
 	timeMs := time.Now().UnixMilli()
 	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
@@ -1082,18 +1083,7 @@ func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
 		traceID[i] = 0xff
 	}
 
-	// Churn the pooled builders and scratch buffers to overwrite the storage
-	// the borrowed labels were built in. Use the same label name and a shorter
-	// value so each borrow overwrites the original scratch buffer in place (a
-	// longer value would reallocate and leave the original bytes intact,
-	// hiding a retention bug).
-	for i := 0; i < 100; i++ {
-		b := registry.NewLabelBuilder()
-		b.Add("label", "x")
-		bl, ok := b.CloseAndBorrowLabels()
-		require.True(t, ok)
-		bl.Release()
-	}
+	overwriteBorrowedScratch(t, scratch)
 
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
@@ -1115,6 +1105,32 @@ func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
 	require.Len(t, appender.exemplars, 1)
 	assert.Equal(t, "102030405060708090a0b0c0d0e0f10", appender.exemplars[0].e.Labels.Get("traceID"))
 	assert.Equal(t, "value-1", appender.exemplars[0].l.Get("label"))
+}
+
+func TestManagedRegistry_targetInfoBorrowedLabelsSurviveScratchReuse(t *testing.T) {
+	appender := &capturingAppender{}
+	registry := New(&Config{}, &mockOverrides{}, "test", appender, log.NewNopLogger(), noopLimiter)
+	defer registry.Close()
+
+	targetInfo := registry.NewGauge("my_target_info")
+	setTargetInfo := func(value float64) {
+		builder := registry.NewInfoMetricLabelBuilder()
+		builder.Add("resource", "resource-1")
+		borrowed, valid := builder.CloseAndBorrowLabels()
+		require.True(t, valid)
+		scratch := borrowed.scratch
+		targetInfo.SetForTargetInfoBorrowed(borrowed, value, time.Now().UnixMilli())
+		borrowed.Release()
+		overwriteBorrowedScratch(t, scratch)
+	}
+
+	setTargetInfo(1)
+	setTargetInfo(2) // Existing target_info series are presence-only and stay at 1.
+
+	expected := []sample{
+		newSample(map[string]string{"__name__": "my_target_info", "resource": "resource-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+	}
+	collectRegistryMetricsAndAssert(t, registry, appender, expected)
 }
 
 // TestManagedRegistry_borrowedLabelsSurviveSanitizerAndLimiter is the
@@ -1190,20 +1206,13 @@ func TestManagedRegistry_retainingLimiterDoesNotCorruptSeries(t *testing.T) {
 	builder.Add("label", "value-1")
 	borrowed, ok := builder.CloseAndBorrowLabels()
 	require.True(t, ok)
+	scratch := borrowed.scratch
 	counter.IncBorrowed(borrowed, 1, time.Now().UnixMilli())
 	borrowed.Release()
 
-	// Churn the pools so anything the limiter wrongly retained is overwritten.
-	// Use the same label name and a shorter value so each borrow overwrites the
-	// original scratch buffer in place (a longer value would reallocate and
-	// leave the original bytes intact, hiding a retention bug).
-	for i := 0; i < 100; i++ {
-		b := registry.NewLabelBuilder()
-		b.Add("label", "x")
-		bl, ok := b.CloseAndBorrowLabels()
-		require.True(t, ok)
-		bl.Release()
-	}
+	// Deterministically overwrite the released scratch so anything the
+	// limiter incorrectly retained now aliases different bytes.
+	overwriteBorrowedScratch(t, scratch)
 
 	require.NotEmpty(t, retained)
 	expected := []sample{
@@ -1213,77 +1222,108 @@ func TestManagedRegistry_retainingLimiterDoesNotCorruptSeries(t *testing.T) {
 	collectRegistryMetricsAndAssert(t, registry, appender, expected)
 }
 
-// TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse covers the native
-// and both-mode histogram borrow path, which is production-reachable
-// (HistogramOverride native/both) but exercised by no other borrow/scratch-reuse
-// test. The native series re-bases its reusable bucket-label builder onto owned
-// labels (native_histogram.go: lb.Reset(newSeries.labels)); a regression there
-// would corrupt the emitted series labels once the pooled scratch is reused.
+// TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse covers both raw
+// and pre-encoded trace IDs in native and both-mode histograms. The native
+// series re-bases its reusable bucket-label builder onto owned labels
+// (native_histogram.go: lb.Reset(newSeries.labels)); a regression there would
+// corrupt emitted labels once pooled scratch is reused.
 func TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse(t *testing.T) {
-	for _, tc := range []struct {
+	modes := []struct {
 		name string
 		mode HistogramMode
 	}{
 		{"native", HistogramModeNative},
 		{"both", HistogramModeBoth},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			appender := &capturingAppender{}
-			overrides := &mockOverrides{
-				nativeHistogramBucketFactor:     1.5,
-				nativeHistogramMaxBucketNumber:  10,
-				nativeHistogramMinResetDuration: time.Minute,
-			}
-			registry := New(&Config{}, overrides, "test", appender, log.NewNopLogger(), noopLimiter)
-			defer registry.Close()
-
-			histogram := registry.NewHistogram("my_histogram", []float64{1.0}, tc.mode)
-
-			traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
-			builder := registry.NewLabelBuilder()
-			builder.Add("label", "value-1")
-			borrowed, valid := builder.CloseAndBorrowLabels()
-			require.True(t, valid)
-			histogram.ObserveBorrowedWithEncodedTraceID(borrowed, 1.5, tempo_util.TraceIDToHexString(traceID), 1.0, time.Now().UnixMilli())
-			borrowed.Release()
-
-			// Churn the pooled builders/scratch so any retained borrowed label
-			// would now read overwritten bytes. Use the same label name and a
-			// shorter value so the next borrow overwrites the original scratch
-			// buffer in place (a longer value would reallocate and leave the
-			// original bytes intact, hiding a retention bug).
-			for i := 0; i < 100; i++ {
-				b := registry.NewLabelBuilder()
-				b.Add("label", "x")
-				bl, ok := b.CloseAndBorrowLabels()
-				require.True(t, ok)
-				bl.Release()
-			}
-
-			require.NoError(t, histogram.collectMetrics(appender, time.Now().UnixMilli()))
-
-			// Gather the labels of every emitted series. Native-only mode emits
-			// native histograms (AppendHistogram) plus exemplars; both-mode also
-			// emits classic float samples. Each must carry the intact owned
-			// label, never corrupted bytes from the churned scratch buffers.
-			var seriesLabels []labels.Labels
-			for _, s := range appender.samples {
-				seriesLabels = append(seriesLabels, s.l)
-			}
-			for _, h := range appender.histograms {
-				seriesLabels = append(seriesLabels, h.l)
-			}
-			require.NotEmpty(t, appender.exemplars, "encoded trace ID produced no exemplar")
-			for _, ex := range appender.exemplars {
-				seriesLabels = append(seriesLabels, ex.l)
-				assert.Equal(t, tempo_util.TraceIDToHexString(traceID), ex.e.Labels.Get("traceID"))
-			}
-			require.NotEmpty(t, seriesLabels, "native histogram emitted no series")
-			for _, l := range seriesLabels {
-				assert.Equal(t, "value-1", l.Get("label"), "series labels corrupted after scratch reuse: %s", l.String())
-			}
-		})
 	}
+	paths := []struct {
+		name          string
+		mutateTraceID bool
+		observe       func(Histogram, *BorrowedLabels, []byte, int64)
+	}{
+		{
+			name:          "raw trace ID",
+			mutateTraceID: true,
+			observe: func(histogram Histogram, borrowed *BorrowedLabels, traceID []byte, timeMs int64) {
+				histogram.ObserveBorrowed(borrowed, 1.5, traceID, 1.0, timeMs)
+			},
+		},
+		{
+			name: "encoded trace ID",
+			observe: func(histogram Histogram, borrowed *BorrowedLabels, traceID []byte, timeMs int64) {
+				histogram.ObserveBorrowedWithEncodedTraceID(borrowed, 1.5, tempo_util.TraceIDToHexString(traceID), 1.0, timeMs)
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		for _, path := range paths {
+			t.Run(mode.name+"/"+path.name, func(t *testing.T) {
+				appender := &capturingAppender{}
+				overrides := &mockOverrides{
+					nativeHistogramBucketFactor:     1.5,
+					nativeHistogramMaxBucketNumber:  10,
+					nativeHistogramMinResetDuration: time.Minute,
+				}
+				registry := New(&Config{}, overrides, "test", appender, log.NewNopLogger(), noopLimiter)
+				defer registry.Close()
+
+				histogram := registry.NewHistogram("my_histogram", []float64{1.0}, mode.mode)
+
+				traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+				wantTraceID := tempo_util.TraceIDToHexString(traceID)
+				builder := registry.NewLabelBuilder()
+				builder.Add("label", "value-1")
+				borrowed, valid := builder.CloseAndBorrowLabels()
+				require.True(t, valid)
+				scratch := borrowed.scratch
+				path.observe(histogram, borrowed, traceID, time.Now().UnixMilli())
+				borrowed.Release()
+
+				// The raw path must copy or encode the caller-owned bytes before
+				// returning. Mutating the slice must not change the exemplar.
+				if path.mutateTraceID {
+					for i := range traceID {
+						traceID[i] = 0xff
+					}
+				}
+
+				overwriteBorrowedScratch(t, scratch)
+
+				require.NoError(t, histogram.collectMetrics(appender, time.Now().UnixMilli()))
+
+				// Gather the labels of every emitted series. Native-only mode emits
+				// native histograms (AppendHistogram) plus exemplars; both-mode also
+				// emits classic float samples. Each must carry the intact owned
+				// label, never corrupted bytes from the churned scratch buffers.
+				var seriesLabels []labels.Labels
+				for _, s := range appender.samples {
+					seriesLabels = append(seriesLabels, s.l)
+				}
+				for _, h := range appender.histograms {
+					seriesLabels = append(seriesLabels, h.l)
+				}
+				require.NotEmpty(t, appender.exemplars, "trace ID produced no exemplar")
+				for _, ex := range appender.exemplars {
+					seriesLabels = append(seriesLabels, ex.l)
+					assert.Equal(t, wantTraceID, ex.e.Labels.Get("traceID"))
+				}
+				require.NotEmpty(t, seriesLabels, "native histogram emitted no series")
+				for _, l := range seriesLabels {
+					assert.Equal(t, "value-1", l.Get("label"), "series labels corrupted after scratch reuse: %s", l.String())
+				}
+			})
+		}
+	}
+}
+
+func overwriteBorrowedScratch(t *testing.T, scratch *labels.ScratchBuilder) {
+	t.Helper()
+
+	scratch.Reset()
+	scratch.Add("label", "x")
+	var overwritten labels.Labels
+	scratch.Overwrite(&overwritten)
+	require.Equal(t, "x", overwritten.Get("label"))
 }
 
 // TestManagedRegistryPerTenantPools verifies that each ManagedRegistry owns its

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/tempo/modules/overrides/histograms"
+	tempo_util "github.com/grafana/tempo/pkg/util"
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
@@ -1072,7 +1073,7 @@ func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
 	traceID := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
 	counter.IncBorrowed(borrowed, 1.0, timeMs)
 	histogram.ObserveBorrowed(borrowed, 1.0, traceID, 1.0, timeMs)
-	gauge.SetForTargetInfoBorrowed(borrowed, 1.0, timeMs)
+	gauge.SetBorrowed(borrowed, 1.0, timeMs)
 	borrowed.Release()
 
 	// Overwrite the caller-owned trace ID slice: the histogram must have
@@ -1243,7 +1244,7 @@ func TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse(t *testing.T) {
 			builder.Add("label", "value-1")
 			borrowed, valid := builder.CloseAndBorrowLabels()
 			require.True(t, valid)
-			histogram.ObserveBorrowed(borrowed, 1.5, traceID, 1.0, time.Now().UnixMilli())
+			histogram.ObserveBorrowedWithEncodedTraceID(borrowed, 1.5, tempo_util.TraceIDToHexString(traceID), 1.0, time.Now().UnixMilli())
 			borrowed.Release()
 
 			// Churn the pooled builders/scratch so any retained borrowed label
@@ -1272,8 +1273,10 @@ func TestManagedRegistry_nativeBorrowedLabelsSurviveScratchReuse(t *testing.T) {
 			for _, h := range appender.histograms {
 				seriesLabels = append(seriesLabels, h.l)
 			}
+			require.NotEmpty(t, appender.exemplars, "encoded trace ID produced no exemplar")
 			for _, ex := range appender.exemplars {
 				seriesLabels = append(seriesLabels, ex.l)
+				assert.Equal(t, tempo_util.TraceIDToHexString(traceID), ex.e.Labels.Get("traceID"))
 			}
 			require.NotEmpty(t, seriesLabels, "native histogram emitted no series")
 			for _, l := range seriesLabels {

--- a/modules/generator/registry/test.go
+++ b/modules/generator/registry/test.go
@@ -164,6 +164,10 @@ func (t *testGauge) Set(lbls labels.Labels, value float64) {
 	t.registry.setMetric(t.n, lbls, value)
 }
 
+func (t *testGauge) SetBorrowed(lbls *BorrowedLabels, value float64, _ int64) {
+	t.Set(lbls.Labels, value)
+}
+
 func (t *testGauge) SetForTargetInfo(lbls labels.Labels, value float64) {
 	t.Set(lbls, value)
 }
@@ -221,6 +225,10 @@ func (t *testHistogram) ObserveWithExemplar(lbls labels.Labels, value float64, _
 func (t *testHistogram) ObserveBorrowed(lbls *BorrowedLabels, value float64, _ []byte, multiplier float64, _ int64) {
 	// testHistogram discards the trace ID (ObserveWithExemplar ignores it), so
 	// skip hex-encoding it — that allocation only inflated benchmark allocs.
+	t.ObserveWithExemplar(lbls.Labels, value, "", multiplier)
+}
+
+func (t *testHistogram) ObserveBorrowedWithEncodedTraceID(lbls *BorrowedLabels, value float64, _ string, multiplier float64, _ int64) {
 	t.ObserveWithExemplar(lbls.Labels, value, "", multiplier)
 }
 


### PR DESCRIPTION
## What this PR does

Moves the service-graphs processor onto the registry's pooled borrowed-label path introduced in #7584. It reduces steady-state allocations while preserving metric names, labels, values, exemplars, filtering behavior, and virtual-node inference.

There are no user-facing configuration changes.

## Review guide

1. `registry: extend borrowed metric updates`

   Adds borrowed-label gauge updates and an encoded trace-ID histogram path. Review the label ownership contract, gauge refresh semantics, and native exemplar handling.

2. `servicegraphs: simplify pooled edge storage`

   Replaces hex string map keys and `container/list` entries with comparable fixed-size keys and intrusive links on pooled edges. Review key equality, malformed-ID fallback behavior, dropped-side correlation, root detection, and edge ownership.

3. `servicegraphs: update metrics with borrowed labels`

   Moves completed-edge metrics to borrowed labels, precomputes dimension names, skips disabled multiplier work, and shares timestamps and native trace-ID encodings. Review emitted-series compatibility and the classic versus native exemplar paths.

4. `servicegraphs: benchmark borrowed-label hot paths`

   Adds production-`ManagedRegistry` benchmarks and the changelog entry. Review benchmark setup, warmup placement, and scenario coverage.

## Implementation details

- Standard trace and span IDs use comparable fixed-size keys without per-upsert encoding.
- Oversized malformed IDs use a lossless encoded fallback.
- Edge trace IDs use reusable edge-owned buffers.
- Classic histograms defer trace-ID encoding until collection.
- Native and both modes encode once per edge and reuse the result.
- Counters, histograms, and connection-info gauges share one borrowed label set and update timestamp.
- Dimension label sanitization is performed during processor construction.
- Span multiplier extraction is skipped when disabled.

## Benchmark coverage

The steady-state benchmark covers:

- Default service graphs
- Additional dimensions
- Client/server-prefixed dimensions
- Span multipliers
- Native and both histogram modes
- Database, messaging, and virtual edges

The standard store pairing path remains at zero allocations per operation.

## Validation

- `make fmt`
- `make lint base=origin/main`
- `make chlog-validate`
- `go vet ./modules/generator/processor/servicegraphs/... ./modules/generator/registry ./modules/generator/processor/spanmetrics`
- `go test -race ./modules/generator/processor/servicegraphs/...`
- `go test -race ./modules/generator/registry`
- `go test ./modules/generator/...`
- Every intermediate commit was tested independently
