### PR TITLE
Propagate tag-value limit and maxStaleValues to queriers and live-store

### DIFF
--- a/.chloggen/tag-values-limit-propagation.yaml
+++ b/.chloggen/tag-values-limit-propagation.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: query-frontend
+note: Tag value queries now propagate the `limit` and `maxStaleValues` parameters to the queriers and live-store, bounding per-block scans and enabling the stale-value early-exit. Previously these were only applied at the query-frontend, so each block was scanned without a count limit.
+issues: []
+subtext:
+user: zalegrala

--- a/modules/frontend/tag_sharder.go
+++ b/modules/frontend/tag_sharder.go
@@ -86,6 +86,8 @@ func (r *tagValueSearchRequest) end() uint32 {
 func (r *tagValueSearchRequest) hash() uint64 {
 	hash := fnv1a.HashString64(r.request.TagName)
 	hash = fnv1a.AddString64(hash, traceql.NormalizeQuery(r.request.Query))
+	hash = fnv1a.AddUint64(hash, uint64(r.request.MaxTagValues))
+	hash = fnv1a.AddUint64(hash, uint64(r.request.StaleValueThreshold))
 
 	return hash
 }

--- a/modules/frontend/tag_sharder_test.go
+++ b/modules/frontend/tag_sharder_test.go
@@ -23,8 +23,29 @@ import (
 	"github.com/grafana/tempo/modules/frontend/combiner"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/tempodb/backend"
 )
+
+// TestTagValueSearchRequestHashIncludesLimits ensures the frontend cache hash
+// distinguishes requests that differ only by MaxTagValues / StaleValueThreshold.
+// Without this, propagating those params (tempo-squad#1355) would let a request
+// with a small limit serve its truncated cached response to a request with a
+// larger limit.
+func TestTagValueSearchRequestHashIncludesLimits(t *testing.T) {
+	newReq := func(mut func(*tempopb.SearchTagValuesRequest)) *tagValueSearchRequest {
+		r := tempopb.SearchTagValuesRequest{TagName: "span.foo", Query: "{ span.bar = `baz` }"}
+		mut(&r)
+		return &tagValueSearchRequest{request: r}
+	}
+
+	base := newReq(func(*tempopb.SearchTagValuesRequest) {})
+	withLimit := newReq(func(r *tempopb.SearchTagValuesRequest) { r.MaxTagValues = 100 })
+	withStale := newReq(func(r *tempopb.SearchTagValuesRequest) { r.StaleValueThreshold = 50 })
+
+	require.NotEqual(t, base.hash(), withLimit.hash(), "hash must vary with MaxTagValues")
+	require.NotEqual(t, base.hash(), withStale.hash(), "hash must vary with StaleValueThreshold")
+}
 
 type fakeReq struct {
 	startValue uint32

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -1004,6 +1004,8 @@ func searchTagValuesV2CacheKey(req *tempopb.SearchTagValuesRequest, limit int, p
 	h := fnv1a.HashString64(req.TagName)
 	h = fnv1a.AddString64(h, cacheKey)
 	h = fnv1a.AddUint64(h, uint64(limit))
+	h = fnv1a.AddUint64(h, uint64(req.MaxTagValues))
+	h = fnv1a.AddUint64(h, uint64(req.StaleValueThreshold))
 
 	return fmt.Sprintf("%s_%v.buf", prefix, h)
 }

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/collector"
 	"github.com/grafana/tempo/pkg/ingest/testkafka"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -41,6 +42,7 @@ import (
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/grafana/tempo/tempodb/encoding"
+	"github.com/grafana/tempo/tempodb/encoding/common"
 	"github.com/grafana/tempo/tempodb/wal"
 )
 
@@ -307,6 +309,134 @@ func TestSearchTagValuesV2DiskCache(t *testing.T) {
 
 	err = services.StopAndAwaitTerminated(t.Context(), ls)
 	require.NoError(t, err)
+}
+
+// TestSearchTagValuesV2CacheKeyIncludesLimits ensures the disk-cache key varies
+// with MaxTagValues / StaleValueThreshold. Since the cached per-block values are
+// truncated at these limits, sharing one entry across differing limits would
+// serve a truncated set as complete once those params propagate (tempo-squad#1355).
+func TestSearchTagValuesV2CacheKeyIncludesLimits(t *testing.T) {
+	const limit = 500000
+	newReq := func(mut func(*tempopb.SearchTagValuesRequest)) *tempopb.SearchTagValuesRequest {
+		r := &tempopb.SearchTagValuesRequest{TagName: "span.foo", Query: "{ span.bar = `baz` }"}
+		mut(r)
+		return r
+	}
+
+	base := searchTagValuesV2CacheKey(newReq(func(*tempopb.SearchTagValuesRequest) {}), limit, "p")
+	withLimit := searchTagValuesV2CacheKey(newReq(func(r *tempopb.SearchTagValuesRequest) { r.MaxTagValues = 100 }), limit, "p")
+	withStale := searchTagValuesV2CacheKey(newReq(func(r *tempopb.SearchTagValuesRequest) { r.StaleValueThreshold = 50 }), limit, "p")
+
+	require.NotEqual(t, base, withLimit, "cache key must vary with MaxTagValues")
+	require.NotEqual(t, base, withStale, "cache key must vary with StaleValueThreshold")
+}
+
+// BenchmarkLocalBlockSearchTagValuesV2Limit measures the block scan cost saved
+// by the per-request count limit (MaxTagValues) and stale-value threshold on the
+// unfiltered tag-value path. The "unlimited" case reflects production behavior
+// before tempo-squad#1355 (limits never reached the block); the limited/stale
+// cases are what the fix enables. Runs at the block level to isolate scan cost
+// from the instance disk cache.
+func BenchmarkLocalBlockSearchTagValuesV2Limit(b *testing.B) {
+	const (
+		numTraces = 4000
+		hcTag     = "bench_hc" // unique value per trace (high cardinality)
+		lcTag     = "bench_lc" // 10 distinct values, many repeats (low cardinality)
+	)
+
+	i, ls := defaultInstance(b)
+	b.Cleanup(func() { _ = services.StopAndAwaitTerminated(context.Background(), ls) })
+
+	ctx := user.InjectOrgID(context.Background(), testTenantID)
+	now := time.Now()
+	for j := 0; j < numTraces; j++ {
+		id := make([]byte, 16)
+		_, err := crand.Read(id)
+		require.NoError(b, err)
+
+		tt := test.MakeTrace(1, id)
+		hcKV := &v1.KeyValue{Key: hcTag, Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "hc-" + strconv.Itoa(j)}}}
+		lcKV := &v1.KeyValue{Key: lcTag, Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "lc-" + strconv.Itoa(j%10)}}}
+		for _, batch := range tt.ResourceSpans {
+			for _, ils := range batch.ScopeSpans {
+				for _, span := range ils.Spans {
+					span.StartTimeUnixNano = uint64(now.UnixNano())
+					span.EndTimeUnixNano = uint64(now.UnixNano())
+					span.Attributes = append(span.Attributes, hcKV, lcKV)
+				}
+			}
+		}
+		trace.SortTrace(tt)
+		traceBytes, err := tt.Marshal()
+		require.NoError(b, err)
+		i.pushBytes(ctx, now, &tempopb.PushBytesRequest{
+			Traces: []tempopb.PreallocBytes{{Slice: traceBytes}},
+			Ids:    [][]byte{id},
+		})
+	}
+
+	// Move live traces -> head -> WAL -> complete block. cutIdleTraces cuts the
+	// head early when it reaches MaxBlockBytes, so loop until all live traces are drained.
+	for {
+		drained, err := i.cutIdleTraces(ctx, true)
+		require.NoError(b, err)
+		blockID, err := i.cutBlocks(ctx, true)
+		require.NoError(b, err)
+		if blockID != uuid.Nil {
+			_, err = i.completeBlock(ctx, blockID)
+			require.NoError(b, err)
+		}
+		if drained {
+			break
+		}
+	}
+
+	// pick the largest complete block so the scan has meaningful cardinality
+	var block *LocalBlock
+	for _, bl := range i.blocks.Load().completeBlocks {
+		if block == nil || bl.BlockMeta().TotalRecords > block.BlockMeta().TotalRecords {
+			block = bl
+		}
+	}
+	require.NotNil(b, block)
+	b.Logf("benchmark block: %d records, %d bytes", block.BlockMeta().TotalRecords, block.BlockMeta().Size_)
+
+	opts := common.DefaultSearchOptions()
+	lenFn := func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) }
+
+	cases := []struct {
+		tag       string
+		name      string
+		maxValues uint32
+		stale     uint32
+	}{
+		{"span." + hcTag, "highcard/unlimited", 0, 0},
+		{"span." + hcTag, "highcard/limit_100", 100, 0},
+		{"span." + hcTag, "highcard/limit_1000", 1000, 0},
+		{"span." + lcTag, "lowcard/unlimited", 0, 0},
+		{"span." + lcTag, "lowcard/stale_50", 0, 50},
+	}
+
+	for _, tc := range cases {
+		tag, err := traceql.ParseIdentifier(tc.tag)
+		require.NoError(b, err)
+
+		// Time (ns/op) and -benchmem (B/op, allocs/op) capture the win: the count
+		// limit and stale threshold stop the scan early, so fewer values are
+		// materialized. Block-level BytesRead() is page-granular and does not drop
+		// on an already-open block, so it is not reported here; the cross-block
+		// byte savings come from Exceeded() skipping whole blocks at the instance layer.
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				d := collector.NewDistinctValue(500_000, tc.maxValues, tc.stale, lenFn)
+				mc := collector.NewMetricsCollector()
+				err := block.SearchTagValuesV2(ctx, tag, traceql.MakeCollectTagValueFunc(d.Collect), mc.Add, opts)
+				require.NoError(b, err)
+			}
+		})
+	}
 }
 
 // nolint:revive,unparam

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -33,6 +33,7 @@ const (
 	urlParamMinDuration     = "minDuration"
 	urlParamMaxDuration     = "maxDuration"
 	urlParamLimit           = "limit"
+	urlParamMaxStaleValues  = "maxStaleValues"
 	urlParamStart           = "start"
 	urlParamEnd             = "end"
 	urlParamSpansPerSpanSet = "spss"

--- a/pkg/api/search_tags.go
+++ b/pkg/api/search_tags.go
@@ -380,6 +380,22 @@ func parseSearchTagValuesRequest(r *http.Request, enforceTraceQL bool) (*tempopb
 		req.End = uint32(end)
 	}
 
+	if s, ok := extractQueryParam(vals, urlParamLimit); ok {
+		limit, err := strconv.ParseUint(s, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid limit: %w", err)
+		}
+		req.MaxTagValues = uint32(limit)
+	}
+
+	if s, ok := extractQueryParam(vals, urlParamMaxStaleValues); ok {
+		staleValues, err := strconv.ParseUint(s, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid maxStaleValues: %w", err)
+		}
+		req.StaleValueThreshold = uint32(staleValues)
+	}
+
 	return req, nil
 }
 
@@ -490,6 +506,12 @@ func BuildSearchTagValuesRequest(req *http.Request, searchReq *tempopb.SearchTag
 		qb.addParam(urlParamEnd, strconv.FormatUint(uint64(searchReq.End), 10))
 	}
 	qb.addParam(urlParamQuery, searchReq.Query)
+	if searchReq.MaxTagValues != 0 {
+		qb.addParam(urlParamLimit, strconv.FormatUint(uint64(searchReq.MaxTagValues), 10))
+	}
+	if searchReq.StaleValueThreshold != 0 {
+		qb.addParam(urlParamMaxStaleValues, strconv.FormatUint(uint64(searchReq.StaleValueThreshold), 10))
+	}
 
 	req.URL.RawQuery = qb.query()
 

--- a/pkg/api/search_tags_test.go
+++ b/pkg/api/search_tags_test.go
@@ -6,8 +6,11 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/pkg/tempopb"
 )
 
 // TestParseSearchTagValues tests the SearchTagValues function
@@ -76,6 +79,67 @@ func TestParseSearchTagValuesRequest(t *testing.T) {
 		}
 		require.Equal(t, expectedTagName, req.TagName)
 	}
+}
+
+// TestSearchTagValuesRequestRoundTripPreservesLimits ensures the per-request
+// MaxTagValues (limit) and StaleValueThreshold survive the frontend->querier
+// serialization round trip. If they don't, queriers/live-store scan with no
+// count limit and no stale-value early-exit (tempo-squad#1355).
+func TestSearchTagValuesRequestRoundTripPreservesLimits(t *testing.T) {
+	original := &tempopb.SearchTagValuesRequest{
+		TagName:             "span.foo",
+		Query:               "{ span.bar = `baz` }",
+		Start:               100,
+		End:                 200,
+		MaxTagValues:        50,
+		StaleValueThreshold: 25,
+	}
+
+	httpReq, err := BuildSearchTagValuesRequest(httptest.NewRequest("GET", "http://tempo/", nil), original)
+	require.NoError(t, err)
+
+	// the querier-side parser reads the tag name from mux vars, mirroring routing
+	httpReq = mux.SetURLVars(httpReq, map[string]string{MuxVarTagName: original.TagName})
+
+	parsed, err := parseSearchTagValuesRequest(httpReq, false)
+	require.NoError(t, err)
+
+	require.Equal(t, original.MaxTagValues, parsed.MaxTagValues, "MaxTagValues (limit) must survive the round trip")
+	require.Equal(t, original.StaleValueThreshold, parsed.StaleValueThreshold, "StaleValueThreshold must survive the round trip")
+}
+
+// TestSearchTagValuesBlockRequestRoundTripPreservesLimits locks that the block
+// request variant (frontend sharder -> querier block search) also carries
+// MaxTagValues / StaleValueThreshold through its SearchReq (tempo-squad#1355).
+func TestSearchTagValuesBlockRequestRoundTripPreservesLimits(t *testing.T) {
+	original := &tempopb.SearchTagValuesBlockRequest{
+		SearchReq: &tempopb.SearchTagValuesRequest{
+			TagName:             "span.foo",
+			Query:               "{ span.bar = `baz` }",
+			Start:               100,
+			End:                 200,
+			MaxTagValues:        50,
+			StaleValueThreshold: 25,
+		},
+		BlockID:       uuid.New().String(),
+		StartPage:     2,
+		PagesToSearch: 10,
+		IndexPageSize: 100,
+		TotalRecords:  1000,
+		Version:       "vParquet4",
+		Size_:         12345,
+		FooterSize:    456,
+	}
+
+	httpReq, err := BuildSearchTagValuesBlockRequest(httptest.NewRequest("GET", "http://tempo/", nil), original)
+	require.NoError(t, err)
+	httpReq = mux.SetURLVars(httpReq, map[string]string{MuxVarTagName: original.SearchReq.TagName})
+
+	parsed, err := ParseSearchTagValuesBlockRequest(httpReq)
+	require.NoError(t, err)
+
+	require.Equal(t, original.SearchReq.MaxTagValues, parsed.SearchReq.MaxTagValues)
+	require.Equal(t, original.SearchReq.StaleValueThreshold, parsed.SearchReq.StaleValueThreshold)
 }
 
 // TestParseSearchTags tests the SearchTagValues function


### PR DESCRIPTION
**What this PR does**:

Propagates the `limit` (`maxTagValues`) and `maxStaleValues` (`staleValueThreshold`) parameters on tag-value lookups (`/api/v2/search/tag/{tag}/values`, v1 and v2) from the query-frontend down to the queriers and live-store.

Previously these were parsed at the frontend and applied only in the response combiner. They were never serialized into the requests sent to queriers, nor parsed on the querier side — so below the frontend the per-block scan ran with **no count limit** and the **stale-value early-exit was disabled**. Every block was scanned up to the byte ceiling (`max_bytes_per_tag_values_query`) regardless of how few values the caller asked for.

Changes:
- Serialize `maxTagValues`/`maxStaleValues` in `BuildSearchTagValuesRequest` and parse them in `parseSearchTagValuesRequest` (honored for both the frontend→querier fan-out and direct HTTP/gRPC clients).
- Include both params in the frontend cache hash and the live-store disk-cache key, so two requests that differ only by limit don't share a truncated cached result.

**Benchmarks** (`BenchmarkLocalBlockSearchTagValuesV2Limit`, single block, n=6):

| case | sec/op | allocs/op |
|---|---|---|
| high-cardinality, unlimited (today) | 29.4 ms | 48.6k |
| high-cardinality, limit=100 | 8.4 ms (**3.5× faster**) | 3.4k |
| high-cardinality, limit=1000 | 13.2 ms | 13.7k |
| low-cardinality, unlimited (today) | 32.0 ms | 86.9k |
| low-cardinality, maxStaleValues=50 | 8.1 ms (**4.0× faster**) | 2.5k |

Time and allocations are the signal; block-level bytes-read is page-granular so it doesn't move on a single already-open block — the larger production win is skipping whole blocks via the between-block `Exceeded()` check during typeahead bursts.

**Which issue(s) this PR fixes**:
No public issue; tracked internally by the Tempo team.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
