### PR TITLE
Lower default gRPC streaming packet size to 1MB

### DIFF
--- a/.chloggen/frontend-grpc-packet-size-1mb.yaml
+++ b/.chloggen/frontend-grpc-packet-size-1mb.yaml
@@ -1,0 +1,19 @@
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: change
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Reduce the default gRPC streaming packet size from 2MB to 1MB.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mdisibio

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -1000,7 +1000,7 @@ stream_over_http_enabled: true
 ```
 
 The query frontend segments streamed diffs and final responses into smaller packets.
-The default packet size is 2 MiB.
+The default packet size is 1 MiB.
 To change the packet size, configure `query_frontend.max_grpc_streaming_packet_size`.
 For details, refer to the [query frontend configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#query-frontend).
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1004,7 +1004,7 @@ query_frontend:
     # This is separate from the process-wide gRPC server response size because downstream clients
     # might need smaller streamed responses.
     # Set to 0 to disable segmentation.
-    # (default: 2097152)
+    # (default: 1048576)
     [max_grpc_streaming_packet_size: <int>]
 
     # Excludes the most recent portion of the time range from queries to avoid returning

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -363,7 +363,7 @@ query_frontend:
         max_regex_conditions: 1
     mcp_server:
         enabled: false
-    max_grpc_streaming_packet_size: 2097152
+    max_grpc_streaming_packet_size: 1048576
     max_query_expression_size_bytes: 131072
     query_end_cutoff: 30s
 metrics_generator:

--- a/docs/sources/tempo/troubleshooting/querying/response-too-large.md
+++ b/docs/sources/tempo/troubleshooting/querying/response-too-large.md
@@ -25,11 +25,11 @@ with messages between the querier and the query frontend.
 
 For gRPC streaming search, tag, and TraceQL metrics responses, the query frontend can split streamed diffs and final responses into smaller packets.
 Use `query_frontend.max_grpc_streaming_packet_size` to set the target packet size in bytes.
-The default is `2097152` bytes, or 2 MiB.
+The default is `1048576` bytes, or 1 MiB.
 
 ```yaml
 query_frontend:
-  max_grpc_streaming_packet_size: 2097152
+  max_grpc_streaming_packet_size: 1048576
 ```
 
 This setting applies to gRPC streaming responses from the query frontend.

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -99,7 +99,7 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 	cfg.Config.MaxBatchSize = 7
 	cfg.MaxRetries = 2
 	cfg.ResponseConsumers = 10
-	cfg.MaxGRPCStreamingPacketSize = 2 * 1024 * 1024 // 2MB
+	cfg.MaxGRPCStreamingPacketSize = 1 * 1024 * 1024 // 1MB
 	cfg.Search = SearchConfig{
 		Sharder: SearchSharderConfig{
 			QueryBackendAfter:      15 * time.Minute,

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -359,7 +359,7 @@ query_frontend:
         max_regex_conditions: 1
     mcp_server:
         enabled: false
-    max_grpc_streaming_packet_size: 2097152
+    max_grpc_streaming_packet_size: 1048576
     max_query_expression_size_bytes: 131072
     query_end_cutoff: 30s
 metrics_generator:


### PR DESCRIPTION
**What this PR does**:

Lowers the default `query_frontend.max_grpc_streaming_packet_size` from 2MB to 1MB.

We found that a 1MB packet size works better in practice and is compatible with more queries, so we're making it the new default.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
