### PR TITLE
docs: migrate TraceQL query examples to stable OTel HTTP semantic conventions

### DIFF
--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -669,13 +669,13 @@ Queries must use a single spanset selector `{}`. Both `&&` and `||` operators ar
 
 Unscoped attributes are supported for filtered tag values. When you use an unscoped attribute name, Tempo looks for matches in both span and resource scopes.
 
-The following request returns all discovered service names on spans with `span.http.method=GET`:
+The following request returns all discovered service names on spans with `span.http.request.method=GET`:
 
 ```
-GET /api/v2/search/tag/resource.service.name/values?q="{span.http.method='GET'}"
+GET /api/v2/search/tag/resource.service.name/values?q="{span.http.request.method='GET'}"
 ```
 
-If a particular service name (for example, `shopping-cart`) is only present on spans with `span.http.method=POST`, it won't be included in the list of values returned.
+If a particular service name (for example, `shopping-cart`) is only present on spans with `span.http.request.method=POST`, it won't be included in the list of values returned.
 
 ### TraceQL Metrics
 

--- a/docs/sources/tempo/metrics-from-traces/metrics-queries/functions.md
+++ b/docs/sources/tempo/metrics-from-traces/metrics-queries/functions.md
@@ -53,8 +53,8 @@ These functions can be added as an operator at the end of any TraceQL query.
 | [`avg_over_time()`](#the-avg_over_time-function)             | Returns the average value for the specified attribute across all matching spans per time interval. | `{ span:name = "GET /:endpoint" } \| avg_over_time(span:duration)`              |
 | [`quantile_over_time()`](#the-quantile_over_time-function)   | The quantile of the values in the specified interval.                                              | `{ span:name = "GET /:endpoint" } \| quantile_over_time(span:duration, .99)`    |
 | [`histogram_over_time()`](#the-histogram_over_time-function) | Evaluate frequency distribution over time.                                                         | `{ } \| histogram_over_time(span:duration) by (span.http.target)`               |
-| [`topk()`](#the-topk-function)                               | Returns only the top `k` results from a metrics query.                                             | `{ resource.service.name = "foo" } \| rate() by (span.http.url) \| topk(10)`    |
-| [`bottomk()`](#the-bottomk-function)                         | Returns only the bottom `k` results from a metrics query.                                          | `{ resource.service.name = "foo" } \| rate() by (span.http.url) \| bottomk(10)` |
+| [`topk()`](#the-topk-function)                               | Returns only the top `k` results from a metrics query.                                             | `{ resource.service.name = "foo" } \| rate() by (span.url.full) \| topk(10)`    |
+| [`bottomk()`](#the-bottomk-function)                         | Returns only the bottom `k` results from a metrics query.                                          | `{ resource.service.name = "foo" } \| rate() by (span.url.full) \| bottomk(10)` |
 | [Comparison operators](#comparison-operators)                 | Filters metric data points that don't meet a threshold condition.                                  | `{ } \| rate() > 10`                                                            |
 | [Arithmetic expressions](#arithmetic-expressions)            | Combines two or more metrics queries with `+`, `-`, `*`, `/`.                                      | `({status=error} \| rate()) / ({} \| rate())`                                   |
 
@@ -135,7 +135,7 @@ This example counts the number of spans with name `"GET /:endpoint"` broken down
 there are 10 `"GET /:endpoint"` spans with status code 200 and 15 `"GET /:endpoint"` spans with status code 400.
 
 ```traceql
-{ span:name = "GET /:endpoint" } | count_over_time() by (span.http.status_code)
+{ span:name = "GET /:endpoint" } | count_over_time() by (span.http.response.status_code)
 
 ```
 
@@ -170,7 +170,7 @@ Any numerical attribute on the span is fair game.
 This example computes the minimum status code value of all spans named `"GET /:endpoint"`.
 
 ```traceql
-{ span:name = "GET /:endpoint" } | min_over_time(span.http.status_code)
+{ span:name = "GET /:endpoint" } | min_over_time(span.http.response.status_code)
 ```
 
 ### The `max_over_time` function
@@ -195,10 +195,10 @@ The `avg_over_time()` function lets you aggregate numerical values by computing 
 important span duration.
 The time interval that the average is computed over is set by the `step` parameter.
 
-This example computes the average duration for each `http.status_code` of all spans named `"GET /:endpoint"`.
+This example computes the average duration for each `http.response.status_code` of all spans named `"GET /:endpoint"`.
 
 ```traceql
-{ span:name = "GET /:endpoint" } | avg_over_time(span:duration) by (span.http.status_code)
+{ span:name = "GET /:endpoint" } | avg_over_time(span:duration) by (span.http.response.status_code)
 ```
 
 ```traceql
@@ -225,10 +225,10 @@ You can group by any span or resource attribute.
 
 Quantiles aren't limited to span duration.
 Any numerical attribute on the span is fair game.
-To demonstrate this flexibility, consider this nonsensical quantile on `span.http.status_code`:
+To demonstrate this flexibility, consider this nonsensical quantile on `span.http.response.status_code`:
 
 ```traceql
-{ span:name = "GET /:endpoint" } | quantile_over_time(span.http.status_code, .99, .9, .5)
+{ span:name = "GET /:endpoint" } | quantile_over_time(span.http.response.status_code, .99, .9, .5)
 ```
 
 This computes the 99th, 90th, and 50th percentile of the values of the `status_code` attribute for all spans named
@@ -417,7 +417,7 @@ from 1 through `k` of the top results.
 For example:
 
 ```traceql
-{ resource.service.name = "foo" } | rate() by (span.http.url)  | topk(10)
+{ resource.service.name = "foo" } | rate() by (span.url.full)  | topk(10)
 ```
 
 The first part, `{ resource.service.name = "foo" }`, takes all spans in the service `foo`.
@@ -444,7 +444,7 @@ from 1 through `k` of the bottom results.
 For example:
 
 ```traceql
-{ resource.service.name = "foo" } | rate() by (span.http.url)  | bottomk(10)
+{ resource.service.name = "foo" } | rate() by (span.url.full)  | bottomk(10)
 ```
 
 The first part, `{ resource.service.name = "foo" }`, takes all spans in the service `foo`.
@@ -502,13 +502,13 @@ Each operation is applied in sequence from left to right.
 For example, you can first select the top 5 series and then filter to only those above a threshold:
 
 ```traceql
-{} | rate() by (span.http.url) | topk(5) > 10
+{} | rate() by (span.url.full) | topk(5) > 10
 ```
 
 Or filter first, then select the top results from what remains:
 
 ```traceql
-{} | rate() by (span.http.url) > 0 | topk(5)
+{} | rate() by (span.url.full) > 0 | topk(5)
 ```
 
 Sampling hints work alongside comparison operators:

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -155,7 +155,7 @@ tempo-cli query api search localhost:3200 '{status = error}' 2024-01-01T00:00:00
 Example using GRPC streaming with organization ID:
 
 ```bash
-tempo-cli query api search --use-grpc --org-id my-org localhost:3200 '{span.http.status_code >= 400}' now-1h now
+tempo-cli query api search --use-grpc --org-id my-org localhost:3200 '{span.http.response.status_code >= 400}' now-1h now
 ```
 
 Example with a custom authentication header over GRPC:

--- a/docs/sources/tempo/solutions-with-traces/traces-diagnose-errors.md
+++ b/docs/sources/tempo/solutions-with-traces/traces-diagnose-errors.md
@@ -55,7 +55,7 @@ The top-level service, `mythical-requester` receives requests and returns respon
 Using Grafana Explore, the operations team starts with a simple TraceQL query to find all traces from this top-level service, where an HTTP response code sent to a user is `400` or above. Status codes in this range include `Forbidden`, `Not found`, `Unauthorized`, and other client and server errors.
 
 ```traceql
-{ resource.service.name = "mythical-requester" && span.http.status_code >= 400 } | select(span.http.target)
+{ resource.service.name = "mythical-requester" && span.http.response.status_code >= 400 } | select(span.http.target)
 ```
 
 Adding the `select` statement to this query (after the `|`) ensures that the query response includes not only the set of matched spans, but also the `http.target` attribute (for example, the endpoints for the SaaS service) for each of those spans.
@@ -72,7 +72,7 @@ Using this query, the team can pinpoint the downstream service that might be cau
 The query below says "Find spans where `status = error` that are descendants of spans from the `mythical-requester` service that have status code `500`."
 
 ```traceql
-{ resource.service.name = "mythical-requester" && span.http.status_code = 500 } >> { status = error }
+{ resource.service.name = "mythical-requester" && span.http.response.status_code = 500 } >> { status = error }
 ```
 
 ![TraceQL results showing expanded span](/media/docs/tempo/intro/traceql-error-insert-handy-site.png)
@@ -90,7 +90,7 @@ Their updated query uses a negated regular expression to find any spans where th
 This should expose any other issues causing an internal server error and filter out the class of issues that they already diagnosed.
 
 ```traceql
-{ resource.service.name = "mythical-requester" && span.http.status_code = 500 } >> { status = error && span.db.statement !~ "INSERT.*" }
+{ resource.service.name = "mythical-requester" && span.http.response.status_code = 500 } >> { status = error && span.db.statement !~ "INSERT.*" }
 ```
 
 This query yields no results, suggesting that the root cause of the issues the operations team are seeing is exclusively due to the failing database `INSERT` statement.

--- a/docs/sources/tempo/traceql/construct-traceql-queries.md
+++ b/docs/sources/tempo/traceql/construct-traceql-queries.md
@@ -30,12 +30,12 @@ Each expression in the pipeline selects or discards spansets from being included
 For example:
 
 ```traceql
-{ span.http.status_code >= 200 && span.http.status_code < 300 } | count() > 2
+{ span.http.response.status_code >= 200 && span.http.response.status_code < 300 } | count() > 2
 ```
 
 In this example, the search reduces traces to those spans where:
 
-- `http.status_code` is in the range of `200` to `299` and
+- `http.response.status_code` is in the range of `200` to `299` and
 - the number of matching spans within a trace is greater than two.
 
 Queries select sets of spans and filter them through a pipeline of aggregators and conditions.
@@ -94,7 +94,7 @@ This example finds all traces on the operation `POST /api/orders` that return wi
 {
   resource.service.name="frontend" &&
   name = "POST /api/orders" &&
-  span.http.status_code >= 500
+  span.http.response.status_code >= 500
 }
 ```
 
@@ -197,25 +197,25 @@ Find spans with high fan-out that spawn more than 10 child spans:
 Find the services where the HTTP status is `200`, and list the service name the span belongs to along with returned traces.
 
 ```
-{ span.http.status_code = 200 } | select(resource.service.name)
+{ span.http.response.status_code = 200 } | select(resource.service.name)
 ```
 
-Find any trace where spans within it have a `deployment.environment` resource attribute set to `production` and a span `http.status_code` attribute set to `200`. In previous examples, all conditions had to be true on one span. These conditions can be true on either different spans or the same spans.
+Find any trace where spans within it have a `deployment.environment` resource attribute set to `production` and a span `http.response.status_code` attribute set to `200`. In previous examples, all conditions had to be true on one span. These conditions can be true on either different spans or the same spans.
 
 ```
-{ resource.deployment.environment = "production" } && { span.http.status_code = 200 }
+{ resource.deployment.environment = "production" } && { span.http.response.status_code = 200 }
 ```
 
-Find any trace where any span has an `http.method` attribute set to `GET` as well as a `status` attribute set to `ok`, and where any other span has an `http.method` attribute set to `DELETE`, but doesn't have a `status` attribute set to `ok`:
+Find any trace where any span has an `http.request.method` attribute set to `GET` as well as a `status` attribute set to `ok`, and where any other span has an `http.request.method` attribute set to `DELETE`, but doesn't have a `status` attribute set to `ok`:
 
 ```
-{ span.http.method = "GET" && status = ok } && { span.http.method = "DELETE" && status != ok }
+{ span.http.request.method = "GET" && status = ok } && { span.http.request.method = "DELETE" && status != ok }
 ```
 
-Find any trace with a `deployment.environment` attribute that matches the regular expression `prod-.*` and `http.status_code` attribute set to `200`:
+Find any trace with a `deployment.environment` attribute that matches the regular expression `prod-.*` and `http.response.status_code` attribute set to `200`:
 
 ```
-{ resource.deployment.environment =~ "prod-.*" && span.http.status_code = 200 }
+{ resource.deployment.environment =~ "prod-.*" && span.http.response.status_code = 200 }
 ```
 
 Find traces that took longer than 5 seconds:
@@ -332,8 +332,15 @@ This provides significant performance benefits because it allows Tempo to only s
 To find traces with the `GET HTTP` method, your query could look like this:
 
 ```
-{ span.http.method = "GET" }
+{ span.http.request.method = "GET" }
 ```
+
+{{< admonition type="note" >}}
+OpenTelemetry's HTTP semantic conventions have changed over time, and instrumentation libraries have adopted the stable attribute names at different paces.
+Tempo doesn't alias these names: `span.http.request.method` and `span.http.method` are distinct attributes, as are `span.http.response.status_code` and `span.http.status_code`.
+Depending on the version of the instrumentation that produced them, your traces may use the stable names (for example, `http.request.method` and `http.response.status_code`) or the legacy names (for example, `http.method` and `http.status_code`).
+Write your queries to match the attribute names present in your data.
+{{< /admonition >}}
 
 For more information about attributes and resources, refer to the [OpenTelemetry Resource SDK](https://opentelemetry.io/docs/reference/specification/resource/sdk/).
 
@@ -423,7 +430,7 @@ A literal is a fixed value written directly in a query, such as `200`, `"GET"`, 
 Integer values can be positive or negative:
 
 ```
-{ span.http.status_code = 200 }
+{ span.http.response.status_code = 200 }
 { span.retry_count > -1 }
 ```
 
@@ -467,7 +474,7 @@ Floating-point values use decimal notation:
 String values are enclosed in double quotes:
 
 ```
-{ span.http.method = "GET" }
+{ span.http.request.method = "GET" }
 ```
 
 #### Nil
@@ -503,22 +510,22 @@ An unanchored query, such as: { span.foo =~ "bar" } is now treated as: { span.fo
 
 If you use TraceQL with regular expressions in your Grafana dashboards and you want the unanchored behavior, update the queries to use the unanchored version, such as { span.foo =~ "._bar._"}.
 
-For example, to find all traces where an `http.status_code` attribute in a span are greater than `400` but less than equal to `500`:
+For example, to find all traces where an `http.response.status_code` attribute in a span are greater than `400` but less than equal to `500`:
 
 ```
-{ span.http.status_code >= 400 && span.http.status_code < 500 }
+{ span.http.response.status_code >= 400 && span.http.response.status_code < 500 }
 ```
 
-This works for `http.status_code` values that are strings as well using lexographic ordering:
+This works for `http.response.status_code` values that are strings as well using lexographic ordering:
 
 ```
-{ span.http.status_code >= "400" }
+{ span.http.response.status_code >= "400" }
 ```
 
-Find all traces where the `http.method` attribute is either `GET` or `DELETE`:
+Find all traces where the `http.request.method` attribute is either `GET` or `DELETE`:
 
 ```
-{ span.http.method =~ "DELETE|GET" }
+{ span.http.request.method =~ "DELETE|GET" }
 ```
 
 Find all traces where `any_attribute` isn't `nil` or where `any_attribute` exists in a span:
@@ -554,22 +561,22 @@ A field expression is a composite of multiple fields that define all of the crit
 
 #### Examples
 
-Find traces with `success` `http.status_code` codes:
+Find traces with `success` `http.response.status_code` codes:
 
 ```
-{ span.http.status_code >= 200 && span.http.status_code < 300 }
+{ span.http.response.status_code >= 200 && span.http.response.status_code < 300 }
 ```
 
 Find traces where a `DELETE` HTTP method was used and the intrinsic span status wasn't OK:
 
 ```
-{ span.http.method = "DELETE" && status != ok }
+{ span.http.request.method = "DELETE" && status != ok }
 ```
 
 Both expressions require all conditions to be true on the same span.
 The entire expression inside of a pair of `{}` must be evaluated as true on a single span for it to be included in the result set.
 
-In the above example, if a span includes an `.http.method` attribute set to `DELETE` where the span also includes a `status` attribute set to `ok`, the trace would not be included in the returned results.
+In the above example, if a span includes an `.http.request.method` attribute set to `DELETE` where the span also includes a `status` attribute set to `ok`, the trace would not be included in the returned results.
 
 ## Combine spansets using operators
 
@@ -624,7 +631,7 @@ Structural operators ALWAYS return matches from the right side of the operator.
 For example, to find a trace where a specific HTTP API interacted with a specific database:
 
 ```
-{ span.http.url = "/path/of/api" } >> { span.db.name = "db-shard-001" }
+{ span.url.full = "/path/of/api" } >> { span.db.name = "db-shard-001" }
 ```
 
 ### Union structural
@@ -641,7 +648,7 @@ return spans that match on both sides of the operator.
 For example, to get a failing endpoint AND all descendant failing spans in one query:
 
 ```
-{ span.http.url = "/path/of/api" && status = error } &>> { status = error }
+{ span.url.full = "/path/of/api" && status = error } &>> { status = error }
 ```
 
 ### Experimental structural
@@ -694,10 +701,10 @@ Find traces where the average duration of the spans in a trace is greater than `
 avg(duration) > 20ms
 ```
 
-For example, find traces that have more than 3 spans with an attribute `http.status_code` with a value of `200`:
+For example, find traces that have more than 3 spans with an attribute `http.response.status_code` with a value of `200`:
 
 ```
-{ span.http.status_code = 200 } | count() > 3
+{ span.http.response.status_code = 200 } | count() > 3
 ```
 
 To find spans where the total of a made-up attribute `bytesProcessed` was more than 1 GB:
@@ -724,7 +731,7 @@ TraceQL supports arbitrary arithmetic in your queries.
 Using arithmetic can make queries more human readable:
 
 ```
-{ span.http.request_content_length > 10 * 1024 * 1024 }
+{ span.http.request.body.size > 10 * 1024 * 1024 }
 ```
 
 or anything else that comes to mind.
@@ -733,10 +740,10 @@ or anything else that comes to mind.
 
 TraceQL can select arbitrary fields from spans.
 This is particularly performant because the selected fields aren't retrieved until all other criteria is met.
-For example, to select the `span.http.status_code` and `span.http.url` from all spans that have an error status code:
+For example, to select the `span.http.response.status_code` and `span.url.full` from all spans that have an error status code:
 
 ```
-{ status = error } | select(span.http.status_code, span.http.url)
+{ status = error } | select(span.http.response.status_code, span.url.full)
 ```
 
 ## Retrieve most recent results (experimental)

--- a/docs/sources/tempo/traceql/construct-traceql-queries.md
+++ b/docs/sources/tempo/traceql/construct-traceql-queries.md
@@ -510,7 +510,7 @@ An unanchored query, such as: { span.foo =~ "bar" } is now treated as: { span.fo
 
 If you use TraceQL with regular expressions in your Grafana dashboards and you want the unanchored behavior, update the queries to use the unanchored version, such as { span.foo =~ "._bar._"}.
 
-For example, to find all traces where an `http.response.status_code` attribute in a span are greater than `400` but less than equal to `500`:
+For example, to find all traces where an `http.response.status_code` attribute in a span is greater than or equal to `400` but less than `500`:
 
 ```
 { span.http.response.status_code >= 400 && span.http.response.status_code < 500 }
@@ -631,7 +631,7 @@ Structural operators ALWAYS return matches from the right side of the operator.
 For example, to find a trace where a specific HTTP API interacted with a specific database:
 
 ```
-{ span.url.full = "/path/of/api" } >> { span.db.name = "db-shard-001" }
+{ span.url.full = "https://example.com/path/of/api" } >> { span.db.name = "db-shard-001" }
 ```
 
 ### Union structural
@@ -648,7 +648,7 @@ return spans that match on both sides of the operator.
 For example, to get a failing endpoint AND all descendant failing spans in one query:
 
 ```
-{ span.url.full = "/path/of/api" && status = error } &>> { status = error }
+{ span.url.full = "https://example.com/path/of/api" && status = error } &>> { status = error }
 ```
 
 ### Experimental structural

--- a/docs/sources/tempo/traceql/tune-traceql-queries.md
+++ b/docs/sources/tempo/traceql/tune-traceql-queries.md
@@ -30,19 +30,19 @@ For example, to match spans with a non‑200 status code on a specific path, use
 The following query returns a single span where the HTTP status code is not `200` and the URL is `/api`:
 
 ```traceql
-{ span.http.status_code != 200 && span.http.url = "/api" }
+{ span.http.response.status_code != 200 && span.url.full = "/api" }
 ```
 
 Also avoid splitting these conditions across multiple selectors joined by `&&`, which matches them on different spans and changes semantics:
 
 ```traceql
-{ span.http.url = "/api" } && { span.http.status_code != 200 }
+{ span.url.full = "/api" } && { span.http.response.status_code != 200 }
 ```
 
 Use a single selector when you want both conditions to be true on the same span.
 
 ```traceql
-{ span.http.url = "/api" && span.http.status_code != 200 }
+{ span.url.full = "/api" && span.http.response.status_code != 200 }
 ```
 
 ## Prefer scoped attributes over attributes without a scope
@@ -54,13 +54,13 @@ To find spans by HTTP status code, prefer a scoped attribute:
 The following query scopes the attribute to the span and runs faster than an equivalent without a scope:
 
 ```traceql
-{ span.http.status_code = 500 }
+{ span.http.response.status_code = 500 }
 ```
 
 Avoid forms without a scope that force extra lookups:
 
 ```traceql
-{ .http.status_code = 500 }
+{ .http.response.status_code = 500 }
 ```
 
 ## Access as few attributes as possible
@@ -72,13 +72,13 @@ For example, if filtering by status code already identifies error spans in your 
 This query filters on both an HTTP status and an explicit status:
 
 ```traceql
-{ span.http.status_code = 500 && status = error }
+{ span.http.response.status_code = 500 && status = error }
 ```
 
 If the status code alone is sufficient, prefer the simpler form:
 
 ```traceql
-{ span.http.status_code = 500 }
+{ span.http.response.status_code = 500 }
 ```
 
 ## Filter by trace‑ and resource‑level attributes
@@ -104,7 +104,7 @@ Tempo exposes many frequently used fields as dedicated columns in Parquet to acc
 For example, the following queries benefit from dedicated columns and scope:
 
 ```traceql
-{ span.http.method = "GET" }
+{ span.http.request.method = "GET" }
 { span.db.system = "postgresql" }
 { resource.cloud.region =~ "us-east-1|us-west-1" }
 ```

--- a/docs/sources/tempo/traceql/tune-traceql-queries.md
+++ b/docs/sources/tempo/traceql/tune-traceql-queries.md
@@ -30,19 +30,19 @@ For example, to match spans with a non‑200 status code on a specific path, use
 The following query returns a single span where the HTTP status code is not `200` and the URL is `/api`:
 
 ```traceql
-{ span.http.response.status_code != 200 && span.url.full = "/api" }
+{ span.http.response.status_code != 200 && span.url.full = "https://example.com/api" }
 ```
 
 Also avoid splitting these conditions across multiple selectors joined by `&&`, which matches them on different spans and changes semantics:
 
 ```traceql
-{ span.url.full = "/api" } && { span.http.response.status_code != 200 }
+{ span.url.full = "https://example.com/api" } && { span.http.response.status_code != 200 }
 ```
 
 Use a single selector when you want both conditions to be true on the same span.
 
 ```traceql
-{ span.url.full = "/api" && span.http.response.status_code != 200 }
+{ span.url.full = "https://example.com/api" && span.http.response.status_code != 200 }
 ```
 
 ## Prefer scoped attributes over attributes without a scope


### PR DESCRIPTION
**What this PR does**:

Migrates the TraceQL query examples in the docs from the legacy OpenTelemetry HTTP semantic-convention attribute names to the stable names, per the mapping in #7547, and adds a note about the transition.

Because Tempo doesn't alias the two schemes (`span.http.status_code` and `span.http.response.status_code` are distinct attributes), I limited the change to genuine query examples and the prose describing them, and left every occurrence that names a real string.

Migrated (6 files, 67 occurrences):
- `traceql/construct-traceql-queries.md`, `traceql/tune-traceql-queries.md`, `metrics-from-traces/metrics-queries/functions.md`, `solutions-with-traces/traces-diagnose-errors.md` — TraceQL query examples and the prose describing them.
- `operations/tempo_cli.md` — the one `query api search` example that passes a TraceQL query.
- `api_docs/_index.md` — the `q="{...}"` query example and its text.

Mapping applied: `http.status_code`→`http.response.status_code`, `http.method`→`http.request.method`, `http.url`→`url.full`, `http.request_content_length`→`http.request.body.size` (`http.route` left unchanged).

Left unchanged on purpose — these name real strings, not queryable examples:
- `operations/schema.md`, `reference-tempo-architecture/block-format.md`, `operations/dedicated_columns.md`, `configuration/manifest.md` — real dedicated / well-known column names and `dedicated_columns:` config.
- Collector/Alloy/span-metrics/service-graph config (`automatic-logging.md`, `span-metrics-alloy.md`, `enable-service-graphs.md`, `active-series.md`) and everything under `release-notes/`.
- `shared/best-practices-traces.md` and `troubleshooting/out-of-memory-errors.md` — conceptual attribute-key prose (the OOM page already shows legacy vs stable side by side).

The transition note (added to `construct-traceql-queries.md`) explains that instrumentation adopted the stable names at different paces, that Tempo doesn't alias them, and that queries need to match whatever names the data actually uses.

One call worth a look: in `api_docs/_index.md` I migrated the three query references but left the literal sample `tagNames`/`tags` responses on the same page in legacy form, since they're sample data — happy to revert those three if you'd rather keep the API reference fully legacy. I couldn't run `make docs` locally (it needs the Docker Hugo image), so I checked the admonition shortcode and code fences by eye.

**Which issue(s) this PR fixes**:
Fixes #7547

**Checklist**
- [ ] Tests updated — n/a (docs only)
- [x] Documentation added
- [ ] Changelog entry — n/a (docs-only change, exempt per CONTRIBUTING.md)
