### PR TITLE
Skip predicate evaluation while seeking parquet iterators to a target row

### DIFF
--- a/.chloggen/synciterator-seek-skip-filter.yaml
+++ b/.chloggen/synciterator-seek-skip-filter.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: querier
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Skip predicate evaluation for values scanned past during parquet iterator seeks, speeding up TraceQL join queries.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mapno

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -612,7 +612,14 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 	if !rn.Valid() {
 		return nil, nil
 	}
-	return c.makeResult(rn, v), nil
+
+	if c.filter == nil || c.filter.KeepValue(*v) {
+		return c.makeResult(rn, v), nil
+	}
+
+	// The value at the seek target didn't pass the filter, continue as a
+	// normal filtered read.
+	return c.Next()
 }
 
 func (c *SyncIterator) popRowGroup() (pq.RowGroup, RowNumber, RowNumber) {
@@ -827,10 +834,11 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 	}
 }
 
-// nextSeek is like next but for use while seeking: values before the seek
-// target are discarded without evaluating the filter, since SeekTo drops
-// them regardless of the filter's decision. Values at or past the target are
-// filtered as usual.
+// nextSeek is like next but for use while seeking: it returns the first
+// value at or past the seek target without evaluating the filter. Values
+// before the target are discarded unfiltered, since SeekTo drops them
+// regardless of the filter's decision. The caller is responsible for
+// filtering the returned value.
 func (c *SyncIterator) nextSeek(to RowNumber, definitionLevel int) (RowNumber, *pq.Value, error) {
 	for {
 		// Consume current buffer until empty
@@ -844,10 +852,6 @@ func (c *SyncIterator) nextSeek(to RowNumber, definitionLevel int) (RowNumber, *
 			c.currPageN++
 
 			if CompareRowNumbers(definitionLevel, c.curr, to) < 0 {
-				continue
-			}
-
-			if c.filter != nil && !c.filter.KeepValue(*v) {
 				continue
 			}
 

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -605,19 +605,14 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 
 	// The row group and page have been selected to where this value is possibly
 	// located. Now scan through the page and look for it.
-	for {
-		rn, v, err := c.next()
-		if err != nil {
-			return nil, err
-		}
-		if !rn.Valid() {
-			return nil, nil
-		}
-
-		if CompareRowNumbers(definitionLevel, rn, to) >= 0 {
-			return c.makeResult(rn, v), nil
-		}
+	rn, v, err := c.nextSeek(to, definitionLevel)
+	if err != nil {
+		return nil, err
 	}
+	if !rn.Valid() {
+		return nil, nil
+	}
+	return c.makeResult(rn, v), nil
 }
 
 func (c *SyncIterator) popRowGroup() (pq.RowGroup, RowNumber, RowNumber) {
@@ -807,10 +802,75 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 // when being called multiple times and throwing away the results like in SeekTo().
 func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 	for {
+		// Consume current buffer until empty
+		for c.currBufN < len(c.currBuf) {
+			v := &c.currBuf[c.currBufN]
+
+			// Inspect all values to track the current row number,
+			// even if the value is filtered out next.
+			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
+			c.currBufN++
+			c.currPageN++
+
+			if c.filter != nil && !c.filter.KeepValue(*v) {
+				continue
+			}
+
+			return c.curr, v, nil
+		}
+
+		// Buffer exhausted, refill it, advancing pages and row groups as needed.
+		ok, err := c.fill()
+		if !ok || err != nil {
+			return EmptyRowNumber(), nil, err
+		}
+	}
+}
+
+// nextSeek is like next but for use while seeking: values before the seek
+// target are discarded without evaluating the filter, since SeekTo drops
+// them regardless of the filter's decision. Values at or past the target are
+// filtered as usual.
+func (c *SyncIterator) nextSeek(to RowNumber, definitionLevel int) (RowNumber, *pq.Value, error) {
+	for {
+		// Consume current buffer until empty
+		for c.currBufN < len(c.currBuf) {
+			v := &c.currBuf[c.currBufN]
+
+			// Inspect all values to track the current row number,
+			// even if the value is filtered out next.
+			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
+			c.currBufN++
+			c.currPageN++
+
+			if CompareRowNumbers(definitionLevel, c.curr, to) < 0 {
+				continue
+			}
+
+			if c.filter != nil && !c.filter.KeepValue(*v) {
+				continue
+			}
+
+			return c.curr, v, nil
+		}
+
+		// Buffer exhausted, refill it, advancing pages and row groups as needed.
+		ok, err := c.fill()
+		if !ok || err != nil {
+			return EmptyRowNumber(), nil, err
+		}
+	}
+}
+
+// fill ensures the current buffer contains unconsumed values, advancing to
+// the next page and row group as needed. It returns false when the iterator
+// is exhausted.
+func (c *SyncIterator) fill() (bool, error) {
+	for c.currBuf == nil || c.currBufN >= len(c.currBuf) {
 		if c.currRowGroup == nil {
 			rg, minRN, maxRN := c.popRowGroup()
 			if rg == nil {
-				return EmptyRowNumber(), nil, nil
+				return false, nil
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
@@ -825,7 +885,7 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 		if c.currPage == nil {
 			pg, err := c.currChunk.NextPage()
 			if err != nil && !errors.Is(err, io.EOF) {
-				return EmptyRowNumber(), nil, err
+				return false, err
 			}
 			if pg == nil || errors.Is(err, io.EOF) {
 				// This row group is exhausted
@@ -845,38 +905,21 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 		if c.currBuf == nil {
 			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
 		}
-		if c.currBufN >= len(c.currBuf) || len(c.currBuf) == 0 {
-			c.currBuf = c.currBuf[:cap(c.currBuf)]
-			n, err := c.currValues.ReadValues(c.currBuf)
-			if err != nil && !errors.Is(err, io.EOF) {
-				return EmptyRowNumber(), nil, err
-			}
-			c.currBuf = c.currBuf[:n]
-			c.currBufN = 0
-			if n == 0 {
-				// This value reader and page are exhausted.
-				c.setPage(nil)
-				continue
-			}
+		c.currBuf = c.currBuf[:cap(c.currBuf)]
+		n, err := c.currValues.ReadValues(c.currBuf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, err
 		}
-
-		// Consume current buffer until empty
-		for c.currBufN < len(c.currBuf) {
-			v := &c.currBuf[c.currBufN]
-
-			// Inspect all values to track the current row number,
-			// even if the value is filtered out next.
-			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
-			c.currBufN++
-			c.currPageN++
-
-			if c.filter != nil && !c.filter.KeepValue(*v) {
-				continue
-			}
-
-			return c.curr, v, nil
+		c.currBuf = c.currBuf[:n]
+		c.currBufN = 0
+		if n == 0 {
+			// This value reader and page are exhausted.
+			c.setPage(nil)
+			continue
 		}
 	}
+
+	return true, nil
 }
 
 func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *ColumnChunkHelper) {

--- a/pkg/parquetquery/iters_test.go
+++ b/pkg/parquetquery/iters_test.go
@@ -2,6 +2,7 @@ package parquetquery
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -172,6 +173,90 @@ func testColumnIteratorSeek(t *testing.T, makeIter makeTestIterFn) {
 	}
 }
 
+// TestColumnIteratorSeekToFilter verifies how SeekTo interacts with the
+// column predicate: values scanned past on the way to the seek target are
+// discarded regardless of the filter's decision and must not be evaluated,
+// while values at/after the target are still filtered.
+func TestColumnIteratorSeekToFilter(t *testing.T) {
+	t.Run("filter not evaluated before target", func(t *testing.T) {
+		count := 10_000
+		pf := createTestFile(t, count)
+
+		pred := &InstrumentedPredicate{}
+		idx, _, _ := GetColumnIndexByPath(pf, "A")
+		iter := NewSyncIterator(context.TODO(), pf.RowGroups(), idx, SyncIteratorOptSelectAs("A"), SyncIteratorOptPredicate(pred), SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel))
+		defer iter.Close()
+
+		// Seek in steps below the page-reslice threshold so the iterator
+		// scans value-by-value toward each target.
+		var inspectedBefore int64
+		for _, seekTo := range []int32{900, 1800, 2700} {
+			rn := EmptyRowNumber()
+			rn[0] = seekTo
+			res, err := iter.SeekTo(rn, 0)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Equal(t, RowNumber{seekTo, -1, -1, -1, -1, -1, -1, -1}, res.RowNumber)
+			require.Equal(t, seekTo, res.ToMap()["A"][0].Int32())
+
+			require.Equal(t, int64(1), pred.InspectedValues-inspectedBefore, "only the value at the seek target should be inspected by the filter")
+			inspectedBefore = pred.InspectedValues
+		}
+	})
+
+	t.Run("filter applies at and after target", func(t *testing.T) {
+		count := 10_000
+		pf := createTestFile(t, count)
+
+		pred := NewIntBetweenPredicate(5000, 5010)
+		idx, _, _ := GetColumnIndexByPath(pf, "A")
+		iter := NewSyncIterator(context.TODO(), pf.RowGroups(), idx, SyncIteratorOptSelectAs("A"), SyncIteratorOptPredicate(pred), SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel))
+		defer iter.Close()
+
+		// The value at the seek target fails the filter; the result must be
+		// the first value at/after the target that passes it.
+		rn := EmptyRowNumber()
+		rn[0] = 900
+		res, err := iter.SeekTo(rn, 0)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, RowNumber{5000, -1, -1, -1, -1, -1, -1, -1}, res.RowNumber)
+		require.Equal(t, int32(5000), res.ToMap()["A"][0].Int32())
+	})
+
+	t.Run("nested column", func(t *testing.T) {
+		type testSpan struct {
+			ID int64
+		}
+		type testTrace struct {
+			Spans []testSpan `parquet:",list"`
+		}
+
+		traces := make([]testTrace, 100)
+		for i := range traces {
+			traces[i].Spans = make([]testSpan, 100)
+			for j := range traces[i].Spans {
+				traces[i].Spans[j].ID = int64(i*1000 + j)
+			}
+		}
+		pf := createFileWith(t, context.Background(), traces)
+
+		pred := &InstrumentedPredicate{}
+		iter := NewSyncIterator(context.TODO(), pf.RowGroups(), 0, SyncIteratorOptSelectAs("ID"), SyncIteratorOptPredicate(pred), SyncIteratorOptMaxDefinitionLevel(1))
+		defer iter.Close()
+
+		// Seek to trace 5, span 50 at definition level 1.
+		to := EmptyRowNumber()
+		to[0], to[1] = 5, 50
+		res, err := iter.SeekTo(to, 1)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, RowNumber{5, 50, -1, -1, -1, -1, -1, -1}, res.RowNumber)
+		require.Equal(t, int64(5*1000+50), res.ToMap()["ID"][0].Int64())
+		require.Equal(t, int64(1), pred.InspectedValues, "only the value at the seek target should be inspected by the filter")
+	})
+}
+
 func TestColumnIteratorPredicate(t *testing.T) {
 	for _, tc := range iterTestCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -202,6 +287,64 @@ func testColumnIteratorPredicate(t *testing.T, makeIter makeTestIterFn) {
 		require.NotNil(t, res)
 		require.Equal(t, RowNumber{expectedResult, -1, -1, -1, -1, -1, -1, -1}, res.RowNumber)
 		require.Equal(t, expectedResult, res.ToMap()["A"][0].Int32())
+	}
+}
+
+// BenchmarkSyncIteratorSeekTo models the join-iterator access pattern:
+// repeated forward seeks with strides below the page-reslice threshold, so
+// the iterator scans values toward each target.
+func BenchmarkSyncIteratorSeekTo(b *testing.B) {
+	count := 100_000
+	type T struct {
+		A int64  `parquet:",delta"`
+		S string `parquet:",dict"`
+	}
+	rows := make([]T, count)
+	for i := range rows {
+		rows[i] = T{A: int64(i), S: fmt.Sprintf("span-name-%d", i%100)}
+	}
+	pf := createFileWith(b, context.Background(), rows)
+
+	aIdx, _, _ := GetColumnIndexByPath(pf, "A")
+	sIdx, _, _ := GetColumnIndexByPath(pf, "S")
+
+	testCases := []struct {
+		name     string
+		column   int
+		makePred func() Predicate
+	}{
+		{"int/nopred", aIdx, func() Predicate { return nil }},
+		{"int/between", aIdx, func() Predicate { return NewIntBetweenPredicate(0, int64(count)) }},
+		{"string/regex", sIdx, func() Predicate {
+			pred, err := NewRegexInPredicate([]string{"span-name-[0-4].*"})
+			require.NoError(b, err)
+			return pred
+		}},
+	}
+
+	for _, tc := range testCases {
+		for _, stride := range []int32{10, 500} {
+			b.Run(fmt.Sprintf("%s/stride=%d", tc.name, stride), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					iter := NewSyncIterator(context.TODO(), pf.RowGroups(), tc.column,
+						SyncIteratorOptSelectAs("v"), SyncIteratorOptPredicate(tc.makePred()), SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel))
+					pos := int32(0)
+					for {
+						rn := EmptyRowNumber()
+						rn[0] = pos
+						res, err := iter.SeekTo(rn, 0)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if res == nil {
+							break
+						}
+						pos = res.RowNumber[0] + stride
+					}
+					iter.Close()
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

Skips predicate evaluation for values scanned past during `SyncIterator.SeekTo`.

`SeekTo` scans toward the seek target by calling `next()`, which evaluates the column predicate on every value — only for `SeekTo` to discard everything before the target.

The new `nextSeek` positions to the first value at/past the target without evaluating the filter, consuming the read buffer inline instead of paying one `next()` call round-trip per scanned value. `SeekTo` filters that value and falls back to `Next()` when it fails. Results are identical.

- Filtered metrics query (`{span.http.host != `` && span.http.flavor=`2`} | rate() by (...)`): **−17.1%**
- Plain `Next()` iteration and unfiltered scans: unchanged

<details>
<summary>benchstat: vParquet5 block benchmarks (main vs PR, n=10)</summary>

```
                                                                                                        │ /tmp/il10s_main.txt │        /tmp/il10s_shawn.txt         │
                                                                                                        │       sec/op        │   sec/op     vs base                │
BackendBlockTraceQL/spanAttValMatch-12                                                                            2.785m ± 7%   2.735m ± 3%        ~ (p=0.218 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12                                                                      594.5µ ± 2%   596.1µ ± 3%        ~ (p=1.000 n=10)
BackendBlockTraceQL/struct-12                                                                                     84.21m ± 2%   84.17m ± 2%        ~ (p=1.000 n=10)
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)-12           87.38m ± 3%   72.46m ± 2%  -17.07% (p=0.000 n=10)
geomean                                                                                                           10.51m        9.986m        -4.95%
```

</details>

<details>
<summary>benchstat: BenchmarkSyncIteratorSeekTo (main vs PR, n=8)</summary>

```
                                              │ /tmp/ilm_main.txt │         /tmp/ilm_head.txt          │
                                              │      sec/op       │   sec/op     vs base               │
SyncIteratorSeekTo/int/nopred/stride=10-12           1.713m ± 19%   1.003m ± 4%  -41.42% (p=0.000 n=8)
SyncIteratorSeekTo/int/nopred/stride=500-12         1619.9µ ± 22%   967.7µ ± 5%  -40.26% (p=0.000 n=8)
SyncIteratorSeekTo/int/between/stride=10-12          1.447m ±  1%   1.064m ± 1%  -26.47% (p=0.000 n=8)
SyncIteratorSeekTo/int/between/stride=500-12         1.245m ±  1%   1.039m ± 2%  -16.57% (p=0.000 n=8)
SyncIteratorSeekTo/string/regex/stride=10-12         3.031m ±  1%   2.061m ± 2%  -31.98% (p=0.000 n=8)
SyncIteratorSeekTo/string/regex/stride=500-12        2.816m ±  2%   1.036m ± 7%  -63.21% (p=0.000 n=8)
geomean                                              1.869m         1.148m       -38.57%
```

</details>

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
