### PR TITLE
bugfix: instant metrics queries not using the per-block job cache due to accidental jitter

### DIFF
--- a/.chloggen/fix-instant-query-cache-reuse.yaml
+++ b/.chloggen/fix-instant-query-cache-reuse.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: traceql
+note: Instant metrics queries now correctly reuse the per-block job results cache.
+issues: [7602]
+subtext:
+user: mdisibio

--- a/.chloggen/fix-instant-query-cache-reuse.yaml
+++ b/.chloggen/fix-instant-query-cache-reuse.yaml
@@ -2,5 +2,6 @@ change_type: bug_fix
 component: traceql
 note: Instant metrics queries now correctly reuse the per-block job results cache.
 issues: [7602]
-subtext:
+subtext: |
+  **Breaking Change** Metrics query requests with identical start and end timestamps are now properly rejected.
 user: mdisibio

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -211,31 +211,36 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 }
 
 // clampInstantQueryEnd pulls an instant query's ending timestamp to within the
-// cutoff range.  This is different from range queries because we don't align it to a step. Another
-// special case is we also do it in a way as to not breaking caching.  Instead of doing a hard overwrite
+// cutoff range. This is different from range queries because we don't align it to a step. Another
+// special case is we also do it in a way as to not break caching. Instead of doing a hard overwrite
 // of the end timestamp, we subtract just the right number of whole seconds to get it in range.
 // For example if we query `Last 6 Hours` multiple times, we get random clock skew and network latency
 // milliseconds across each run, so the naive cutoff ends up as `Last 5h59m30.xyzs` and xyz vary
-// every time. This breaks caching and is unnecessarily precise.  The cutoff range is just provies some buffer
+// every time. This breaks caching and is unnecessarily precise. The cutoff range just provides some buffer
 // and is not a hard cutoff. Subtracting in whole seconds eliminates all of the xyz ms jitter,
-// and even though final range can still vary, predominately it fall into repeated values and caches much better.
+// and even though final range can still vary, predominantly it falls into repeated values and caches much better.
 func clampInstantQueryEnd(cfg Config, req *tempopb.QueryRangeRequest) error {
 	var (
 		cutoff = time.Now().Add(-cfg.QueryEndCutoff)
+		start  = time.Unix(0, int64(req.Start))
 		end    = time.Unix(0, int64(req.End))
 	)
 
+	if !end.After(start) {
+		return errEndMustBeGreaterThanStart
+	}
 	if end.Before(cutoff) {
 		return nil
 	}
 
 	// Fewest whole seconds that land the end at or before the cutoff.
 	reduce := time.Duration(math.Ceil(end.Sub(cutoff).Seconds())) * time.Second
-
 	end = end.Add(-reduce)
-	if end.Before(time.Unix(0, int64(req.Start))) {
+
+	if !end.After(start) {
 		return errQueryWindowWithinEndCutoff
 	}
+
 	req.End = uint64(end.UnixNano())
 	return nil
 }

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"path"
@@ -59,7 +60,7 @@ func newQueryInstantStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTri
 		}
 		qr.SetInstant(true)
 
-		if err := clampQueryEndForValidation(cfg, qr); err != nil {
+		if err := clampInstantQueryEnd(cfg, qr); err != nil {
 			return status.Error(codes.InvalidArgument, err.Error())
 		}
 		qr.Step = qr.End - qr.Start // keep Step == End-Start for instant
@@ -143,7 +144,7 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 		}
 		qr.SetInstant(true)
 
-		if err := clampQueryEndForValidation(cfg, qr); err != nil {
+		if err := clampInstantQueryEnd(cfg, qr); err != nil {
 			return httpInvalidRequest(err), nil
 		}
 		qr.Step = qr.End - qr.Start // keep Step == End-Start for instant
@@ -207,6 +208,36 @@ func newMetricsQueryInstantHTTPHandler(cfg Config, next pipeline.AsyncRoundTripp
 
 		return resp, nil
 	})
+}
+
+// clampInstantQueryEnd pulls an instant query's ending timestamp to within the
+// cutoff range.  This is different from range queries because we don't align it to a step. Another
+// special case is we also do it in a way as to not breaking caching.  Instead of doing a hard overwrite
+// of the end timestamp, we subtract just the right number of whole seconds to get it in range.
+// For example if we query `Last 6 Hours` multiple times, we get random clock skew and network latency
+// milliseconds across each run, so the naive cutoff ends up as `Last 5h59m30.xyzs` and xyz vary
+// every time. This breaks caching and is unnecessarily precise.  The cutoff range is just provies some buffer
+// and is not a hard cutoff. Subtracting in whole seconds eliminates all of the xyz ms jitter,
+// and even though final range can still vary, predominately it fall into repeated values and caches much better.
+func clampInstantQueryEnd(cfg Config, req *tempopb.QueryRangeRequest) error {
+	var (
+		cutoff = time.Now().Add(-cfg.QueryEndCutoff)
+		end    = time.Unix(0, int64(req.End))
+	)
+
+	if end.Before(cutoff) {
+		return nil
+	}
+
+	// Fewest whole seconds that land the end at or before the cutoff.
+	reduce := time.Duration(math.Ceil(end.Sub(cutoff).Seconds())) * time.Second
+
+	end = end.Add(-reduce)
+	if end.Before(time.Unix(0, int64(req.Start))) {
+		return errQueryWindowWithinEndCutoff
+	}
+	req.End = uint64(end.UnixNano())
+	return nil
 }
 
 func translateQueryRangeToInstant(input tempopb.QueryRangeResponse) tempopb.QueryInstantResponse {

--- a/modules/frontend/metrics_query_handler_test.go
+++ b/modules/frontend/metrics_query_handler_test.go
@@ -9,22 +9,52 @@ import (
 )
 
 func TestClampInstantQueryEnd(t *testing.T) {
-	// A "last 6 hours" instant query. The end carries a sub-second remainder to
-	// mimic a real client timestamp; start is exactly 6h earlier and shares that
-	// same remainder.
-	end := time.Now().Truncate(time.Second).Add(123456789 * time.Nanosecond)
-	start := end.Add(-6 * time.Hour)
-
-	req := &tempopb.QueryRangeRequest{
-		Start: uint64(start.UnixNano()),
-		End:   uint64(end.UnixNano()),
-	}
-
 	cfg := Config{QueryEndCutoff: 30 * time.Second}
-	require.NoError(t, clampInstantQueryEnd(cfg, req))
 
-	// The clamped range must be a whole number of seconds - the sub-second jitter
-	// is gone - which is what keeps the query-range cache key stable across refreshes.
-	rng := req.End - req.Start
-	require.Zero(t, rng%uint64(time.Second), "range %v is not a whole number of seconds", time.Duration(rng))
+	t.Run("whole-second clamp for cache stability", func(t *testing.T) {
+		// A "last 6 hours" instant query. The end carries a sub-second remainder to
+		// mimic a real client timestamp; start is exactly 6h earlier and shares that
+		// same remainder.
+		end := time.Now().Truncate(time.Second).Add(123456789 * time.Nanosecond)
+		start := end.Add(-6 * time.Hour)
+
+		req := &tempopb.QueryRangeRequest{
+			Start: uint64(start.UnixNano()),
+			End:   uint64(end.UnixNano()),
+		}
+
+		require.NoError(t, clampInstantQueryEnd(cfg, req))
+
+		// The clamped range must be a whole number of seconds - the sub-second jitter
+		// is gone - which is what keeps the query-range cache key stable across refreshes.
+		rng := req.End - req.Start
+		require.Zero(t, rng%uint64(time.Second), "range %v is not a whole number of seconds", time.Duration(rng))
+	})
+
+	t.Run("inverted window", func(t *testing.T) {
+		now := time.Now()
+		req := &tempopb.QueryRangeRequest{
+			Start: uint64(now.UnixNano()),
+			End:   uint64(now.Add(-time.Minute).UnixNano()),
+		}
+		require.ErrorIs(t, clampInstantQueryEnd(cfg, req), errEndMustBeGreaterThanStart)
+	})
+
+	t.Run("zero-width window", func(t *testing.T) {
+		now := time.Now()
+		req := &tempopb.QueryRangeRequest{
+			Start: uint64(now.UnixNano()),
+			End:   uint64(now.UnixNano()),
+		}
+		require.ErrorIs(t, clampInstantQueryEnd(cfg, req), errEndMustBeGreaterThanStart)
+	})
+
+	t.Run("window entirely within cutoff", func(t *testing.T) {
+		now := time.Now()
+		req := &tempopb.QueryRangeRequest{
+			Start: uint64(now.Add(-10 * time.Second).UnixNano()),
+			End:   uint64(now.UnixNano()),
+		}
+		require.ErrorIs(t, clampInstantQueryEnd(cfg, req), errQueryWindowWithinEndCutoff)
+	})
 }

--- a/modules/frontend/metrics_query_handler_test.go
+++ b/modules/frontend/metrics_query_handler_test.go
@@ -1,0 +1,30 @@
+package frontend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClampInstantQueryEnd(t *testing.T) {
+	// A "last 6 hours" instant query. The end carries a sub-second remainder to
+	// mimic a real client timestamp; start is exactly 6h earlier and shares that
+	// same remainder.
+	end := time.Now().Truncate(time.Second).Add(123456789 * time.Nanosecond)
+	start := end.Add(-6 * time.Hour)
+
+	req := &tempopb.QueryRangeRequest{
+		Start: uint64(start.UnixNano()),
+		End:   uint64(end.UnixNano()),
+	}
+
+	cfg := Config{QueryEndCutoff: 30 * time.Second}
+	require.NoError(t, clampInstantQueryEnd(cfg, req))
+
+	// The clamped range must be a whole number of seconds - the sub-second jitter
+	// is gone - which is what keeps the query-range cache key stable across refreshes.
+	rng := req.End - req.Start
+	require.Zero(t, rng%uint64(time.Second), "range %v is not a whole number of seconds", time.Duration(rng))
+}

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -199,12 +199,12 @@ func newMetricsQueryRangeHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper
 // internally aligned range. If the cutoff removes the whole query window, it
 // returns a cutoff-specific error instead of the generic start/end error.
 func clampQueryEndForValidation(cfg Config, req *tempopb.QueryRangeRequest) error {
-	if req.Start > req.End {
-		return nil
+	if req.Start >= req.End {
+		return errEndMustBeGreaterThanStart
 	}
 
 	clamped := clampQueryEndToCutoff(cfg, req)
-	if clamped && req.Start > req.End {
+	if clamped && req.Start >= req.End {
 		return errQueryWindowWithinEndCutoff
 	}
 	return nil

--- a/modules/frontend/metrics_query_validation.go
+++ b/modules/frontend/metrics_query_validation.go
@@ -11,11 +11,13 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 )
 
+var errEndMustBeGreaterThanStart = errors.New("end must be greater than start")
+
 // validateQueryRangeReq must run before traceql.AlignRequest, which inflates
 // the range by up to ~3*step and would cause valid requests to fail the cap.
 func validateQueryRangeReq(ctx context.Context, cfg Config, o overrides.Interface, req *tempopb.QueryRangeRequest) error {
-	if req.Start > req.End {
-		return errors.New("end must be greater than start")
+	if req.Start >= req.End {
+		return errEndMustBeGreaterThanStart
 	}
 	if err := validateMetricsQueryMaxDuration(ctx, o, cfg.Metrics.Sharder.MaxDuration, req); err != nil {
 		return err


### PR DESCRIPTION
**What this PR does**:

Instant queries clamped their end to `now - QueryEndCutoff`, which has sub-second precision, so the step (`End - Start`) jittered every request. The step is part of the query-range cache key, so per-block job results were never reused.

The fix is: we subtract a whole number of seconds from the end instead of hard-overwriting it, so that way the step (end-start) is stable and the results are cacheable.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
