### PR TITLE
feat(log): add SlogFromGoKit adapter for slog migration

### DIFF
--- a/.chloggen/7616-slog-from-gokit-adapter.yaml
+++ b/.chloggen/7616-slog-from-gokit-adapter.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: operations
+note: Add SlogFromGoKit adapter to bridge go-kit/log and log/slog during the slog migration.
+issues: [7616]
+subtext:
+user: amarkdotdev

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.153.0
 	github.com/parquet-go/parquet-go v0.30.1
 	github.com/redis/go-redis/v9 v9.20.0
+	github.com/tjhop/slog-gokit v0.1.4
 	github.com/twmb/franz-go v1.21.2
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260421215025-4e7a1e1569ac

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.153.0
 	github.com/parquet-go/parquet-go v0.30.1
 	github.com/redis/go-redis/v9 v9.20.0
-	github.com/tjhop/slog-gokit v0.1.4
+	github.com/tjhop/slog-gokit v0.2.0
 	github.com/twmb/franz-go v1.21.2
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
 	github.com/twmb/franz-go/pkg/kfake v0.0.0-20260421215025-4e7a1e1569ac

--- a/go.sum
+++ b/go.sum
@@ -807,6 +807,8 @@ github.com/thanos-io/objstore v0.0.0-20220809103346-8ef1f215e2bf h1:onQsPyHlq2yI
 github.com/thanos-io/objstore v0.0.0-20220809103346-8ef1f215e2bf/go.mod h1:v0NhuxxxUFUPatQcVNSCUkBEVezXzl7LSdaBOZygq98=
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=
 github.com/tinylib/msgp v1.6.1/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
+github.com/tjhop/slog-gokit v0.1.4 h1:uj/vbDt3HaF0Py8bHPV4ti/s0utnO0miRbO277FLBKM=
+github.com/tjhop/slog-gokit v0.1.4/go.mod h1:Bbu5v2748qpAWH7k6gse/kw3076IJf6owJmh7yArmJs=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/go.sum
+++ b/go.sum
@@ -807,8 +807,8 @@ github.com/thanos-io/objstore v0.0.0-20220809103346-8ef1f215e2bf h1:onQsPyHlq2yI
 github.com/thanos-io/objstore v0.0.0-20220809103346-8ef1f215e2bf/go.mod h1:v0NhuxxxUFUPatQcVNSCUkBEVezXzl7LSdaBOZygq98=
 github.com/tinylib/msgp v1.6.1 h1:ESRv8eL3u+DNHUoSAAQRE50Hm162zqAnBoGv9PzScPY=
 github.com/tinylib/msgp v1.6.1/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
-github.com/tjhop/slog-gokit v0.1.4 h1:uj/vbDt3HaF0Py8bHPV4ti/s0utnO0miRbO277FLBKM=
-github.com/tjhop/slog-gokit v0.1.4/go.mod h1:Bbu5v2748qpAWH7k6gse/kw3076IJf6owJmh7yArmJs=
+github.com/tjhop/slog-gokit v0.2.0 h1:tUNkuukDjpswQ2abhsugEobRRxN1aHEW8h4rvwdHMqU=
+github.com/tjhop/slog-gokit v0.2.0/go.mod h1:yA48zAHvV+Sg4z4VRyeFyFUNNXd3JY5Zg84u3USICq0=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -13,16 +13,21 @@ import (
 // Prefer accepting a non-global logger as an argument.
 var Logger = kitlog.NewNopLogger()
 
+// logLevel tracks the configured level for slog adapters (see SlogFromGoKit).
+var logLevel = "info"
+
 // InitLogger initialises the global gokit logger and overrides the
 // default logger for the server.
 func InitLogger(cfg *server.Config) {
+	logLevel = cfg.LogLevel.String()
+
 	logger := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
 	if cfg.LogFormat == "json" {
 		logger = kitlog.NewJSONLogger(kitlog.NewSyncWriter(os.Stderr))
 	}
 
 	// add support for level based logging
-	logger = level.NewFilter(logger, LevelFilter(cfg.LogLevel.String()))
+	logger = level.NewFilter(logger, LevelFilter(logLevel))
 
 	// use UTC timestamps
 	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -14,7 +14,7 @@ import (
 var Logger = kitlog.NewNopLogger()
 
 // logLevel tracks the configured level for slog adapters (see SlogFromGoKit).
-var logLevel = "info"
+var logLevel = levelInfo
 
 // InitLogger initialises the global gokit logger and overrides the
 // default logger for the server.
@@ -46,13 +46,13 @@ func InitLogger(cfg *server.Config) {
 // -> we can then revert to using Level.Gokit
 func LevelFilter(l string) level.Option {
 	switch l {
-	case "debug":
+	case levelDebug:
 		return level.AllowDebug()
-	case "info":
+	case levelInfo:
 		return level.AllowInfo()
-	case "warn":
+	case levelWarn:
 		return level.AllowWarn()
-	case "error":
+	case levelError:
 		return level.AllowError()
 	default:
 		return level.AllowAll()

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -13,6 +13,10 @@ import (
 // Prefer accepting a non-global logger as an argument.
 var Logger = kitlog.NewNopLogger()
 
+// goKitBase is the level-filtered logger without ts/caller. slog-gokit adds
+// time and caller itself, so SlogFromGoKit wraps this instead of Logger.
+var goKitBase = kitlog.NewNopLogger()
+
 // logLevel tracks the configured level for slog adapters (see SlogFromGoKit).
 var logLevel = levelInfo
 
@@ -28,6 +32,9 @@ func InitLogger(cfg *server.Config) {
 
 	// add support for level based logging
 	logger = level.NewFilter(logger, LevelFilter(logLevel))
+
+	// Keep a copy without ts/caller for the slog adapter.
+	goKitBase = logger
 
 	// use UTC timestamps
 	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC)

--- a/pkg/util/log/slogadapter.go
+++ b/pkg/util/log/slogadapter.go
@@ -1,0 +1,30 @@
+package log
+
+import (
+	"log/slog"
+
+	"github.com/go-kit/log"
+	slgk "github.com/tjhop/slog-gokit"
+)
+
+// SlogFromGoKit returns a slog.Logger backed by the given go-kit logger.
+// This is the first step toward replacing go-kit/log with log/slog (#4819):
+// new code can take *slog.Logger while existing call sites keep using go-kit
+// until they are migrated. dskit still expects go-kit.Logger on server.Config.
+func SlogFromGoKit(logger log.Logger) *slog.Logger {
+	var sl slog.Level
+	switch logLevel {
+	case "info":
+		sl = slog.LevelInfo
+	case "warn":
+		sl = slog.LevelWarn
+	case "error":
+		sl = slog.LevelError
+	default:
+		sl = slog.LevelDebug
+	}
+
+	lvl := slog.LevelVar{}
+	lvl.Set(sl)
+	return slog.New(slgk.NewGoKitHandler(logger, &lvl))
+}

--- a/pkg/util/log/slogadapter.go
+++ b/pkg/util/log/slogadapter.go
@@ -7,6 +7,13 @@ import (
 	slgk "github.com/tjhop/slog-gokit"
 )
 
+const (
+	levelInfo  = "info"
+	levelWarn  = "warn"
+	levelError = "error"
+	levelDebug = "debug"
+)
+
 // SlogFromGoKit returns a slog.Logger backed by the given go-kit logger.
 // This is the first step toward replacing go-kit/log with log/slog (#4819):
 // new code can take *slog.Logger while existing call sites keep using go-kit
@@ -14,11 +21,11 @@ import (
 func SlogFromGoKit(logger log.Logger) *slog.Logger {
 	var sl slog.Level
 	switch logLevel {
-	case "info":
+	case levelInfo:
 		sl = slog.LevelInfo
-	case "warn":
+	case levelWarn:
 		sl = slog.LevelWarn
-	case "error":
+	case levelError:
 		sl = slog.LevelError
 	default:
 		sl = slog.LevelDebug

--- a/pkg/util/log/slogadapter.go
+++ b/pkg/util/log/slogadapter.go
@@ -18,7 +18,17 @@ const (
 // This is the first step toward replacing go-kit/log with log/slog (#4819):
 // new code can take *slog.Logger while existing call sites keep using go-kit
 // until they are migrated. dskit still expects go-kit.Logger on server.Config.
+//
+// Do not pass Logger from InitLogger: that logger already has "ts" and
+// "caller", and slog-gokit adds those attributes itself. Pass a bare logger
+// (for example from tests), or nil / Logger to use the process-wide base
+// logger that omits those fields.
 func SlogFromGoKit(logger log.Logger) *slog.Logger {
+	// Using the global Logger would duplicate ts/caller that slog-gokit adds.
+	if logger == nil || logger == Logger {
+		logger = goKitBase
+	}
+
 	var sl slog.Level
 	switch logLevel {
 	case levelInfo:

--- a/pkg/util/log/slogadapter_test.go
+++ b/pkg/util/log/slogadapter_test.go
@@ -1,0 +1,28 @@
+package log
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlogFromGoKit(t *testing.T) {
+	var buf bytes.Buffer
+	kit := kitlog.NewLogfmtLogger(&buf)
+	logLevel = "info"
+
+	logger := SlogFromGoKit(kit)
+	require.NotNil(t, logger)
+
+	logger.Info("hello", "k", "v")
+	require.Contains(t, buf.String(), "hello")
+	require.Contains(t, buf.String(), "k=v")
+
+	// debug should be filtered at info level
+	buf.Reset()
+	logger.Log(t.Context(), slog.LevelDebug, "hidden")
+	require.Empty(t, buf.String())
+}

--- a/pkg/util/log/slogadapter_test.go
+++ b/pkg/util/log/slogadapter_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"log/slog"
+	"strings"
 	"testing"
 
 	kitlog "github.com/go-kit/log"
@@ -25,4 +26,24 @@ func TestSlogFromGoKit(t *testing.T) {
 	buf.Reset()
 	logger.Log(t.Context(), slog.LevelDebug, "hidden")
 	require.Empty(t, buf.String())
+}
+
+func TestSlogFromGoKitNoDuplicateTSOrCaller(t *testing.T) {
+	var buf bytes.Buffer
+	base := kitlog.NewLogfmtLogger(&buf)
+	goKitBase = base
+	// Simulate InitLogger enriching the global Logger with ts/caller.
+	Logger = kitlog.With(base, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.Caller(3))
+	logLevel = levelInfo
+
+	logger := SlogFromGoKit(Logger)
+	logger.Info("hello", "k", "v")
+	out := buf.String()
+
+	require.Contains(t, out, "hello")
+	require.Contains(t, out, "k=v")
+	// slog-gokit emits time=; go-kit InitLogger uses ts=. Using the base
+	// logger means we should not also get ts= from the enriched Logger.
+	require.NotContains(t, out, "ts=")
+	require.Equal(t, 1, strings.Count(out, "caller="), "caller should appear once, not duplicated")
 }

--- a/pkg/util/log/slogadapter_test.go
+++ b/pkg/util/log/slogadapter_test.go
@@ -12,7 +12,7 @@ import (
 func TestSlogFromGoKit(t *testing.T) {
 	var buf bytes.Buffer
 	kit := kitlog.NewLogfmtLogger(&buf)
-	logLevel = "info"
+	logLevel = levelInfo
 
 	logger := SlogFromGoKit(kit)
 	require.NotNil(t, logger)

--- a/vendor/github.com/tjhop/slog-gokit/.goreleaser.yaml
+++ b/vendor/github.com/tjhop/slog-gokit/.goreleaser.yaml
@@ -1,0 +1,29 @@
+version: 2
+
+builds:
+- skip: true
+gomod:
+  proxy: true
+  mod: mod
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^Merge pull request'
+      - '^ci(?:\(\w+\))?\!?:'
+      - '^docs(?:\(\w+\))?\!?:'
+      - '^test(?:\(\w+\))?\!?:'
+      - '^style(?:\(\w+\))?\!?:'
+  groups:
+    - title: "New Features And Changes"
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "Fixes"
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "Other Changes"
+      order: 999

--- a/vendor/github.com/tjhop/slog-gokit/LICENSE
+++ b/vendor/github.com/tjhop/slog-gokit/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/tjhop/slog-gokit/Makefile
+++ b/vendor/github.com/tjhop/slog-gokit/Makefile
@@ -1,0 +1,27 @@
+GOCMD := go
+GOFMT := ${GOCMD} fmt
+GOMOD := ${GOCMD} mod
+GOTEST := ${GOCMD} test
+GOLANGCILINT_CACHE := ${CURDIR}/.golangci-lint/build/cache
+
+# autogenerate help messages for comment lines with 2 `#`
+.PHONY: help
+help: ## print this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-z0-9A-Z_-]+:.*?##/ { printf "  \033[36m%-30s\033[0m%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+.PHONY: tidy
+tidy: ## tidy modules
+	${GOMOD} tidy
+
+.PHONY: fmt
+fmt: ## apply go code style formatter
+	${GOFMT} -x ./...
+
+.PHONY:	lint
+lint: ## run linters
+	mkdir -p ${GOLANGCILINT_CACHE} || true
+	docker run --rm -v ${CURDIR}:/app -v ${GOLANGCILINT_CACHE}:/root/.cache -w /app docker.io/golangci/golangci-lint:latest golangci-lint run -v
+
+.PHONY: test
+test: ## run go tests
+	${GOTEST} -race -v .

--- a/vendor/github.com/tjhop/slog-gokit/Makefile
+++ b/vendor/github.com/tjhop/slog-gokit/Makefile
@@ -25,3 +25,7 @@ lint: ## run linters
 .PHONY: test
 test: ## run go tests
 	${GOTEST} -race -v .
+
+.PHONY: bench
+bench: ## run go benchmarks
+	${GOTEST} -bench=. -benchmem -count=10 -run='^$$' -memprofile=mem.out -cpuprofile=cpu.out .

--- a/vendor/github.com/tjhop/slog-gokit/README.md
+++ b/vendor/github.com/tjhop/slog-gokit/README.md
@@ -1,0 +1,61 @@
+[![license](https://img.shields.io/github/license/tjhop/slog-gokit)](https://github.com/tjhop/slog-gokit/blob/master/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/tjhop/slog-gokit)](https://goreportcard.com/report/github.com/tjhop/slog-gokit)
+[![golangci-lint](https://github.com/tjhop/slog-gokit/actions/workflows/golangci-lint.yaml/badge.svg)](https://github.com/tjhop/slog-gokit/actions/workflows/golangci-lint.yaml)
+[![Latest Release](https://img.shields.io/github/v/release/tjhop/slog-gokit)](https://github.com/tjhop/slog-gokit/releases/latest)
+
+# Go slog-gokit Adapter
+
+This library provides a custom slog.Handler that wraps a go-kit Logger, so that loggers created via `slog.New()` chain their log calls to the internal go-kit Logger.
+
+## Install
+
+```bash
+go get github.com/tjhop/slog-gokit
+```
+
+## Documentation
+
+Documentation can be found here:
+
+https://pkg.go.dev/github.com/tjhop/slog-gokit
+
+## Example
+
+```go
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/go-kit/log"
+	slgk "github.com/tjhop/slog-gokit"
+)
+
+func main() {
+	// Take an existing go-kit/log Logger:
+	gklogger := log.NewLogfmtLogger(os.Stderr)
+
+	// Create an slog Logger that chains log calls to the go-kit/log Logger:
+	slogger := slog.New(slgk.NewGoKitHandler(gklogger, nil))
+	slogger.WithGroup("example_group").With("foo", "bar").Info("hello world")
+
+	// The slog Logger produces logs at slog.LevelInfo by default.
+	// Optionally create an slog.Leveler to dynamically adjust the level of
+	// the slog Logger.
+	lvl := &slog.LevelVar{}
+	lvl.Set(slog.LevelDebug)
+	slogger = slog.New(slgk.NewGoKitHandler(gklogger, lvl))
+	slogger.WithGroup("example_group").With("foo", "bar").Info("hello world")
+}
+```
+
+## Development
+
+Contributions are welcome! Commits should follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) syntax.
+
+### Required Software/Tools
+
+- Working Go environment
+- Docker
+- GNU Make

--- a/vendor/github.com/tjhop/slog-gokit/handler.go
+++ b/vendor/github.com/tjhop/slog-gokit/handler.go
@@ -1,0 +1,171 @@
+package sloggokit
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/go-kit/log"
+)
+
+var _ slog.Handler = (*GoKitHandler)(nil)
+
+var defaultGoKitLogger = log.NewLogfmtLogger(os.Stderr)
+
+// GoKitHandler implements the slog.Handler interface. It holds an internal
+// go-kit logger that is used to perform the true logging.
+type GoKitHandler struct {
+	level        slog.Leveler
+	logger       log.Logger
+	preformatted []slog.Attr
+	group        string
+}
+
+// NewGoKitHandler returns a new slog logger from the provided go-kit
+// logger. Calls to the slog logger are chained to the handler's internal
+// go-kit logger. If provided a level, it will be used to filter log events in
+// the handler's Enabled() method.
+func NewGoKitHandler(logger log.Logger, level slog.Leveler) slog.Handler {
+	if logger == nil {
+		logger = defaultGoKitLogger
+	}
+
+	// Adjust runtime call depth to compensate for the adapter and point to
+	// the appropriate source line.
+	logger = log.With(logger, "caller", log.Caller(6))
+
+	if level == nil {
+		level = &slog.LevelVar{} // Info level by default.
+	}
+
+	return &GoKitHandler{logger: logger, level: level}
+}
+
+// Enabled returns true if the internal slog.Leveler is enabled for the
+// provided log level. It implements slog.Handler.
+func (h *GoKitHandler) Enabled(_ context.Context, level slog.Level) bool {
+	if h.level == nil {
+		h.level = &slog.LevelVar{} // Info level by default.
+	}
+
+	return level >= h.level.Level()
+}
+
+// Handler take an slog.Record created by an slog.Logger and dispatches the log
+// call to the internal go-kit logger. Groups and attributes created by slog
+// are formatted and added to the log call as individual key/value pairs. It
+// implements slog.Handler.
+func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
+	if h.logger == nil {
+		h.logger = defaultGoKitLogger
+	}
+
+	logger := goKitLevelFunc(h.logger, record.Level)
+
+	// 1 slog.Attr == 1 key and 1 value, set capacity >= (2 * num attrs).
+	//
+	// Note: this could probably be (micro)-optimized further -- we know we
+	// need to also append on a timestamp from the record, the message, the
+	// preformatted vals, all things we more or less know the size of at
+	// creation time here.
+	pairs := make([]any, 0, (2 * record.NumAttrs()))
+	if !record.Time.IsZero() {
+		pairs = append(pairs, slog.TimeKey, record.Time)
+	}
+	pairs = append(pairs, slog.MessageKey, record.Message)
+
+	// preformatted attributes have already had their group prefix applied in WithAttr
+	for _, a := range h.preformatted {
+		pairs = appendPair(pairs, "", a)
+	}
+
+	record.Attrs(func(a slog.Attr) bool {
+		pairs = appendPair(pairs, h.group, a)
+		return true
+	})
+
+	return logger.Log(pairs...)
+}
+
+// WithAttrs formats the provided attributes and caches them in the handler to
+// attach to all future log calls. It implements slog.Handler.
+func (h *GoKitHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	pairs := make([]slog.Attr, 0, len(attrs)+len(h.preformatted))
+	for _, attr := range attrs {
+		// preresolve the group to simplify attr tracking
+		if h.group != "" {
+			attr.Key = h.group + "." + attr.Key
+		}
+		pairs = append(pairs, attr)
+	}
+
+	if h.preformatted != nil {
+		pairs = append(h.preformatted, pairs...)
+	}
+
+	return &GoKitHandler{
+		logger:       h.logger,
+		level:        h.level,
+		preformatted: pairs,
+		group:        h.group,
+	}
+}
+
+// WithGroup sets the group prefix string and caches it within the handler to
+// use to prefix all future log attribute pairs. It implements slog.Handler.
+func (h *GoKitHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+
+	g := name
+	if h.group != "" {
+		g = h.group + "." + g
+	}
+
+	return &GoKitHandler{
+		logger:       h.logger,
+		level:        h.level,
+		preformatted: h.preformatted,
+		group:        g,
+	}
+}
+
+func appendPair(pairs []any, groupPrefix string, attr slog.Attr) []any {
+	if attr.Equal(slog.Attr{}) {
+		return pairs
+	}
+
+	switch attr.Value.Kind() {
+	case slog.KindGroup:
+		attrs := attr.Value.Group()
+		if len(attrs) > 0 {
+			// Only process groups that have non-empty attributes
+			// to properly conform to slog.Handler interface
+			// contract.
+
+			if attr.Key != "" {
+				// If a group's key is empty, attributes should
+				// be inlined to properly conform to
+				// slog.Handler interface contract.
+				if groupPrefix != "" {
+					groupPrefix = groupPrefix + "." + attr.Key
+				} else {
+					groupPrefix = attr.Key
+				}
+			}
+			for _, a := range attrs {
+				pairs = appendPair(pairs, groupPrefix, a)
+			}
+		}
+	default:
+		key := attr.Key
+		if groupPrefix != "" {
+			key = groupPrefix + "." + key
+		}
+
+		pairs = append(pairs, key, attr.Value.Resolve())
+	}
+
+	return pairs
+}

--- a/vendor/github.com/tjhop/slog-gokit/handler.go
+++ b/vendor/github.com/tjhop/slog-gokit/handler.go
@@ -12,12 +12,19 @@ var _ slog.Handler = (*GoKitHandler)(nil)
 
 var defaultGoKitLogger = log.NewLogfmtLogger(os.Stderr)
 
+// Pay boxing cost once at package init, save 2 heap escapes per Handle() call.
+var (
+	timeKey any = slog.TimeKey
+	msgKey  any = slog.MessageKey
+)
+
 // GoKitHandler implements the slog.Handler interface. It holds an internal
 // go-kit logger that is used to perform the true logging.
 type GoKitHandler struct {
 	level        slog.Leveler
 	logger       log.Logger
-	preformatted []slog.Attr
+	levelLoggers *levelLoggerCache // pre-built leveled loggers
+	preformatted []any             // pre-flattened key-value pairs, ready to pass directly to logger.Log()
 	group        string
 }
 
@@ -38,16 +45,16 @@ func NewGoKitHandler(logger log.Logger, level slog.Leveler) slog.Handler {
 		level = &slog.LevelVar{} // Info level by default.
 	}
 
-	return &GoKitHandler{logger: logger, level: level}
+	return &GoKitHandler{
+		logger:       logger,
+		level:        level,
+		levelLoggers: newLevelCache(logger),
+	}
 }
 
 // Enabled returns true if the internal slog.Leveler is enabled for the
 // provided log level. It implements slog.Handler.
 func (h *GoKitHandler) Enabled(_ context.Context, level slog.Level) bool {
-	if h.level == nil {
-		h.level = &slog.LevelVar{} // Info level by default.
-	}
-
 	return level >= h.level.Level()
 }
 
@@ -56,28 +63,29 @@ func (h *GoKitHandler) Enabled(_ context.Context, level slog.Level) bool {
 // are formatted and added to the log call as individual key/value pairs. It
 // implements slog.Handler.
 func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
-	if h.logger == nil {
-		h.logger = defaultGoKitLogger
-	}
+	logger := h.levelLoggers.get(record.Level)
 
-	logger := goKitLevelFunc(h.logger, record.Level)
-
-	// 1 slog.Attr == 1 key and 1 value, set capacity >= (2 * num attrs).
+	// Pre-compute slice capacity. h.preformatted is already flattened to []any
+	// key-value pairs at WithAttrs time, so len(h.preformatted) is the exact
+	// item count -- no expansion buffer needed for that portion. Record attrs
+	// may contain groups that expand beyond 2 items per attr, so include a 50%
+	// buffer for that portion's estimated capacity only.
 	//
-	// Note: this could probably be (micro)-optimized further -- we know we
-	// need to also append on a timestamp from the record, the message, the
-	// preformatted vals, all things we more or less know the size of at
-	// creation time here.
-	pairs := make([]any, 0, (2 * record.NumAttrs()))
+	// We know we need:
+	// - 2 for timestamp (key + value)
+	// - 2 for message (key + value)
+	// - len(h.preformatted) exact items (pre-flattened, no expansion)
+	// - 2 * record.NumAttrs() for record attrs, +50% buffer for group expansion
+	capacity := 4 + len(h.preformatted) + (3 * record.NumAttrs())
+	pairs := make([]any, 0, capacity)
 	if !record.Time.IsZero() {
-		pairs = append(pairs, slog.TimeKey, record.Time)
+		pairs = append(pairs, timeKey, record.Time)
 	}
-	pairs = append(pairs, slog.MessageKey, record.Message)
+	pairs = append(pairs, msgKey, record.Message)
 
-	// preformatted attributes have already had their group prefix applied in WithAttr
-	for _, a := range h.preformatted {
-		pairs = appendPair(pairs, "", a)
-	}
+	// Bulk-append pre-flattened attrs, group prefixes were resolved at
+	// WithAttrs() call.
+	pairs = append(pairs, h.preformatted...)
 
 	record.Attrs(func(a slog.Attr) bool {
 		pairs = appendPair(pairs, h.group, a)
@@ -90,22 +98,24 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 // WithAttrs formats the provided attributes and caches them in the handler to
 // attach to all future log calls. It implements slog.Handler.
 func (h *GoKitHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	pairs := make([]slog.Attr, 0, len(attrs)+len(h.preformatted))
-	for _, attr := range attrs {
-		// preresolve the group to simplify attr tracking
-		if h.group != "" {
-			attr.Key = h.group + "." + attr.Key
-		}
-		pairs = append(pairs, attr)
-	}
+	// Make a defensive copy of preformatted attrs to avoid race conditions
+	// when multiple goroutines call WithAttrs concurrently on the same handler.
+	// Attrs are pre-flattened to []any key-value pairs here so that Handle()
+	// can bulk-copy them without per-attr processing on every log call.
+	//
+	// Capacity estimate: existing items + 2 per new attr (minimum, more if
+	// attrs contain groups that expand to multiple pairs).
+	pairs := make([]any, len(h.preformatted), len(h.preformatted)+(len(attrs)*2))
+	copy(pairs, h.preformatted)
 
-	if h.preformatted != nil {
-		pairs = append(h.preformatted, pairs...)
+	for _, attr := range attrs {
+		pairs = appendPair(pairs, h.group, attr)
 	}
 
 	return &GoKitHandler{
 		logger:       h.logger,
 		level:        h.level,
+		levelLoggers: h.levelLoggers,
 		preformatted: pairs,
 		group:        h.group,
 	}
@@ -126,6 +136,7 @@ func (h *GoKitHandler) WithGroup(name string) slog.Handler {
 	return &GoKitHandler{
 		logger:       h.logger,
 		level:        h.level,
+		levelLoggers: h.levelLoggers,
 		preformatted: h.preformatted,
 		group:        g,
 	}

--- a/vendor/github.com/tjhop/slog-gokit/level.go
+++ b/vendor/github.com/tjhop/slog-gokit/level.go
@@ -1,0 +1,23 @@
+package sloggokit
+
+import (
+	"log/slog"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+func goKitLevelFunc(logger log.Logger, lvl slog.Level) log.Logger {
+	switch lvl {
+	case slog.LevelInfo:
+		logger = level.Info(logger)
+	case slog.LevelWarn:
+		logger = level.Warn(logger)
+	case slog.LevelError:
+		logger = level.Error(logger)
+	default:
+		logger = level.Debug(logger)
+	}
+
+	return logger
+}

--- a/vendor/github.com/tjhop/slog-gokit/level.go
+++ b/vendor/github.com/tjhop/slog-gokit/level.go
@@ -7,17 +7,34 @@ import (
 	"github.com/go-kit/log/level"
 )
 
-func goKitLevelFunc(logger log.Logger, lvl slog.Level) log.Logger {
-	switch lvl {
-	case slog.LevelInfo:
-		logger = level.Info(logger)
-	case slog.LevelWarn:
-		logger = level.Warn(logger)
-	case slog.LevelError:
-		logger = level.Error(logger)
-	default:
-		logger = level.Debug(logger)
-	}
+// levelLoggerCache holds pre-built leveled loggers so that Handle() can
+// retrieve an existing leveled logger rather than creating a new one each
+// time.
+type levelLoggerCache struct {
+	debugLogger log.Logger
+	infoLogger  log.Logger
+	warnLogger  log.Logger
+	errorLogger log.Logger
+}
 
-	return logger
+func newLevelCache(logger log.Logger) *levelLoggerCache {
+	return &levelLoggerCache{
+		debugLogger: level.Debug(logger),
+		infoLogger:  level.Info(logger),
+		warnLogger:  level.Warn(logger),
+		errorLogger: level.Error(logger),
+	}
+}
+
+func (c *levelLoggerCache) get(lvl slog.Level) log.Logger {
+	switch {
+	case lvl >= slog.LevelError:
+		return c.errorLogger
+	case lvl >= slog.LevelWarn:
+		return c.warnLogger
+	case lvl >= slog.LevelInfo:
+		return c.infoLogger
+	default:
+		return c.debugLogger
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1552,6 +1552,9 @@ github.com/subosito/gotenv
 ## explicit; go 1.24
 github.com/tinylib/msgp/msgp
 github.com/tinylib/msgp/msgp/setof
+# github.com/tjhop/slog-gokit v0.1.4
+## explicit; go 1.21
+github.com/tjhop/slog-gokit
 # github.com/tklauser/go-sysconf v0.3.16
 ## explicit; go 1.24.0
 github.com/tklauser/go-sysconf

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1552,7 +1552,7 @@ github.com/subosito/gotenv
 ## explicit; go 1.24
 github.com/tinylib/msgp/msgp
 github.com/tinylib/msgp/msgp/setof
-# github.com/tjhop/slog-gokit v0.1.4
+# github.com/tjhop/slog-gokit v0.2.0
 ## explicit; go 1.21
 github.com/tjhop/slog-gokit
 # github.com/tklauser/go-sysconf v0.3.16


### PR DESCRIPTION
Related to #4819

Full go-kit → slog replacement is blocked on dskit still taking `go-kit/log.Logger` for `server.Config.Log`, and on unanswered questions about log-line stability.

This is the same first step Loki/Mimir took: add `SlogFromGoKit` so new code can use `*slog.Logger` while existing call sites stay on go-kit. Follow-up PRs can migrate packages one at a time.

## Testing

- `go test ./pkg/util/log/ -count=1`