### PR TITLE
fix(metrics-generator): allow overriding the Kafka consumer group

### DIFF
--- a/.chloggen/7613_metrics_generator_consumer_group.yaml
+++ b/.chloggen/7613_metrics_generator_consumer_group.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: metrics-generator
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Respect a configured `ingest.kafka.consumer_group` instead of always forcing the default in partition ring mode, so multiple metrics-generator deployments can share a single Kafka cluster without colliding on the same consumer group
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7613]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: yakir-shriker

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -315,7 +315,9 @@ func (t *App) initGenerator() (services.Service, error) {
 func (t *App) configureGenerator() {
 	t.cfg.Generator.Ingest = t.cfg.Ingest
 	t.cfg.Generator.ConsumeFromKafka = !IsSingleBinary(t.cfg.Target)
-	if t.cfg.Generator.ConsumeFromKafka && t.cfg.Generator.RingMode == generator.RingModePartition {
+	// Only default the consumer group when unset, so it can be overridden to let multiple
+	// metrics-generators share one Kafka cluster (otherwise they all collide on this group).
+	if t.cfg.Generator.ConsumeFromKafka && t.cfg.Generator.RingMode == generator.RingModePartition && t.cfg.Generator.Ingest.Kafka.ConsumerGroup == "" {
 		t.cfg.Generator.Ingest.Kafka.ConsumerGroup = generator.ConsumerGroup
 	}
 }


### PR DESCRIPTION
## What this PR does

In partition ring mode, `configureGenerator` force-sets the metrics-generator's Kafka consumer group to the default `"metrics-generator"` **unconditionally**, discarding any configured `ingest.kafka.consumer_group`:

```go
if t.cfg.Generator.ConsumeFromKafka && t.cfg.Generator.RingMode == generator.RingModePartition {
    t.cfg.Generator.Ingest.Kafka.ConsumerGroup = generator.ConsumerGroup
}
```

Because the group name can't be overridden, **multiple metrics-generator deployments cannot share a single Kafka cluster**. When two installations (or two clusters pointing at the same Kafka) run the metrics-generator against different topics:

- they all join the same `metrics-generator` consumer group;
- the cooperative-sticky assignor cross-assigns one deployment the *other's* topic, and the consumer then panics in `franz-go`'s `fetchOffsets` fetching offsets for a topic it isn't configured for;
- deployments that share an instance ID (e.g. identically-named StatefulSet pods) fence each other with `FENCED_INSTANCE_ID`.

## Fix

Only fall back to the default when no consumer group is configured:

```go
if ... && t.cfg.Generator.Ingest.Kafka.ConsumerGroup == "" {
    t.cfg.Generator.Ingest.Kafka.ConsumerGroup = generator.ConsumerGroup
}
```

This is backward compatible — the default `"metrics-generator"` still applies when unset — and lets operators set a unique `ingest.kafka.consumer_group` per deployment so several metrics-generators can share one Kafka cluster. It also aligns with the generator config validation, which already treats an empty `ingest.kafka.consumer_group` as "not configured".

## Which issue(s) this PR fixes

Allows multiple metrics-generator deployments to share a Kafka cluster (block-builder/live-store already avoid this via direct partition consumption).