### PR TITLE
metrics-generator: skip stale backlog on startup

### DIFF
--- a/.chloggen/generator-skip-stale-backlog.yaml
+++ b/.chloggen/generator-skip-stale-backlog.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: metrics-generator
+note: Add `skip_stale_backlog_on_startup` to seek partitions forward to the ingestion-slack horizon on startup instead of replaying backlog the slack would discard, keeping the partition-lag metric honest on restart.
+issues: [7611]
+subtext:
+user: zalegrala

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -898,6 +898,12 @@ metrics_generator:
     # This is to filter out spans that are outdated.
     [metrics_ingestion_time_range_slack: <duration> | default = 30s]
 
+    # When true, on startup the metrics-generator seeks each Kafka partition forward to
+    # (now - metrics_ingestion_time_range_slack) instead of replaying from the committed
+    # offset. This skips backlog that the slack would discard anyway, avoiding wasted work
+    # and a misleading partition-lag spike on restart. Requires Kafka ingest.
+    [skip_stale_backlog_on_startup: <bool> | default = false]
+
     # Overrides the key used to register the metrics-generator in the ring.
     [override_ring_key: <string> | default = "metrics-generator"]
 ```

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -496,6 +496,7 @@ metrics_generator:
     ingest_concurrency: 16
     instance_id: hostname
     leave_consumer_group_on_shutdown: false
+    skip_stale_backlog_on_startup: false
 ingest:
     kafka:
         address: localhost:9092

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -492,6 +492,7 @@ metrics_generator:
     ingest_concurrency: 16
     instance_id: hostname
     leave_consumer_group_on_shutdown: false
+    skip_stale_backlog_on_startup: false
 ingest:
     kafka:
         address: localhost:9092

--- a/modules/generator/config.go
+++ b/modules/generator/config.go
@@ -78,6 +78,13 @@ type Config struct {
 	// explicitly; set to true when deploying as a Deployment (random pod names) to avoid
 	// the session-timeout delay on partition reassignment. Requires Kafka ingest enabled.
 	LeaveConsumerGroupOnShutdown bool `yaml:"leave_consumer_group_on_shutdown" category:"advanced"`
+
+	// SkipStaleBacklogOnStartup, when true, seeks each partition forward to
+	// now-metrics_ingestion_time_range_slack on startup instead of replaying from
+	// the committed offset. This avoids fetching and decoding backlog that the
+	// metrics ingestion slack would discard anyway, and keeps the partition-lag
+	// metric honest on restart. Requires Kafka ingest enabled.
+	SkipStaleBacklogOnStartup bool `yaml:"skip_stale_backlog_on_startup" category:"advanced"`
 }
 
 // RegisterFlagsAndApplyDefaults registers the flags.
@@ -103,6 +110,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	}
 	f.StringVar(&cfg.InstanceID, prefix+".instance-id", hostname, "Instance id.")
 	f.BoolVar(&cfg.LeaveConsumerGroupOnShutdown, prefix+".leave-consumer-group-on-shutdown", false, "If true, send LeaveGroup to Kafka on shutdown for immediate partition reassignment. Default false; set to true for Deployment rollouts where pod names change on each restart.")
+	f.BoolVar(&cfg.SkipStaleBacklogOnStartup, prefix+".skip-stale-backlog-on-startup", false, "If true, on startup seek partitions forward to now-metrics_ingestion_time_range_slack instead of replaying from the committed offset, skipping backlog the slack would drop. Requires Kafka ingest.")
 }
 
 func (cfg *Config) Validate() error {

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -116,11 +116,7 @@ func New(cfg *Config, overrides metricsGeneratorOverrides, reg prometheus.Regist
 
 func (g *Generator) starting(ctx context.Context) error {
 	if g.cfg.ConsumeFromKafka {
-		kafkaClient, err := ingest.NewGroupReaderClient(
-			g.cfg.Ingest.Kafka,
-			g.partitionRing,
-			ingest.NewReaderClientMetrics("generator", prometheus.DefaultRegisterer),
-			g.logger,
+		opts := []kgo.Opt{
 			kgo.InstanceID(g.cfg.InstanceID),
 			kgo.OnPartitionsAssigned(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
 				g.handlePartitionsAssigned(m)
@@ -128,6 +124,19 @@ func (g *Generator) starting(ctx context.Context) error {
 			kgo.OnPartitionsRevoked(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
 				g.handlePartitionsRevoked(m)
 			}),
+		}
+		// When enabled, seek past stale backlog on startup instead of replaying
+		// from the committed offset (see adjustStartupOffsets).
+		if g.cfg.SkipStaleBacklogOnStartup {
+			opts = append(opts, kgo.AdjustFetchOffsetsFn(g.adjustStartupOffsets))
+		}
+
+		kafkaClient, err := ingest.NewGroupReaderClient(
+			g.cfg.Ingest.Kafka,
+			g.partitionRing,
+			ingest.NewReaderClientMetrics("generator", prometheus.DefaultRegisterer),
+			g.logger,
+			opts...,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create kafka reader client: %w", err)

--- a/modules/generator/generator_kafka.go
+++ b/modules/generator/generator_kafka.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/tempo/pkg/ingest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -259,4 +260,104 @@ func revokePartitions(assigned, revoked []int32) []int32 {
 
 	// Resize assigned to only include retained elements
 	return assigned[:k]
+}
+
+// kafkaOffsetNone marks the absence of a committed group offset for a partition.
+const kafkaOffsetNone = int64(-1)
+
+// startupSeekOffset decides which offset to resume a partition from at startup
+// when skip_stale_backlog_on_startup is enabled. It never rewinds behind the
+// committed offset, but skips forward to horizonOffset (the offset of the first
+// record at/after now-horizon) when the committed offset is behind that horizon
+// or absent. The returned bool reports whether an explicit seek is needed;
+// false means resume from the committed offset as usual.
+func startupSeekOffset(committed, horizonOffset int64) (int64, bool) {
+	if committed != kafkaOffsetNone && committed >= horizonOffset {
+		return committed, false
+	}
+	return horizonOffset, true
+}
+
+// startupSeekOffsets builds the set of offsets to seek to for the given
+// partitions, applying startupSeekOffset per partition. A partition is included
+// only when it has a known horizon offset and its committed offset is behind
+// that horizon (or absent); partitions already at/ahead of the horizon are
+// omitted so consumption resumes from the committed offset as usual.
+func startupSeekOffsets(partitions []int32, committed, horizon map[int32]int64) map[int32]int64 {
+	out := make(map[int32]int64)
+	for _, p := range partitions {
+		h, ok := horizon[p]
+		if !ok {
+			continue
+		}
+		c, ok := committed[p]
+		if !ok {
+			c = kafkaOffsetNone
+		}
+		if target, seek := startupSeekOffset(c, h); seek {
+			out[p] = target
+		}
+	}
+	return out
+}
+
+// adjustStartupOffsets is the franz-go AdjustFetchOffsetsFn hook. When
+// skip_stale_backlog_on_startup is enabled it rewrites the fetch offsets for the
+// joining partitions to skip forward past backlog older than
+// metrics_ingestion_time_range_slack, so the generator does not replay spans the
+// slack would discard and its partition-lag metric stays honest on restart.
+// Partitions already at/ahead of the slack horizon keep their committed offset.
+func (g *Generator) adjustStartupOffsets(ctx context.Context, offsets map[string]map[int32]kgo.Offset) (map[string]map[int32]kgo.Offset, error) {
+	topic := g.cfg.Ingest.Kafka.Topic
+	parts := offsets[topic]
+	if len(parts) == 0 {
+		return offsets, nil
+	}
+
+	partitionIDs := make([]int32, 0, len(parts))
+	committed := make(map[int32]int64, len(parts))
+	for p, off := range parts {
+		partitionIDs = append(partitionIDs, p)
+		committed[p] = off.EpochOffset().Offset
+	}
+
+	horizonMs := time.Now().Add(-g.cfg.MetricsIngestionSlack).UnixMilli()
+	horizonOffsets, err := g.partitionClient.FetchPartitionsOffsetsAfterMilli(ctx, horizonMs, partitionIDs)
+	if err != nil {
+		// Best-effort optimization: on lookup failure, fall back to replaying
+		// from the committed offset rather than blocking startup.
+		level.Warn(g.logger).Log("msg", "skip stale backlog on startup: horizon offset lookup failed, replaying from committed offset", "err", err)
+		return offsets, nil
+	}
+
+	// Resolve the seek target per partition. A horizon offset of -1 means no
+	// record is at/after the horizon (all backlog is stale), so seek to the end.
+	var endOffsets kadm.ListedOffsets
+	horizon := make(map[int32]int64, len(partitionIDs))
+	for _, p := range partitionIDs {
+		o, ok := horizonOffsets[topic][p]
+		if !ok {
+			continue
+		}
+		if o.Offset >= 0 {
+			horizon[p] = o.Offset
+			continue
+		}
+		if endOffsets == nil {
+			if endOffsets, err = g.partitionClient.FetchPartitionsLastProducedOffsets(ctx, partitionIDs); err != nil {
+				level.Warn(g.logger).Log("msg", "skip stale backlog on startup: end offset lookup failed, replaying from committed offset", "err", err)
+				return offsets, nil
+			}
+		}
+		if eo, ok := endOffsets[topic][p]; ok {
+			horizon[p] = eo.Offset
+		}
+	}
+
+	for p, target := range startupSeekOffsets(partitionIDs, committed, horizon) {
+		parts[p] = kgo.NewOffset().At(target).WithEpoch(-1)
+		level.Info(g.logger).Log("msg", "skipping stale backlog on startup",
+			"partition", p, "committed", committed[p], "seek_to", target)
+	}
+	return offsets, nil
 }

--- a/modules/generator/generator_kafka_startup_test.go
+++ b/modules/generator/generator_kafka_startup_test.go
@@ -1,0 +1,138 @@
+package generator
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+
+	"github.com/grafana/tempo/pkg/ingest"
+	"github.com/grafana/tempo/pkg/ingest/testkafka"
+)
+
+// TestGenerator_adjustStartupOffsets_skipsStaleBacklog verifies the
+// AdjustFetchOffsetsFn hook seeks a partition forward past backlog older than
+// the startup replay horizon to the first in-horizon record, when the committed
+// offset is behind that horizon.
+func TestGenerator_adjustStartupOffsets_skipsStaleBacklog(t *testing.T) {
+	ctx := context.Background()
+	const topic = "test-topic"
+	_, addr := testkafka.CreateCluster(t, 1, topic)
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(addr),
+		kgo.DefaultProduceTopic(topic),
+		kgo.RecordPartitioner(kgo.ManualPartitioner()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	now := time.Now()
+	produce := func(ts time.Time) {
+		rec := &kgo.Record{Topic: topic, Partition: 0, Timestamp: ts, Value: []byte("x")}
+		require.NoError(t, client.ProduceSync(ctx, rec).FirstErr())
+	}
+	produce(now.Add(-time.Hour))        // offset 0, stale
+	produce(now.Add(-30 * time.Minute)) // offset 1, stale
+	produce(now)                        // offset 2, within horizon
+
+	g := minimalGeneratorForKafkaTest()
+	g.cfg.SkipStaleBacklogOnStartup = true
+	g.cfg.MetricsIngestionSlack = 5 * time.Minute
+	g.partitionClient = ingest.NewPartitionOffsetClient(client, topic)
+
+	// Committed at offset 0 (behind the horizon) -> should seek forward to 2.
+	offsets := map[string]map[int32]kgo.Offset{topic: {0: kgo.NewOffset().At(0)}}
+	got, err := g.adjustStartupOffsets(ctx, offsets)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), got[topic][0].EpochOffset().Offset)
+}
+
+// TestGenerator_adjustStartupOffsets_failOpenOnFetchError verifies the hook
+// fails open: if the offset lookup errors (here, a canceled context) it returns
+// the original committed offsets unchanged rather than surfacing an error and
+// blocking startup. Skipping stale backlog is a best-effort optimization.
+func TestGenerator_adjustStartupOffsets_failOpenOnFetchError(t *testing.T) {
+	const topic = "test-topic"
+	_, addr := testkafka.CreateCluster(t, 1, topic)
+	client, err := kgo.NewClient(kgo.SeedBrokers(addr))
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
+
+	g := minimalGeneratorForKafkaTest()
+	g.cfg.SkipStaleBacklogOnStartup = true
+	g.cfg.MetricsIngestionSlack = 5 * time.Minute
+	g.partitionClient = ingest.NewPartitionOffsetClient(client, topic)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel() // force the horizon lookup to fail
+
+	in := map[string]map[int32]kgo.Offset{topic: {0: kgo.NewOffset().At(7)}}
+	got, err := g.adjustStartupOffsets(canceled, in)
+	require.NoError(t, err)
+	assert.Equal(t, int64(7), got[topic][0].EpochOffset().Offset, "committed offset should be preserved on fetch error")
+}
+
+// TestStartupSeekOffsets verifies the per-partition decision is aggregated into
+// a seek map: only partitions whose committed offset is behind the horizon (or
+// absent) are included, and partitions without a known horizon offset are left
+// untouched.
+func TestStartupSeekOffsets(t *testing.T) {
+	partitions := []int32{0, 1, 2, 3, 4}
+	committedOffsets := map[int32]int64{
+		0: 100,             // ahead of horizon -> no seek
+		1: 50,              // behind horizon -> seek forward
+		2: kafkaOffsetNone, // no commit -> seek to horizon
+		// 3: absent from committed map -> treated as no commit -> seek
+		4: 10, // behind horizon, but no horizon offset known -> skip
+	}
+	horizonOffsets := map[int32]int64{
+		0: 80,
+		1: 120,
+		2: 30,
+		3: 200,
+		// 4: absent -> cannot seek
+	}
+
+	got := startupSeekOffsets(partitions, committedOffsets, horizonOffsets)
+	assert.Equal(t, map[int32]int64{1: 120, 2: 30, 3: 200}, got)
+}
+
+// TestConfig_skipStaleBacklogOnStartupDefault verifies the feature is off by default.
+func TestConfig_skipStaleBacklogOnStartupDefault(t *testing.T) {
+	cfg := &Config{}
+	f := flag.NewFlagSet("test", flag.PanicOnError)
+	cfg.RegisterFlagsAndApplyDefaults("", f)
+
+	assert.False(t, cfg.SkipStaleBacklogOnStartup, "skip should default off")
+}
+
+// TestStartupSeekOffset verifies the offset the generator resumes from when
+// skip_stale_backlog_on_startup is enabled: it never rewinds behind the group's
+// committed offset, but it skips forward past stale backlog to the horizon
+// offset (the first record at/after now-horizon) when the commit is behind that
+// horizon or absent.
+func TestStartupSeekOffset(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		committed     int64
+		horizonOffset int64
+		wantOffset    int64
+		wantSeek      bool
+	}{
+		{"committed ahead of horizon keeps position, no seek", 100, 50, 100, false},
+		{"committed behind horizon skips forward", 50, 100, 100, true},
+		{"no committed offset seeks to horizon", kafkaOffsetNone, 100, 100, true},
+		{"committed equal to horizon does not seek", 100, 100, 100, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			offset, seek := startupSeekOffset(tc.committed, tc.horizonOffset)
+			assert.Equal(t, tc.wantOffset, offset, "offset")
+			assert.Equal(t, tc.wantSeek, seek, "seek")
+		})
+	}
+}

--- a/pkg/ingest/partition_offset_client.go
+++ b/pkg/ingest/partition_offset_client.go
@@ -56,6 +56,22 @@ func (p *PartitionOffsetClient) FetchPartitionsStartProducedOffsets(ctx context.
 	return p.fetchPartitionsOffsets(ctx, kafkaOffsetStart, partitionIDs)
 }
 
+// FetchPartitionsOffsetsAfterMilli fetches, for each input partition, the offset of the
+// first record whose timestamp is at or after the given millisecond timestamp, or -1 if
+// no such record exists (all records are older than the timestamp). Used to skip stale
+// backlog on startup. A negative milli is clamped to 0 (earliest) so it can never collide
+// with Kafka's reserved ListOffsets timestamps (-1 = end, -2 = start).
+func (p *PartitionOffsetClient) FetchPartitionsOffsetsAfterMilli(ctx context.Context, milli int64, partitionIDs []int32) (kadm.ListedOffsets, error) {
+	if len(partitionIDs) == 0 {
+		return nil, nil
+	}
+	if milli < 0 {
+		milli = 0
+	}
+
+	return p.fetchPartitionsOffsets(ctx, milli, partitionIDs)
+}
+
 // fetchPartitionsOffsets fetches and returns offsets for the specified partitions using Kafka's ListOffsets API.
 // The fetchOffset parameter determines which offsets to retrieve:
 //   - kafkaOffsetStart (-2): earliest available offset in each partition

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -246,3 +246,50 @@ func RecordVersionHeader(version int) kgo.RecordHeader {
 		Value: b[:],
 	}
 }
+
+func produceRecordAt(ctx context.Context, t *testing.T, writeClient *kgo.Client, partitionID int32, ts time.Time, content []byte) {
+	rec := &kgo.Record{
+		Value:     content,
+		Topic:     topicName,
+		Partition: partitionID,
+		Timestamp: ts,
+	}
+	require.NoError(t, writeClient.ProduceSync(ctx, rec).FirstErr())
+}
+
+// TestPartitionOffsetClient_FetchPartitionsOffsetsAfterMilli verifies the
+// timestamp lookup: it returns the first offset at/after the given millisecond
+// timestamp, offset 0 when the timestamp precedes all records, and -1 when no
+// record is at/after the timestamp.
+func TestPartitionOffsetClient_FetchPartitionsOffsetsAfterMilli(t *testing.T) {
+	ctx := context.Background()
+	_, clusterAddr := testkafka.CreateCluster(t, 1, topicName)
+	client := createTestKafkaClient(t, createTestKafkaConfig(clusterAddr))
+	reader := NewPartitionOffsetClient(client, topicName)
+
+	base := time.Now().Add(-time.Hour).Truncate(time.Millisecond)
+	produceRecordAt(ctx, t, client, 0, base, []byte("r0"))
+	produceRecordAt(ctx, t, client, 0, base.Add(10*time.Minute), []byte("r1"))
+	produceRecordAt(ctx, t, client, 0, base.Add(20*time.Minute), []byte("r2"))
+
+	// Before all records -> first offset (0).
+	offsets, err := reader.FetchPartitionsOffsetsAfterMilli(ctx, base.Add(-time.Minute).UnixMilli(), []int32{0})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), getPartitionsOffsets(offsets)[0])
+
+	// At/after the second record's timestamp -> offset 1.
+	offsets, err = reader.FetchPartitionsOffsetsAfterMilli(ctx, base.Add(10*time.Minute).UnixMilli(), []int32{0})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), getPartitionsOffsets(offsets)[0])
+
+	// After all records -> -1 (no record at/after the timestamp).
+	offsets, err = reader.FetchPartitionsOffsetsAfterMilli(ctx, base.Add(time.Hour).UnixMilli(), []int32{0})
+	require.NoError(t, err)
+	assert.Equal(t, int64(-1), getPartitionsOffsets(offsets)[0])
+
+	// A negative timestamp is clamped to 0 (earliest) rather than colliding with
+	// Kafka's reserved ListOffsets values (-1 = end, -2 = start).
+	offsets, err = reader.FetchPartitionsOffsetsAfterMilli(ctx, -1, []int32{0})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), getPartitionsOffsets(offsets)[0])
+}


### PR DESCRIPTION
## What

Adds an opt-in `skip_stale_backlog_on_startup` for the metrics-generator. When enabled, on startup/(re)assignment the generator seeks each partition forward to the first record at/after `now − metrics_ingestion_time_range_slack` instead of replaying from the committed offset.

## Why

- Generator samples are stamped at **collection time**, not span time (`registry.go` `CollectMetrics` uses `time.Now()`). Replaying old backlog on restart does **not** backfill the outage gap — it folds old observations into the *current* counters/histograms, distorting present `rate()`/quantiles. And `metrics_ingestion_time_range_slack` already drops spans older than the slack, so that backlog is fetched, decoded, and thrown away.
- `tempo_ingest_group_partition_lag_seconds` is the age of the oldest *fetched* record, so on restart it spikes to the full backlog age — including data that will be dropped — which can fire `TempoMetricsGeneratorPartitionLagCritical` on benign startup catch-up. Seeking to the slack horizon makes the metric honest **without special-casing the alert**; genuine within-horizon lag still shows.

## How

- An `AdjustFetchOffsetsFn` hook (`adjustStartupOffsets`) rewrites the joining partitions' fetch offsets to `max(committed, first-offset-at/after now−horizon)`. Partitions already at/ahead of the horizon keep their committed offset (no rewind).
- Horizon offset via the new `PartitionOffsetClient.FetchPartitionsOffsetsAfterMilli`; a `-1` result (all backlog older than the horizon) resolves to the end offset so all stale backlog is skipped.
- Best-effort: if the offset lookup fails, the hook falls back to normal committed-offset replay rather than blocking startup.
- Registered only when `skip_stale_backlog_on_startup` is set. Default **off**.

## Tradeoff

Seeking forward permanently skips offsets older than the horizon — intentional, best-effort for metrics, and the **same net emitted metrics as today** (the slack filter drops them anyway).

## Testing

- Unit: seek policy, seek-map aggregation, config default.
- `FetchPartitionsOffsetsAfterMilli` against testkafka with backdated record timestamps.
- `adjustStartupOffsets` against kfake: skips stale records to the first in-horizon offset, and fails open on lookup error.
- Full `modules/generator` + `pkg/ingest` suites pass; `go build` + `go vet` clean.

## Checklist

- [x] Changelog entry under `.chloggen/`
- [x] Config docs updated (`docs/sources/tempo/configuration/_index.md`)
- [x] Tests
- [x] Rebased on `main`
