### PR TITLE
fix: repair missing root span in TraceQL search results

### DIFF
--- a/.chloggen/fix_root-span-not-received-search.yaml
+++ b/.chloggen/fix_root-span-not-received-search.yaml
@@ -1,0 +1,24 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: repair the root service/span name in TraceQL search results that show "<root span not yet received>" even though the trace has a root span, by fetching the trace by ID when a result is missing that info
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  This can happen when a trace's root span is written to a block that never gets compacted
+  together with the rest of the trace. Controlled by the new `repair_root_span` (default `true`)
+  and `repair_root_span_max_traces` (default `5`) options under `query_frontend.search`.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: elinacse

--- a/.chloggen/fix_root-span-not-received-search.yaml
+++ b/.chloggen/fix_root-span-not-received-search.yaml
@@ -17,8 +17,8 @@ issues: []
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
 subtext: |
   This can happen when a trace's root span is written to a block that never gets compacted
-  together with the rest of the trace. Controlled by the new `repair_root_span` (default `true`)
-  and `repair_root_span_max_traces` (default `5`) options under `query_frontend.search`.
+  together with the rest of the trace. Controlled by the new `repair_root_span_max_traces`
+  option (default `5`) under `query_frontend.search`; set to `0` to disable.
 
 # The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
 user: elinacse

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1085,6 +1085,18 @@ query_frontend:
         # The maximum allowed value of spans per span set. 0 disables this limit.
         [max_spans_per_span_set: <int> | default = 100]
 
+        # If a search result is missing its root service/span name (shown as
+        # "<root span not yet received>"), attempt to backfill it by fetching the trace by ID.
+        # This can resolve traces whose root span landed in a block that was never compacted
+        # together with the rest of the trace, which trace-by-ID lookups already handle by
+        # combining every block that contains the trace ID.
+        [repair_root_span: <bool> | default = true]
+
+        # The maximum number of traces per search response to attempt a root span repair for.
+        # Each attempt is an extra trace-by-ID round trip, so this bounds the added cost when
+        # many results in a page are missing root info.
+        [repair_root_span_max_traces: <int> | default = 5]
+
         # SLO configuration for Metadata (tags and tag values) endpoints.
         metadata_slo:
             # If set to a non-zero value, it's value will be used to decide if metadata query is within SLO or not.

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -1090,11 +1090,8 @@ query_frontend:
         # This can resolve traces whose root span landed in a block that was never compacted
         # together with the rest of the trace, which trace-by-ID lookups already handle by
         # combining every block that contains the trace ID.
-        [repair_root_span: <bool> | default = true]
-
-        # The maximum number of traces per search response to attempt a root span repair for.
-        # Each attempt is an extra trace-by-ID round trip, so this bounds the added cost when
-        # many results in a page are missing root info.
+        # 0 disables repair. A positive value enables it and caps how many traces per search
+        # response get a repair attempt, since each attempt is an extra trace-by-ID round trip.
         [repair_root_span_max_traces: <int> | default = 5]
 
         # SLO configuration for Metadata (tags and tag values) endpoints.

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -342,6 +342,8 @@ query_frontend:
         most_recent_shards: 200
         default_spans_per_span_set: 3
         max_spans_per_span_set: 100
+        repair_root_span: true
+        repair_root_span_max_traces: 5
     trace_by_id:
         query_shards: 50
         blocks_per_shard: 30

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -342,7 +342,6 @@ query_frontend:
         most_recent_shards: 200
         default_spans_per_span_set: 3
         max_spans_per_span_set: 100
-        repair_root_span: true
         repair_root_span_max_traces: 5
     trace_by_id:
         query_shards: 50

--- a/modules/frontend/combiner/search.go
+++ b/modules/frontend/combiner/search.go
@@ -32,8 +32,14 @@ var _ PipelineResponse = (*SearchJobResponse)(nil)
 
 var _ GRPCCombiner[*tempopb.SearchResponse] = (*genericCombiner[*tempopb.SearchResponse])(nil)
 
+// RootSpanRepairFunc attempts to resolve the root service and span name for a trace whose
+// search metadata is missing that information, most commonly because the block fragment that
+// matched the search filter was written before the trace's root span arrived and was never
+// compacted together with the fragment that holds it. It returns ok=false if it can't help.
+type RootSpanRepairFunc func(traceID string) (serviceName, spanName string, ok bool)
+
 // NewSearch returns a search combiner
-func NewSearch(limit int, keepMostRecent bool, marshalingFormat api.MarshallingFormat, padTraceIDs bool) Combiner {
+func NewSearch(limit int, keepMostRecent bool, marshalingFormat api.MarshallingFormat, padTraceIDs bool, repair RootSpanRepairFunc, maxRepairs int) Combiner {
 	metadataCombiner := traceql.NewMetadataCombiner(limit, keepMostRecent)
 	diffTraces := map[string]struct{}{}
 	completedThroughTracker := &shardtracker.CompletionTracker{}
@@ -80,6 +86,9 @@ func NewSearch(limit int, keepMostRecent bool, marshalingFormat api.MarshallingF
 			// metrics are already combined on the passed in final
 			final.Traces = metadataCombiner.Metadata()
 			final.Metrics = metricsCombiner.Metrics
+			// only attempt repair once, on the complete response. repairing on every streaming
+			// diff would repeat the same lookups as more shards complete.
+			repairMissingRootSpans(final.Traces, repair, maxRepairs)
 			addRootSpanNotReceivedText(final.Traces)
 			if padTraceIDs {
 				padTraceIDsInResponse(final.Traces)
@@ -146,8 +155,33 @@ func addRootSpanNotReceivedText(results []*tempopb.TraceSearchMetadata) {
 	}
 }
 
-func NewTypedSearch(limit int, keepMostRecent bool, marshalingFormat api.MarshallingFormat, padTraceIDs bool) GRPCCombiner[*tempopb.SearchResponse] {
-	return NewSearch(limit, keepMostRecent, marshalingFormat, padTraceIDs).(GRPCCombiner[*tempopb.SearchResponse])
+// repairMissingRootSpans attempts, via repair, to resolve root service/span name for traces
+// still missing it after combining all shard results. Bounded by maxRepairs since each attempt
+// is a network round trip; a search page with many broken traces only pays for the first few.
+func repairMissingRootSpans(results []*tempopb.TraceSearchMetadata, repair RootSpanRepairFunc, maxRepairs int) {
+	if repair == nil {
+		return
+	}
+
+	attempted := 0
+	for _, tr := range results {
+		if tr.RootServiceName != "" {
+			continue
+		}
+		if attempted >= maxRepairs {
+			return
+		}
+		attempted++
+
+		if serviceName, spanName, ok := repair(tr.TraceID); ok {
+			tr.RootServiceName = serviceName
+			tr.RootTraceName = spanName
+		}
+	}
+}
+
+func NewTypedSearch(limit int, keepMostRecent bool, marshalingFormat api.MarshallingFormat, padTraceIDs bool, repair RootSpanRepairFunc, maxRepairs int) GRPCCombiner[*tempopb.SearchResponse] {
+	return NewSearch(limit, keepMostRecent, marshalingFormat, padTraceIDs, repair, maxRepairs).(GRPCCombiner[*tempopb.SearchResponse])
 }
 
 // padTraceIDsInResponse left-pads all trace IDs in the given search metadata to 32 hex characters.

--- a/modules/frontend/combiner/search_test.go
+++ b/modules/frontend/combiner/search_test.go
@@ -26,33 +26,33 @@ func TestSearchProgressShouldQuitAnyProtobuf(t *testing.T) {
 
 func testSearchProgressShouldQuitAny(t *testing.T, marshalingFormat api.MarshallingFormat) {
 	// new combiner should not quit
-	c := NewSearch(0, false, marshalingFormat, false)
+	c := NewSearch(0, false, marshalingFormat, false, nil, 0)
 	should := c.ShouldQuit()
 	require.False(t, should)
 
 	// 500 response should quit
-	c = NewSearch(0, false, marshalingFormat, false)
+	c = NewSearch(0, false, marshalingFormat, false, nil, 0)
 	err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{}, 500, nil, marshalingFormat))
 	require.NoError(t, err)
 	should = c.ShouldQuit()
 	require.True(t, should)
 
 	// 429 response should quit
-	c = NewSearch(0, false, marshalingFormat, false)
+	c = NewSearch(0, false, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{}, 429, nil, marshalingFormat))
 	require.NoError(t, err)
 	should = c.ShouldQuit()
 	require.True(t, should)
 
 	// unparseable body should not quit, but should return an error
-	c = NewSearch(0, false, marshalingFormat, false)
+	c = NewSearch(0, false, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(&testPipelineResponse{r: &http.Response{Body: io.NopCloser(strings.NewReader("foo")), StatusCode: 200}})
 	require.Error(t, err)
 	should = c.ShouldQuit()
 	require.False(t, should)
 
 	// under limit should not quit
-	c = NewSearch(2, false, marshalingFormat, false)
+	c = NewSearch(2, false, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
@@ -65,7 +65,7 @@ func testSearchProgressShouldQuitAny(t *testing.T, marshalingFormat api.Marshall
 	require.False(t, should)
 
 	// over limit should quit
-	c = NewSearch(1, false, marshalingFormat, false)
+	c = NewSearch(1, false, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
@@ -91,33 +91,33 @@ func TestSearchProgressShouldQuitMostRecentProtobuf(t *testing.T) {
 
 func testSearchProgressShouldQuitMostRecent(t *testing.T, marshalingFormat api.MarshallingFormat) {
 	// new combiner should not quit
-	c := NewSearch(0, true, marshalingFormat, false)
+	c := NewSearch(0, true, marshalingFormat, false, nil, 0)
 	should := c.ShouldQuit()
 	require.False(t, should)
 
 	// 500 response should quit
-	c = NewSearch(0, true, marshalingFormat, false)
+	c = NewSearch(0, true, marshalingFormat, false, nil, 0)
 	err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{}, 500, nil, marshalingFormat))
 	require.NoError(t, err)
 	should = c.ShouldQuit()
 	require.True(t, should)
 
 	// 429 response should quit
-	c = NewSearch(0, true, marshalingFormat, false)
+	c = NewSearch(0, true, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{}, 429, nil, marshalingFormat))
 	require.NoError(t, err)
 	should = c.ShouldQuit()
 	require.True(t, should)
 
 	// unparseable body should not quit, but should return an error
-	c = NewSearch(0, true, marshalingFormat, false)
+	c = NewSearch(0, true, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(&testPipelineResponse{r: &http.Response{Body: io.NopCloser(strings.NewReader("foo")), StatusCode: 200}})
 	require.Error(t, err)
 	should = c.ShouldQuit()
 	require.False(t, should)
 
 	// under limit should not quit
-	c = NewSearch(2, true, marshalingFormat, false)
+	c = NewSearch(2, true, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
@@ -130,7 +130,7 @@ func testSearchProgressShouldQuitMostRecent(t *testing.T, marshalingFormat api.M
 	require.False(t, should)
 
 	// over limit but no search job response, should not quit
-	c = NewSearch(1, true, marshalingFormat, false)
+	c = NewSearch(1, true, marshalingFormat, false, nil, 0)
 	err = c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
 		Traces: []*tempopb.TraceSearchMetadata{
 			{
@@ -198,7 +198,7 @@ func testSearchCombinesResults(t *testing.T, marshalingFormat api.MarshallingFor
 		start := time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC)
 		traceID := "traceID"
 
-		c := NewSearch(10, keepMostRecent, marshalingFormat, false)
+		c := NewSearch(10, keepMostRecent, marshalingFormat, false, nil, 0)
 		sr := toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
 			Traces: []*tempopb.TraceSearchMetadata{
 				{
@@ -420,7 +420,7 @@ func testSearchResponseCombiner(t *testing.T, marshalingFormat api.MarshallingFo
 
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
-				combiner := NewTypedSearch(20, keepMostRecent, marshalingFormat, false)
+				combiner := NewTypedSearch(20, keepMostRecent, marshalingFormat, false, nil, 0)
 
 				err := combiner.AddResponse(tc.response1)
 				require.NoError(t, err)
@@ -691,7 +691,7 @@ func testCombinerShards(t *testing.T, marshalingFormat api.MarshallingFormat) {
 
 	// apply tests one at a time to the combiner and check expected results
 
-	combiner := NewTypedSearch(5, true, marshalingFormat, false)
+	combiner := NewTypedSearch(5, true, marshalingFormat, false, nil, 0)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.pipelineResponse != nil {
@@ -767,7 +767,7 @@ func TestSearchCombinerPadTraceIDs(t *testing.T) {
 				traces = append(traces, &tempopb.TraceSearchMetadata{TraceID: id})
 			}
 
-			c := NewTypedSearch(10, false, tc.marshalingFmt, tc.padTraceIDs)
+			c := NewTypedSearch(10, false, tc.marshalingFmt, tc.padTraceIDs, nil, 0)
 			err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{Traces: traces}, 200, nil, tc.marshalingFmt))
 			require.NoError(t, err)
 
@@ -855,5 +855,113 @@ func TestSegmentSearchResponse(t *testing.T) {
 		require.Equal(t, input.Metrics, out[0].Metrics)
 		require.Equal(t, input.Metrics, out[1].Metrics)
 		require.Equal(t, input.Metrics, out[2].Metrics)
+	})
+}
+
+func TestSearchRootSpanRepair(t *testing.T) {
+	marshalingFormat := api.MarshallingFormatJSON
+
+	t.Run("repairs traces missing root service name", func(t *testing.T) {
+		var repairedIDs []string
+		repair := func(traceID string) (string, string, bool) {
+			repairedIDs = append(repairedIDs, traceID)
+			return "envoy", "ingress", true
+		}
+
+		c := NewTypedSearch(0, false, marshalingFormat, false, repair, 5)
+		err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
+			Traces: []*tempopb.TraceSearchMetadata{
+				{TraceID: "1234"}, // RootServiceName intentionally empty
+			},
+		}, 200, nil, marshalingFormat))
+		require.NoError(t, err)
+
+		resp, err := c.GRPCFinal()
+		require.NoError(t, err)
+		require.Equal(t, []string{"1234"}, repairedIDs)
+		require.Equal(t, "envoy", resp.Traces[0].RootServiceName)
+		require.Equal(t, "ingress", resp.Traces[0].RootTraceName)
+	})
+
+	t.Run("falls back to placeholder text when repair can't help", func(t *testing.T) {
+		repair := func(_ string) (string, string, bool) { return "", "", false }
+
+		c := NewTypedSearch(0, false, marshalingFormat, false, repair, 5)
+		err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
+			Traces: []*tempopb.TraceSearchMetadata{
+				{TraceID: "1234"},
+			},
+		}, 200, nil, marshalingFormat))
+		require.NoError(t, err)
+
+		resp, err := c.GRPCFinal()
+		require.NoError(t, err)
+		require.Equal(t, search.RootSpanNotYetReceivedText, resp.Traces[0].RootServiceName)
+	})
+
+	t.Run("nil repair func is a no-op", func(t *testing.T) {
+		c := NewTypedSearch(0, false, marshalingFormat, false, nil, 5)
+		err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
+			Traces: []*tempopb.TraceSearchMetadata{
+				{TraceID: "1234"},
+			},
+		}, 200, nil, marshalingFormat))
+		require.NoError(t, err)
+
+		resp, err := c.GRPCFinal()
+		require.NoError(t, err)
+		require.Equal(t, search.RootSpanNotYetReceivedText, resp.Traces[0].RootServiceName)
+	})
+
+	t.Run("does not repair traces that already have a root service name", func(t *testing.T) {
+		repair := func(_ string) (string, string, bool) {
+			t.Fatal("repair should not be called for traces that already have root info")
+			return "", "", false
+		}
+
+		c := NewTypedSearch(0, false, marshalingFormat, false, repair, 5)
+		err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
+			Traces: []*tempopb.TraceSearchMetadata{
+				{TraceID: "1234", RootServiceName: "app"},
+			},
+		}, 200, nil, marshalingFormat))
+		require.NoError(t, err)
+
+		resp, err := c.GRPCFinal()
+		require.NoError(t, err)
+		require.Equal(t, "app", resp.Traces[0].RootServiceName)
+	})
+
+	t.Run("bounded by maxRepairs", func(t *testing.T) {
+		attempts := 0
+		repair := func(_ string) (string, string, bool) {
+			attempts++
+			return "svc", "span", true
+		}
+
+		c := NewTypedSearch(0, false, marshalingFormat, false, repair, 2)
+		err := c.AddResponse(toHTTPResponseWithFormat(t, &tempopb.SearchResponse{
+			Traces: []*tempopb.TraceSearchMetadata{
+				{TraceID: "1"},
+				{TraceID: "2"},
+				{TraceID: "3"},
+			},
+		}, 200, nil, marshalingFormat))
+		require.NoError(t, err)
+
+		resp, err := c.GRPCFinal()
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+
+		var repaired, unrepaired int
+		for _, tr := range resp.Traces {
+			if tr.RootServiceName == "svc" {
+				repaired++
+			} else if tr.RootServiceName == search.RootSpanNotYetReceivedText {
+				unrepaired++
+			}
+		}
+		require.Equal(t, 2, repaired)
+		require.Equal(t, 1, unrepaired)
 	})
 }

--- a/modules/frontend/combiner/search_test.go
+++ b/modules/frontend/combiner/search_test.go
@@ -955,9 +955,10 @@ func TestSearchRootSpanRepair(t *testing.T) {
 
 		var repaired, unrepaired int
 		for _, tr := range resp.Traces {
-			if tr.RootServiceName == "svc" {
+			switch tr.RootServiceName {
+			case "svc":
 				repaired++
-			} else if tr.RootServiceName == search.RootSpanNotYetReceivedText {
+			case search.RootSpanNotYetReceivedText:
 				unrepaired++
 			}
 		}

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -67,6 +67,16 @@ type SearchConfig struct {
 	Sharder     SearchSharderConfig `yaml:",inline"`
 	SLO         SLOConfig           `yaml:",inline"`
 	MetadataSLO SLOConfig           `yaml:"metadata_slo,omitempty"`
+
+	// RepairRootSpan controls whether the frontend attempts to backfill the root service/span
+	// name for search results that are missing it (shown as "<root span not yet received>")
+	// by fetching the trace by ID, which combines fragments across all blocks regardless of
+	// whether they were ever compacted together. This can happen permanently for a trace whose
+	// root span fragment lands in a different compaction window than the rest of the trace.
+	RepairRootSpan bool `yaml:"repair_root_span,omitempty"`
+	// RepairRootSpanMaxTraces caps how many traces per search response get a repair attempt,
+	// since each attempt is an extra round trip to fetch the trace by ID.
+	RepairRootSpanMaxTraces int `yaml:"repair_root_span_max_traces,omitempty"`
 }
 
 type TraceByIDConfig struct {
@@ -120,7 +130,9 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 			DefaultSpansPerSpanSet: 3,
 			MaxSpansPerSpanSet:     100,
 		},
-		SLO: slo,
+		SLO:                     slo,
+		RepairRootSpan:          true,
+		RepairRootSpanMaxTraces: 5,
 	}
 	cfg.TraceByID = TraceByIDConfig{
 		QueryShards:    50,

--- a/modules/frontend/config.go
+++ b/modules/frontend/config.go
@@ -68,14 +68,14 @@ type SearchConfig struct {
 	SLO         SLOConfig           `yaml:",inline"`
 	MetadataSLO SLOConfig           `yaml:"metadata_slo,omitempty"`
 
-	// RepairRootSpan controls whether the frontend attempts to backfill the root service/span
-	// name for search results that are missing it (shown as "<root span not yet received>")
-	// by fetching the trace by ID, which combines fragments across all blocks regardless of
-	// whether they were ever compacted together. This can happen permanently for a trace whose
-	// root span fragment lands in a different compaction window than the rest of the trace.
-	RepairRootSpan bool `yaml:"repair_root_span,omitempty"`
-	// RepairRootSpanMaxTraces caps how many traces per search response get a repair attempt,
-	// since each attempt is an extra round trip to fetch the trace by ID.
+	// RepairRootSpanMaxTraces controls whether the frontend attempts to backfill the root
+	// service/span name for search results that are missing it (shown as
+	// "<root span not yet received>") by fetching the trace by ID, which combines fragments
+	// across all blocks regardless of whether they were ever compacted together. This can happen
+	// permanently for a trace whose root span fragment lands in a different compaction window
+	// than the rest of the trace. 0 disables repair; a positive value enables it and caps how
+	// many traces per search response get a repair attempt, since each attempt is an extra round
+	// trip to fetch the trace by ID.
 	RepairRootSpanMaxTraces int `yaml:"repair_root_span_max_traces,omitempty"`
 }
 
@@ -131,7 +131,6 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(prefix string, f *flag.FlagSet)
 			MaxSpansPerSpanSet:     100,
 		},
 		SLO:                     slo,
-		RepairRootSpan:          true,
 		RepairRootSpanMaxTraces: 5,
 	}
 	cfg.TraceByID = TraceByIDConfig{

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -338,6 +338,8 @@ query_frontend:
         most_recent_shards: 200
         default_spans_per_span_set: 3
         max_spans_per_span_set: 100
+        repair_root_span: true
+        repair_root_span_max_traces: 5
     trace_by_id:
         query_shards: 50
         blocks_per_shard: 30

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -338,7 +338,6 @@ query_frontend:
         most_recent_shards: 200
         default_spans_per_span_set: 3
         max_spans_per_span_set: 100
-        repair_root_span: true
         repair_root_span_max_traces: 5
     trace_by_id:
         query_shards: 50

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -240,7 +240,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	traces := newTraceIDHandler(cfg, tracePipeline, o, combiner.NewTypedTraceByID, logger, dataAccessController)
 	tracesV2 := newTraceIDV2Handler(cfg, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
 	traceDiff := newTraceDiffHandler(cfg, apiPrefix, tracePipeline, o, combiner.NewTypedTraceByIDV2, cacheProvider, logger, dataAccessController)
-	search := newSearchHTTPHandler(cfg, searchPipeline, o, logger, dataAccessController)
+	search := newSearchHTTPHandler(cfg, searchPipeline, tracePipeline, apiPrefix, o, logger, dataAccessController)
 	searchTags := newTagsHTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagsV2 := newTagsV2HTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagValues := newTagValuesHTTPHandler(cfg, searchTagValuesPipeline, o, logger, dataAccessController)
@@ -262,7 +262,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 		MetricsQueryRangeHandler:   newHandler(cfg.Config.LogQueryRequestHeaders, queryRange, logger),
 
 		// grpc/streaming
-		streamingSearch:       newSearchStreamingGRPCHandler(cfg, searchPipeline, apiPrefix, o, logger, dataAccessController),
+		streamingSearch:       newSearchStreamingGRPCHandler(cfg, searchPipeline, tracePipeline, apiPrefix, o, logger, dataAccessController),
 		streamingTags:         newTagsStreamingGRPCHandler(cfg, searchTagsPipeline, apiPrefix, o, logger, dataAccessController),
 		streamingTagsV2:       newTagsV2StreamingGRPCHandler(cfg, searchTagsPipeline, apiPrefix, o, logger, dataAccessController),
 		streamingTagValues:    newTagValuesStreamingGRPCHandler(cfg, searchTagValuesPipeline, apiPrefix, o, logger, dataAccessController),

--- a/modules/frontend/pipeline/responses_test.go
+++ b/modules/frontend/pipeline/responses_test.go
@@ -312,7 +312,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					bridge := &pipelineBridge{
 						next: tc.finalRT(cancel),
 					}
-					httpCollector := NewHTTPCollector(sharder{next: bridge}, 0, combiner.NewSearch(0, false, api.HeaderAcceptJSON, false))
+					httpCollector := NewHTTPCollector(sharder{next: bridge}, 0, combiner.NewSearch(0, false, api.HeaderAcceptJSON, false, nil, 0))
 
 					_, _ = httpCollector.RoundTrip(req)
 
@@ -336,7 +336,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					bridge := &pipelineBridge{
 						next: tc.finalRT(cancel),
 					}
-					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
+					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](sharder{next: bridge}, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false, nil, 0), func(_ *tempopb.SearchResponse) error { return nil })
 
 					_ = grpcCollector.RoundTrip(req)
 
@@ -362,7 +362,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					}
 
 					s := sharder{next: sharder{next: bridge}, funcSharder: true}
-					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
+					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false, nil, 0), func(_ *tempopb.SearchResponse) error { return nil })
 
 					_ = grpcCollector.RoundTrip(req)
 
@@ -387,7 +387,7 @@ func TestAsyncResponsesDoesNotLeak(t *testing.T) {
 					}
 
 					s := sharder{next: sharder{next: bridge, funcSharder: true}}
-					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false), func(_ *tempopb.SearchResponse) error { return nil })
+					grpcCollector := NewGRPCCollector[*tempopb.SearchResponse](s, 0, 0, combiner.NewTypedSearch(0, false, api.HeaderAcceptJSON, false, nil, 0), func(_ *tempopb.SearchResponse) error { return nil })
 
 					_ = grpcCollector.RoundTrip(req)
 

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -26,7 +26,7 @@ import (
 )
 
 // newSearchStreamingGRPCHandler returns a handler that streams results from the HTTP handler
-func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) streamingSearchHandler {
+func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) streamingSearchHandler {
 	postSLOHook := searchSLOPostHook(cfg.Search.SLO)
 	downstreamPath := path.Join(apiPrefix, api.PathSearch)
 
@@ -59,7 +59,12 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 		tenant, _ := user.ExtractOrgID(ctx)
 		start := time.Now()
 
-		comb, err := newCombiner(req, cfg.Search.Sharder, api.MarshallingFormatProtobuf, o.LeftPadTraceIDs(tenant))
+		var repair combiner.RootSpanRepairFunc
+		if cfg.Search.RepairRootSpan {
+			repair = newRootSpanRepairFunc(ctx, tenant, headers, apiPrefix, tracePipeline, o, dataAccessController, logger)
+		}
+
+		comb, err := newCombiner(req, cfg.Search.Sharder, api.MarshallingFormatProtobuf, o.LeftPadTraceIDs(tenant), repair, cfg.Search.RepairRootSpanMaxTraces)
 		if err != nil {
 			level.Error(logger).Log("msg", "search streaming: could not create combiner", "err", err)
 			return status.Error(codes.InvalidArgument, err.Error())
@@ -87,7 +92,7 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 }
 
 // newSearchHTTPHandler returns a handler that returns a single response from the HTTP handler
-func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.PipelineResponse], tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], apiPrefix string, o overrides.Interface, logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
 	postSLOHook := searchSLOPostHook(cfg.Search.SLO)
 
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
@@ -116,7 +121,12 @@ func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 		// check marshalling format
 		marshallingFormat := api.MarshalingFormatFromAcceptHeader(req.Header)
 
-		comb, err := newCombiner(searchReq, cfg.Search.Sharder, marshallingFormat, o.LeftPadTraceIDs(tenant))
+		var repair combiner.RootSpanRepairFunc
+		if cfg.Search.RepairRootSpan {
+			repair = newRootSpanRepairFunc(req.Context(), tenant, req.Header, apiPrefix, tracePipeline, o, dataAccessController, logger)
+		}
+
+		comb, err := newCombiner(searchReq, cfg.Search.Sharder, marshallingFormat, o.LeftPadTraceIDs(tenant), repair, cfg.Search.RepairRootSpanMaxTraces)
 		if err != nil {
 			level.Error(logger).Log("msg", "search: could not create combiner", "err", err)
 			return httpInvalidRequest(err), nil
@@ -143,7 +153,7 @@ func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 	})
 }
 
-func newCombiner(req *tempopb.SearchRequest, cfg SearchSharderConfig, marshalingFormat api.MarshallingFormat, padTraceIDs bool) (combiner.GRPCCombiner[*tempopb.SearchResponse], error) {
+func newCombiner(req *tempopb.SearchRequest, cfg SearchSharderConfig, marshalingFormat api.MarshallingFormat, padTraceIDs bool, repair combiner.RootSpanRepairFunc, maxRepairs int) (combiner.GRPCCombiner[*tempopb.SearchResponse], error) {
 	limit, err := adjustLimit(req.Limit, cfg.DefaultLimit, cfg.MaxLimit)
 	if err != nil {
 		return nil, err
@@ -162,7 +172,7 @@ func newCombiner(req *tempopb.SearchRequest, cfg SearchSharderConfig, marshaling
 		}
 	}
 
-	return combiner.NewTypedSearch(int(limit), mostRecent, marshalingFormat, padTraceIDs), nil
+	return combiner.NewTypedSearch(int(limit), mostRecent, marshalingFormat, padTraceIDs, repair, maxRepairs), nil
 }
 
 // adjusts the limit based on provided config

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -60,7 +60,7 @@ func newSearchStreamingGRPCHandler(cfg Config, next pipeline.AsyncRoundTripper[c
 		start := time.Now()
 
 		var repair combiner.RootSpanRepairFunc
-		if cfg.Search.RepairRootSpan {
+		if cfg.Search.RepairRootSpanMaxTraces > 0 {
 			repair = newRootSpanRepairFunc(ctx, tenant, headers, apiPrefix, tracePipeline, o, dataAccessController, logger)
 		}
 
@@ -122,7 +122,7 @@ func newSearchHTTPHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.P
 		marshallingFormat := api.MarshalingFormatFromAcceptHeader(req.Header)
 
 		var repair combiner.RootSpanRepairFunc
-		if cfg.Search.RepairRootSpan {
+		if cfg.Search.RepairRootSpanMaxTraces > 0 {
 			repair = newRootSpanRepairFunc(req.Context(), tenant, req.Header, apiPrefix, tracePipeline, o, dataAccessController, logger)
 		}
 

--- a/modules/frontend/search_root_repair.go
+++ b/modules/frontend/search_root_repair.go
@@ -27,6 +27,9 @@ const rootSpanServiceNameKey = "service.name"
 // fetch can't hold up an otherwise-complete search response.
 const rootSpanRepairTimeout = 2 * time.Second
 
+// urlParamTraceID is the mux var / log key name used for a trace ID, matching api.urlParamTraceID.
+const urlParamTraceID = "traceID"
+
 // newRootSpanRepairFunc builds a combiner.RootSpanRepairFunc that resolves a trace's root
 // service/span name by fetching it by ID through the same trace pipeline used to serve
 // /api/v2/traces/{traceID}. That path combines every block containing the trace ID regardless
@@ -50,7 +53,7 @@ func newRootSpanRepairFunc(ctx context.Context, tenant string, headers http.Head
 
 		resps, err := tracePipeline.RoundTrip(pipeline.NewHTTPRequest(req))
 		if err != nil {
-			level.Warn(logger).Log("msg", "search: root span repair failed to fetch trace", "traceID", traceID, "err", err)
+			level.Warn(logger).Log("msg", "search: root span repair failed to fetch trace", urlParamTraceID, traceID, "err", err)
 			return "", "", false
 		}
 
@@ -58,12 +61,12 @@ func newRootSpanRepairFunc(ctx context.Context, tenant string, headers http.Head
 		for {
 			resp, done, err := resps.Next(repairCtx)
 			if err != nil {
-				level.Warn(logger).Log("msg", "search: root span repair failed to read trace response", "traceID", traceID, "err", err)
+				level.Warn(logger).Log("msg", "search: root span repair failed to read trace response", urlParamTraceID, traceID, "err", err)
 				return "", "", false
 			}
 			if resp != nil {
 				if err := comb.AddResponse(resp); err != nil {
-					level.Warn(logger).Log("msg", "search: root span repair failed to combine trace response", "traceID", traceID, "err", err)
+					level.Warn(logger).Log("msg", "search: root span repair failed to combine trace response", urlParamTraceID, traceID, "err", err)
 					return "", "", false
 				}
 			}
@@ -99,7 +102,7 @@ func buildRootSpanRepairRequest(ctx context.Context, apiPrefix string, traceID s
 	}).WithContext(ctx)
 	req.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
 
-	return mux.SetURLVars(req, map[string]string{"traceID": traceID})
+	return mux.SetURLVars(req, map[string]string{urlParamTraceID: traceID})
 }
 
 // rootSpanFromTrace finds the span with no parent and the earliest start time, mirroring how

--- a/modules/frontend/search_root_repair.go
+++ b/modules/frontend/search_root_repair.go
@@ -1,0 +1,144 @@
+package frontend
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level" //nolint:all //deprecated
+	"github.com/gorilla/mux"
+
+	"github.com/grafana/tempo/modules/frontend/combiner"
+	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1_resource "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+)
+
+// rootSpanServiceNameKey mirrors the "service.name" resource attribute used everywhere else in
+// Tempo to identify a resource's service (see e.g. vparquet5's LabelServiceName).
+const rootSpanServiceNameKey = "service.name"
+
+// rootSpanRepairTimeout bounds a single repair lookup so that a slow or unlucky trace-by-ID
+// fetch can't hold up an otherwise-complete search response.
+const rootSpanRepairTimeout = 2 * time.Second
+
+// newRootSpanRepairFunc builds a combiner.RootSpanRepairFunc that resolves a trace's root
+// service/span name by fetching it by ID through the same trace pipeline used to serve
+// /api/v2/traces/{traceID}. That path combines every block containing the trace ID regardless
+// of whether those blocks were ever compacted together, which is why opening a trace directly
+// always shows the root span even when TraceQL search can't.
+func newRootSpanRepairFunc(ctx context.Context, tenant string, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, dataAccessController DataAccessController, logger log.Logger) combiner.RootSpanRepairFunc {
+	return func(traceID string) (serviceName, spanName string, ok bool) {
+		repairCtx, cancel := context.WithTimeout(ctx, rootSpanRepairTimeout)
+		defer cancel()
+
+		req := buildRootSpanRepairRequest(repairCtx, apiPrefix, traceID, headers)
+
+		var traceRedactor combiner.TraceRedactor
+		if dataAccessController != nil {
+			redactor, err := dataAccessController.HandleHTTPTraceByIDReq(req)
+			if err != nil {
+				return "", "", false
+			}
+			traceRedactor = redactor
+		}
+
+		resps, err := tracePipeline.RoundTrip(pipeline.NewHTTPRequest(req))
+		if err != nil {
+			level.Warn(logger).Log("msg", "search: root span repair failed to fetch trace", "traceID", traceID, "err", err)
+			return "", "", false
+		}
+
+		comb := combiner.NewTypedTraceByIDV2(o.MaxBytesPerTrace(tenant), api.MarshallingFormatProtobuf, traceRedactor, combiner.TraceByIDV2Options{})
+		for {
+			resp, done, err := resps.Next(repairCtx)
+			if err != nil {
+				level.Warn(logger).Log("msg", "search: root span repair failed to read trace response", "traceID", traceID, "err", err)
+				return "", "", false
+			}
+			if resp != nil {
+				if err := comb.AddResponse(resp); err != nil {
+					level.Warn(logger).Log("msg", "search: root span repair failed to combine trace response", "traceID", traceID, "err", err)
+					return "", "", false
+				}
+			}
+			if comb.ShouldQuit() || done {
+				break
+			}
+		}
+
+		traceResp, err := comb.GRPCFinal()
+		if err != nil || traceResp == nil {
+			return "", "", false
+		}
+
+		return rootSpanFromTrace(traceResp.Trace)
+	}
+}
+
+func buildRootSpanRepairRequest(ctx context.Context, apiPrefix string, traceID string, headers http.Header) *http.Request {
+	u := &url.URL{
+		Path: path.Join(apiPrefix, "/api/v2/traces", traceID),
+	}
+
+	reqHeaders := headers.Clone()
+	if reqHeaders == nil {
+		reqHeaders = http.Header{}
+	}
+
+	req := (&http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Header: reqHeaders,
+		Body:   http.NoBody,
+	}).WithContext(ctx)
+	req.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
+
+	return mux.SetURLVars(req, map[string]string{"traceID": traceID})
+}
+
+// rootSpanFromTrace finds the span with no parent and the earliest start time, mirroring how
+// blocks determine a trace's root span at write time (see traceToParquetWithMapping).
+func rootSpanFromTrace(trace *tempopb.Trace) (serviceName, spanName string, ok bool) {
+	if trace == nil {
+		return "", "", false
+	}
+
+	var earliestStart uint64
+	for _, rs := range trace.ResourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			for _, s := range ss.Spans {
+				if len(s.ParentSpanId) != 0 {
+					continue
+				}
+				if ok && s.StartTimeUnixNano >= earliestStart {
+					continue
+				}
+
+				spanName = s.Name
+				serviceName = resourceServiceName(rs.Resource)
+				earliestStart = s.StartTimeUnixNano
+				ok = true
+			}
+		}
+	}
+
+	return serviceName, spanName, ok
+}
+
+func resourceServiceName(res *v1_resource.Resource) string {
+	if res == nil {
+		return ""
+	}
+	for _, a := range res.Attributes {
+		if a.Key == rootSpanServiceNameKey {
+			return a.Value.GetStringValue()
+		}
+	}
+	return ""
+}

--- a/modules/frontend/search_root_repair_test.go
+++ b/modules/frontend/search_root_repair_test.go
@@ -1,0 +1,106 @@
+package frontend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+func resourceWithServiceName(name string) *resourcev1.Resource {
+	return &resourcev1.Resource{
+		Attributes: []*commonv1.KeyValue{
+			{Key: "service.name", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: name}}},
+		},
+	}
+}
+
+func TestRootSpanFromTrace(t *testing.T) {
+	t.Run("nil trace", func(t *testing.T) {
+		svc, name, ok := rootSpanFromTrace(nil)
+		require.False(t, ok)
+		require.Empty(t, svc)
+		require.Empty(t, name)
+	})
+
+	t.Run("no root span", func(t *testing.T) {
+		trace := &tempopb.Trace{
+			ResourceSpans: []*tracev1.ResourceSpans{
+				{
+					Resource: resourceWithServiceName("router"),
+					ScopeSpans: []*tracev1.ScopeSpans{
+						{Spans: []*tracev1.Span{
+							{Name: "egress", ParentSpanId: []byte{1}, StartTimeUnixNano: 100},
+						}},
+					},
+				},
+			},
+		}
+
+		svc, name, ok := rootSpanFromTrace(trace)
+		require.False(t, ok)
+		require.Empty(t, svc)
+		require.Empty(t, name)
+	})
+
+	t.Run("finds root span with empty parent", func(t *testing.T) {
+		trace := &tempopb.Trace{
+			ResourceSpans: []*tracev1.ResourceSpans{
+				{
+					Resource: resourceWithServiceName("router"),
+					ScopeSpans: []*tracev1.ScopeSpans{
+						{Spans: []*tracev1.Span{
+							{Name: "egress", ParentSpanId: []byte{1}, StartTimeUnixNano: 200},
+						}},
+					},
+				},
+				{
+					Resource: resourceWithServiceName("envoy"),
+					ScopeSpans: []*tracev1.ScopeSpans{
+						{Spans: []*tracev1.Span{
+							{Name: "ingress", ParentSpanId: nil, StartTimeUnixNano: 100},
+						}},
+					},
+				},
+			},
+		}
+
+		svc, name, ok := rootSpanFromTrace(trace)
+		require.True(t, ok)
+		require.Equal(t, "envoy", svc)
+		require.Equal(t, "ingress", name)
+	})
+
+	t.Run("multiple parentless spans picks the earliest", func(t *testing.T) {
+		trace := &tempopb.Trace{
+			ResourceSpans: []*tracev1.ResourceSpans{
+				{
+					Resource: resourceWithServiceName("late"),
+					ScopeSpans: []*tracev1.ScopeSpans{
+						{Spans: []*tracev1.Span{
+							{Name: "late-root", ParentSpanId: nil, StartTimeUnixNano: 500},
+						}},
+					},
+				},
+				{
+					Resource: resourceWithServiceName("early"),
+					ScopeSpans: []*tracev1.ScopeSpans{
+						{Spans: []*tracev1.Span{
+							{Name: "early-root", ParentSpanId: nil, StartTimeUnixNano: 100},
+						}},
+					},
+				},
+			},
+		}
+
+		svc, name, ok := rootSpanFromTrace(trace)
+		require.True(t, ok)
+		require.Equal(t, "early", svc)
+		require.Equal(t, "early-root", name)
+	})
+}


### PR DESCRIPTION
A trace's root span can be flushed to a block that never gets compacted with the rest of the trace (compaction groups blocks into fixed hourly windows), permanently leaving the block's RootServiceName/RootSpanName empty even though the full trace is intact. Search then shows "<root span not yet received>" forever, while trace-by-ID works fine because it combines every block containing the trace ID unconditionally.

When a search result is still missing root info after combining all shards, the query-frontend now does a bounded trace-by-ID lookup (same path as opening the trace) to backfill it, capped by the new repair_root_span_max_traces option (default 5) and gated by repair_root_span (default true).

Fixes #7494


**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)