### PR TITLE
enhancement: add SASL/SCRAM authentication for Kafka

### DIFF
--- a/.chloggen/kafka-sasl-scram.yaml
+++ b/.chloggen/kafka-sasl-scram.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: distributor
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Add support for SASL/SCRAM (SCRAM-SHA-256 and SCRAM-SHA-512) authentication to the Kafka client via the `sasl_mechanism` setting, in addition to the existing SASL/PLAIN mechanism.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: matanbaruch

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -469,6 +469,10 @@ ingest:
         # The SASL password for authentication.
         [sasl_password: <string>]
 
+        # The SASL mechanism used for authentication.
+        # Supported values are PLAIN, SCRAM-SHA-256 and SCRAM-SHA-512.
+        [sasl_mechanism: <string> | default = "PLAIN"]
+
         # Enable auto-creation of Kafka topic if it doesn't exist.
         [auto_create_topic_enabled: <bool> | default = true]
 

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -229,6 +229,7 @@ distributor:
         write_timeout: 0s
         sasl_username: ""
         sasl_password: ""
+        sasl_mechanism: ""
         consumer_group: ""
         consumer_group_offset_commit_interval: 0s
         last_produced_offset_retry_timeout: 0s
@@ -505,6 +506,7 @@ ingest:
         write_timeout: 10s
         sasl_username: ""
         sasl_password: ""
+        sasl_mechanism: PLAIN
         consumer_group: ""
         consumer_group_offset_commit_interval: 1s
         last_produced_offset_retry_timeout: 10s

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -166,6 +166,9 @@ ingest:
     topic: <KAFKA_TOPIC>
     sasl_username: <USERNAME>
     sasl_password: <PASSWORD>
+    # Optional. Defaults to PLAIN. Set to SCRAM-SHA-256 or SCRAM-SHA-512 if your
+    # Kafka cluster uses SASL/SCRAM authentication.
+    sasl_mechanism: PLAIN
 ```
 
 For the full list of options, refer to the [Ingest](/docs/tempo/<TEMPO_VERSION>/configuration/#ingest), [Block-builder](/docs/tempo/<TEMPO_VERSION>/configuration/#block-builder), and [Live-store](/docs/tempo/<TEMPO_VERSION>/configuration/#live-store) configuration reference.

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -225,6 +225,7 @@ distributor:
         write_timeout: 0s
         sasl_username: ""
         sasl_password: ""
+        sasl_mechanism: ""
         consumer_group: ""
         consumer_group_offset_commit_interval: 0s
         last_produced_offset_retry_timeout: 0s
@@ -501,6 +502,7 @@ ingest:
         write_timeout: 10s
         sasl_username: ""
         sasl_password: ""
+        sasl_mechanism: PLAIN
         consumer_group: ""
         consumer_group_offset_commit_interval: 1s
         last_produced_offset_retry_timeout: 10s

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -35,6 +35,13 @@ const (
 	minProducerRecordDataBytesLimit = 1024 * 1024
 )
 
+// Supported SASL authentication mechanisms.
+const (
+	SASLMechanismPlain       = "PLAIN"
+	SASLMechanismScramSHA256 = "SCRAM-SHA-256"
+	SASLMechanismScramSHA512 = "SCRAM-SHA-512"
+)
+
 var (
 	ErrMissingKafkaAddress               = errors.New("the Kafka address has not been configured")
 	ErrMissingKafkaTopic                 = errors.New("the Kafka topic has not been configured")
@@ -42,6 +49,7 @@ var (
 	ErrInvalidMaxConsumerLagAtStartup    = errors.New("the configured max consumer lag at startup must greater or equal than the configured target consumer lag")
 	ErrInvalidProducerMaxRecordSizeBytes = fmt.Errorf("the configured producer max record size bytes must be a value between %d and %d", minProducerRecordDataBytesLimit, maxProducerRecordDataBytesLimit)
 	ErrInconsistentSASLCredentials       = errors.New("the SASL username and password must be both configured to enable SASL authentication")
+	ErrUnsupportedSASLMechanism          = fmt.Errorf("the SASL mechanism is not supported, must be one of %s, %s or %s", SASLMechanismPlain, SASLMechanismScramSHA256, SASLMechanismScramSHA512)
 )
 
 type Config struct {
@@ -64,8 +72,9 @@ type KafkaConfig struct {
 	DialTimeout  time.Duration `yaml:"dial_timeout"`
 	WriteTimeout time.Duration `yaml:"write_timeout"`
 
-	SASLUsername string         `yaml:"sasl_username"`
-	SASLPassword flagext.Secret `yaml:"sasl_password"`
+	SASLUsername  string         `yaml:"sasl_username"`
+	SASLPassword  flagext.Secret `yaml:"sasl_password"`
+	SASLMechanism string         `yaml:"sasl_mechanism"`
 
 	ConsumerGroup                     string        `yaml:"consumer_group"`
 	ConsumerGroupOffsetCommitInterval time.Duration `yaml:"consumer_group_offset_commit_interval"`
@@ -103,6 +112,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 
 	f.StringVar(&cfg.SASLUsername, prefix+".sasl-username", "", "The SASL username for authentication.")
 	f.Var(&cfg.SASLPassword, prefix+".sasl-password", "The SASL password for authentication.")
+	f.StringVar(&cfg.SASLMechanism, prefix+".sasl-mechanism", SASLMechanismPlain, fmt.Sprintf("The SASL mechanism used for authentication. Supported values are %s, %s and %s.", SASLMechanismPlain, SASLMechanismScramSHA256, SASLMechanismScramSHA512))
 
 	f.StringVar(&cfg.ConsumerGroup, prefix+".consumer-group", "", "The consumer group used by the consumer to track the last consumed offset. The consumer group must be different for each ingester. If the configured consumer group contains the '<partition>' placeholder, it is replaced with the actual partition ID owned by the ingester. When empty (recommended), Tempo uses the ingester instance ID to guarantee uniqueness.")
 	f.DurationVar(&cfg.ConsumerGroupOffsetCommitInterval, prefix+".consumer-group-offset-commit-interval", time.Second, "How frequently a consumer should commit the consumed offset to Kafka. The last committed offset is used at startup to continue the consumption from where it was left.")
@@ -145,6 +155,12 @@ func (cfg *KafkaConfig) Validate() error {
 		return ErrInconsistentSASLCredentials
 	}
 
+	switch cfg.SASLMechanism {
+	case "", SASLMechanismPlain, SASLMechanismScramSHA256, SASLMechanismScramSHA512:
+	default:
+		return ErrUnsupportedSASLMechanism
+	}
+
 	return nil
 }
 
@@ -164,7 +180,13 @@ func (cfg KafkaConfig) SetDefaultNumberOfPartitionsForAutocreatedTopics(logger l
 		return
 	}
 
-	cl, err := kgo.NewClient(commonKafkaClientOptions(cfg, nil, logger)...)
+	opts, err := commonKafkaClientOptions(cfg, nil, logger)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to build kafka client options", "err", err)
+		return
+	}
+
+	cl, err := kgo.NewClient(opts...)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to create kafka client", "err", err)
 		return

--- a/pkg/ingest/config_test.go
+++ b/pkg/ingest/config_test.go
@@ -1,13 +1,100 @@
 package ingest
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
+
+func TestKafkaConfigValidate(t *testing.T) {
+	// validConfig returns a config with all mandatory fields populated with valid
+	// defaults so each test case can focus on the SASL fields under test.
+	validConfig := func() KafkaConfig {
+		cfg := KafkaConfig{}
+		cfg.RegisterFlags(flag.NewFlagSet("test", flag.PanicOnError))
+		cfg.Address = "localhost:9092"
+		cfg.Topic = "test-topic"
+		return cfg
+	}
+
+	tests := []struct {
+		name        string
+		mutate      func(cfg *KafkaConfig)
+		expectedErr error
+	}{
+		{
+			name:   "valid defaults",
+			mutate: func(*KafkaConfig) {},
+		},
+		{
+			name: "plain with credentials",
+			mutate: func(cfg *KafkaConfig) {
+				cfg.SASLUsername = "user"
+				cfg.SASLPassword = flagext.SecretWithValue("pass")
+				cfg.SASLMechanism = SASLMechanismPlain
+			},
+		},
+		{
+			name: "scram-sha-256 with credentials",
+			mutate: func(cfg *KafkaConfig) {
+				cfg.SASLUsername = "user"
+				cfg.SASLPassword = flagext.SecretWithValue("pass")
+				cfg.SASLMechanism = SASLMechanismScramSHA256
+			},
+		},
+		{
+			name: "scram-sha-512 with credentials",
+			mutate: func(cfg *KafkaConfig) {
+				cfg.SASLUsername = "user"
+				cfg.SASLPassword = flagext.SecretWithValue("pass")
+				cfg.SASLMechanism = SASLMechanismScramSHA512
+			},
+		},
+		{
+			name: "empty mechanism is allowed",
+			mutate: func(cfg *KafkaConfig) {
+				cfg.SASLUsername = "user"
+				cfg.SASLPassword = flagext.SecretWithValue("pass")
+				cfg.SASLMechanism = ""
+			},
+		},
+		{
+			name: "unsupported mechanism",
+			mutate: func(cfg *KafkaConfig) {
+				cfg.SASLUsername = "user"
+				cfg.SASLPassword = flagext.SecretWithValue("pass")
+				cfg.SASLMechanism = "SCRAM-SHA-1"
+			},
+			expectedErr: ErrUnsupportedSASLMechanism,
+		},
+		{
+			name: "username without password",
+			mutate: func(cfg *KafkaConfig) {
+				cfg.SASLUsername = "user"
+			},
+			expectedErr: ErrInconsistentSASLCredentials,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			tt.mutate(&cfg)
+
+			err := cfg.Validate()
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
 
 func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 	cluster, err := kfake.NewCluster(kfake.NumBrokers(1))

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -201,7 +201,8 @@ func createTestKafkaConfig(clusterAddr string) KafkaConfig {
 
 func createTestKafkaClient(t *testing.T, cfg KafkaConfig) *kgo.Client {
 	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
-	opts := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	opts, err := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
+	require.NoError(t, err)
 
 	// Use the manual partitioner because produceRecord() utility explicitly specifies
 	// the partition to write to in the kgo.Record itself.

--- a/pkg/ingest/reader_client.go
+++ b/pkg/ingest/reader_client.go
@@ -19,7 +19,11 @@ import (
 func NewReaderClient(kafkaCfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger, opts ...kgo.Opt) (*kgo.Client, error) {
 	const fetchMaxBytes = 100_000_000
 
-	opts = append(opts, commonKafkaClientOptions(kafkaCfg, metrics, logger)...)
+	commonOpts, err := commonKafkaClientOptions(kafkaCfg, metrics, logger)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, commonOpts...)
 	opts = append(opts,
 		kgo.FetchMinBytes(1),
 		kgo.FetchMaxBytes(fetchMaxBytes),

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -14,7 +14,9 @@ import (
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
+	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
+	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/plugin/kotel"
 	"github.com/twmb/franz-go/plugin/kprom"
 	"go.opentelemetry.io/otel/propagation"
@@ -35,8 +37,12 @@ func NewWriterClient(kafkaCfg KafkaConfig, maxInflightProduceRequests int, logge
 		kprom.Registerer(reg),
 		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes))
 
-	opts := append(
-		commonKafkaClientOptions(kafkaCfg, metrics, logger),
+	opts, err := commonKafkaClientOptions(kafkaCfg, metrics, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts,
 		kgo.RequiredAcks(kgo.AllISRAcks()),
 		kgo.DefaultProduceTopic(kafkaCfg.Topic),
 
@@ -101,7 +107,7 @@ func (o onlySampledTraces) Inject(ctx context.Context, carrier propagation.TextM
 	o.TextMapPropagator.Inject(ctx, carrier)
 }
 
-func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger) []kgo.Opt {
+func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger) ([]kgo.Opt, error) {
 	opts := []kgo.Opt{
 		kgo.ClientID(cfg.ClientID),
 		kgo.SeedBrokers(cfg.Address),
@@ -149,14 +155,13 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		opts = append(opts, kgo.AllowAutoTopicCreation())
 	}
 
-	// SASL plain auth.
-	if cfg.SASLUsername != "" && cfg.SASLPassword.String() != "" {
-		opts = append(opts, kgo.SASL(plain.Plain(func(_ context.Context) (plain.Auth, error) {
-			return plain.Auth{
-				User: cfg.SASLUsername,
-				Pass: cfg.SASLPassword.String(),
-			}, nil
-		})))
+	// SASL auth.
+	mechanism, err := saslMechanism(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if mechanism != nil {
+		opts = append(opts, kgo.SASL(mechanism))
 	}
 
 	tracer := kotel.NewTracer(
@@ -171,7 +176,37 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		opts = append(opts, kgo.WithHooks(metrics))
 	}
 
-	return opts
+	return opts, nil
+}
+
+// saslMechanism returns the SASL mechanism to use to authenticate against Kafka
+// based on the configured credentials and mechanism. It returns a nil mechanism
+// (and no error) when SASL authentication is disabled, i.e. no credentials are
+// configured.
+func saslMechanism(cfg KafkaConfig) (sasl.Mechanism, error) {
+	if cfg.SASLUsername == "" && cfg.SASLPassword.String() == "" {
+		return nil, nil
+	}
+
+	switch cfg.SASLMechanism {
+	case "", SASLMechanismPlain:
+		return plain.Auth{
+			User: cfg.SASLUsername,
+			Pass: cfg.SASLPassword.String(),
+		}.AsMechanism(), nil
+	case SASLMechanismScramSHA256:
+		return scram.Auth{
+			User: cfg.SASLUsername,
+			Pass: cfg.SASLPassword.String(),
+		}.AsSha256Mechanism(), nil
+	case SASLMechanismScramSHA512:
+		return scram.Auth{
+			User: cfg.SASLUsername,
+			Pass: cfg.SASLPassword.String(),
+		}.AsSha512Mechanism(), nil
+	default:
+		return nil, ErrUnsupportedSASLMechanism
+	}
 }
 
 // Producer is a kgo.Client wrapper exposing some higher level features and metrics useful for producers.

--- a/pkg/ingest/writer_client_test.go
+++ b/pkg/ingest/writer_client_test.go
@@ -6,12 +6,93 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/grafana/dskit/flagext"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func TestSASLMechanism(t *testing.T) {
+	tests := []struct {
+		name         string
+		username     string
+		password     string
+		mechanism    string
+		expectedName string // empty string means we expect a nil mechanism
+		expectedErr  error
+	}{
+		{
+			name:         "no credentials disables SASL",
+			username:     "",
+			password:     "",
+			mechanism:    SASLMechanismPlain,
+			expectedName: "",
+		},
+		{
+			name:         "empty mechanism defaults to plain",
+			username:     "user",
+			password:     "pass",
+			mechanism:    "",
+			expectedName: SASLMechanismPlain,
+		},
+		{
+			name:         "plain",
+			username:     "user",
+			password:     "pass",
+			mechanism:    SASLMechanismPlain,
+			expectedName: SASLMechanismPlain,
+		},
+		{
+			name:         "scram-sha-256",
+			username:     "user",
+			password:     "pass",
+			mechanism:    SASLMechanismScramSHA256,
+			expectedName: SASLMechanismScramSHA256,
+		},
+		{
+			name:         "scram-sha-512",
+			username:     "user",
+			password:     "pass",
+			mechanism:    SASLMechanismScramSHA512,
+			expectedName: SASLMechanismScramSHA512,
+		},
+		{
+			name:        "unsupported mechanism returns an error",
+			username:    "user",
+			password:    "pass",
+			mechanism:   "SCRAM-SHA-1",
+			expectedErr: ErrUnsupportedSASLMechanism,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := KafkaConfig{
+				SASLUsername:  tt.username,
+				SASLPassword:  flagext.SecretWithValue(tt.password),
+				SASLMechanism: tt.mechanism,
+			}
+
+			mechanism, err := saslMechanism(cfg)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+				require.Nil(t, mechanism)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.expectedName == "" {
+				require.Nil(t, mechanism)
+				return
+			}
+
+			require.NotNil(t, mechanism)
+			require.Equal(t, tt.expectedName, mechanism.Name())
+		})
+	}
+}
 
 func TestStatusFromProduceErr(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What this PR does**:

We want to integrate Tempo 3 with AWS MSK Express brokers, which support only SASL/SCRAM authentication. Today Tempo's Kafka client supports only SASL/PLAIN, so we currently run kafka-proxy to bridge the gap. This PR adds SASL/SCRAM support (SCRAM-SHA-256 and SCRAM-SHA-512) through a new `sasl_mechanism` option, in addition to the existing PLAIN mechanism, removing the need for the proxy.

The new `sasl_mechanism` setting defaults to `PLAIN`, so existing configurations that set only `sasl_username`/`sasl_password` keep working unchanged. An unsupported mechanism value is rejected during config validation. The change lives in the shared Kafka client options, so it covers both the producer (distributor) and the consumer (block-builder, live-store) paths.

**Which issue(s) this PR fixes**:

N/A (happy to open a tracking issue if preferred).

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`

---

_AI disclosure (per CONTRIBUTING.md): this change was developed with the assistance of Claude (Anthropic). I have reviewed all of it and take full responsibility for the contribution._
