### PR TITLE
traces: add optional composed trace diff output

### DIFF
--- a/.chloggen/trace-diff-composed.yaml
+++ b/.chloggen/trace-diff-composed.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: query-frontend
+note: Add trace-summary-v0-composed as an optional experimental trace diff API and tempo-cli format. Responses always include a compact summary and include the full patch up to 64 KiB; larger patches report that the patch was omitted. The default remains trace-patch-v0.
+issues: [7593]
+subtext:
+user: carles-grafana

--- a/cmd/tempo-cli/cmd-experimental-trace-diff.go
+++ b/cmd/tempo-cli/cmd-experimental-trace-diff.go
@@ -16,7 +16,7 @@ import (
 type experimentalTraceDiffCmd struct {
 	TraceA string `name:"trace-a" type:"path" required:"" help:"Baseline trace JSON file"`
 	TraceB string `name:"trace-b" type:"path" required:"" help:"Comparison trace JSON file"`
-	Format string `help:"Output format" default:"trace-patch-v0" enum:"trace-patch-v0,trace-summary-v0-native"`
+	Format string `help:"Output format" default:"trace-patch-v0" enum:"trace-patch-v0,trace-summary-v0-native,trace-summary-v0-composed"`
 	Out    string `short:"o" type:"path" help:"File to write output to, instead of stdout" default:""`
 	Pretty bool   `help:"Pretty-print JSON output"`
 }
@@ -71,6 +71,12 @@ func buildTraceDiffOutput(base, compare *tempopb.Trace, format string, warnings 
 			return nil, err
 		}
 		result.Warnings = append(result.Warnings, warnings...)
+		return result, nil
+	case tracediff.VersionTraceSummaryV0Composed:
+		result, err := tracediff.Compose(base, compare, tracediff.DefaultPatchBudgetBytes, warnings)
+		if err != nil {
+			return nil, err
+		}
 		return result, nil
 	default:
 		return nil, fmt.Errorf("%q: %w", format, tracediff.ErrUnsupportedFormat)

--- a/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
+++ b/cmd/tempo-cli/cmd-experimental-trace-diff_test.go
@@ -101,6 +101,48 @@ func TestExperimentalTraceDiffWritesTraceSummary(t *testing.T) {
 	require.Len(t, result.Services, 1)
 }
 
+func TestExperimentalTraceDiffWritesComposed(t *testing.T) {
+	dir := t.TempDir()
+	traceAFile := filepath.Join(dir, "trace-a.json")
+	traceBFile := filepath.Join(dir, "trace-b.json")
+	outFile := filepath.Join(dir, "composed.json")
+
+	writeExperimentalTraceDiffTraceFile(t, traceAFile, experimentalTraceDiffTrace(1, 100_000_000))
+	writeExperimentalTraceDiffResponseFile(t, traceBFile, &tempopb.TraceByIDResponse{
+		Trace:   experimentalTraceDiffTrace(2, 150_000_000),
+		Status:  tempopb.PartialStatus_PARTIAL,
+		Message: "deadline exceeded",
+	})
+
+	cmd := experimentalTraceDiffCmd{
+		TraceA: traceAFile,
+		TraceB: traceBFile,
+		Format: tracediff.VersionTraceSummaryV0Composed,
+		Out:    outFile,
+	}
+	require.NoError(t, cmd.Run(nil))
+
+	bytes, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+
+	var result tracediff.ComposedResult
+	require.NoError(t, json.Unmarshal(bytes, &result))
+	require.Equal(t, tracediff.VersionTraceSummaryV0Composed, result.Version)
+	require.NotNil(t, result.Summary)
+	require.Equal(t, tracediff.VersionTraceSummaryV0Native, result.Summary.Version)
+	require.Nil(t, result.PatchOmitted)
+
+	var patch tracediff.Result
+	require.NoError(t, json.Unmarshal(result.Patch, &patch))
+	require.Equal(t, tracediff.VersionTracePatchV0, patch.Version)
+	require.Len(t, patch.Warnings, 1)
+	assert.Equal(t, tracediff.WarningPartialTrace, patch.Warnings[0].Code)
+
+	require.Len(t, result.Summary.Warnings, 1)
+	assert.Equal(t, tracediff.WarningPartialTrace, result.Summary.Warnings[0].Code)
+	assert.Contains(t, result.Summary.Warnings[0].Message, "trace-b")
+}
+
 func TestExperimentalTraceDiffSummaryWarnsOnPartialTraceFile(t *testing.T) {
 	dir := t.TempDir()
 	traceAFile := filepath.Join(dir, "trace-a.json")

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -745,10 +745,11 @@ GET /api/metrics/query?q={status=error}|count_over_time()by(resource.service.nam
 ### Trace diff
 
 {{< admonition type="warning" >}}
-This endpoint is experimental. The request format and behavior may change in future releases. The diff computation isn't implemented yet; the endpoint currently returns `501 Not Implemented` for valid requests.
+This endpoint is experimental. The request and response formats may change in future releases.
 {{< /admonition >}}
 
-This endpoint will compare two traces and produce a structural diff. Send a `POST` request with a JSON body that identifies both traces by their IDs.
+This endpoint compares two complete traces. Send a `POST` request with a JSON
+body that identifies both traces by their IDs. Partial traces are rejected.
 
 ```
 POST /api/v2/traces/diff
@@ -767,7 +768,8 @@ Request body:
     "traceId": "<COMPARE_TRACE_ID>",
     "start": 1700100000,
     "end": 1700103600
-  }
+  },
+  "format": "trace-summary-v0-composed"
 }
 ```
 
@@ -785,8 +787,19 @@ Parameters:
   Optional. Start of the time range to search for the comparison trace (UNIX epoch seconds).
 - `compare.end`
   Optional. End of the time range to search for the comparison trace (UNIX epoch seconds).
+- `format`
+  Optional. Output format. The default is `trace-patch-v0`. Use
+  `trace-summary-v0-native` for only the compact summary or
+  `trace-summary-v0-composed` for the summary with a size-bounded patch.
 
-When `start` and `end` are provided, the request validates that `start` is before `end`. When the endpoint is fully implemented, these fields will limit block search to that time range. If omitted, Tempo will search across all blocks.
+The composed response always includes a native summary. It includes the full
+patch when the serialized patch is no larger than 64 KiB. Otherwise,
+`patchOmitted` reports the patch size and the reason `over_budget`; send another
+request with `format` set to `trace-patch-v0` to retrieve it.
+
+When `start` and `end` are provided, the request validates that `start` is
+before `end` and limits the block search to that time range. If omitted, Tempo
+searches across all blocks.
 
 Only `POST` is allowed. Other methods return `405 Method Not Allowed`.
 

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -866,9 +866,9 @@ tempo-cli gen attr-index --add-intrinsics ./path/to/block
 This command is experimental. The output format and behavior may change in future releases.
 {{< /admonition >}}
 
-Compare two local trace JSON files. Use the default `trace-patch-v0` format for
-an exact mechanical change list, or `trace-summary-v0-native` for a compact
-triage and service-localization view.
+Compare two local trace JSON files. The default `trace-patch-v0` format returns
+the complete mechanical change list. You can instead request a compact native
+summary or a composed summary with a size-bounded patch.
 
 Use this command to compare traces captured at different times or from different environments, for example, to understand how a deployment changed trace structure.
 
@@ -883,11 +883,17 @@ Arguments:
 
 Options:
 
-- `--format <value>` Output format: `trace-patch-v0` (default) or `trace-summary-v0-native`.
+- `--format <value>` Output format: `trace-patch-v0` (default), `trace-summary-v0-native`, or `trace-summary-v0-composed`.
 - `-o, --out <path>` File to write output to. If not specified, output is printed to `stdout`.
 - `--pretty` Pretty-print JSON output.
 
 The input files can be either raw OpenTelemetry JSON traces or Tempo `TraceByIDResponse` JSON responses.
+
+The `trace-summary-v0-composed` format always includes a
+`trace-summary-v0-native` document. If
+the serialized `trace-patch-v0` document is no larger than 64 KiB, it is
+included in `patch`. Otherwise, `patchOmitted` reports its size and the reason
+`over_budget`; rerun with `--format trace-patch-v0` to retrieve the full patch.
 
 Example:
 

--- a/integration/api/api_test.go
+++ b/integration/api/api_test.go
@@ -594,8 +594,33 @@ func TestTraceDiff(t *testing.T) {
 func callTraceDiffAndAssert(t *testing.T, h *util.TempoHarness, base, compare *tempoUtil.TraceInfo) {
 	t.Helper()
 
-	body := strings.NewReader(fmt.Sprintf(`{"base":{"traceId":"%s"},"compare":{"traceId":"%s"}}`, base.HexID(), compare.HexID()))
-	req, err := http.NewRequest(http.MethodPost, h.BaseURL()+"/api/v2/traces/diff", body)
+	// Default request (no format): the bare trace-patch-v0 document.
+	respBody := postTraceDiff(t, h, fmt.Sprintf(`{"base":{"traceId":"%s"},"compare":{"traceId":"%s"}}`, base.HexID(), compare.HexID()))
+
+	var patch tracediff.Result
+	require.NoError(t, json.Unmarshal(respBody, &patch))
+	assertTraceDiffPatch(t, &patch, base, compare)
+
+	// Explicit composed request: the summary with the full patch embedded
+	// because the vulture traces fit the patch budget.
+	respBody = postTraceDiff(t, h, fmt.Sprintf(`{"base":{"traceId":"%s"},"compare":{"traceId":"%s"},"format":"trace-summary-v0-composed"}`, base.HexID(), compare.HexID()))
+
+	var composed tracediff.ComposedResult
+	require.NoError(t, json.Unmarshal(respBody, &composed))
+	require.Equal(t, tracediff.VersionTraceSummaryV0Composed, composed.Version)
+	require.NotNil(t, composed.Summary)
+	require.Equal(t, tracediff.VersionTraceSummaryV0Native, composed.Summary.Version)
+	require.Nil(t, composed.PatchOmitted)
+
+	var embeddedPatch tracediff.Result
+	require.NoError(t, json.Unmarshal(composed.Patch, &embeddedPatch))
+	assertTraceDiffPatch(t, &embeddedPatch, base, compare)
+}
+
+func postTraceDiff(t *testing.T, h *util.TempoHarness, body string) []byte {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodPost, h.BaseURL()+"/api/v2/traces/diff", strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -606,9 +631,12 @@ func callTraceDiffAndAssert(t *testing.T, h *util.TempoHarness, base, compare *t
 	respBody, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode, string(respBody))
+	return respBody
+}
 
-	var result tracediff.Result
-	require.NoError(t, json.Unmarshal(respBody, &result))
+func assertTraceDiffPatch(t *testing.T, result *tracediff.Result, base, compare *tempoUtil.TraceInfo) {
+	t.Helper()
+
 	require.Equal(t, tracediff.VersionTracePatchV0, result.Version)
 	require.Equal(t, base.HexID(), result.Base.TraceID)
 	require.Equal(t, compare.HexID(), result.Compare.TraceID)

--- a/modules/frontend/tracediff_handler.go
+++ b/modules/frontend/tracediff_handler.go
@@ -68,6 +68,7 @@ func newTraceDiffHandler(_ Config, apiPrefix string, tracePipeline pipeline.Asyn
 			"msg", "trace diff request",
 			"tenant", tenant,
 			"path", req.URL.Path,
+			"format", diffReq.Format,
 			"base_trace_id", diffReq.Base.TraceID,
 			"base_start", traceDiffTimeParam(diffReq.Base.Start),
 			"base_end", traceDiffTimeParam(diffReq.Base.End),
@@ -86,7 +87,7 @@ func newTraceDiffHandler(_ Config, apiPrefix string, tracePipeline pipeline.Asyn
 			return traceDiffErrorResponse(err), nil
 		}
 
-		result, err := tracediff.Diff(baseResp.Trace, compareResp.Trace, tracediff.Format(diffReq.Format))
+		result, err := buildTraceDiffResponse(baseResp.Trace, compareResp.Trace, diffReq.Format)
 		if err != nil {
 			return traceDiffErrorResponse(err), nil
 		}
@@ -97,6 +98,21 @@ func newTraceDiffHandler(_ Config, apiPrefix string, tracePipeline pipeline.Asyn
 		}
 		return traceDiffJSONResponse(body), nil
 	})
+}
+
+// buildTraceDiffResponse dispatches the already-validated request format to
+// the tracediff builder for that format.
+func buildTraceDiffResponse(base, compare *tempopb.Trace, format string) (any, error) {
+	switch format {
+	case tracediff.VersionTraceSummaryV0Composed:
+		return tracediff.Compose(base, compare, tracediff.DefaultPatchBudgetBytes, nil)
+	case tracediff.VersionTracePatchV0:
+		return tracediff.Diff(base, compare, tracediff.FormatTracePatchV0)
+	case tracediff.VersionTraceSummaryV0Native:
+		return tracediff.Summarize(base, compare)
+	default:
+		return nil, fmt.Errorf("%q: %w", format, tracediff.ErrUnsupportedFormat)
+	}
 }
 
 func traceDiffTimeParam(v *int64) any {

--- a/modules/frontend/tracediff_handler_test.go
+++ b/modules/frontend/tracediff_handler_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/grafana/tempo/pkg/tempopb"
 	tempotest "github.com/grafana/tempo/pkg/util/test"
 	"github.com/prometheus/client_golang/prometheus"
@@ -183,23 +185,70 @@ func (traceDiffHidingRedactor) RedactTraceAttributes(_ *tempopb.Trace) error {
 }
 
 func TestTraceDiffHandlerReturnsDiff(t *testing.T) {
-	tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
-		"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
-		"def456": {Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
-	})
-	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
-	require.NoError(t, err)
-	handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), nil), log.NewNopLogger())
+	tests := []struct {
+		name       string
+		body       string
+		assertBody func(t *testing.T, body []byte)
+	}{
+		{
+			name: "default format returns patch",
+			body: `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`,
+			assertBody: func(t *testing.T, body []byte) {
+				t.Helper()
+				var result tracediff.Result
+				require.NoError(t, json.Unmarshal(body, &result))
+				require.Equal(t, tracediff.VersionTracePatchV0, result.Version)
+			},
+		},
+		{
+			name: "composed format returns summary and patch",
+			body: `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"},"format":"trace-summary-v0-composed"}`,
+			assertBody: func(t *testing.T, body []byte) {
+				t.Helper()
+				var result tracediff.ComposedResult
+				require.NoError(t, json.Unmarshal(body, &result))
+				require.Equal(t, tracediff.VersionTraceSummaryV0Composed, result.Version)
+				require.NotNil(t, result.Summary)
+				require.Equal(t, tracediff.VersionTraceSummaryV0Native, result.Summary.Version)
+				require.Nil(t, result.PatchOmitted)
+				var patch tracediff.Result
+				require.NoError(t, json.Unmarshal(result.Patch, &patch))
+				require.Equal(t, tracediff.VersionTracePatchV0, patch.Version)
+			},
+		},
+		{
+			name: "native summary format returns bare summary",
+			body: `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"},"format":"trace-summary-v0-native"}`,
+			assertBody: func(t *testing.T, body []byte) {
+				t.Helper()
+				var result tracediff.SummaryResult
+				require.NoError(t, json.Unmarshal(body, &result))
+				require.Equal(t, tracediff.VersionTraceSummaryV0Native, result.Version)
+			},
+		},
+	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(`{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"}}`))
-	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
-	resp := httptest.NewRecorder()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracePipeline := traceDiffTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+				"abc123": {Trace: tempotest.MakeTrace(1, []byte{0xab, 0xc1, 0x23})},
+				"def456": {Trace: tempotest.MakeTrace(1, []byte{0xde, 0xf4, 0x56})},
+			})
+			o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+			require.NoError(t, err)
+			handler := newHandler(nil, newTraceDiffHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, nil, log.NewNopLogger(), nil), log.NewNopLogger())
 
-	handler.ServeHTTP(resp, req)
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/traces/diff", strings.NewReader(tt.body))
+			req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+			resp := httptest.NewRecorder()
 
-	require.Equal(t, http.StatusOK, resp.Code)
-	require.Equal(t, api.HeaderAcceptJSON, resp.Header().Get(api.HeaderContentType))
-	require.Contains(t, resp.Body.String(), `"version":"trace-patch-v0"`)
+			handler.ServeHTTP(resp, req)
+
+			require.Equal(t, http.StatusOK, resp.Code)
+			require.Equal(t, api.HeaderAcceptJSON, resp.Header().Get(api.HeaderContentType))
+			tt.assertBody(t, resp.Body.Bytes())
+		})
+	}
 }
 
 func TestTraceDiffHandlerRejectsOversizedCombinedInput(t *testing.T) {

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -120,7 +120,7 @@ const (
 type TraceDiffRequest struct {
 	Base    TraceDiffTraceRequest `json:"base"`
 	Compare TraceDiffTraceRequest `json:"compare"`
-	Format  string                `json:"-"`
+	Format  string                `json:"format,omitempty"`
 }
 
 // TraceDiffTraceRequest identifies one side of a trace diff request.
@@ -819,7 +819,15 @@ func ParseTraceDiffRequest(r *http.Request) (*TraceDiffRequest, error) {
 		return nil, fmt.Errorf("invalid trace diff request body: %w", err)
 	}
 
-	req.Format = tracediff.VersionTracePatchV0
+	if req.Format == "" {
+		req.Format = tracediff.VersionTracePatchV0
+	}
+	switch req.Format {
+	case tracediff.VersionTraceSummaryV0Composed, tracediff.VersionTracePatchV0, tracediff.VersionTraceSummaryV0Native:
+	default:
+		return nil, fmt.Errorf("invalid format %q: must be one of %q, %q, %q",
+			req.Format, tracediff.VersionTraceSummaryV0Composed, tracediff.VersionTracePatchV0, tracediff.VersionTraceSummaryV0Native)
+	}
 
 	if err := parseTraceDiffTraceRequest("base", &req.Base); err != nil {
 		return nil, err

--- a/pkg/api/http_test.go
+++ b/pkg/api/http_test.go
@@ -558,6 +558,35 @@ func TestParseTraceDiffRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "explicit composed format",
+			body: `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"},"format":"trace-summary-v0-composed"}`,
+			assertReq: func(t *testing.T, req *TraceDiffRequest) {
+				t.Helper()
+				assert.Equal(t, tracediff.VersionTraceSummaryV0Composed, req.Format)
+			},
+		},
+		{
+			name: "explicit patch format",
+			body: `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"},"format":"trace-patch-v0"}`,
+			assertReq: func(t *testing.T, req *TraceDiffRequest) {
+				t.Helper()
+				assert.Equal(t, tracediff.VersionTracePatchV0, req.Format)
+			},
+		},
+		{
+			name: "explicit native summary format",
+			body: `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"},"format":"trace-summary-v0-native"}`,
+			assertReq: func(t *testing.T, req *TraceDiffRequest) {
+				t.Helper()
+				assert.Equal(t, tracediff.VersionTraceSummaryV0Native, req.Format)
+			},
+		},
+		{
+			name:        "unknown format",
+			body:        `{"base":{"traceId":"abc123"},"compare":{"traceId":"def456"},"format":"trace-summary-v1"}`,
+			expectedErr: `invalid format "trace-summary-v1": must be one of "trace-summary-v0-composed", "trace-patch-v0", "trace-summary-v0-native"`,
+		},
+		{
 			name:        "empty body",
 			body:        "",
 			expectedErr: "invalid trace diff request body",

--- a/pkg/model/tracediff/composed.go
+++ b/pkg/model/tracediff/composed.go
@@ -1,0 +1,68 @@
+package tracediff
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+const (
+	// VersionTraceSummaryV0Composed is an optional diff response shape: the
+	// native summary is always present, plus the full trace-patch-v0
+	// attached iff it fits the byte budget, omitted whole with a disclosure
+	// otherwise. Never truncated: a truncated change list lies by omission.
+	// Consumers needing the full patch when it exceeds the budget re-request
+	// with format trace-patch-v0; the two-request cost is accepted for the
+	// experimental endpoint rather than adding a bypass knob.
+	VersionTraceSummaryV0Composed = "trace-summary-v0-composed"
+
+	// DefaultPatchBudgetBytes bounds the patch attached to a composed
+	// response. The benchmark validated the attach/omit mechanism (attached
+	// at <=21.5KB fixtures, omitted at 2.3MB); 64KB is a policy pick inside
+	// that validated band, not a measured optimum. Tooling that wants the
+	// patch at any size asks for trace-patch-v0 directly.
+	DefaultPatchBudgetBytes = 64 * 1024
+)
+
+// ComposedResult is the composed diff response: summary for triage and
+// localization, patch for span-level evidence when it fits the budget.
+type ComposedResult struct {
+	Version      string          `json:"version"`
+	Summary      *SummaryResult  `json:"summary"`
+	Patch        json.RawMessage `json:"patch,omitempty"`
+	PatchOmitted *PatchOmitted   `json:"patchOmitted,omitempty"`
+}
+
+// PatchOmitted discloses an omitted patch and its size, so consumers can
+// decide whether to fetch it (scoped or whole) instead of silently not
+// knowing it existed.
+type PatchOmitted struct {
+	Bytes  int    `json:"bytes"`
+	Reason string `json:"reason"`
+}
+
+// Compose diffs the two traces once and returns the composed response. Extra
+// warnings are added before building the summary and sizing the patch, keeping
+// both views and the budget decision consistent.
+func Compose(base, compare *tempopb.Trace, budgetBytes int, additionalWarnings []Warning) (*ComposedResult, error) {
+	patch, baseTrace, compareTrace, err := diffTraceInputs(base, compare)
+	if err != nil {
+		return nil, err
+	}
+	patch.Warnings = append(patch.Warnings, additionalWarnings...)
+	summary := summarizeFromPatch(patch, baseTrace, compareTrace)
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("marshal patch for composed response: %w", err)
+	}
+
+	result := &ComposedResult{Version: VersionTraceSummaryV0Composed, Summary: summary}
+	if len(patchBytes) <= budgetBytes {
+		result.Patch = patchBytes
+	} else {
+		result.PatchOmitted = &PatchOmitted{Bytes: len(patchBytes), Reason: "over_budget"}
+	}
+	return result, nil
+}

--- a/pkg/model/tracediff/composed_test.go
+++ b/pkg/model/tracediff/composed_test.go
@@ -1,0 +1,133 @@
+package tracediff
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComposeUnderBudgetAttachesPatch(t *testing.T) {
+	base, compare := summaryFixtureTraces()
+
+	got, err := Compose(base, compare, DefaultPatchBudgetBytes, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, VersionTraceSummaryV0Composed, got.Version)
+	require.NotNil(t, got.Summary)
+	assert.Equal(t, VersionTraceSummaryV0Native, got.Summary.Version)
+	assert.Nil(t, got.PatchOmitted)
+	wantSummary, err := Summarize(base, compare)
+	require.NoError(t, err)
+	assert.Equal(t, wantSummary, got.Summary)
+
+	var patch Result
+	require.NoError(t, json.Unmarshal(got.Patch, &patch))
+	assert.Equal(t, VersionTracePatchV0, patch.Version)
+
+	want, err := Diff(base, compare, FormatTracePatchV0)
+	require.NoError(t, err)
+	wantBytes, err := json.Marshal(want)
+	require.NoError(t, err)
+	assert.Equal(t, json.RawMessage(wantBytes), got.Patch)
+}
+
+func TestComposeBudgetBoundary(t *testing.T) {
+	base, compare := summaryFixtureTraces()
+
+	// Compose itself pins the serialized patch size the boundary is tested
+	// against.
+	got, err := Compose(base, compare, DefaultPatchBudgetBytes, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Patch)
+	patchSize := len(got.Patch)
+
+	atBudget, err := Compose(base, compare, patchSize, nil)
+	require.NoError(t, err)
+	assert.Equal(t, got.Patch, atBudget.Patch)
+	assert.Nil(t, atBudget.PatchOmitted)
+
+	overBudget, err := Compose(base, compare, patchSize-1, nil)
+	require.NoError(t, err)
+	assert.Equal(t, VersionTraceSummaryV0Composed, overBudget.Version)
+	require.NotNil(t, overBudget.Summary)
+	assert.Equal(t, VersionTraceSummaryV0Native, overBudget.Summary.Version)
+	assert.Nil(t, overBudget.Patch)
+	require.NotNil(t, overBudget.PatchOmitted)
+	assert.Equal(t, PatchOmitted{Bytes: patchSize, Reason: "over_budget"}, *overBudget.PatchOmitted)
+
+	warning := Warning{Code: WarningPartialTrace, Message: "input may be incomplete"}
+	withWarning, err := Compose(base, compare, patchSize, []Warning{warning})
+	require.NoError(t, err)
+	assert.Nil(t, withWarning.Patch)
+	require.NotNil(t, withWarning.PatchOmitted)
+	assert.Greater(t, withWarning.PatchOmitted.Bytes, patchSize)
+	assert.Contains(t, withWarning.Summary.Warnings, warning)
+}
+
+func TestComposeJSONShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		budget   int
+		wantKeys []string
+	}{
+		{
+			name:     "patch attached",
+			budget:   DefaultPatchBudgetBytes,
+			wantKeys: []string{"version", "summary", "patch"},
+		},
+		{
+			name:     "patch omitted",
+			budget:   1,
+			wantKeys: []string{"version", "summary", "patchOmitted"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base, compare := summaryFixtureTraces()
+			got, err := Compose(base, compare, tt.budget, nil)
+			require.NoError(t, err)
+			data, err := json.Marshal(got)
+			require.NoError(t, err)
+
+			var doc map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(data, &doc))
+			keys := make([]string, 0, len(doc))
+			for key := range doc {
+				keys = append(keys, key)
+			}
+			assert.ElementsMatch(t, tt.wantKeys, keys)
+			assert.Equal(t, json.RawMessage(`"trace-summary-v0-composed"`), doc["version"])
+			if omitted, ok := doc["patchOmitted"]; ok {
+				var disclosure map[string]json.RawMessage
+				require.NoError(t, json.Unmarshal(omitted, &disclosure))
+				assert.Contains(t, disclosure, "bytes")
+				assert.Contains(t, disclosure, "reason")
+			}
+		})
+	}
+}
+
+func TestComposeRejectsNilInputs(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    *tempopb.Trace
+		compare *tempopb.Trace
+	}{
+		{name: "nil base", base: nil, compare: &tempopb.Trace{}},
+		{name: "nil compare", base: &tempopb.Trace{}, compare: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Compose(tt.base, tt.compare, DefaultPatchBudgetBytes, nil)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrNilTrace))
+			assert.Nil(t, got)
+		})
+	}
+}

--- a/pkg/model/tracediff/summary.go
+++ b/pkg/model/tracediff/summary.go
@@ -120,7 +120,12 @@ func Summarize(base, compare *tempopb.Trace) (*SummaryResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	return summarizeFromPatch(patch, baseTrace, compareTrace), nil
+}
 
+// summarizeFromPatch builds the native summary from an already-computed diff,
+// so composed responses do not normalize and diff the traces twice.
+func summarizeFromPatch(patch *Result, baseTrace, compareTrace normalizedTrace) *SummaryResult {
 	baseSummary, baseDurations := summarizeNormalizedTrace(baseTrace)
 	compareSummary, compareDurations := summarizeNormalizedTrace(compareTrace)
 	structureChanged := structureChangedServices(structureSignature(baseTrace), structureSignature(compareTrace))
@@ -154,7 +159,7 @@ func Summarize(base, compare *tempopb.Trace) (*SummaryResult, error) {
 		structureChanged,
 	)
 	result.Warnings = patch.Warnings
-	return result, nil
+	return result
 }
 
 type traceDurationAggregate struct {


### PR DESCRIPTION
## What this PR does

Adds `trace-summary-v0-composed` as an optional output format for the experimental trace diff API and `tempo-cli`.

The composed response:

- Always includes the compact `trace-summary-v0-native` summary introduced in #7510.
- Includes the complete `trace-patch-v0` document when its serialized size is at most 64 KiB.
- Omits the patch as a whole when it exceeds that budget and returns `patchOmitted` with the patch size and the reason `over_budget`.
- Builds the summary and patch from one normalized diff so their counts, warnings, and matching results remain consistent.

Callers select the format explicitly with `"format": "trace-summary-v0-composed"` in the API request or `--format trace-summary-v0-composed` in `tempo-cli`. The existing `trace-patch-v0` output remains the default for backward compatibility, and `trace-summary-v0-native` remains available when only the compact summary is needed.

## Why

The full patch is the source of span-level evidence, but dense trace changes can produce payloads too large for efficient first-pass inspection or an LLM context window. The native summary provides bounded triage and service localization, while small patches are still useful to include alongside it.

The composed format combines both views without silently truncating evidence. When the patch is too large, the response explicitly reports its omission and size so the caller can request `trace-patch-v0` separately. Keeping the new format opt-in avoids changing the response shape expected by existing API and CLI consumers.

## Validation

- `go test ./pkg/model/tracediff`
- `go test ./pkg/api`
- `go test ./modules/frontend`
- `go test ./cmd/tempo-cli`
- `go test -race ./pkg/model/tracediff`
- `make lint base=origin/main`
- `make chlog-validate`
