### PR TITLE
Add option to configure client.rack for kafka clients

### DIFF
--- a/.chloggen/kafka-client-rack.yaml
+++ b/.chloggen/kafka-client-rack.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: feature
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: tempo
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: 'Add `client_rack` Kafka config option to enable rack-aware fetching (KIP-392) and reduce cross-zone Kafka traffic.'
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7414]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: AvivGuiser

--- a/.chloggen/kafka-client-rack.yaml
+++ b/.chloggen/kafka-client-rack.yaml
@@ -12,7 +12,7 @@ note: 'Add `client_rack` Kafka config option to enable rack-aware fetching (KIP-
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.
-issues: [7414]
+issues: [7594]
 
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
 subtext:

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -457,6 +457,11 @@ ingest:
         # The Kafka client ID.
         [client_id: <string>]
 
+        # The rack identifier for this Kafka client. Corresponds to the Kafka client.rack
+        # setting and enables fetching from the closest replica (KIP-392). Set this to the
+        # instance's availability zone to reduce cross-zone Kafka traffic.
+        [client_rack: <string>]
+
         # The maximum time allowed to open a connection to a Kafka broker.
         [dial_timeout: <duration> | default = 2s]
 

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -225,6 +225,7 @@ distributor:
         address: ""
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 0s
         write_timeout: 0s
         sasl_username: ""
@@ -501,6 +502,7 @@ ingest:
         address: localhost:9092
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 2s
         write_timeout: 10s
         sasl_username: ""

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -225,6 +225,7 @@ distributor:
         address: ""
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 0s
         write_timeout: 0s
         sasl_mechanism: ""
@@ -527,6 +528,7 @@ ingest:
         address: localhost:9092
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 2s
         write_timeout: 10s
         sasl_mechanism: PLAIN

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -221,6 +221,7 @@ distributor:
         address: ""
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 0s
         write_timeout: 0s
         sasl_username: ""
@@ -497,6 +498,7 @@ ingest:
         address: localhost:9092
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 2s
         write_timeout: 10s
         sasl_username: ""

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -221,6 +221,7 @@ distributor:
         address: ""
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 0s
         write_timeout: 0s
         sasl_mechanism: ""
@@ -523,6 +524,7 @@ ingest:
         address: localhost:9092
         topic: ""
         client_id: ""
+        client_rack: ""
         dial_timeout: 2s
         write_timeout: 10s
         sasl_mechanism: PLAIN

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -61,6 +61,7 @@ type KafkaConfig struct {
 	Address      string        `yaml:"address"`
 	Topic        string        `yaml:"topic"`
 	ClientID     string        `yaml:"client_id"`
+	ClientRack   string        `yaml:"client_rack"`
 	DialTimeout  time.Duration `yaml:"dial_timeout"`
 	WriteTimeout time.Duration `yaml:"write_timeout"`
 
@@ -98,6 +99,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.Address, prefix+".address", "localhost:9092", "The Kafka backend address.")
 	f.StringVar(&cfg.Topic, prefix+".topic", "", "The Kafka topic name.")
 	f.StringVar(&cfg.ClientID, prefix+".client-id", "", "The Kafka client ID.")
+	f.StringVar(&cfg.ClientRack, prefix+".client-rack", "", "The rack identifier for this Kafka client. Corresponds to the Kafka client.rack setting and enables fetching from the closest replica (KIP-392). Set this to the instance's availability zone to reduce cross-zone Kafka traffic.")
 	f.DurationVar(&cfg.DialTimeout, prefix+".dial-timeout", 2*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
 	f.DurationVar(&cfg.WriteTimeout, prefix+".write-timeout", 10*time.Second, "How long to wait for an incoming write request to be successfully committed to the Kafka backend.")
 

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -107,6 +107,7 @@ type KafkaConfig struct {
 	Address      string        `yaml:"address"`
 	Topic        string        `yaml:"topic"`
 	ClientID     string        `yaml:"client_id"`
+	ClientRack   string        `yaml:"client_rack"`
 	DialTimeout  time.Duration `yaml:"dial_timeout"`
 	WriteTimeout time.Duration `yaml:"write_timeout"`
 
@@ -147,6 +148,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 	f.StringVar(&cfg.Address, prefix+".address", "localhost:9092", "The Kafka backend address.")
 	f.StringVar(&cfg.Topic, prefix+".topic", "", "The Kafka topic name.")
 	f.StringVar(&cfg.ClientID, prefix+".client-id", "", "The Kafka client ID.")
+	f.StringVar(&cfg.ClientRack, prefix+".client-rack", "", "The rack identifier for this Kafka client. Corresponds to the Kafka client.rack setting and enables fetching from the closest replica (KIP-392). Set this to the instance's availability zone to reduce cross-zone Kafka traffic.")
 	f.DurationVar(&cfg.DialTimeout, prefix+".dial-timeout", 2*time.Second, "The maximum time allowed to open a connection to a Kafka broker.")
 	f.DurationVar(&cfg.WriteTimeout, prefix+".write-timeout", 10*time.Second, "How long to wait for an incoming write request to be successfully committed to the Kafka backend.")
 

--- a/pkg/ingest/config_test.go
+++ b/pkg/ingest/config_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -8,6 +9,22 @@ import (
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
+
+func TestKafkaConfig_ClientRackFlag(t *testing.T) {
+	var cfg KafkaConfig
+	f := flag.NewFlagSet("test", flag.PanicOnError)
+	cfg.RegisterFlags(f)
+
+	// Defaults to empty so rack-aware fetching is opt-in.
+	require.Empty(t, cfg.ClientRack)
+
+	fl := f.Lookup("kafka.client-rack")
+	require.NotNil(t, fl, "kafka.client-rack flag should be registered")
+	require.Equal(t, "", fl.DefValue)
+
+	require.NoError(t, f.Parse([]string{"-kafka.client-rack=us-east-1a"}))
+	require.Equal(t, "us-east-1a", cfg.ClientRack)
+}
 
 func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))

--- a/pkg/ingest/config_test.go
+++ b/pkg/ingest/config_test.go
@@ -1,6 +1,7 @@
 package ingest
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/go-kit/log"
@@ -9,6 +10,22 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
+
+func TestKafkaConfig_ClientRackFlag(t *testing.T) {
+	var cfg KafkaConfig
+	f := flag.NewFlagSet("test", flag.PanicOnError)
+	cfg.RegisterFlags(f)
+
+	// Defaults to empty so rack-aware fetching is opt-in.
+	require.Empty(t, cfg.ClientRack)
+
+	fl := f.Lookup("kafka.client-rack")
+	require.NotNil(t, fl, "kafka.client-rack flag should be registered")
+	require.Equal(t, "", fl.DefValue)
+
+	require.NoError(t, f.Parse([]string{"-kafka.client-rack=us-east-1a"}))
+	require.Equal(t, "us-east-1a", cfg.ClientRack)
+}
 
 func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -140,6 +140,11 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		}),
 	}
 
+	// Enable rack-aware fetching (KIP-392) so consumers can fetch from the closest replica.
+	if cfg.ClientRack != "" {
+		opts = append(opts, kgo.Rack(cfg.ClientRack))
+	}
+
 	// Disable client metrics if explicitly disabled to reduce noise.
 	if cfg.DisableKafkaTelemetry {
 		opts = append(opts, kgo.DisableClientMetrics())

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -154,6 +154,11 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		}),
 	}
 
+	// Enable rack-aware fetching (KIP-392) so consumers can fetch from the closest replica.
+	if cfg.ClientRack != "" {
+		opts = append(opts, kgo.Rack(cfg.ClientRack))
+	}
+
 	// Disable client metrics if explicitly disabled to reduce noise.
 	if cfg.DisableKafkaTelemetry {
 		opts = append(opts, kgo.DisableClientMetrics())

--- a/pkg/ingest/writer_client_test.go
+++ b/pkg/ingest/writer_client_test.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/plugin/kprom"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/grafana/tempo/pkg/util/test"
 )
 
 func TestStatusFromProduceErr(t *testing.T) {
@@ -39,4 +43,31 @@ func TestStatusFromProduceErr(t *testing.T) {
 			require.Contains(t, got.Error(), tt.err.Error())
 		})
 	}
+}
+
+func TestCommonKafkaClientOptions_ClientRack(t *testing.T) {
+	// kgo.Opt values are opaque, so we can't assert on the Rack option directly.
+	// Instead we verify that setting ClientRack still produces a valid client
+	// that kgo.NewClient accepts.
+	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
+	cfg := KafkaConfig{Address: "localhost:9092", Topic: "test", ClientRack: "us-east-1a"}
+
+	opts := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+
+	client, err := kgo.NewClient(opts...)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+}
+
+func TestCommonKafkaClientOptions_EmptyClientRack(t *testing.T) {
+	// An empty ClientRack must not add the Rack option, so rack-aware fetching
+	// stays disabled by default.
+	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
+	cfg := KafkaConfig{Address: "localhost:9092", Topic: "test"}
+
+	opts := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+
+	client, err := kgo.NewClient(opts...)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
 }

--- a/pkg/ingest/writer_client_test.go
+++ b/pkg/ingest/writer_client_test.go
@@ -52,7 +52,8 @@ func TestCommonKafkaClientOptions_ClientRack(t *testing.T) {
 	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
 	cfg := KafkaConfig{Address: "localhost:9092", Topic: "test", ClientRack: "us-east-1a"}
 
-	opts := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	opts, err := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	require.NoError(t, err)
 
 	client, err := kgo.NewClient(opts...)
 	require.NoError(t, err)
@@ -65,7 +66,8 @@ func TestCommonKafkaClientOptions_EmptyClientRack(t *testing.T) {
 	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
 	cfg := KafkaConfig{Address: "localhost:9092", Topic: "test"}
 
-	opts := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	opts, err := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	require.NoError(t, err)
 
 	client, err := kgo.NewClient(opts...)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

This PR add option in kafka config to set client.rack in the config

**Which issue(s) this PR fixes**:
Fixes #7414 

**Checklist**
- [X] Tests updated
- [X] Documentation added
- [X] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)