### PR TITLE
Tag values: search the block instead of skipping it on a corrupt/unreadable disk-cache entry

### DIFF
--- a/.chloggen/tag-values-tolerate-corrupt-cache.yaml
+++ b/.chloggen/tag-values-tolerate-corrupt-cache.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: live-store
+note: Tag value queries no longer silently drop a block's values when its disk-cache entry is unreadable or fails to unmarshal; the block is re-searched instead of being skipped.
+issues: []
+subtext:
+user: zalegrala

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -570,12 +570,9 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 				_ = level.Warn(i.logger).Log("msg", "GetDiskCache unmarshal failed", "err", err)
 			} else {
 				span.SetAttributes(attribute.Bool("cached", true))
-				// Instead of the reporting the InspectedBytes of the cached response.
-				// we report the size of cacheData as the Inspected bytes in case we hit disk cache.
-				// we do this because, because it's incorrect and misleading to report the metrics of cachedResponse
-				// we report the size of the cacheData as the amount of data was read to search this block.
-				// this can skew our metrics because this will be lower than the data read to search the block.
-				// we can remove this if this becomes an issue but leave it in for now to more accurate.
+				// On a cache hit we only read the cache file, so report its size as the
+				// inspected bytes for this block. The cached payload stores only TagValues
+				// (not Metrics), so the original scan's byte count isn't available here.
 				mCollector.Add(uint64(len(cacheData)))
 
 				for _, v := range resp.TagValues {

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -553,41 +553,41 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 		// pulled from context to add attrs below
 		span := oteltrace.SpanFromContext(ctx)
 
-		// check the cache first
+		// check the cache first. GetDiskCache maps a cache miss to (nil, nil), so a
+		// non-nil error here is a real read failure. Either way we fall through to
+		// search the block rather than dropping its values from the response.
 		cacheData, err := localB.GetDiskCache(ctx, cacheKey)
 		if err != nil {
-			// just log the error and move on...we will search the block
 			_ = level.Warn(i.logger).Log("msg", "GetDiskCache failed", "err", err)
-			return nil
+			cacheData = nil
 		}
 
 		// we got data...unmarshall, and add values to central collector and add bytesRead
 		if len(cacheData) > 0 {
 			resp := &tempopb.SearchTagValuesV2Response{}
-			err = proto.Unmarshal(cacheData, resp)
-			if err != nil {
+			if err := proto.Unmarshal(cacheData, resp); err != nil {
+				// corrupt cache entry: log and fall through to search the block below
 				_ = level.Warn(i.logger).Log("msg", "GetDiskCache unmarshal failed", "err", err)
+			} else {
+				span.SetAttributes(attribute.Bool("cached", true))
+				// Instead of the reporting the InspectedBytes of the cached response.
+				// we report the size of cacheData as the Inspected bytes in case we hit disk cache.
+				// we do this because, because it's incorrect and misleading to report the metrics of cachedResponse
+				// we report the size of the cacheData as the amount of data was read to search this block.
+				// this can skew our metrics because this will be lower than the data read to search the block.
+				// we can remove this if this becomes an issue but leave it in for now to more accurate.
+				mCollector.Add(uint64(len(cacheData)))
+
+				for _, v := range resp.TagValues {
+					if vCollector.Collect(*v) {
+						return errComplete
+					}
+				}
 				return nil
 			}
-
-			span.SetAttributes(attribute.Bool("cached", true))
-			// Instead of the reporting the InspectedBytes of the cached response.
-			// we report the size of cacheData as the Inspected bytes in case we hit disk cache.
-			// we do this because, because it's incorrect and misleading to report the metrics of cachedResponse
-			// we report the size of the cacheData as the amount of data was read to search this block.
-			// this can skew our metrics because this will be lower than the data read to search the block.
-			// we can remove this if this becomes an issue but leave it in for now to more accurate.
-			mCollector.Add(uint64(len(cacheData)))
-
-			for _, v := range resp.TagValues {
-				if vCollector.Collect(*v) {
-					return errComplete
-				}
-			}
-			return nil
 		}
 
-		// cache miss, search the block. We will cache the results if we find any.
+		// cache miss or unusable cache entry, search the block. We will cache the results if we find any.
 		span.SetAttributes(attribute.Bool("cached", false))
 		// using local collector to collect values from the block and cache them.
 		localCol := collector.NewDistinctValue[tempopb.TagValue](limit, req.MaxTagValues, req.StaleValueThreshold, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -439,6 +439,54 @@ func BenchmarkLocalBlockSearchTagValuesV2Limit(b *testing.B) {
 	}
 }
 
+// TestSearchTagValuesV2ToleratesCorruptDiskCache ensures a block whose disk-cache
+// entry is unreadable/corrupt is still searched, rather than silently skipped and
+// dropped from the response (tempo-squad#1358).
+func TestSearchTagValuesV2ToleratesCorruptDiskCache(t *testing.T) {
+	i, ls := defaultInstance(t)
+
+	tagKey := foo
+	tagValue := bar
+
+	_, expectedTagValues, _, _ := writeTracesForSearch(t, i, "", tagKey, tagValue, true, false)
+
+	blockID, err := i.cutBlocks(t.Context(), true)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, blockID)
+	_, err = i.completeBlock(t.Context(), blockID)
+	require.NoError(t, err)
+
+	userCtx := user.InjectOrgID(t.Context(), testTenantID)
+	req := &tempopb.SearchTagValuesRequest{TagName: "." + tagKey}
+
+	// seed a corrupt (non-unmarshalable) cache entry on the complete block
+	var block *LocalBlock
+	for _, b := range i.blocks.Load().completeBlocks {
+		block = b
+		break
+	}
+	require.NotNil(t, block)
+	limit := i.overrides.MaxBytesPerTagValuesQuery(testTenantID)
+	cacheKey := searchTagValuesV2CacheKey(req, limit, "cache_search_tagvaluesv2")
+	// field 1, length-delimited, claims 10 bytes but supplies none -> proto.Unmarshal fails
+	require.NoError(t, block.SetDiskCache(userCtx, cacheKey, []byte{0x0a, 0x0a}))
+
+	// the block must still be searched despite the corrupt entry
+	resp, err := i.SearchTagValuesV2(userCtx, req)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(resp.TagValues))
+	for _, v := range resp.TagValues {
+		got = append(got, v.Value)
+	}
+	for _, want := range expectedTagValues {
+		require.Contains(t, got, want, "corrupt cache must not drop the block's values")
+	}
+
+	err = services.StopAndAwaitTerminated(t.Context(), ls)
+	require.NoError(t, err)
+}
+
 // nolint:revive,unparam
 func testSearchTagsAndValues(t *testing.T, ctx context.Context, i *instance, tagName string, expectedTagValues []string) {
 	checkSearchTags := func(scope string, contains bool) {


### PR DESCRIPTION
**What this PR does**:

On the tag-value read path, a block was **silently dropped** from the `SearchTagValuesV2` response when its live-store disk-cache entry returned a read error or failed to unmarshal. `searchWithCache` logged and `return nil`, skipping the block entirely.

`GetDiskCache` already maps a cache miss to `(nil, nil)`, so a non-nil error there is a *real* read failure — not a normal miss. Likewise a corrupt cached blob meant the block's values were silently missing from the response (results look complete but aren't), with only a warn log.

This changes both the read-error and unmarshal-failure paths to fall through and search the block, instead of skipping it.

Adds a regression test that seeds a corrupt cache entry and asserts the block's values are still returned.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
