### PR TITLE
Tag values: cache empty per-block results so tag-less blocks aren't re-scanned

### DIFF
--- a/.chloggen/tag-values-cache-empty-results.yaml
+++ b/.chloggen/tag-values-cache-empty-results.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: live-store
+note: Tag value queries now cache empty (negative) results per block, so a block that contains no values for the requested tag is not re-scanned on every query.
+issues: []
+subtext:
+user: zalegrala

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -41,6 +41,12 @@ var (
 	tracer = otel.Tracer("modules/livestore")
 
 	errComplete = errors.New("complete")
+
+	// emptyTagValuesCacheEntry is a non-empty sentinel written to the tag-value disk
+	// cache when a block yields no values, so tag-less blocks aren't re-scanned on
+	// every query. 0x00 is not a valid protobuf tag (field 0), so it never collides
+	// with a marshaled SearchTagValuesV2Response.
+	emptyTagValuesCacheEntry = []byte{0x00}
 )
 
 const (
@@ -544,7 +550,11 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 	}
 
 	searchWithCache := func(ctx context.Context, _ *backend.BlockMeta, b block) error {
-		// if not a local block, fall back to regular search
+		// Only complete (Local) blocks are cached. Complete blocks are immutable, so a
+		// cached result -- including a negative/empty one -- stays correct for the block's
+		// lifetime. The head and WAL blocks (which still receive appends before being cut)
+		// are always searched fresh here, so newly-arrived values can never be masked by a
+		// cache entry: new data lands in the head block and is searched directly.
 		localB, ok := b.(*LocalBlock)
 		if !ok {
 			return search(ctx, b, vCollector.Collect)
@@ -564,6 +574,12 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 
 		// we got data...unmarshall, and add values to central collector and add bytesRead
 		if len(cacheData) > 0 {
+			if bytes.Equal(cacheData, emptyTagValuesCacheEntry) {
+				// negative cache hit: this block has no values for the tag, so don't re-scan it
+				span.SetAttributes(attribute.Bool("cached", true))
+				mCollector.Add(uint64(len(cacheData)))
+				return nil
+			}
 			resp := &tempopb.SearchTagValuesV2Response{}
 			if err := proto.Unmarshal(cacheData, resp); err != nil {
 				// corrupt cache entry: log and fall through to search the block below
@@ -584,7 +600,8 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 			}
 		}
 
-		// cache miss or unusable cache entry, search the block. We will cache the results if we find any.
+		// cache miss or unusable cache entry, search the block and cache the result
+		// (empty results are cached too, via a sentinel; see below).
 		span.SetAttributes(attribute.Bool("cached", false))
 		// using local collector to collect values from the block and cache them.
 		localCol := collector.NewDistinctValue[tempopb.TagValue](limit, req.MaxTagValues, req.StaleValueThreshold, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
@@ -596,9 +613,14 @@ func (i *instance) SearchTagValuesV2(ctx context.Context, req *tempopb.SearchTag
 		// marshal the values local collector and set the cache
 		values := localCol.Values()
 		v2RespProto, err := valuesToTagValuesV2RespProto(values)
-		if err == nil && len(v2RespProto) > 0 {
-			err2 := localB.SetDiskCache(ctx, cacheKey, v2RespProto)
-			if err2 != nil {
+		if err == nil {
+			// cache the result, using a sentinel for empty results so a tag-less
+			// block records a hit and isn't re-scanned on the next query.
+			cacheEntry := v2RespProto
+			if len(cacheEntry) == 0 {
+				cacheEntry = emptyTagValuesCacheEntry
+			}
+			if err2 := localB.SetDiskCache(ctx, cacheKey, cacheEntry); err2 != nil {
 				_ = level.Warn(i.logger).Log("msg", "SetDiskCache failed", "err", err2)
 			}
 		}

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -487,6 +487,54 @@ func TestSearchTagValuesV2ToleratesCorruptDiskCache(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestSearchTagValuesV2CachesEmptyResults ensures a block that yields no values
+// for the requested tag still writes a cache entry, so tag-less blocks aren't
+// re-scanned on every query (tempo-squad#1359).
+func TestSearchTagValuesV2CachesEmptyResults(t *testing.T) {
+	i, ls := defaultInstance(t)
+
+	// block contains foo=bar* but not the tag we will query
+	_, _, _, _ = writeTracesForSearch(t, i, "", foo, bar, true, false)
+
+	blockID, err := i.cutBlocks(t.Context(), true)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, blockID)
+	_, err = i.completeBlock(t.Context(), blockID)
+	require.NoError(t, err)
+
+	userCtx := user.InjectOrgID(t.Context(), testTenantID)
+	req := &tempopb.SearchTagValuesRequest{TagName: "span.does_not_exist"}
+
+	// first query: cache miss, scans the block and finds nothing
+	resp1, err := i.SearchTagValuesV2(userCtx, req)
+	require.NoError(t, err)
+	require.Empty(t, resp1.TagValues, "tag is absent from the block")
+
+	// a cache entry (sentinel) should have been written for the tag-less block
+	var block *LocalBlock
+	for _, b := range i.blocks.Load().completeBlocks {
+		block = b
+		break
+	}
+	require.NotNil(t, block)
+	limit := i.overrides.MaxBytesPerTagValuesQuery(testTenantID)
+	cacheKey := searchTagValuesV2CacheKey(req, limit, "cache_search_tagvaluesv2")
+	cacheData, err := block.GetDiskCache(t.Context(), cacheKey)
+	require.NoError(t, err)
+	require.NotEmpty(t, cacheData, "an empty tag-value result should still be cached so the block isn't re-scanned next time")
+
+	// second query: must be a negative-cache hit -- still empty, and inspecting far
+	// fewer bytes than the initial scan (it reads only the sentinel, not the block)
+	resp2, err := i.SearchTagValuesV2(userCtx, req)
+	require.NoError(t, err)
+	require.Empty(t, resp2.TagValues)
+	require.Less(t, resp2.Metrics.InspectedBytes, resp1.Metrics.InspectedBytes,
+		"negative-cache hit should inspect fewer bytes than the initial block scan")
+
+	err = services.StopAndAwaitTerminated(t.Context(), ls)
+	require.NoError(t, err)
+}
+
 // nolint:revive,unparam
 func testSearchTagsAndValues(t *testing.T, ctx context.Context, i *instance, tagName string, expectedTagValues []string) {
 	checkSearchTags := func(scope string, contains bool) {


### PR DESCRIPTION
**What this PR does**:

On the live-store tag-value path, a block that yields **no values** for the requested tag was never cached: `SetDiskCache` was gated on `len(result) > 0`, and an empty result marshals to 0 bytes. So tag-less blocks were re-scanned on every query. For unfiltered tag-value enumeration (Explore filter typeahead fans out across many tags), most complete blocks lack any given tag, so the disk cache did almost nothing on the hot path.

This caches empty results too, using a 1-byte sentinel (`0x00` — not a valid protobuf tag, so it can never collide with a marshaled response). On read, a sentinel match is a negative-cache hit and the block is not re-scanned.

Adds a regression test asserting a tag-less block writes a cache entry.

**Which issue(s) this PR fixes**:
No public issue; tracked internally by the Tempo team.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
