### PR TITLE
chore(parquetquery): apply metrics sampling via a SyncIterator option

### DIFF
--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -438,6 +438,21 @@ func SyncIteratorOptMaxDefinitionLevel(maxDefinitionLevel int) SyncIteratorOpt {
 	}
 }
 
+// Sampler thins values during iteration. It is intentionally narrower than
+// traceql.Sampler so this package takes no dependency on traceql.
+type Sampler interface {
+	// Expect reports an accepted page's value count: the population to sample from.
+	Expect(count uint64)
+	Sample() bool
+}
+
+// SyncIteratorOptSampler applies a sampler to values that pass the predicate.
+func SyncIteratorOptSampler(s Sampler) SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.sampler = s
+	}
+}
+
 // SyncIterator is a synchronous column iterator. It scans through the given row
 // groups and column, and applies the optional predicate to each chunk, page, and value.
 // Results are read by calling Next() until it returns nil.
@@ -451,6 +466,7 @@ type SyncIterator struct {
 	rgsMax     []RowNumber // Exclusive, row number of next one past the row group
 	readSize   int
 	filter     Predicate
+	sampler    Sampler
 
 	// Status
 	span            trace.Span
@@ -874,6 +890,10 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 				continue
 			}
 
+			if c.sampler != nil && !c.sampler.Sample() {
+				continue
+			}
+
 			return c.curr, v, nil
 		}
 	}
@@ -918,6 +938,10 @@ func (c *SyncIterator) setPage(pg pq.Page) {
 		c.currPageMin = c.curr
 		c.currPageMax = rn
 		c.currValues = pg.Values()
+
+		if c.sampler != nil {
+			c.sampler.Expect(uint64(pg.NumValues()))
+		}
 	}
 }
 

--- a/pkg/parquetquery/sampler_test.go
+++ b/pkg/parquetquery/sampler_test.go
@@ -24,33 +24,56 @@ func (s *fakeSampler) Sample() bool {
 	return s.seen%s.keepEvery == 1
 }
 
-func TestSyncIteratorSampler(t *testing.T) {
+// writeInts writes the given int64 values as testInt rows. Each break index forces
+// a Flush after that many rows, which parquet-go emits as a separate row group (one
+// page each here) — letting callers exercise per-page sampler bookkeeping.
+func writeInts(t *testing.T, values []int64, breaks ...int) []parquet.RowGroup {
+	t.Helper()
+	breakAt := map[int]bool{}
+	for _, b := range breaks {
+		breakAt[b] = true
+	}
+
 	buf := new(bytes.Buffer)
 	w := parquet.NewWriter(buf)
-	const n = 6
-	for i := 0; i < n; i++ {
-		require.NoError(t, w.Write(&testInt{int64(i)}))
+	for i, v := range values {
+		require.NoError(t, w.Write(&testInt{v}))
+		if breakAt[i+1] {
+			require.NoError(t, w.Flush())
+		}
 	}
 	require.NoError(t, w.Flush())
 	require.NoError(t, w.Close())
+
 	r, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
 	require.NoError(t, err)
+	return r.RowGroups()
+}
 
-	s := &fakeSampler{keepEvery: 2}
-	it := NewSyncIterator(context.TODO(), r.RowGroups(), 0,
-		SyncIteratorOptSelectAs("v"),
-		SyncIteratorOptSampler(s))
-	defer it.Close()
-
+func drainInt64(t *testing.T, it Iterator) []int64 {
+	t.Helper()
 	var got []int64
 	for {
 		res, err := it.Next()
 		require.NoError(t, err)
 		if res == nil {
-			break
+			return got
 		}
 		got = append(got, res.Entries[0].Value.Int64())
 	}
+}
+
+func TestSyncIteratorSampler(t *testing.T) {
+	const n = 6
+	rgs := writeInts(t, []int64{0, 1, 2, 3, 4, 5})
+
+	s := &fakeSampler{keepEvery: 2}
+	it := NewSyncIterator(context.TODO(), rgs, 0,
+		SyncIteratorOptSelectAs("v"),
+		SyncIteratorOptSampler(s))
+	defer it.Close()
+
+	got := drainInt64(t, it)
 
 	// Sampler was offered every value that passed the (absent) predicate...
 	require.Equal(t, n, s.seen, "Sample called once per value")
@@ -58,4 +81,67 @@ func TestSyncIteratorSampler(t *testing.T) {
 	require.Equal(t, uint64(n), s.expected, "Expect called with page value count")
 	// keepEvery=2 keeps the 1st, 3rd, 5th offered values (0-indexed 0,2,4).
 	require.Equal(t, []int64{0, 2, 4}, got, "only sampled values returned")
+}
+
+// TestSyncIteratorSamplerAfterPredicate pins the ordering that motivated moving
+// sampling off the predicate: Sample() must only be offered values that already
+// passed the predicate, while Expect() still reports the full (unfiltered) page
+// population so the sampler can reason about the whole dataset.
+func TestSyncIteratorSamplerAfterPredicate(t *testing.T) {
+	const n = 8
+	rgs := writeInts(t, []int64{0, 1, 2, 3, 4, 5, 6, 7})
+
+	// Predicate keeps [2,6] inclusive: 2,3,4,5,6 (5 values).
+	s := &fakeSampler{keepEvery: 2}
+	it := NewSyncIterator(context.TODO(), rgs, 0,
+		SyncIteratorOptSelectAs("v"),
+		SyncIteratorOptPredicate(NewIntBetweenPredicate(2, 6)),
+		SyncIteratorOptSampler(s))
+	defer it.Close()
+
+	got := drainInt64(t, it)
+
+	// Sample() is called only on the 5 values that passed the predicate, not all 8.
+	require.Equal(t, 5, s.seen, "Sample offered only predicate-passing values")
+	// Expect() still sees the whole page population, not the filtered count.
+	require.Equal(t, uint64(n), s.expected, "Expect reports unfiltered page count")
+	// keepEvery=2 over the passing values 2,3,4,5,6 keeps the 1st/3rd/5th: 2,4,6.
+	require.Equal(t, []int64{2, 4, 6}, got, "sampling applied after the predicate")
+}
+
+// TestSyncIteratorSamplerMultiPage verifies Expect() is called once per accepted
+// page (accumulating the total population) and that sampling carries across page
+// boundaries rather than resetting per page. Two row groups, one page each.
+func TestSyncIteratorSamplerMultiPage(t *testing.T) {
+	const n = 6
+	// Break after index 3 -> two row groups (one page each): [0,1,2] and [3,4,5].
+	rgs := writeInts(t, []int64{0, 1, 2, 3, 4, 5}, 3)
+	require.Len(t, rgs, 2, "break should produce two row groups")
+
+	s := &fakeSampler{keepEvery: 2}
+	it := NewSyncIterator(context.TODO(), rgs, 0,
+		SyncIteratorOptSelectAs("v"),
+		SyncIteratorOptSampler(s))
+	defer it.Close()
+
+	got := drainInt64(t, it)
+
+	require.Equal(t, n, s.seen, "Sample called once per value across pages")
+	// Expect fires per page; the two pages sum to the full population.
+	require.Equal(t, uint64(n), s.expected, "Expect accumulated across pages")
+	// The sampler's counter is not reset at the page boundary, so the kept set is
+	// the 1st/3rd/5th values overall: 0,2,4.
+	require.Equal(t, []int64{0, 2, 4}, got, "sampling continues across page boundary")
+}
+
+// TestSyncIteratorNoSampler confirms the default (nil sampler) path returns every
+// value untouched.
+func TestSyncIteratorNoSampler(t *testing.T) {
+	rgs := writeInts(t, []int64{0, 1, 2, 3, 4, 5})
+
+	it := NewSyncIterator(context.TODO(), rgs, 0,
+		SyncIteratorOptSelectAs("v"))
+	defer it.Close()
+
+	require.Equal(t, []int64{0, 1, 2, 3, 4, 5}, drainInt64(t, it))
 }

--- a/pkg/parquetquery/sampler_test.go
+++ b/pkg/parquetquery/sampler_test.go
@@ -1,0 +1,61 @@
+package parquetquery
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSampler keeps every keepEvery-th value that passes the predicate and records
+// the population reported via Expect.
+type fakeSampler struct {
+	keepEvery int
+	seen      int
+	expected  uint64
+}
+
+func (s *fakeSampler) Expect(count uint64) { s.expected += count }
+
+func (s *fakeSampler) Sample() bool {
+	s.seen++
+	return s.seen%s.keepEvery == 1
+}
+
+func TestSyncIteratorSampler(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf)
+	const n = 6
+	for i := 0; i < n; i++ {
+		require.NoError(t, w.Write(&testInt{int64(i)}))
+	}
+	require.NoError(t, w.Flush())
+	require.NoError(t, w.Close())
+	r, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	s := &fakeSampler{keepEvery: 2}
+	it := NewSyncIterator(context.TODO(), r.RowGroups(), 0,
+		SyncIteratorOptSelectAs("v"),
+		SyncIteratorOptSampler(s))
+	defer it.Close()
+
+	var got []int64
+	for {
+		res, err := it.Next()
+		require.NoError(t, err)
+		if res == nil {
+			break
+		}
+		got = append(got, res.Entries[0].Value.Int64())
+	}
+
+	// Sampler was offered every value that passed the (absent) predicate...
+	require.Equal(t, n, s.seen, "Sample called once per value")
+	// ...and Expect was told the page population.
+	require.Equal(t, uint64(n), s.expected, "Expect called with page value count")
+	// keepEvery=2 keeps the 1st, 3rd, 5th offered values (0-indexed 0,2,4).
+	require.Equal(t, []int64{0, 2, 4}, got, "only sampled values returned")
+}

--- a/pkg/parquetquery/sampler_test.go
+++ b/pkg/parquetquery/sampler_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeSampler keeps every keepEvery-th value that passes the predicate and records
+// testSampler keeps every keepEvery-th value that passes the predicate and records
 // the population reported via Expect.
-type fakeSampler struct {
+type testSampler struct {
 	keepEvery int
 	seen      int
 	expected  uint64
 }
 
-func (s *fakeSampler) Expect(count uint64) { s.expected += count }
+func (s *testSampler) Expect(count uint64) { s.expected += count }
 
-func (s *fakeSampler) Sample() bool {
+func (s *testSampler) Sample() bool {
 	s.seen++
 	return s.seen%s.keepEvery == 1
 }
@@ -67,7 +67,7 @@ func TestSyncIteratorSampler(t *testing.T) {
 	const n = 6
 	rgs := writeInts(t, []int64{0, 1, 2, 3, 4, 5})
 
-	s := &fakeSampler{keepEvery: 2}
+	s := &testSampler{keepEvery: 2}
 	it := NewSyncIterator(context.TODO(), rgs, 0,
 		SyncIteratorOptSelectAs("v"),
 		SyncIteratorOptSampler(s))
@@ -92,7 +92,7 @@ func TestSyncIteratorSamplerAfterPredicate(t *testing.T) {
 	rgs := writeInts(t, []int64{0, 1, 2, 3, 4, 5, 6, 7})
 
 	// Predicate keeps [2,6] inclusive: 2,3,4,5,6 (5 values).
-	s := &fakeSampler{keepEvery: 2}
+	s := &testSampler{keepEvery: 2}
 	it := NewSyncIterator(context.TODO(), rgs, 0,
 		SyncIteratorOptSelectAs("v"),
 		SyncIteratorOptPredicate(NewIntBetweenPredicate(2, 6)),
@@ -118,7 +118,7 @@ func TestSyncIteratorSamplerMultiPage(t *testing.T) {
 	rgs := writeInts(t, []int64{0, 1, 2, 3, 4, 5}, 3)
 	require.Len(t, rgs, 2, "break should produce two row groups")
 
-	s := &fakeSampler{keepEvery: 2}
+	s := &testSampler{keepEvery: 2}
 	it := NewSyncIterator(context.TODO(), rgs, 0,
 		SyncIteratorOptSelectAs("v"),
 		SyncIteratorOptSampler(s))

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -344,10 +344,11 @@ func rawToResults(ctx context.Context, pf *parquet.File, rgs []parquet.RowGroup,
 }
 
 // makeIterFn is a helper to create an iterator, that abstracts away context like file and row groups.
-type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string) pq.Iterator
+// sampler is optional (at most one) and ignored by nil iterators.
+type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator
 
 func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead
@@ -363,13 +364,16 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 		if name != columnPathSpanID && name != columnPathTraceID {
 			opts = append(opts, pq.SyncIteratorOptIntern())
 		}
+		if len(sampler) > 0 && sampler[0] != nil {
+			opts = append(opts, pq.SyncIteratorOptSampler(sampler[0]))
+		}
 
 		return pq.NewSyncIterator(ctx, rgs, index, opts...)
 	}
 }
 
 func makeNilIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, _ ...pq.Sampler) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -344,11 +344,12 @@ func rawToResults(ctx context.Context, pf *parquet.File, rgs []parquet.RowGroup,
 }
 
 // makeIterFn is a helper to create an iterator, that abstracts away context like file and row groups.
-// sampler is optional (at most one) and ignored by nil iterators.
-type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator
+// moreOpts are appended after the standard options; nil entries are ignored and nil iterators
+// ignore them entirely.
+type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string, moreOpts ...pq.SyncIteratorOpt) pq.Iterator
 
 func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, moreOpts ...pq.SyncIteratorOpt) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead
@@ -364,8 +365,10 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 		if name != columnPathSpanID && name != columnPathTraceID {
 			opts = append(opts, pq.SyncIteratorOptIntern())
 		}
-		if len(sampler) > 0 && sampler[0] != nil {
-			opts = append(opts, pq.SyncIteratorOptSampler(sampler[0]))
+		for _, o := range moreOpts {
+			if o != nil {
+				opts = append(opts, o)
+			}
 		}
 
 		return pq.NewSyncIterator(ctx, rgs, index, opts...)
@@ -373,7 +376,7 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 }
 
 func makeNilIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string, _ ...pq.Sampler) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, _ ...pq.SyncIteratorOpt) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1943,6 +1943,9 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 		nestedSetLeftExplicit   = false
 		nestedSetRightExplicit  = false
 		nestedSetParentExplicit = false
+		// The sampler attaches to this column's iterator in the build loop, not where
+		// it's set below, because that iterator isn't built yet.
+		samplerColumn string
 	)
 
 	// todo: improve these methods. if addPredicate gets a nil predicate shouldn't it just wipe out the existing predicates instead of appending?
@@ -2015,14 +2018,12 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 				return nil, err
 			}
 
-			if sampler != nil {
-				pred = newSamplingPredicate(sampler, pred)
-				// Removed so that it's not used down below.
-				sampler = nil
-			}
-
 			addPredicate(columnPathSpanStartTime, pred)
 			columnSelectAs[columnPathSpanStartTime] = columnPathSpanStartTime
+
+			if sampler != nil {
+				samplerColumn = columnPathSpanStartTime
+			}
 			continue
 
 		case traceql.IntrinsicName:
@@ -2208,7 +2209,11 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	}
 
 	for columnPath, predicates := range columnPredicates {
-		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
+		var s []parquetquery.Sampler
+		if columnPath == samplerColumn && sampler != nil {
+			s = []parquetquery.Sampler{sampler}
+		}
+		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], s...))
 	}
 
 	attrIter, err := createAttributeIterator(makeIter, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
@@ -2258,11 +2263,11 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	// Also note that this breaks optimizations related to requireAtLeastOneMatch and requireAtLeastOneMatchOverall b/c it will add a kind attribute
 	//  to the span attributes map in spanCollector
 	if len(required) == 0 {
-		var pred parquetquery.Predicate
-		if sampler != nil {
-			pred = newSamplingPredicate(sampler, nil)
+		var s []parquetquery.Sampler
+		if sampler != nil && samplerColumn == "" {
+			s = []parquetquery.Sampler{sampler}
 		}
-		required = []parquetquery.Iterator{makeIter(columnPathSpanStatusCode, pred, "")}
+		required = []parquetquery.Iterator{makeIter(columnPathSpanStatusCode, nil, "", s...)}
 	}
 
 	// Left join here means the span id/start/end iterators + 1 are required,
@@ -2607,8 +2612,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 		// TODO: We might be able to do this without loading a real column, by using
 		// the fact that every trace is a top-level row and there are no gaps. We could
 		// inspect the number of rows in the given row groups and generate virtual row numbers.
-		pred := newSamplingPredicate(sampler, nil)
-		i := makeIter(columnPathRootServiceName, pred, "")
+		i := makeIter(columnPathRootServiceName, nil, "", sampler)
 		required = append([]parquetquery.Iterator{i}, required...)
 	}
 
@@ -3921,50 +3925,4 @@ func otlpKindToTraceqlKind(v uint64) traceql.Kind {
 	default:
 		return traceql.Kind(v)
 	}
-}
-
-type samplingPredicate struct {
-	sampler traceql.Sampler
-	inner   parquetquery.Predicate
-}
-
-var _ parquetquery.Predicate = (*samplingPredicate)(nil)
-
-func newSamplingPredicate(sampler traceql.Sampler, inner parquetquery.Predicate) *samplingPredicate {
-	return &samplingPredicate{
-		sampler: sampler,
-		inner:   inner,
-	}
-}
-
-func (p *samplingPredicate) String() string {
-	return "samplingPredicate{}"
-}
-
-func (p *samplingPredicate) KeepColumnChunk(chunk *parquetquery.ColumnChunkHelper) bool {
-	if p.inner != nil {
-		return p.inner.KeepColumnChunk(chunk)
-	}
-	return true
-}
-
-func (p *samplingPredicate) KeepPage(page parquet.Page) bool {
-	if p.inner != nil && !p.inner.KeepPage(page) {
-		return false
-	}
-
-	// We call Expect() on page because it is closer to the actual data
-	// to be processed.  We could call it earlier in KeepColumnChunk()
-	// but it reduces effectiveness of the sampler because we may
-	// skip around or exit early due to any other conditions.
-	p.sampler.Expect(uint64(page.NumValues()))
-	return true
-}
-
-func (p *samplingPredicate) KeepValue(value parquet.Value) bool {
-	if p.inner != nil && !p.inner.KeepValue(value) {
-		return false
-	}
-
-	return p.sampler.Sample()
 }

--- a/tempodb/encoding/vparquet4/block_traceql.go
+++ b/tempodb/encoding/vparquet4/block_traceql.go
@@ -1943,9 +1943,13 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 		nestedSetLeftExplicit   = false
 		nestedSetRightExplicit  = false
 		nestedSetParentExplicit = false
-		// The sampler attaches to this column's iterator in the build loop, not where
-		// it's set below, because that iterator isn't built yet.
-		samplerColumn string
+		// columnSyncIterOpts folds extra SyncIterator options into a specific column's
+		// iterator when it is built below.
+		columnSyncIterOpts = map[string][]parquetquery.SyncIteratorOpt{}
+		// samplerPlaced records whether the sampler was attached to a real column; if
+		// not it falls back to the status-code iterator built when nothing else is
+		// required.
+		samplerPlaced bool
 	)
 
 	// todo: improve these methods. if addPredicate gets a nil predicate shouldn't it just wipe out the existing predicates instead of appending?
@@ -2021,8 +2025,9 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 			addPredicate(columnPathSpanStartTime, pred)
 			columnSelectAs[columnPathSpanStartTime] = columnPathSpanStartTime
 
-			if sampler != nil {
-				samplerColumn = columnPathSpanStartTime
+			if sampler != nil && !samplerPlaced {
+				columnSyncIterOpts[columnPathSpanStartTime] = append(columnSyncIterOpts[columnPathSpanStartTime], parquetquery.SyncIteratorOptSampler(sampler))
+				samplerPlaced = true
 			}
 			continue
 
@@ -2209,11 +2214,7 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	}
 
 	for columnPath, predicates := range columnPredicates {
-		var s []parquetquery.Sampler
-		if columnPath == samplerColumn && sampler != nil {
-			s = []parquetquery.Sampler{sampler}
-		}
-		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], s...))
+		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], columnSyncIterOpts[columnPath]...))
 	}
 
 	attrIter, err := createAttributeIterator(makeIter, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
@@ -2263,11 +2264,11 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	// Also note that this breaks optimizations related to requireAtLeastOneMatch and requireAtLeastOneMatchOverall b/c it will add a kind attribute
 	//  to the span attributes map in spanCollector
 	if len(required) == 0 {
-		var s []parquetquery.Sampler
-		if sampler != nil && samplerColumn == "" {
-			s = []parquetquery.Sampler{sampler}
+		var opt parquetquery.SyncIteratorOpt
+		if sampler != nil && !samplerPlaced {
+			opt = parquetquery.SyncIteratorOptSampler(sampler)
 		}
-		required = []parquetquery.Iterator{makeIter(columnPathSpanStatusCode, nil, "", s...)}
+		required = []parquetquery.Iterator{makeIter(columnPathSpanStatusCode, nil, "", opt)}
 	}
 
 	// Left join here means the span id/start/end iterators + 1 are required,
@@ -2612,7 +2613,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 		// TODO: We might be able to do this without loading a real column, by using
 		// the fact that every trace is a top-level row and there are no gaps. We could
 		// inspect the number of rows in the given row groups and generate virtual row numbers.
-		i := makeIter(columnPathRootServiceName, nil, "", sampler)
+		i := makeIter(columnPathRootServiceName, nil, "", parquetquery.SyncIteratorOptSampler(sampler))
 		required = append([]parquetquery.Iterator{i}, required...)
 	}
 

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -995,6 +995,67 @@ func makeReq(conditions ...traceql.Condition) traceql.FetchSpansRequest {
 	}
 }
 
+// countingSampler is a keep-all traceql.Sampler that records how many values it
+// was offered (Sample) and the population reported to it (Expect). Keeping every
+// value means results are identical to running without a sampler, so any non-zero
+// count proves the sampler was wired into the fetch path.
+type countingSampler struct {
+	sampled, expected uint64
+}
+
+var _ traceql.Sampler = (*countingSampler)(nil)
+
+func (s *countingSampler) Sample() bool                { s.sampled++; return true }
+func (s *countingSampler) Measured()                   {}
+func (s *countingSampler) Expect(count uint64)         { s.expected += count }
+func (s *countingSampler) FinalScalingFactor() float64 { return 1 }
+
+// TestBackendBlockSearchTraceQLSamplerWiring checks that a sampler set on the
+// fetch request is actually attached to and driven by the storage iterators, for
+// both the span-level and trace-level sampler slots.
+func TestBackendBlockSearchTraceQLSamplerWiring(t *testing.T) {
+	wantTraceID := test.ValidTraceID(nil)
+	b := makeBackendBlockWithTraces(t, []*Trace{fullyPopulatedTestTrace(wantTraceID)})
+	ctx := context.Background()
+
+	countSpans := func(t *testing.T, mutate func(*traceql.FetchSpansRequest)) int {
+		t.Helper()
+		req := traceql.MustExtractFetchSpansRequestWithMetadata("{}")
+		mutate(&req)
+		resp, err := b.Fetch(ctx, req, common.DefaultSearchOptions())
+		require.NoError(t, err)
+		n := 0
+		for {
+			ss, err := resp.Results.Next(ctx)
+			require.NoError(t, err)
+			if ss == nil {
+				break
+			}
+			n += len(ss.Spans)
+		}
+		return n
+	}
+
+	baseline := countSpans(t, func(*traceql.FetchSpansRequest) {})
+	require.Positive(t, baseline, "baseline query should return spans")
+
+	t.Run("span sampler", func(t *testing.T) {
+		s := &countingSampler{}
+		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.SpanSampler = s })
+		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
+		require.Positive(t, s.sampled, "Sample() driven through the span iterator")
+		require.Positive(t, s.expected, "Expect() driven through the span iterator")
+	})
+
+	t.Run("trace sampler", func(t *testing.T) {
+		s := &countingSampler{}
+		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.TraceSampler = s })
+		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
+		require.Positive(t, s.sampled, "Sample() driven through the trace iterator")
+		require.Positive(t, s.expected, "Expect() driven through the trace iterator")
+	})
+}
+
 func parse(t *testing.T, q string) traceql.Condition {
 	req, err := traceql.ExtractFetchSpansRequest(q)
 	require.NoError(t, err, "query:", q)

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -995,20 +995,20 @@ func makeReq(conditions ...traceql.Condition) traceql.FetchSpansRequest {
 	}
 }
 
-// countingSampler is a keep-all traceql.Sampler that records how many values it
+// testSampler is a keep-all traceql.Sampler that records how many values it
 // was offered (Sample) and the population reported to it (Expect). Keeping every
 // value means results are identical to running without a sampler, so any non-zero
 // count proves the sampler was wired into the fetch path.
-type countingSampler struct {
+type testSampler struct {
 	sampled, expected uint64
 }
 
-var _ traceql.Sampler = (*countingSampler)(nil)
+var _ traceql.Sampler = (*testSampler)(nil)
 
-func (s *countingSampler) Sample() bool                { s.sampled++; return true }
-func (s *countingSampler) Measured()                   {}
-func (s *countingSampler) Expect(count uint64)         { s.expected += count }
-func (s *countingSampler) FinalScalingFactor() float64 { return 1 }
+func (s *testSampler) Sample() bool                { s.sampled++; return true }
+func (s *testSampler) Measured()                   {}
+func (s *testSampler) Expect(count uint64)         { s.expected += count }
+func (s *testSampler) FinalScalingFactor() float64 { return 1 }
 
 // TestBackendBlockSearchTraceQLSamplerWiring checks that a sampler set on the
 // fetch request is actually attached to and driven by the storage iterators, for
@@ -1040,7 +1040,7 @@ func TestBackendBlockSearchTraceQLSamplerWiring(t *testing.T) {
 	require.Positive(t, baseline, "baseline query should return spans")
 
 	t.Run("span sampler", func(t *testing.T) {
-		s := &countingSampler{}
+		s := &testSampler{}
 		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.SpanSampler = s })
 		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
 		require.Positive(t, s.sampled, "Sample() driven through the span iterator")
@@ -1048,7 +1048,7 @@ func TestBackendBlockSearchTraceQLSamplerWiring(t *testing.T) {
 	})
 
 	t.Run("trace sampler", func(t *testing.T) {
-		s := &countingSampler{}
+		s := &testSampler{}
 		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.TraceSampler = s })
 		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
 		require.Positive(t, s.sampled, "Sample() driven through the trace iterator")

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -362,10 +362,11 @@ func rawToResults(ctx context.Context, pf *parquet.File, rgs []parquet.RowGroup,
 }
 
 // makeIterFn is a helper to create an iterator, that abstracts away context like file and row groups.
-type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string) pq.Iterator
+// sampler is optional (at most one) and ignored by nil iterators.
+type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator
 
 func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead
@@ -381,13 +382,16 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 		if name != columnPathSpanID && name != columnPathTraceID {
 			opts = append(opts, pq.SyncIteratorOptIntern())
 		}
+		if len(sampler) > 0 && sampler[0] != nil {
+			opts = append(opts, pq.SyncIteratorOptSampler(sampler[0]))
+		}
 
 		return pq.NewSyncIterator(ctx, rgs, index, opts...)
 	}
 }
 
 func makeNilIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, _ ...pq.Sampler) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -362,11 +362,12 @@ func rawToResults(ctx context.Context, pf *parquet.File, rgs []parquet.RowGroup,
 }
 
 // makeIterFn is a helper to create an iterator, that abstracts away context like file and row groups.
-// sampler is optional (at most one) and ignored by nil iterators.
-type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator
+// moreOpts are appended after the standard options; nil entries are ignored and nil iterators
+// ignore them entirely.
+type makeIterFn func(columnName string, predicate pq.Predicate, selectAs string, moreOpts ...pq.SyncIteratorOpt) pq.Iterator
 
 func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string, sampler ...pq.Sampler) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, moreOpts ...pq.SyncIteratorOpt) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead
@@ -382,8 +383,10 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 		if name != columnPathSpanID && name != columnPathTraceID {
 			opts = append(opts, pq.SyncIteratorOptIntern())
 		}
-		if len(sampler) > 0 && sampler[0] != nil {
-			opts = append(opts, pq.SyncIteratorOptSampler(sampler[0]))
+		for _, o := range moreOpts {
+			if o != nil {
+				opts = append(opts, o)
+			}
 		}
 
 		return pq.NewSyncIterator(ctx, rgs, index, opts...)
@@ -391,7 +394,7 @@ func makeIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File)
 }
 
 func makeNilIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.File) makeIterFn {
-	return func(name string, predicate pq.Predicate, selectAs string, _ ...pq.Sampler) pq.Iterator {
+	return func(name string, predicate pq.Predicate, selectAs string, _ ...pq.SyncIteratorOpt) pq.Iterator {
 		index, _, maxDef := pq.GetColumnIndexByPath(pf, name)
 		if index == -1 {
 			// TODO - don't panic, error instead

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -2023,6 +2023,9 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 		nestedSetLeftExplicit   = false
 		nestedSetRightExplicit  = false
 		nestedSetParentExplicit = false
+		// The sampler attaches to this column's iterator in the build loop, not where
+		// it's set below, because that iterator isn't built yet.
+		samplerColumn string
 	)
 
 	// todo: improve these methods. if addPredicate gets a nil predicate shouldn't it just wipe out the existing predicates instead of appending?
@@ -2096,30 +2099,26 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 				return nil, err
 			}
 
-			if sampler != nil {
-				pred = newSamplingPredicate(sampler, pred)
-				// Removed so that it's not used down below.
-				sampler = nil
-			}
-
 			// Choose the least precise column possible.
 			// The step interval must be an even multiple of the pre-rounded precision.
+			var startCol string
 			switch {
 			case cond.Precision >= 3600*time.Second && cond.Precision%(3600*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded3600, pred)
-				columnSelectAs[columnPathSpanStartRounded3600] = columnPathSpanStartRounded3600
+				startCol = columnPathSpanStartRounded3600
 			case cond.Precision >= 300*time.Second && cond.Precision%(300*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded300, pred)
-				columnSelectAs[columnPathSpanStartRounded300] = columnPathSpanStartRounded300
+				startCol = columnPathSpanStartRounded300
 			case cond.Precision >= 60*time.Second && cond.Precision%(60*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded60, pred)
-				columnSelectAs[columnPathSpanStartRounded60] = columnPathSpanStartRounded60
+				startCol = columnPathSpanStartRounded60
 			case cond.Precision >= 15*time.Second && cond.Precision%(15*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded15, pred)
-				columnSelectAs[columnPathSpanStartRounded15] = columnPathSpanStartRounded15
+				startCol = columnPathSpanStartRounded15
 			default:
-				addPredicate(columnPathSpanStartTime, pred)
-				columnSelectAs[columnPathSpanStartTime] = columnPathSpanStartTime
+				startCol = columnPathSpanStartTime
+			}
+			addPredicate(startCol, pred)
+			columnSelectAs[startCol] = startCol
+
+			if sampler != nil {
+				samplerColumn = startCol
 			}
 			continue
 
@@ -2297,7 +2296,11 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	}
 
 	for columnPath, predicates := range columnPredicates {
-		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
+		var s []parquetquery.Sampler
+		if columnPath == samplerColumn && sampler != nil {
+			s = []parquetquery.Sampler{sampler}
+		}
+		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], s...))
 	}
 
 	attrIter, err := createAttributeIterator(makeIter, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
@@ -2341,11 +2344,11 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	// If there are no direct conditions imposed on the span level we are evaluating the SpanCount column to
 	// calculate all span row numbers.
 	if len(required) == 0 {
-		var pred parquetquery.Predicate
-		if sampler != nil {
-			pred = newSamplingPredicate(sampler, nil)
+		var s []parquetquery.Sampler
+		if sampler != nil && samplerColumn == "" {
+			s = []parquetquery.Sampler{sampler}
 		}
-		required = []parquetquery.Iterator{newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, pred, "spanCount"), DefinitionLevelResourceSpansILSSpan)}
+		required = []parquetquery.Iterator{newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, nil, "spanCount", s...), DefinitionLevelResourceSpansILSSpan)}
 	}
 
 	// Left join here means the span id/start/end iterators + 1 are required,
@@ -2690,8 +2693,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 		// TODO: We might be able to do this without loading a real column, by using
 		// the fact that every trace is a top-level row and there are no gaps. We could
 		// inspect the number of rows in the given row groups and generate virtual row numbers.
-		pred := newSamplingPredicate(sampler, nil)
-		i := makeIter(columnPathRootServiceName, pred, "")
+		i := makeIter(columnPathRootServiceName, nil, "", sampler)
 		required = append([]parquetquery.Iterator{i}, required...)
 	}
 
@@ -4033,50 +4035,4 @@ func otlpKindToTraceqlKind(v uint64) traceql.Kind {
 	default:
 		return traceql.Kind(v)
 	}
-}
-
-type samplingPredicate struct {
-	sampler traceql.Sampler
-	inner   parquetquery.Predicate
-}
-
-var _ parquetquery.Predicate = (*samplingPredicate)(nil)
-
-func newSamplingPredicate(sampler traceql.Sampler, inner parquetquery.Predicate) *samplingPredicate {
-	return &samplingPredicate{
-		sampler: sampler,
-		inner:   inner,
-	}
-}
-
-func (p *samplingPredicate) String() string {
-	return "samplingPredicate{}"
-}
-
-func (p *samplingPredicate) KeepColumnChunk(chunk *parquetquery.ColumnChunkHelper) bool {
-	if p.inner != nil {
-		return p.inner.KeepColumnChunk(chunk)
-	}
-	return true
-}
-
-func (p *samplingPredicate) KeepPage(page parquet.Page) bool {
-	if p.inner != nil && !p.inner.KeepPage(page) {
-		return false
-	}
-
-	// We call Expect() on page because it is closer to the actual data
-	// to be processed.  We could call it earlier in KeepColumnChunk()
-	// but it reduces effectiveness of the sampler because we may
-	// skip around or exit early due to any other conditions.
-	p.sampler.Expect(uint64(page.NumValues()))
-	return true
-}
-
-func (p *samplingPredicate) KeepValue(value parquet.Value) bool {
-	if p.inner != nil && !p.inner.KeepValue(value) {
-		return false
-	}
-
-	return p.sampler.Sample()
 }

--- a/tempodb/encoding/vparquet5/block_traceql.go
+++ b/tempodb/encoding/vparquet5/block_traceql.go
@@ -2023,9 +2023,13 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 		nestedSetLeftExplicit   = false
 		nestedSetRightExplicit  = false
 		nestedSetParentExplicit = false
-		// The sampler attaches to this column's iterator in the build loop, not where
-		// it's set below, because that iterator isn't built yet.
-		samplerColumn string
+		// columnSyncIterOpts folds extra SyncIterator options into a specific column's
+		// iterator when it is built below.
+		columnSyncIterOpts = map[string][]parquetquery.SyncIteratorOpt{}
+		// samplerPlaced records whether the sampler was attached to a real column; if
+		// not it falls back to the span-count iterator built when nothing else is
+		// required.
+		samplerPlaced bool
 	)
 
 	// todo: improve these methods. if addPredicate gets a nil predicate shouldn't it just wipe out the existing predicates instead of appending?
@@ -2117,8 +2121,9 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 			addPredicate(startCol, pred)
 			columnSelectAs[startCol] = startCol
 
-			if sampler != nil {
-				samplerColumn = startCol
+			if sampler != nil && !samplerPlaced {
+				columnSyncIterOpts[startCol] = append(columnSyncIterOpts[startCol], parquetquery.SyncIteratorOptSampler(sampler))
+				samplerPlaced = true
 			}
 			continue
 
@@ -2296,11 +2301,7 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	}
 
 	for columnPath, predicates := range columnPredicates {
-		var s []parquetquery.Sampler
-		if columnPath == samplerColumn && sampler != nil {
-			s = []parquetquery.Sampler{sampler}
-		}
-		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], s...))
+		iters = append(iters, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], columnSyncIterOpts[columnPath]...))
 	}
 
 	attrIter, err := createAttributeIterator(makeIter, genericConditions, DefinitionLevelResourceSpansILSSpanAttrs,
@@ -2344,11 +2345,11 @@ func createSpanIterator(makeIter, makeNilIter makeIterFn, innerIterators []parqu
 	// If there are no direct conditions imposed on the span level we are evaluating the SpanCount column to
 	// calculate all span row numbers.
 	if len(required) == 0 {
-		var s []parquetquery.Sampler
-		if sampler != nil && samplerColumn == "" {
-			s = []parquetquery.Sampler{sampler}
+		var opt parquetquery.SyncIteratorOpt
+		if sampler != nil && !samplerPlaced {
+			opt = parquetquery.SyncIteratorOptSampler(sampler)
 		}
-		required = []parquetquery.Iterator{newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, nil, "spanCount", s...), DefinitionLevelResourceSpansILSSpan)}
+		required = []parquetquery.Iterator{newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, nil, "spanCount", opt), DefinitionLevelResourceSpansILSSpan)}
 	}
 
 	// Left join here means the span id/start/end iterators + 1 are required,
@@ -2693,7 +2694,7 @@ func createTraceIterator(makeIter makeIterFn, resourceIter parquetquery.Iterator
 		// TODO: We might be able to do this without loading a real column, by using
 		// the fact that every trace is a top-level row and there are no gaps. We could
 		// inspect the number of rows in the given row groups and generate virtual row numbers.
-		i := makeIter(columnPathRootServiceName, nil, "", sampler)
+		i := makeIter(columnPathRootServiceName, nil, "", parquetquery.SyncIteratorOptSampler(sampler))
 		required = append([]parquetquery.Iterator{i}, required...)
 	}
 

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -483,6 +483,9 @@ func createSpanIterators(
 		columnPredicates  = map[string][]parquetquery.Predicate{}
 		genericConditions []traceql.Condition
 		columnMapping     = dedicatedColumnsToColumnMapping(dedicatedColumns, backend.DedicatedColumnScopeSpan)
+		// The sampler attaches to this column's iterator in the build loop, not where
+		// it's set below, because that iterator isn't built yet.
+		samplerColumn string
 	)
 
 	// todo: improve these methods. if addPredicate gets a nil predicate shouldn't it just wipe out the existing predicates instead of appending?
@@ -556,30 +559,26 @@ func createSpanIterators(
 				return nil, nil, nil, err
 			}
 
-			if sampler != nil {
-				pred = newSamplingPredicate(sampler, pred)
-				// Removed so that it's not used down below.
-				sampler = nil
-			}
-
 			// Choose the least precise column possible.
 			// The step interval must be an even multiple of the pre-rounded precision.
+			var startCol string
 			switch {
 			case cond.Precision >= 3600*time.Second && cond.Precision%(3600*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded3600, pred)
-				columnSelectAs[columnPathSpanStartRounded3600] = columnPathSpanStartRounded3600
+				startCol = columnPathSpanStartRounded3600
 			case cond.Precision >= 300*time.Second && cond.Precision%(300*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded300, pred)
-				columnSelectAs[columnPathSpanStartRounded300] = columnPathSpanStartRounded300
+				startCol = columnPathSpanStartRounded300
 			case cond.Precision >= 60*time.Second && cond.Precision%(60*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded60, pred)
-				columnSelectAs[columnPathSpanStartRounded60] = columnPathSpanStartRounded60
+				startCol = columnPathSpanStartRounded60
 			case cond.Precision >= 15*time.Second && cond.Precision%(15*time.Second) == 0:
-				addPredicate(columnPathSpanStartRounded15, pred)
-				columnSelectAs[columnPathSpanStartRounded15] = columnPathSpanStartRounded15
+				startCol = columnPathSpanStartRounded15
 			default:
-				addPredicate(columnPathSpanStartTime, pred)
-				columnSelectAs[columnPathSpanStartTime] = columnPathSpanStartTime
+				startCol = columnPathSpanStartTime
+			}
+			addPredicate(startCol, pred)
+			columnSelectAs[startCol] = startCol
+
+			if sampler != nil {
+				samplerColumn = startCol
 			}
 			continue
 		case traceql.IntrinsicName:
@@ -756,7 +755,11 @@ func createSpanIterators(
 	}
 
 	for columnPath, predicates := range columnPredicates {
-		optional = append(optional, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath]))
+		var s []parquetquery.Sampler
+		if columnPath == samplerColumn && sampler != nil {
+			s = []parquetquery.Sampler{sampler}
+		}
+		optional = append(optional, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], s...))
 	}
 
 	attrIter, err := createScopedAttributeIterator(
@@ -792,11 +795,11 @@ func createSpanIterators(
 	// iterator for other cases.
 	if needDriver {
 		if len(required) == 0 {
-			var pred parquetquery.Predicate
-			if sampler != nil {
-				pred = newSamplingPredicate(sampler, nil)
+			var s []parquetquery.Sampler
+			if sampler != nil && samplerColumn == "" {
+				s = []parquetquery.Sampler{sampler}
 			}
-			driver = newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, pred, "spanCount"), DefinitionLevelResourceSpansILSSpan)
+			driver = newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, nil, "spanCount", s...), DefinitionLevelResourceSpansILSSpan)
 		} else {
 			// use the first required iterator as the driver
 			driver = required[0]

--- a/tempodb/encoding/vparquet5/block_traceql_fetch.go
+++ b/tempodb/encoding/vparquet5/block_traceql_fetch.go
@@ -483,9 +483,13 @@ func createSpanIterators(
 		columnPredicates  = map[string][]parquetquery.Predicate{}
 		genericConditions []traceql.Condition
 		columnMapping     = dedicatedColumnsToColumnMapping(dedicatedColumns, backend.DedicatedColumnScopeSpan)
-		// The sampler attaches to this column's iterator in the build loop, not where
-		// it's set below, because that iterator isn't built yet.
-		samplerColumn string
+		// columnSyncIterOpts folds extra SyncIterator options into a specific column's
+		// iterator when it is built below.
+		columnSyncIterOpts = map[string][]parquetquery.SyncIteratorOpt{}
+		// samplerPlaced records whether the sampler was attached to a real column; if
+		// not it falls back to the span-count iterator built when nothing else is
+		// required.
+		samplerPlaced bool
 	)
 
 	// todo: improve these methods. if addPredicate gets a nil predicate shouldn't it just wipe out the existing predicates instead of appending?
@@ -577,8 +581,9 @@ func createSpanIterators(
 			addPredicate(startCol, pred)
 			columnSelectAs[startCol] = startCol
 
-			if sampler != nil {
-				samplerColumn = startCol
+			if sampler != nil && !samplerPlaced {
+				columnSyncIterOpts[startCol] = append(columnSyncIterOpts[startCol], parquetquery.SyncIteratorOptSampler(sampler))
+				samplerPlaced = true
 			}
 			continue
 		case traceql.IntrinsicName:
@@ -755,11 +760,7 @@ func createSpanIterators(
 	}
 
 	for columnPath, predicates := range columnPredicates {
-		var s []parquetquery.Sampler
-		if columnPath == samplerColumn && sampler != nil {
-			s = []parquetquery.Sampler{sampler}
-		}
-		optional = append(optional, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], s...))
+		optional = append(optional, makeIter(columnPath, orIfNeeded(predicates), columnSelectAs[columnPath], columnSyncIterOpts[columnPath]...))
 	}
 
 	attrIter, err := createScopedAttributeIterator(
@@ -795,11 +796,11 @@ func createSpanIterators(
 	// iterator for other cases.
 	if needDriver {
 		if len(required) == 0 {
-			var s []parquetquery.Sampler
-			if sampler != nil && samplerColumn == "" {
-				s = []parquetquery.Sampler{sampler}
+			var opt parquetquery.SyncIteratorOpt
+			if sampler != nil && !samplerPlaced {
+				opt = parquetquery.SyncIteratorOptSampler(sampler)
 			}
-			driver = newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, nil, "spanCount", s...), DefinitionLevelResourceSpansILSSpan)
+			driver = newVirtualRowNumberIterator(makeIter(columnPathScopeSpansSpanCount, nil, "spanCount", opt), DefinitionLevelResourceSpansILSSpan)
 		} else {
 			// use the first required iterator as the driver
 			driver = required[0]

--- a/tempodb/encoding/vparquet5/block_traceql_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_test.go
@@ -1042,6 +1042,67 @@ func parse(t *testing.T, q string) traceql.Condition {
 	return req.Conditions[0]
 }
 
+// countingSampler is a keep-all traceql.Sampler that records how many values it
+// was offered (Sample) and the population reported to it (Expect). Keeping every
+// value means results are identical to running without a sampler, so any non-zero
+// count proves the sampler was wired into the fetch path.
+type countingSampler struct {
+	sampled, expected uint64
+}
+
+var _ traceql.Sampler = (*countingSampler)(nil)
+
+func (s *countingSampler) Sample() bool                { s.sampled++; return true }
+func (s *countingSampler) Measured()                   {}
+func (s *countingSampler) Expect(count uint64)         { s.expected += count }
+func (s *countingSampler) FinalScalingFactor() float64 { return 1 }
+
+// TestBackendBlockSearchTraceQLSamplerWiring checks that a sampler set on the
+// fetch request is actually attached to and driven by the storage iterators, for
+// both the span-level and trace-level sampler slots.
+func TestBackendBlockSearchTraceQLSamplerWiring(t *testing.T) {
+	wantTraceID := test.ValidTraceID(nil)
+	b := makeBackendBlockWithTraces(t, []*Trace{fullyPopulatedTestTrace(wantTraceID)})
+	ctx := context.Background()
+
+	countSpans := func(t *testing.T, mutate func(*traceql.FetchSpansRequest)) int {
+		t.Helper()
+		req := traceql.MustExtractFetchSpansRequestWithMetadata("{}")
+		mutate(&req)
+		resp, err := b.Fetch(ctx, req, common.DefaultSearchOptions())
+		require.NoError(t, err)
+		n := 0
+		for {
+			ss, err := resp.Results.Next(ctx)
+			require.NoError(t, err)
+			if ss == nil {
+				break
+			}
+			n += len(ss.Spans)
+		}
+		return n
+	}
+
+	baseline := countSpans(t, func(*traceql.FetchSpansRequest) {})
+	require.Positive(t, baseline, "baseline query should return spans")
+
+	t.Run("span sampler", func(t *testing.T) {
+		s := &countingSampler{}
+		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.SpanSampler = s })
+		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
+		require.Positive(t, s.sampled, "Sample() driven through the span iterator")
+		require.Positive(t, s.expected, "Expect() driven through the span iterator")
+	})
+
+	t.Run("trace sampler", func(t *testing.T) {
+		s := &countingSampler{}
+		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.TraceSampler = s })
+		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
+		require.Positive(t, s.sampled, "Sample() driven through the trace iterator")
+		require.Positive(t, s.expected, "Expect() driven through the trace iterator")
+	})
+}
+
 func fullyPopulatedTestTrace(id common.ID) *Trace {
 	return fullyPopulatedTestTraceWithOption(id, false)
 }

--- a/tempodb/encoding/vparquet5/block_traceql_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_test.go
@@ -1042,20 +1042,20 @@ func parse(t *testing.T, q string) traceql.Condition {
 	return req.Conditions[0]
 }
 
-// countingSampler is a keep-all traceql.Sampler that records how many values it
+// testSampler is a keep-all traceql.Sampler that records how many values it
 // was offered (Sample) and the population reported to it (Expect). Keeping every
 // value means results are identical to running without a sampler, so any non-zero
 // count proves the sampler was wired into the fetch path.
-type countingSampler struct {
+type testSampler struct {
 	sampled, expected uint64
 }
 
-var _ traceql.Sampler = (*countingSampler)(nil)
+var _ traceql.Sampler = (*testSampler)(nil)
 
-func (s *countingSampler) Sample() bool                { s.sampled++; return true }
-func (s *countingSampler) Measured()                   {}
-func (s *countingSampler) Expect(count uint64)         { s.expected += count }
-func (s *countingSampler) FinalScalingFactor() float64 { return 1 }
+func (s *testSampler) Sample() bool                { s.sampled++; return true }
+func (s *testSampler) Measured()                   {}
+func (s *testSampler) Expect(count uint64)         { s.expected += count }
+func (s *testSampler) FinalScalingFactor() float64 { return 1 }
 
 // TestBackendBlockSearchTraceQLSamplerWiring checks that a sampler set on the
 // fetch request is actually attached to and driven by the storage iterators, for
@@ -1083,23 +1083,53 @@ func TestBackendBlockSearchTraceQLSamplerWiring(t *testing.T) {
 		return n
 	}
 
+	// countSpansOnly drives the FetchSpans path (createSpanIterators), which the
+	// metrics engine also uses and which wires the span sampler separately.
+	countSpansOnly := func(t *testing.T, mutate func(*traceql.FetchSpansRequest)) int {
+		t.Helper()
+		req := traceql.MustExtractFetchSpansRequestWithMetadata("{}")
+		mutate(&req)
+		resp, err := b.FetchSpans(ctx, req, common.DefaultSearchOptions())
+		require.NoError(t, err)
+		n := 0
+		for {
+			s, err := resp.Results.Next(ctx)
+			require.NoError(t, err)
+			if s == nil {
+				break
+			}
+			n++
+		}
+		return n
+	}
+
 	baseline := countSpans(t, func(*traceql.FetchSpansRequest) {})
 	require.Positive(t, baseline, "baseline query should return spans")
+	spansOnlyBaseline := countSpansOnly(t, func(*traceql.FetchSpansRequest) {})
+	require.Positive(t, spansOnlyBaseline, "baseline FetchSpans query should return spans")
 
-	t.Run("span sampler", func(t *testing.T) {
-		s := &countingSampler{}
+	t.Run("span sampler (Fetch)", func(t *testing.T) {
+		s := &testSampler{}
 		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.SpanSampler = s })
 		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
 		require.Positive(t, s.sampled, "Sample() driven through the span iterator")
 		require.Positive(t, s.expected, "Expect() driven through the span iterator")
 	})
 
-	t.Run("trace sampler", func(t *testing.T) {
-		s := &countingSampler{}
+	t.Run("trace sampler (Fetch)", func(t *testing.T) {
+		s := &testSampler{}
 		got := countSpans(t, func(req *traceql.FetchSpansRequest) { req.TraceSampler = s })
 		require.Equal(t, baseline, got, "keep-all sampler returns the same spans")
 		require.Positive(t, s.sampled, "Sample() driven through the trace iterator")
 		require.Positive(t, s.expected, "Expect() driven through the trace iterator")
+	})
+
+	t.Run("span sampler (FetchSpans)", func(t *testing.T) {
+		s := &testSampler{}
+		got := countSpansOnly(t, func(req *traceql.FetchSpansRequest) { req.SpanSampler = s })
+		require.Equal(t, spansOnlyBaseline, got, "keep-all sampler returns the same spans")
+		require.Positive(t, s.sampled, "Sample() driven through the FetchSpans span iterator")
+		require.Positive(t, s.expected, "Expect() driven through the FetchSpans span iterator")
 	})
 }
 


### PR DESCRIPTION
**What this PR does**:

Extracts TraceQL metrics sampling out of `samplingPredicate` into a `SyncIterator` option. A new `parquetquery.Sampler` interface (`Expect`/`Sample`) + `SyncIteratorOptSampler` let the iterator call `Sample()` on values that pass the predicate and `Expect()` once per accepted page; `makeIterFn` attaches it to the sampling driver column. `samplingPredicate` is removed from vparquet4/vparquet5.

Sampling is stream-thinning, not predicate shape, so it belongs on the iterator rather than wrapped in a predicate. This also unblocks simplifying the `parquetquery.Predicate` interface. No behavior change.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated — new `TestSyncIteratorSampler`; `pkg/parquetquery`, `vparquet4/5`, `pkg/traceql` suites pass; `gofmt`/`go vet` clean
- [ ] Documentation added — n/a
- [ ] Changelog entry added under `.chloggen/` — n/a, internal refactor with no behavior change
