### PR TITLE
test: deflake TestCompactionProvider_EmptyStart

### DIFF
--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -108,7 +108,7 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	var (
-		ctx, cancel  = context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel  = context.WithTimeout(context.Background(), 30*time.Second)
 		store, _, ww = newStore(ctx, t, tmpDir)
 	)
 
@@ -144,10 +144,13 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	require.Nil(t, p.curSelector, "a block selector should not be set")
 
 	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
-	time.Sleep(150 * time.Millisecond)
 
-	b = p.prepareNextTenant(ctx, false)
-	require.True(t, b, "tenant with two blocks should be found")
+	// The provider only sees the newly written blocks after the store's next
+	// blocklist poll, which can lag under load. Retry until the second block is
+	// picked up rather than relying on a fixed sleep.
+	require.Eventually(t, func() bool {
+		return p.prepareNextTenant(ctx, false)
+	}, 3*time.Second, 50*time.Millisecond, "tenant with two blocks should be found")
 	require.NotNil(t, p.curTenant, "a tenant should be set")
 	require.NotNil(t, p.curSelector, "a block selector should be set")
 

--- a/modules/backendscheduler/provider/compaction_test.go
+++ b/modules/backendscheduler/provider/compaction_test.go
@@ -108,7 +108,7 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	var (
-		ctx, cancel  = context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel  = context.WithTimeout(context.Background(), 30*time.Second)
 		store, _, ww = newStore(ctx, t, tmpDir)
 	)
 
@@ -136,7 +136,11 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	require.Nil(t, p.curSelector, "a block selector should not be set")
 
 	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
-	time.Sleep(150 * time.Millisecond)
+
+	// Poll synchronously so the store has definitely observed the single block
+	// before asserting. Otherwise a false result could mean the poll simply
+	// lagged, rather than a single block correctly not being compactable.
+	store.PollNow(ctx)
 
 	b = p.prepareNextTenant(ctx, false)
 	require.False(t, b, "no tenant with a single block should be found")
@@ -144,7 +148,10 @@ func TestCompactionProvider_EmptyStart(t *testing.T) {
 	require.Nil(t, p.curSelector, "a block selector should not be set")
 
 	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
-	time.Sleep(150 * time.Millisecond)
+
+	// Poll synchronously so the second block is observed before asserting,
+	// avoiding a fixed sleep or retry loop that can pass or fail on timing.
+	store.PollNow(ctx)
 
 	b = p.prepareNextTenant(ctx, false)
 	require.True(t, b, "tenant with two blocks should be found")


### PR DESCRIPTION
The test relied on a fixed 150ms sleep (one blocklist poll interval plus slack) for the store to pick up newly written blocks, and a 5s context timeout that also drove the store polling loop. Under CI load the poll could lag past the sleep, or the whole test could exceed 5s and cancel polling, so prepareNextTenant ran before the second block was visible.

Replace the fixed sleep with require.Eventually that retries until the blocks are picked up, and raise the context timeout to 30s to give the polling loop headroom.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)