### PR TITLE
docs: adopt semantic line breaks and discourage force pushes to reviewed PRs

### DIFF
--- a/.agents/guidance/precommit.md
+++ b/.agents/guidance/precommit.md
@@ -81,3 +81,21 @@ make test-e2e-clean
 2. `make lint base=origin/main` — no new lint errors
 3. `make test` — all unit tests pass
 4. `go test -race ./...` (or `make test-with-cover`) — no races in changed packages
+
+---
+
+## Pushing to a PR Under Review
+
+Once a PR has received a review,
+don't rewrite history the reviewer has already seen.
+
+- Address review feedback by pushing new commits —
+  don't amend, squash, or rebase commits that have been reviewed.
+- Don't force push to a branch under active review.
+  This includes `git push --force-with-lease`;
+  it protects against clobbering others' work,
+  but it still rewrites history
+  and breaks GitHub's "changes since your last review" view.
+- The one exception is rebasing on `main`, for example to resolve conflicts.
+  When you must, push the rebase on its own with no other changes mixed in,
+  and note it in a PR comment.

--- a/.agents/guidance/writing.md
+++ b/.agents/guidance/writing.md
@@ -1,0 +1,41 @@
+# Writing Standards
+
+Guidance for prose in this repository:
+documentation, READMEs, design docs, and agent guidance.
+Apply these when writing new prose or editing existing paragraphs.
+
+---
+
+## Semantic Line Breaks (SemBr)
+
+Write Markdown and other soft-wrapped prose using [Semantic Line Breaks](https://sembr.org):
+break source lines at semantic boundaries
+instead of hard-wrapping at a fixed column or putting whole paragraphs on one line.
+Line breaks within a paragraph don't affect the rendered output,
+so this is a source-formatting convention only.
+
+### Why
+
+- Diffs show which sentence or clause changed, not a rewrapped paragraph.
+- Reviewers can comment on a single sentence instead of a whole paragraph.
+- LLM-assisted writing tends to produce long, dense paragraphs;
+  SemBr keeps those edits reviewable.
+
+### How
+
+Use the official SemBr agent skill vendored at
+[`.claude/skills/sembr-reformat/SKILL.md`](../../.claude/skills/sembr-reformat/SKILL.md)
+(from [sembr/skills](https://github.com/sembr/skills), MIT licensed).
+It defines the break rules, the regions to skip,
+and the quality checks for rendering- and meaning-equivalence.
+Agents that support skills discover it automatically;
+humans can read it as the rule reference.
+
+### Scope
+
+- Apply SemBr to new prose and to paragraphs you're already editing.
+- Don't mass-reformat otherwise-untouched files —
+  that churns diffs, which is exactly what SemBr is meant to avoid.
+- Leave alone: code blocks, tables, YAML frontmatter,
+  and any markup where line breaks are syntactically significant
+  (for example, Markdown hard breaks).

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -13,6 +13,7 @@ AI skills for documentation and maintenance workflows in the Tempo repository. F
 | Audience fit | `/persona-check` | Check whether content matches its intended audience |
 | Vendor conflicts | `/fix-vendor-conflicts` | Resolve `vendor/` conflicts during a merge, rebase, or dependency upgrade |
 | Go version update | `/update-go-version` | Update Go version across go.mod, Dockerfile, CI workflows, and tools |
+| SemBr reformat | `/sembr-reformat` | Reformat prose with [Semantic Line Breaks](https://sembr.org) without changing rendered output |
 
 ## Set up
 
@@ -53,6 +54,13 @@ Use `/docs-workflow` to run the full pipeline, or invoke each step individually.
 - *Vendor conflicts* — `/fix-vendor-conflicts`. Resolve `vendor/` directory conflicts during a merge, rebase, or dependency upgrade on main or release branches.
 
 - *Go version update* — `/update-go-version`. Update the Go version across all relevant files: `go.mod`, `tools/go.mod`, Dockerfile, CI workflows, and the tools image tag.
+
+- *SemBr reformat* — `/sembr-reformat`.
+  Reformat prose using [Semantic Line Breaks](https://sembr.org)
+  while preserving rendered output and meaning.
+  Vendored unmodified from the official [sembr/skills](https://github.com/sembr/skills) repo (MIT).
+  Refer to [`.agents/guidance/writing.md`](../../.agents/guidance/writing.md)
+  for when and where to apply SemBr in this repo.
 
 ## Shared resources
 

--- a/.claude/skills/sembr-reformat/LICENSE
+++ b/.claude/skills/sembr-reformat/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mattt Zmuda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/sembr-reformat/SKILL.md
+++ b/.claude/skills/sembr-reformat/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: sembr-reformat
+description: Reformat prose using Semantic Line Breaks (SemBr) from https://sembr.org while preserving rendered output and meaning. Use when asked to reflow plain text or compatible markup (Markdown, AsciiDoc, reStructuredText, LaTeX, Org, MediaWiki) into semantic one-thought-per-line formatting, or when improving prose diffs and editorial readability.
+---
+
+# Reformat With SemBr
+
+Apply Semantic Line Breaks to prose without changing what readers see.
+Preserve wording, punctuation, and intent.
+
+## Reformat Workflow
+
+1. Identify prose regions that support soft-wrapped lines.
+2. Skip regions where line breaks are syntactically significant:
+   - fenced code blocks and indented code blocks
+   - tables
+   - YAML frontmatter
+   - URLs or markup tokens that must stay contiguous
+3. Rewrite only line wrapping, not content.
+4. Keep paragraphs and list structures intact.
+5. Return full rewritten text unless asked for a targeted excerpt.
+
+## SemBr Rules
+
+Apply these rules in order:
+
+1. Break after every sentence ending in `.`, `!`, or `?`.
+2. Prefer a break after independent clauses ending in `,`, `;`, `:`, or `—`.
+3. Optionally break after dependent clauses when it clarifies structure.
+4. Insert a break before an enumerated or itemized list.
+5. Optionally add breaks between list items to group related items.
+6. Never break inside a hyphenated word.
+7. Allow breaks around hyperlinks and before inline markup when helpful.
+8. Target 80 columns when possible; allow longer lines for URLs, code spans, or unavoidable markup.
+
+## Quality Checks
+
+Before returning output, verify:
+
+- Rendering-equivalence: no hard-break syntax added accidentally.
+- Meaning-equivalence: no word changes or punctuation edits.
+- Structure-equivalence: headings, lists, and block boundaries unchanged.
+- Diff-friendliness: edits are mostly line-wrap changes.
+
+## Output Style
+
+Use minimal explanation.
+Return reformatted text directly.
+If any segment cannot be safely reformatted, leave it unchanged and add a one-line note.

--- a/.claude/skills/sembr-reformat/agents/openai.yaml
+++ b/.claude/skills/sembr-reformat/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Reformat with SemBr"
+  short_description: "Reformat prose using Semantic Line Breaks."
+  default_prompt: "Reformat selected prose according to the Semantic Line Breaks specification at sembr.org while preserving meaning and rendered output."

--- a/.claude/skills/shared/style-guide.md
+++ b/.claude/skills/shared/style-guide.md
@@ -19,6 +19,7 @@ Style:
 - Use present simple tense, second-person, and active voice
 - Use simple words, short sentences, and few adjectives or adverbs
 - Prefer contractions
+- Write source prose with semantic line breaks ([SemBr](https://sembr.org)): break lines after sentences and clauses, not at a fixed column
 - Use sentence case for titles, headings, and UI
 - Bold UI text
 - Reference UI text, not element types such as button or tab

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ Before writing or modifying Go code, read [`.agents/guidance/coding.md`](.agents
 
 Before reviewing code, read [`.agents/guidance/code-review.md`](.agents/guidance/code-review.md).
 
+## Writing Standards
+
+Before writing or editing Markdown prose (docs, READMEs, design docs), read [`.agents/guidance/writing.md`](.agents/guidance/writing.md).
+
 ## Pre-Commit Checklist
 
 Before pushing or opening a PR, read [`.agents/guidance/precommit.md`](.agents/guidance/precommit.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -461,6 +461,17 @@ See `.chloggen/README.md` for details.
 
 Rebase your PR on `main` if it gets out of sync. Don't merge `main` into your branch.
 
+Once your PR has received a review,
+avoid force pushes — including `git push --force-with-lease`.
+Rewriting history breaks GitHub's "changes since your last review" view
+and forces reviewers to re-read the entire PR.
+Address review feedback by pushing new commits instead.
+If you need to rebase on `main` to resolve conflicts,
+push the rebase on its own with no other changes mixed in,
+and mention it in a PR comment.
+This applies doubly to AI coding agents,
+which tend to reach for `--force-with-lease` by default.
+
 ## Documentation
 
 Anyone can help with Tempo's documentation by writing new content, updating existing content, or creating an issue.


### PR DESCRIPTION
**What this PR does**:

Two team-agreed process changes:

- Adopt [Semantic Line Breaks](https://sembr.org) for Markdown prose.
  Adds `.agents/guidance/writing.md`
  and vendors the official [sembr/skills](https://github.com/sembr/skills) agent skill (MIT, unmodified)
  into `.claude/skills/sembr-reformat/`.
- Discourage force pushes (including `--force-with-lease`) to PRs under review,
  in `.agents/guidance/precommit.md` and `CONTRIBUTING.md`.
  Push new commits for review feedback; rebases on `main` go in their own push.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated — n/a, docs only
- [x] Documentation added
- [ ] Changelog entry — not required, docs only (`type/docs`)
