### PR TITLE
frontend: mirror query result log fields as span attributes

### DIFF
--- a/.chloggen/frontend-result-span-attrs.yaml
+++ b/.chloggen/frontend-result-span-attrs.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Mirror per-query response log fields as span attributes on all query paths. Query-shape span attributes renamed to snake_case (`queryType` -> `query_type`, etc.).
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mapno

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -232,7 +232,7 @@ func logQueryInstantResult(ctx context.Context, logger log.Logger, tenantID stri
 	traceID, _ := tracing.ExtractTraceID(ctx)
 
 	if resp == nil {
-		logWithShape(level.Info(logger), ctx,
+		recordResult(level.Info(logger), ctx,
 			"msg", "query instant results - no resp",
 			"tenant", tenantID,
 			"traceID", traceID,
@@ -243,7 +243,7 @@ func logQueryInstantResult(ctx context.Context, logger log.Logger, tenantID stri
 	}
 
 	if resp.Metrics == nil {
-		logWithShape(level.Info(logger), ctx,
+		recordResult(level.Info(logger), ctx,
 			"msg", "query instant results - no metrics",
 			"tenant", tenantID,
 			"traceID", traceID,
@@ -255,7 +255,7 @@ func logQueryInstantResult(ctx context.Context, logger log.Logger, tenantID stri
 		return
 	}
 
-	logWithShape(level.Info(logger), ctx,
+	recordResult(level.Info(logger), ctx,
 		"msg", "query instant results",
 		"tenant", tenantID,
 		"traceID", traceID,

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -256,7 +256,7 @@ func logQueryRangeResult(ctx context.Context, logger log.Logger, tenantID string
 	traceID, _ := tracing.ExtractTraceID(ctx)
 
 	if resp == nil {
-		logWithShape(level.Info(logger), ctx,
+		recordResult(level.Info(logger), ctx,
 			"msg", "query range response - no resp",
 			"tenant", tenantID,
 			"traceID", traceID,
@@ -267,7 +267,7 @@ func logQueryRangeResult(ctx context.Context, logger log.Logger, tenantID string
 	}
 
 	if resp.Metrics == nil {
-		logWithShape(level.Info(logger), ctx,
+		recordResult(level.Info(logger), ctx,
 			"msg", "query range response - no metrics",
 			"tenant", tenantID,
 			"traceID", traceID,
@@ -279,7 +279,7 @@ func logQueryRangeResult(ctx context.Context, logger log.Logger, tenantID string
 		return
 	}
 
-	logWithShape(level.Info(logger), ctx,
+	recordResult(level.Info(logger), ctx,
 		"msg", "query range response",
 		"tenant", tenantID,
 		"traceID", traceID,

--- a/modules/frontend/metrics_query_range_sharder.go
+++ b/modules/frontend/metrics_query_range_sharder.go
@@ -79,7 +79,6 @@ func (s queryRangeSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline
 
 	ctx, span := tracer.Start(r.Context(), spanName)
 	defer span.End()
-	setQueryShapeSpanAttrs(span, pipelineRequest.QueryShape())
 
 	req, err := api.ParseQueryRangeRequest(r)
 	if err != nil {

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -189,7 +189,7 @@ func logResult(ctx context.Context, logger log.Logger, tenantID string, duration
 	}
 
 	if resp == nil {
-		logWithShape(level.Info(logger), ctx,
+		recordResult(level.Info(logger), ctx,
 			"msg", "search response - no resp",
 			"tenant", tenantID,
 			"traceID", traceID,
@@ -201,7 +201,7 @@ func logResult(ctx context.Context, logger log.Logger, tenantID string, duration
 	}
 
 	if resp.Metrics == nil {
-		logWithShape(level.Info(logger), ctx,
+		recordResult(level.Info(logger), ctx,
 			"msg", "search response - no metrics",
 			"tenant", tenantID,
 			"traceID", traceID,
@@ -214,7 +214,7 @@ func logResult(ctx context.Context, logger log.Logger, tenantID string, duration
 		return
 	}
 
-	logWithShape(level.Info(logger), ctx,
+	recordResult(level.Info(logger), ctx,
 		"msg", "search response",
 		"tenant", tenantID,
 		"traceID", traceID,

--- a/modules/frontend/search_sharder.go
+++ b/modules/frontend/search_sharder.go
@@ -98,7 +98,6 @@ func (s asyncSearchSharder) RoundTrip(pipelineRequest pipeline.Request) (pipelin
 	}
 	ctx, span := tracer.Start(requestCtx, "frontend.ShardSearch")
 	defer span.End()
-	setQueryShapeSpanAttrs(span, pipelineRequest.QueryShape())
 
 	// calculate and enforce max search duration
 	maxDuration := s.maxDuration(tenantID)

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -578,7 +578,7 @@ func logTagsRequest(logger log.Logger, tenantID, handler, scope string, rangeSec
 
 func logTagsResult(ctx context.Context, logger log.Logger, tenantID, handler, scope string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
 	traceID, _ := tracing.ExtractTraceID(ctx)
-	logWithShape(level.Info(logger), ctx,
+	recordResult(level.Info(logger), ctx,
 		"msg", "search tag response",
 		"tenant", tenantID,
 		"traceID", traceID,
@@ -604,7 +604,7 @@ func logTagValuesRequest(logger log.Logger, tenantID, handler, tagName, query st
 
 func logTagValuesResult(ctx context.Context, logger log.Logger, tenantID, handler, tagName, query string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
 	traceID, _ := tracing.ExtractTraceID(ctx)
-	logWithShape(level.Info(logger), ctx,
+	recordResult(level.Info(logger), ctx,
 		"msg", "search tag values response",
 		"tenant", tenantID,
 		"traceID", traceID,

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -213,7 +213,6 @@ func (s searchTagSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline.
 	ctx, span := tracer.Start(ctx, "frontend.ShardSearchTags")
 	defer span.End()
 	pipelineRequest.SetContext(ctx)
-	setQueryShapeSpanAttrs(span, pipelineRequest.QueryShape())
 
 	// calculate and enforce max search duration
 	maxDuration := s.maxDuration(tenantID)

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -70,7 +70,7 @@ func newTraceIDHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pipe
 		postSLOHook(resp, tenant, inspectBytes, elapsed, err)
 
 		traceID, _ := tracing.ExtractTraceID(req.Context())
-		logWithShape(level.Info(logger), req.Context(),
+		recordResult(level.Info(logger), req.Context(),
 			"msg", "trace id response",
 			"tenant", tenant,
 			"traceID", traceID,
@@ -143,7 +143,7 @@ func newTraceIDV2Handler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pi
 		postSLOHook(resp, tenant, bytesProcessed, elapsed, err)
 
 		traceID, _ := tracing.ExtractTraceID(req.Context())
-		logWithShape(level.Info(logger), req.Context(),
+		recordResult(level.Info(logger), req.Context(),
 			"msg", "trace id response",
 			"tenant", tenant,
 			"traceID", traceID,

--- a/modules/frontend/traceid_sharder.go
+++ b/modules/frontend/traceid_sharder.go
@@ -68,7 +68,6 @@ func (s asyncTraceSharder) RoundTrip(pipelineRequest pipeline.Request) (pipeline
 	ctx, span := tracer.Start(pipelineRequest.Context(), "frontend.ShardQuery")
 	defer span.End()
 	pipelineRequest.SetContext(ctx)
-	setQueryShapeSpanAttrs(span, pipelineRequest.QueryShape())
 
 	_, _, _, startTime, endTime, err := api.ParseTraceByIDRequest(pipelineRequest.HTTPRequest())
 	if err != nil {

--- a/modules/frontend/util.go
+++ b/modules/frontend/util.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -35,15 +36,74 @@ func acceptAllBlocks(_ *backend.BlockMeta) bool { return true }
 // Called from each sharder after starting its span.
 func setQueryShapeSpanAttrs(span trace.Span, qs pipeline.QueryShape) {
 	span.SetAttributes(
-		attribute.String("queryType", qs.Type),
-		attribute.Int("queryWeight", qs.Weight),
-		attribute.Int("querySubQueries", qs.SubQueries),
-		attribute.Int("queryConditions", qs.Conditions),
-		attribute.Int("queryRegexConditions", qs.RegexConditions),
-		attribute.Bool("queryHasOr", qs.HasOr),
-		attribute.Bool("queryNeedsFullTrace", qs.NeedsFullTrace),
-		attribute.Bool("querySelectAll", qs.SelectAll),
+		attribute.String("query_type", qs.Type),
+		attribute.Int("query_weight", qs.Weight),
+		attribute.Int("query_sub_queries", qs.SubQueries),
+		attribute.Int("query_conditions", qs.Conditions),
+		attribute.Int("query_regex_conditions", qs.RegexConditions),
+		attribute.Bool("query_has_or", qs.HasOr),
+		attribute.Bool("query_needs_full_trace", qs.NeedsFullTrace),
+		attribute.Bool("query_select_all", qs.SelectAll),
 	)
+}
+
+// recordResult logs the response fields and mirrors them as span attributes.
+//
+//nolint:revive // logger first to match logWithShape's calling convention: recordResult(level.Info(logger), ctx, ...)
+func recordResult(logger log.Logger, ctx context.Context, fields ...any) {
+	logWithShape(logger, ctx, fields...)
+	setSpanAttrsWithShape(ctx, fields...)
+}
+
+// setSpanAttrsWithShape mirrors response log fields plus query-shape fields as
+// attributes on the span in ctx, if one is recording.
+func setSpanAttrsWithShape(ctx context.Context, fields ...any) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	attrs := make([]attribute.KeyValue, 0, len(fields)/2)
+	for i := 0; i+1 < len(fields); i += 2 {
+		key, ok := fields[i].(string)
+		if !ok || key == "msg" || key == "traceID" { // log field keys that are redundant on a span
+			continue
+		}
+		if attr, ok := spanAttr(key, fields[i+1]); ok {
+			attrs = append(attrs, attr)
+		}
+	}
+	span.SetAttributes(attrs...)
+
+	if qs, ok := pipeline.QueryShapeFromContext(ctx); ok {
+		setQueryShapeSpanAttrs(span, qs)
+	}
+}
+
+// spanAttr converts one log field value to a span attribute. ok=false for nil values.
+func spanAttr(key string, val any) (attribute.KeyValue, bool) {
+	switch v := val.(type) {
+	case nil:
+		return attribute.KeyValue{}, false
+	case string:
+		return attribute.String(key, v), true
+	case bool:
+		return attribute.Bool(key, v), true
+	case int:
+		return attribute.Int(key, v), true
+	case int64:
+		return attribute.Int64(key, v), true
+	case uint32:
+		return attribute.Int64(key, int64(v)), true
+	case uint64:
+		return attribute.Int64(key, int64(v)), true
+	case float64:
+		return attribute.Float64(key, v), true
+	case error:
+		return attribute.String(key, v.Error()), true
+	default:
+		return attribute.String(key, fmt.Sprint(v)), true
+	}
 }
 
 // logWithShape emits a per-query response log line with query-shape fields

--- a/modules/frontend/util.go
+++ b/modules/frontend/util.go
@@ -97,7 +97,7 @@ func spanAttr(key string, val any) (attribute.KeyValue, bool) {
 		return attribute.Int64(key, int64(v)), true
 	case uint64:
 		// OTel attributes don't support uint64; cast to int64 when safe, otherwise fall back to string.
-		if v > uint64(^uint64(0)>>1) {
+		if v > ^uint64(0)>>1 {
 			return attribute.String(key, fmt.Sprint(v)), true
 		}
 		return attribute.Int64(key, int64(v)), true //nolint:gosec // G115

--- a/modules/frontend/util.go
+++ b/modules/frontend/util.go
@@ -96,7 +96,11 @@ func spanAttr(key string, val any) (attribute.KeyValue, bool) {
 	case uint32:
 		return attribute.Int64(key, int64(v)), true
 	case uint64:
-		return attribute.Int64(key, int64(v)), true
+		// OTel attributes don't support uint64; cast to int64 when safe, otherwise fall back to string.
+		if v > uint64(^uint64(0)>>1) {
+			return attribute.String(key, fmt.Sprint(v)), true
+		}
+		return attribute.Int64(key, int64(v)), true //nolint:gosec // G115
 	case float64:
 		return attribute.Float64(key, v), true
 	case error:

--- a/modules/frontend/util.go
+++ b/modules/frontend/util.go
@@ -33,7 +33,6 @@ func extractTenant(req *http.Request, logger log.Logger) (string, *http.Response
 func acceptAllBlocks(_ *backend.BlockMeta) bool { return true }
 
 // setQueryShapeSpanAttrs stamps the query-shape attributes on the given span.
-// Called from each sharder after starting its span.
 func setQueryShapeSpanAttrs(span trace.Span, qs pipeline.QueryShape) {
 	span.SetAttributes(
 		attribute.String("query_type", qs.Type),
@@ -66,7 +65,11 @@ func setSpanAttrsWithShape(ctx context.Context, fields ...any) {
 	attrs := make([]attribute.KeyValue, 0, len(fields)/2)
 	for i := 0; i+1 < len(fields); i += 2 {
 		key, ok := fields[i].(string)
-		if !ok || key == "msg" || key == "traceID" { // log field keys that are redundant on a span
+		// skip log field keys that are redundant on a span: the span has its own
+		// name, trace ID and duration, and the server middleware records the
+		// tenant, status code and path.
+		if !ok || key == "msg" || key == "traceID" || key == "tenant" ||
+			key == "duration_seconds" || key == "status_code" || key == "path" {
 			continue
 		}
 		if attr, ok := spanAttr(key, fields[i+1]); ok {

--- a/modules/frontend/util_test.go
+++ b/modules/frontend/util_test.go
@@ -99,7 +99,7 @@ func TestSpanAttr(t *testing.T) {
 		{"uint64_overflow", ^uint64(0), attribute.String("k", "18446744073709551615"), true},
 		{"float64", 1.5, attribute.Float64("k", 1.5), true},
 		{"error", errors.New("boom"), attribute.String("k", "boom"), true},
-		{"fallback", time.Second, attribute.String("k", "1s"), true}
+		{"fallback", time.Second, attribute.String("k", "1s"), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/modules/frontend/util_test.go
+++ b/modules/frontend/util_test.go
@@ -1,14 +1,22 @@
 package frontend
 
 import (
+	"context"
+	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestExtractTenant(t *testing.T) {
@@ -71,5 +79,112 @@ func TestExtractTenant(t *testing.T) {
 
 		// Should contain error message about missing org ID
 		assert.Contains(t, bodyStr, "no org id")
+	})
+}
+
+func TestSpanAttr(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want attribute.KeyValue
+		ok   bool
+	}{
+		{"nil", nil, attribute.KeyValue{}, false},
+		{"string", "foo", attribute.String("k", "foo"), true},
+		{"bool", true, attribute.Bool("k", true), true},
+		{"int", 42, attribute.Int("k", 42), true},
+		{"int64", int64(-7), attribute.Int64("k", -7), true},
+		{"uint32", uint32(3600), attribute.Int64("k", 3600), true},
+		{"uint64", uint64(123456), attribute.Int64("k", 123456), true},
+		{"float64", 1.5, attribute.Float64("k", 1.5), true},
+		{"error", errors.New("boom"), attribute.String("k", "boom"), true},
+		{"fallback", time.Second, attribute.String("k", "1s"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := spanAttr("k", tt.val)
+			require.Equal(t, tt.ok, ok)
+			if ok {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestSetSpanAttrsWithShape(t *testing.T) {
+	attrsOf := func(rec *tracetest.SpanRecorder) map[attribute.Key]attribute.Value {
+		ended := rec.Ended()
+		require.Len(t, ended, 1)
+		out := map[attribute.Key]attribute.Value{}
+		for _, kv := range ended[0].Attributes() {
+			out[kv.Key] = kv.Value
+		}
+		return out
+	}
+
+	t.Run("mirrors fields, skips msg, traceID and nil values", func(t *testing.T) {
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		ctx, span := tp.Tracer("test").Start(context.Background(), "test")
+
+		setSpanAttrsWithShape(ctx,
+			"msg", "search response",
+			"traceID", "abcd",
+			"query", "{}",
+			"duration_seconds", 1.5,
+			"inspected_bytes", uint64(1024),
+			"status_code", 200,
+			"error", nil,
+		)
+		span.End()
+
+		attrs := attrsOf(rec)
+		assert.NotContains(t, attrs, attribute.Key("msg"))
+		assert.NotContains(t, attrs, attribute.Key("traceID"))
+		assert.NotContains(t, attrs, attribute.Key("error"))
+		assert.Equal(t, "{}", attrs["query"].AsString())
+		assert.Equal(t, 1.5, attrs["duration_seconds"].AsFloat64())
+		assert.Equal(t, int64(1024), attrs["inspected_bytes"].AsInt64())
+		assert.Equal(t, int64(200), attrs["status_code"].AsInt64())
+		// no shape stamped on ctx -> no shape attrs
+		assert.NotContains(t, attrs, attribute.Key("query_type"))
+	})
+
+	t.Run("appends query-shape attrs when stamped on ctx", func(t *testing.T) {
+		rec := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+		ctx, span := tp.Tracer("test").Start(context.Background(), "test")
+		ctx = pipeline.WithQueryShapeCell(ctx)
+
+		// stamp the shape the same way production does: via the weight middleware
+		httpReq, err := http.NewRequest(http.MethodGet, "http://example.com/api/search?q="+url.QueryEscape("{ span.foo = `bar` }"), nil)
+		require.NoError(t, err)
+		httpReq = httpReq.WithContext(ctx)
+		rt := pipeline.NewWeightRequestWare(pipeline.TraceQLSearch, pipeline.WeightsConfig{
+			RequestWithWeights:   true,
+			MaxTraceQLConditions: 4,
+			MaxRegexConditions:   1,
+		}).Wrap(pipeline.GetRoundTripperFunc())
+		_, err = rt.RoundTrip(pipeline.NewHTTPRequest(httpReq))
+		require.NoError(t, err)
+
+		setSpanAttrsWithShape(ctx, "query", "{ span.foo = `bar` }")
+		span.End()
+
+		attrs := attrsOf(rec)
+		assert.Equal(t, "{ span.foo = `bar` }", attrs["query"].AsString())
+		assert.Equal(t, pipeline.QueryTypeSearch, attrs["query_type"].AsString())
+		assert.GreaterOrEqual(t, attrs["query_weight"].AsInt64(), int64(1))
+		assert.Equal(t, int64(1), attrs["query_sub_queries"].AsInt64())
+		assert.Equal(t, int64(1), attrs["query_conditions"].AsInt64())
+		assert.Equal(t, int64(0), attrs["query_regex_conditions"].AsInt64())
+		assert.False(t, attrs["query_has_or"].AsBool())
+		assert.False(t, attrs["query_needs_full_trace"].AsBool())
+		assert.False(t, attrs["query_select_all"].AsBool())
+	})
+
+	t.Run("no-op without a recording span", func(_ *testing.T) {
+		// must not panic with a noop span from a bare context
+		setSpanAttrsWithShape(context.Background(), "query", "{}")
 	})
 }

--- a/modules/frontend/util_test.go
+++ b/modules/frontend/util_test.go
@@ -122,7 +122,7 @@ func TestSetSpanAttrsWithShape(t *testing.T) {
 		return out
 	}
 
-	t.Run("mirrors fields, skips msg, traceID and nil values", func(t *testing.T) {
+	t.Run("mirrors fields, skips nil values and redundant keys", func(t *testing.T) {
 		rec := tracetest.NewSpanRecorder()
 		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
 		ctx, span := tp.Tracer("test").Start(context.Background(), "test")
@@ -130,10 +130,12 @@ func TestSetSpanAttrsWithShape(t *testing.T) {
 		setSpanAttrsWithShape(ctx,
 			"msg", "search response",
 			"traceID", "abcd",
-			"query", "{}",
+			"tenant", "test-tenant",
 			"duration_seconds", 1.5,
-			"inspected_bytes", uint64(1024),
 			"status_code", 200,
+			"path", "/api/search",
+			"query", "{}",
+			"inspected_bytes", uint64(1024),
 			"error", nil,
 		)
 		span.End()
@@ -141,11 +143,13 @@ func TestSetSpanAttrsWithShape(t *testing.T) {
 		attrs := attrsOf(rec)
 		assert.NotContains(t, attrs, attribute.Key("msg"))
 		assert.NotContains(t, attrs, attribute.Key("traceID"))
+		assert.NotContains(t, attrs, attribute.Key("tenant"))
+		assert.NotContains(t, attrs, attribute.Key("duration_seconds"))
+		assert.NotContains(t, attrs, attribute.Key("status_code"))
+		assert.NotContains(t, attrs, attribute.Key("path"))
 		assert.NotContains(t, attrs, attribute.Key("error"))
 		assert.Equal(t, "{}", attrs["query"].AsString())
-		assert.Equal(t, 1.5, attrs["duration_seconds"].AsFloat64())
 		assert.Equal(t, int64(1024), attrs["inspected_bytes"].AsInt64())
-		assert.Equal(t, int64(200), attrs["status_code"].AsInt64())
 		// no shape stamped on ctx -> no shape attrs
 		assert.NotContains(t, attrs, attribute.Key("query_type"))
 	})

--- a/modules/frontend/util_test.go
+++ b/modules/frontend/util_test.go
@@ -96,9 +96,10 @@ func TestSpanAttr(t *testing.T) {
 		{"int64", int64(-7), attribute.Int64("k", -7), true},
 		{"uint32", uint32(3600), attribute.Int64("k", 3600), true},
 		{"uint64", uint64(123456), attribute.Int64("k", 123456), true},
+		{"uint64_overflow", ^uint64(0), attribute.String("k", "18446744073709551615"), true},
 		{"float64", 1.5, attribute.Float64("k", 1.5), true},
 		{"error", errors.New("boom"), attribute.String("k", "boom"), true},
-		{"fallback", time.Second, attribute.String("k", "1s"), true},
+		{"fallback", time.Second, attribute.String("k", "1s"), true}
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Adds `recordResult`, which emits the per-query response log line and mirrors the same fields (plus query shape) as attributes on the request's span, on all query paths: search (HTTP + streaming), tags/tag values, trace-by-id, and metrics (instant + range).

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
