### PR TITLE
ci: sign and attest the main tempo image

### DIFF
--- a/.chloggen/sign-tempo-image.yaml
+++ b/.chloggen/sign-tempo-image.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: operations
+note: Sign and attest the main tempo container image, completing signing coverage across all published images (tempo, tempo-vulture, tempo-query, tempo-cli).
+issues: []
+user: mattdurham

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -140,10 +140,9 @@ jobs:
           docker manifest push "$IMAGE_NAME:$TAG"
 
   # Resolve the digest of each pushed multi-arch manifest so it can be signed by
-  # digest (not by tag). Covers tempo-vulture, tempo-query, and tempo-cli — the
-  # main `tempo` image is deliberately excluded for now (it's the most impactful
-  # and is rolled out separately). Emits a JSON map of component -> digest-pinned
-  # image ref that the matrixed sign job below looks up via fromJSON.
+  # digest (not by tag). Covers all published components. Emits a JSON map of
+  # component -> digest-pinned image ref that the matrixed sign job below looks
+  # up via fromJSON.
   resolve-digests:
     if: github.repository == 'grafana/tempo'
     needs: ['get-tag', 'manifest']
@@ -169,7 +168,7 @@ jobs:
           # jobs. Build a JSON object mapping each component to its digest-pinned
           # image reference, consumed by the matrixed sign job via fromJSON.
           images='{}'
-          for component in tempo-vulture tempo-query tempo-cli; do
+          for component in tempo tempo-vulture tempo-query tempo-cli; do
             IMAGE_NAME="${DOCKERHUB_MIRROR_REPOSITORY}/${component}"
             DIGEST="$(docker buildx imagetools inspect "$IMAGE_NAME:$TAG" --format '{{.Manifest.Digest}}')"
             if [[ "$DIGEST" != sha256:* ]]; then
@@ -193,7 +192,7 @@ jobs:
       # is independent and signed best-effort.
       fail-fast: false
       matrix:
-        component: [ tempo-vulture, tempo-query, tempo-cli ]
+        component: [ tempo, tempo-vulture, tempo-query, tempo-cli ]
     uses: ./.github/workflows/sign-and-attest.yml
     permissions:
       contents: read

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -56,10 +56,8 @@ attestations store.
 
 ## Coverage
 
-`docker.yml` invokes this workflow (matrixed) for **`tempo-vulture`, `tempo-query`,
-and `tempo-cli`**. The main **`tempo`** image is deliberately not signed here yet —
-it's the most impactful image and is rolled out separately once the rest are proven
-out in production.
+`docker.yml` invokes this workflow (matrixed) for every published component:
+**`tempo`, `tempo-vulture`, `tempo-query`, and `tempo-cli`**.
 
 ## Step flow
 


### PR DESCRIPTION
## What this does

Adds the main **`tempo`** image to the container signing + SLSA provenance attestation flow, completing coverage across **all four** published images (`tempo`, `tempo-vulture`, `tempo-query`, `tempo-cli`).

## Why now

`tempo` was deliberately held back in #7543 as "the most impactful image, rolled out separately once the rest are proven out." That condition is now met:

- **Signing auth works** — #7565 fixed the GAR auth; the `sign (*)` jobs are green on every `main` push.
- **Signatures reach Docker Hub** — the GAR→Docker Hub mirror now carries OCI 1.1 referrers (`grafana/deployment_tools#614819` / PR #634447). Verified end-to-end for `tempo-vulture`/`tempo-query`/`tempo-cli` on real Docker Hub digests:
  - `cosign verify …` → signature PASS
  - `gh attestation verify oci://… --repo grafana/tempo` → provenance PASS
- **Mirror allowlist already includes `tempo`**, so no `deployment_tools` change is needed.

## Safety

Signing is best-effort by design and **not** a gate on the release or `cd-to-dev-env`:
- `sign` is `fail-fast: false` (one component can't cancel others).
- `cd-to-dev-env` only `needs: [manifest, get-tag]`, not `sign`.

So adding `tempo` cannot block deploys even if its signing step failed; a failure surfaces as a failed check on the run.

## Changes

- `.github/workflows/docker.yml` — add `tempo` to the `resolve-digests` loop and the `sign` matrix; refresh the now-stale comment.
- `.github/workflows/sign-and-attest.md` — update the Coverage section to list all four images.
- `.chloggen/` — changelog entry.

Follow-up to #7543 and #7565.
