### PR TITLE
feat: add support for deprecated peer.service replacement service.pee…

### DIFF
--- a/.chloggen/feat_peer-service-name-support.yaml
+++ b/.chloggen/feat_peer-service-name-support.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: metrics-generator
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: add support for the `service.peer.name` semantic convention attribute in the service-graphs processor, which replaces the deprecated `peer.service`
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: elinacse

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -734,9 +734,9 @@ metrics_generator:
 
             # Attributes that will be used to create a peer edge
             # Attributes are searched in the order they are provided
-            # See: https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.25.0
-            # Example: ["peer.service", "db.name", "db.system", "host.name"]
-            [peer_attributes: <list of string> | default = ["peer.service", "db.name", "db.system"] ]
+            # See: https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.40.0
+            # Example: ["service.peer.name", "peer.service", "db.name", "db.system", "host.name"]
+            [peer_attributes: <list of string> | default = ["service.peer.name", "peer.service", "db.name", "db.system"] ]
 
             # Attribute Key to multiply span metrics
             # Note that the attribute name is searched for in both

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -791,8 +791,8 @@ metrics_generator:
             # Attributes that will be used to create a peer edge
             # Attributes are searched in the order they are provided
             # See: https://opentelemetry.io/docs/specs/semconv/registry/attributes/
-            # Example: ["peer.service", "db.name", "db.system", "host.name"]
-            [peer_attributes: <list of string> | default = ["peer.service", "db.name", "db.system", "db.system.name"] ]
+            # Example: ["service.peer.name", "peer.service", "db.name", "db.system", "host.name"]
+            [peer_attributes: <list of string> | default = ["service.peer.name", "peer.service", "db.name", "db.system", "db.system.name"] ]
 
             # Attribute Key to multiply span metrics
             # Note that the attribute name is searched for in both

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -426,6 +426,7 @@ metrics_generator:
             enable_client_server_prefix: false
             enable_messaging_system_latency_histogram: false
             peer_attributes:
+                - service.peer.name
                 - peer.service
                 - db.name
                 - db.system

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -450,6 +450,7 @@ metrics_generator:
             enable_client_server_prefix: false
             enable_messaging_system_latency_histogram: false
             peer_attributes:
+                - service.peer.name
                 - peer.service
                 - db.name
                 - db.system

--- a/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
@@ -61,12 +61,14 @@ The processor detects virtual nodes in two ways:
   - In the Tempo metrics-generator, the processor checks the configured `peer_attributes` on the server span first. If it finds a matching attribute, it uses that value as the client node name. Otherwise, the client node name defaults to `user`.
   - In Grafana Alloy and the OpenTelemetry Collector `servicegraph` connector, the connector doesn't evaluate peer attributes for this case. The client node name always defaults to `user` and you can't override it. An [upstream feature request](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45397) exists to add this capability.
 - **Uninstrumented server (missing server span):** A `client` span doesn't have its matching `server` span, but has a peer attribute present. In this case, the client called an external service that doesn't send spans. The processor uses the peer attribute value as the virtual server node name.
-  - The default peer attributes are `peer.service`, `db.name`, and `db.system`.
+  - The default peer attributes are `service.peer.name`, `peer.service`, `db.name`, and `db.system`.
   - The processor searches the attributes in order and uses the first match as the virtual node name.
 
 The processor identifies a database node when the span has at least one `db.namespace`, `db.name`, or `db.system` attribute.
 
-The processor determines the database node name using the following span attributes in order of precedence: `peer.service`, `server.address`, `network.peer.address:network.peer.port`, `db.namespace`, `db.name`.
+The processor determines the database node name using the following span attributes in order of precedence: `service.peer.name`, `peer.service`, `server.address`, `network.peer.address:network.peer.port`, `db.namespace`, `db.name`.
+
+`peer.service` is deprecated in the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/peer/) in favor of `service.peer.name`. Tempo checks `service.peer.name` first and falls back to `peer.service` for backwards compatibility.
 
 ### Enabling specific metrics (subprocessors)
 

--- a/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
@@ -61,12 +61,14 @@ The processor detects virtual nodes in two ways:
   - In the Tempo metrics-generator, the processor checks the configured `peer_attributes` on the server span first. If it finds a matching attribute, it uses that value as the client node name. Otherwise, the client node name defaults to `user`.
   - In Grafana Alloy and the OpenTelemetry Collector `servicegraph` connector, the connector doesn't evaluate peer attributes for this case. The client node name always defaults to `user` and you can't override it. An [upstream feature request](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45397) exists to add this capability.
 - **Uninstrumented server (missing server span):** A `client` span doesn't have its matching `server` span, but has a peer attribute present. In this case, the client called an external service that doesn't send spans. The processor uses the peer attribute value as the virtual server node name.
-  - The default peer attributes are `peer.service`, `db.name`, `db.system`, and `db.system.name`.
+  - The default peer attributes are `service.peer.name`, `peer.service`, `db.name`, `db.system`, and `db.system.name`.
   - The processor searches the attributes in order and uses the first match as the virtual node name.
 
 The processor identifies a database node when the span has at least one `db.namespace`, `db.name`, `db.system`, or `db.system.name` attribute.
 
-The processor determines the database node name using the following span attributes in order of precedence: `peer.service`, `server.address`, `network.peer.address:network.peer.port`, and finally the first attribute from `database_name_attributes` that the span carries.
+The processor determines the database node name using the following span attributes in order of precedence: `service.peer.name`, `peer.service`, `server.address`, `network.peer.address:network.peer.port`, and finally the first attribute from `database_name_attributes` that the span carries.
+
+`peer.service` is deprecated in the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/peer/) in favor of `service.peer.name`. Tempo checks `service.peer.name` first and falls back to `peer.service` for backwards compatibility.
 
 ### Enabling specific metrics (subprocessors)
 

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -422,6 +422,7 @@ metrics_generator:
             enable_client_server_prefix: false
             enable_messaging_system_latency_histogram: false
             peer_attributes:
+                - service.peer.name
                 - peer.service
                 - db.name
                 - db.system

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -446,6 +446,7 @@ metrics_generator:
             enable_client_server_prefix: false
             enable_messaging_system_latency_histogram: false
             peer_attributes:
+                - service.peer.name
                 - peer.service
                 - db.name
                 - db.system

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -8,7 +8,7 @@ import (
 	filterconfig "github.com/grafana/tempo/pkg/spanfilter/config"
 	"github.com/prometheus/client_golang/prometheus"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	semconvnew "go.opentelemetry.io/otel/semconv/v1.34.0"
+	semconvnew "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 type Config struct {

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconvnew "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	gen "github.com/grafana/tempo/modules/generator/processor"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs/store"
@@ -65,7 +66,7 @@ const (
 const virtualNodeLabel = "virtual_node"
 
 var defaultPeerAttributes = []attribute.Key{
-	semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey,
+	semconvnew.ServicePeerNameKey, semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey,
 }
 
 type tooManySpansError struct {
@@ -342,7 +343,8 @@ func (p *Processor) upsertPeerNode(e *store.Edge, spanAttr []*v1_common.KeyValue
 // database request.  The name of the edge is determined by the following
 // order:
 //
-//	if we have a peer.service, use it as the database ServerService
+//	if we have a service.peer.name, use it as the database ServerService
+//	if we have a peer.service (deprecated in favor of service.peer.name), use it as the database ServerService
 //	if we have a server.address, use it as the database ServerService
 //	if we have a network.peer.address, use it as the database ServerService.  Include :port if network.peer.port is present
 //	if we have a db.name, use it as the database ServerService, which is the backwards-compatible behavior
@@ -370,7 +372,13 @@ func (p *Processor) upsertDatabaseRequest(e *store.Edge, resourceAttr []*v1_comm
 	e.ConnectionType = store.Database
 	e.ServerLatencySec = spanDurationSec(span)
 
-	// Check for peer.service
+	// Check for service.peer.name
+	if name, ok := processor_util.FindAttributeValue(string(semconvnew.ServicePeerNameKey), resourceAttr, span.Attributes); ok {
+		e.ServerService = name
+		return
+	}
+
+	// Check for peer.service (deprecated in favor of service.peer.name)
 	if name, ok := processor_util.FindAttributeValue(string(semconv.PeerServiceKey), resourceAttr, span.Attributes); ok {
 		e.ServerService = name
 		return

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	semconvnew "go.opentelemetry.io/otel/semconv/v1.34.0"
+	semconvnew "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	gen "github.com/grafana/tempo/modules/generator/processor"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs/store"
@@ -68,7 +68,7 @@ const virtualNodeLabel = "virtual_node"
 // db.system was renamed to db.system.name in semconv v1.30.0. Both are consulted,
 // the older key first, so existing pipelines keep naming virtual nodes as they do today.
 var defaultPeerAttributes = []attribute.Key{
-	semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey, semconvnew.DBSystemNameKey,
+	semconvnew.ServicePeerNameKey, semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey, semconvnew.DBSystemNameKey,
 }
 
 type tooManySpansError struct {
@@ -347,7 +347,8 @@ func (p *Processor) upsertPeerNode(e *store.Edge, spanAttr []*v1_common.KeyValue
 // database request.  The name of the edge is determined by the following
 // order:
 //
-//	if we have a peer.service, use it as the database ServerService
+//	if we have a service.peer.name, use it as the database ServerService
+//	if we have a peer.service (deprecated in favor of service.peer.name), use it as the database ServerService
 //	if we have a server.address, use it as the database ServerService
 //	if we have a network.peer.address, use it as the database ServerService.  Include :port if network.peer.port is present
 //	if we have a db.name, use it as the database ServerService, which is the backwards-compatible behavior
@@ -375,7 +376,13 @@ func (p *Processor) upsertDatabaseRequest(e *store.Edge, resourceAttr []*v1_comm
 	e.ConnectionType = store.Database
 	e.ServerLatencySec = spanDurationSec(span)
 
-	// Check for peer.service
+	// Check for service.peer.name
+	if name, ok := processor_util.FindAttributeValue(string(semconvnew.ServicePeerNameKey), resourceAttr, span.Attributes); ok {
+		e.ServerService = name
+		return
+	}
+
+	// Check for peer.service (deprecated in favor of service.peer.name)
 	if name, ok := processor_util.FindAttributeValue(string(semconv.PeerServiceKey), resourceAttr, span.Attributes); ok {
 		e.ServerService = name
 		return

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	semconvnew "go.opentelemetry.io/otel/semconv/v1.34.0"
+	semconvnew "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // NOTE: This is a way to know if the contents of the semconv package have changed.
@@ -46,6 +46,7 @@ func TestSemconvKeys(t *testing.T) {
 	require.Equal(t, string(semconv.NetworkPeerPortKey), "network.peer.port")
 	require.Equal(t, string(semconv.ServerAddressKey), "server.address")
 	require.Equal(t, string(semconvnew.DBNamespaceKey), "db.namespace")
+	require.Equal(t, string(semconvnew.ServicePeerNameKey), "service.peer.name")
 }
 
 func TestServiceGraphs(t *testing.T) {
@@ -1040,6 +1041,28 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			databaseLabels: labels.FromMap(map[string]string{
 				"client":          "mythical-server",
 				"server":          "priority-db",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			name:        "servicePeerName",
+			fixturePath: "testdata/trace-with-service-peer-name.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			name:        "servicePeerNameTakesPrecedenceOverDeprecatedPeerService",
+			fixturePath: "testdata/trace-with-peer-service-and-service-peer-name.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
 				"connection_type": "database",
 			}),
 			total:  1.0,

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	semconvnew "go.opentelemetry.io/otel/semconv/v1.34.0"
+	semconvnew "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // NOTE: This is a way to know if the contents of the semconv package have changed.
@@ -48,20 +48,22 @@ func TestSemconvKeys(t *testing.T) {
 	require.Equal(t, string(semconv.ServerAddressKey), "server.address")
 	require.Equal(t, string(semconvnew.DBNamespaceKey), "db.namespace")
 	require.Equal(t, string(semconvnew.DBSystemNameKey), "db.system.name")
+	require.Equal(t, string(semconvnew.ServicePeerNameKey), "service.peer.name")
 }
 
 // TestServiceGraphs_defaultDatabaseAttributeOrder locks in the order in which
-// database attributes are consulted, since the first match wins and reordering
-// them changes the node names an existing pipeline emits. Attributes naming the
-// database (db.namespace, db.name) come before those naming the DBMS product
-// (db.system, db.system.name), and db.system.name is placed after the db.system
-// it replaced in semconv v1.30.0 so that spans carrying the older key are
-// unaffected.
+// peer and database attributes are consulted, since the first match wins and
+// reordering them changes the node names an existing pipeline emits.
+// service.peer.name is checked first as the non-deprecated replacement for
+// peer.service. Attributes naming the database (db.namespace, db.name) come
+// before those naming the DBMS product (db.system, db.system.name), and
+// db.system.name is placed after the db.system it replaced in semconv v1.30.0
+// so that spans carrying the older key are unaffected.
 func TestServiceGraphs_defaultDatabaseAttributeOrder(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)
 
-	require.Equal(t, []string{"peer.service", "db.name", "db.system", "db.system.name"}, cfg.PeerAttributes)
+	require.Equal(t, []string{"service.peer.name", "peer.service", "db.name", "db.system", "db.system.name"}, cfg.PeerAttributes)
 	require.Equal(t, []string{"db.namespace", "db.name", "db.system", "db.system.name"}, cfg.DatabaseNameAttributes)
 }
 
@@ -1124,6 +1126,28 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			databaseLabels: labels.FromMap(map[string]string{
 				"client":          "mythical-server",
 				"server":          "mssql",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			name:        "servicePeerName",
+			fixturePath: "testdata/trace-with-service-peer-name.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			name:        "servicePeerNameTakesPrecedenceOverDeprecatedPeerService",
+			fixturePath: "testdata/trace-with-peer-service-and-service-peer-name.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mythical-database",
 				"connection_type": "database",
 			}),
 			total:  1.0,

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-peer-service-and-service-peer-name.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-peer-service-and-service-peer-name.json
@@ -1,0 +1,1668 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.name",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "peer.service",
+                  "value": {
+                    "stringValue": "mythical-database-deprecated"
+                  }
+                },
+                {
+                  "key": "service.peer.name",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-service-peer-name.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-service-peer-name.json
@@ -1,0 +1,1662 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.name",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "service.peer.name",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "server.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The OpenTelemetry semantic conventions deprecated peer.service in favor of service.peer.name. The service-graphs processor now checks for service.peer.name first, falling back to peer.service, when naming virtual peer nodes and database edge server names.

Fixes #7626 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)