### PR TITLE
fix: merge per-tenant runtime overrides with defaults per section

### DIFF
--- a/.chloggen/fix_per-tenant-override-defaults.yaml
+++ b/.chloggen/fix_per-tenant-override-defaults.yaml
@@ -1,0 +1,24 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: overrides
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: per-tenant runtime overrides that set only one top-level section (e.g. `compaction`) no longer reset every other section for that tenant to zero instead of inheriting `overrides.defaults`
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  Per-tenant overrides now merge with defaults at the top-level section granularity (ingestion,
+  read, compaction, metrics_generator, global, storage, cost_attribution, forwarders): a section
+  a tenant's block doesn't mention now inherits fully from `overrides.defaults`.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: elinacse

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2716,7 +2716,9 @@ overrides:
       [max_bytes_per_trace: <int>]
 ```
 
-When a tenant matches a per-tenant override entry, Tempo doesn't merge that entry field-by-field with `defaults`. Most fields require you to set every value a tenant needs within its own block (some settings, such as `ingestion.rate_strategy`, always use `defaults`). A few metrics-generator fields fall back to `defaults` when unset, but most, including `processors` and `remote_write_headers`, don't.
+When a tenant matches a per-tenant override entry, Tempo merges it with `defaults` one top-level section at a time (`ingestion`, `read`, `compaction`, `metrics_generator`, `global`, `storage`, `cost_attribution`, and `forwarders`). A section the tenant's block doesn't mention at all inherits entirely from `defaults` — for example, overriding only `compaction.block_retention` for a tenant doesn't affect that tenant's `ingestion` limits, which continue to come from `defaults`.
+
+Within a section the tenant's block *does* mention, however, you still need to set every field that section needs: fields left out of an explicitly-set section reset to their zero value rather than falling back to `defaults` (some settings, such as `ingestion.rate_strategy`, always use `defaults` regardless). A few `metrics_generator` fields are further exceptions and always fall back to `defaults` when zero: `native_histogram_bucket_factor`, `native_histogram_max_bucket_number`, `native_histogram_min_reset_duration`, and `span_name_sanitization`.
 
 For a complete per-tenant `metrics_generator` example, including `remote_write_headers` for per-tenant authentication and environment variable expansion, refer to [Multi-tenancy support](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-generator/multitenancy/).
 

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2716,7 +2716,8 @@ overrides:
       [max_bytes_per_trace: <int>]
 ```
 
-When a tenant matches a per-tenant override entry, Tempo merges it with `defaults` one top-level section at a time (`ingestion`, `read`, `compaction`, `metrics_generator`, `global`, `storage`, `cost_attribution`, and `forwarders`). A section the tenant's block doesn't mention at all inherits entirely from `defaults` — for example, overriding only `compaction.block_retention` for a tenant doesn't affect that tenant's `ingestion` limits, which continue to come from `defaults`.
+When a tenant matches a per-tenant override entry, Tempo merges it with `defaults` one top-level section at a time (`ingestion`, `read`, `compaction`, `metrics_generator`, `global`, `storage`, `cost_attribution`, and `forwarders`). A section the tenant's block doesn't mention at all inherits entirely from `defaults`. 
+For example, overriding only `compaction.block_retention` for a tenant doesn't affect that tenant's `ingestion` limits, which continue to come from `defaults`.
 
 Within a section the tenant's block *does* mention, however, you still need to set every field that section needs: fields left out of an explicitly-set section reset to their zero value rather than falling back to `defaults` (some settings, such as `ingestion.rate_strategy`, always use `defaults` regardless). A few `metrics_generator` fields are further exceptions and always fall back to `defaults` when zero: `native_histogram_bucket_factor`, `native_histogram_max_bucket_number`, `native_histogram_min_reset_duration`, and `span_name_sanitization`.
 

--- a/modules/overrides/overrides_test.go
+++ b/modules/overrides/overrides_test.go
@@ -81,7 +81,7 @@ func TestPerTenantLegacyOverridesDisabledByDefault(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			loader := loadPerTenantOverrides(&mockValidator{}, ConfigTypeNew, false, tc.enableLegacy)
+			loader := loadPerTenantOverrides(nil, &mockValidator{}, ConfigTypeNew, false, tc.enableLegacy)
 			result, err := loader(bytes.NewReader(buff))
 			if tc.expectErr != "" {
 				require.Error(t, err)

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/drone/envsubst"
@@ -34,6 +35,13 @@ type perTenantOverrides struct {
 	TenantLimits map[string]*Overrides `yaml:"overrides"`
 
 	ConfigType ConfigType `yaml:"-"` // ConfigType is the type of overrides config we are using: legacy or new
+
+	// defaults, when set, seeds each tenant's Overrides before applying whatever fields are
+	// explicitly present in that tenant's YAML block, so fields the tenant doesn't mention
+	// inherit the global default value instead of the Go zero value. nil seeds with a zero
+	// Overrides{}, matching the previous behavior — used by UnmarshalPerTenantOverrides, which
+	// has no live default limits to merge against (it's a format-conversion helper for tempo-cli).
+	defaults *Overrides `yaml:"-"`
 }
 
 func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -46,6 +54,11 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	err := unmarshal((*rawConfig)(o))
 	if err == nil {
 		o.ConfigType = ConfigTypeNew
+		if o.defaults != nil {
+			if err := o.applyDefaults(unmarshal); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 	if isExtensionError(err) || !isLegacyExtensionKeyError(err) {
@@ -60,6 +73,108 @@ func (o *perTenantOverrides) UnmarshalYAML(unmarshal func(interface{}) error) er
 	*o = legacyConfig.toNewOverrides()
 	o.ConfigType = ConfigTypeLegacy
 	return nil
+}
+
+// applyDefaults fills in, for every tenant already decoded into o.TenantLimits, whichever
+// top-level sections that tenant's YAML block didn't explicitly mention, using o.defaults for
+// those. Without this, a tenant that overrides e.g. only "compaction" would otherwise have every
+// other section (ingestion, read, ...) reset to the Go zero value instead of inheriting the
+// configured global default — see https://github.com/grafana/tempo/issues/7238.
+//
+// Section presence is determined by re-decoding the same document (the unmarshal closure decodes
+// the same underlying YAML node each time it's called, same as the legacy-format fallback above)
+// into a raw key-only shape, since by the time a tenant's block is fully decoded into *Overrides
+// there's no way to distinguish "explicitly set to the zero value" from "not mentioned at all".
+func (o *perTenantOverrides) applyDefaults(unmarshal func(interface{}) error) error {
+	var raw struct {
+		TenantLimits map[string]map[string]interface{} `yaml:"overrides"`
+	}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	for tenant, decoded := range o.TenantLimits {
+		if decoded == nil {
+			// an empty/null tenant block (e.g. "user1:" with nothing under it) is handled by
+			// forUser's nil check, which falls back to the full default limits already.
+			continue
+		}
+		o.TenantLimits[tenant] = mergeOverridesSections(decoded, o.defaults, raw.TenantLimits[tenant])
+	}
+	return nil
+}
+
+// overridesSectionKeys are the top-level YAML keys of the Overrides struct, used to verify
+// mergeOverridesSections stays in sync with the struct — see the assertion in its test.
+var overridesSectionKeys = sync.OnceValue(func() map[string]struct{} {
+	return fieldNamesFor(Overrides{}, "yaml")
+})
+
+// mergeOverridesSections returns a new *Overrides built section by section: for each top-level
+// section present in the tenant's raw block (present), it keeps decoded's value (what the tenant
+// explicitly set); for every other section, it takes defaults' value instead of decoded's Go zero
+// value. This intentionally merges at section (struct-field) granularity, not per leaf field —
+// overriding one field within e.g. "compaction" takes over the whole compaction section, matching
+// how per-tenant overrides files are conventionally written (a full sub-block per changed area).
+//
+// Sections are copied by value assignment, never by mutating defaults in place, so it's safe even
+// though multiple tenants and reloads share the same *o.defaults instance.
+func mergeOverridesSections(decoded, defaults *Overrides, present map[string]interface{}) *Overrides {
+	merged := &Overrides{}
+
+	if _, ok := present["ingestion"]; ok {
+		merged.Ingestion = decoded.Ingestion
+	} else {
+		merged.Ingestion = defaults.Ingestion
+	}
+	if _, ok := present["read"]; ok {
+		merged.Read = decoded.Read
+	} else {
+		merged.Read = defaults.Read
+	}
+	if _, ok := present["compaction"]; ok {
+		merged.Compaction = decoded.Compaction
+	} else {
+		merged.Compaction = defaults.Compaction
+	}
+	if _, ok := present["metrics_generator"]; ok {
+		merged.MetricsGenerator = decoded.MetricsGenerator
+	} else {
+		merged.MetricsGenerator = defaults.MetricsGenerator
+	}
+	if _, ok := present["forwarders"]; ok {
+		merged.Forwarders = decoded.Forwarders
+	} else {
+		merged.Forwarders = defaults.Forwarders
+	}
+	if _, ok := present["global"]; ok {
+		merged.Global = decoded.Global
+	} else {
+		merged.Global = defaults.Global
+	}
+	if _, ok := present["storage"]; ok {
+		merged.Storage = decoded.Storage
+	} else {
+		merged.Storage = defaults.Storage
+	}
+	if _, ok := present["cost_attribution"]; ok {
+		merged.CostAttribution = decoded.CostAttribution
+	} else {
+		merged.CostAttribution = defaults.CostAttribution
+	}
+
+	// Extensions are keyed catch-all entries (yaml:",inline"), not a single named section, so
+	// they're merged key by key: the tenant's own entries win, everything else comes from
+	// defaults. maps.Clone gives merged its own map so nothing writes back into defaults.Extensions.
+	merged.Extensions = maps.Clone(defaults.Extensions)
+	for k, v := range decoded.Extensions {
+		if merged.Extensions == nil {
+			merged.Extensions = make(map[string]any, len(decoded.Extensions))
+		}
+		merged.Extensions[k] = v
+	}
+
+	return merged
 }
 
 // UnmarshalPerTenantOverrides parses a per-tenant overrides file, handling both legacy
@@ -82,11 +197,11 @@ func (o *perTenantOverrides) forUser(userID string) *Overrides {
 }
 
 // loadPerTenantOverrides is of type runtimeconfig.Loader
-func loadPerTenantOverrides(validator Validator, typ ConfigType, expandEnv bool, enableLegacy bool) func(r io.Reader) (interface{}, error) {
+func loadPerTenantOverrides(defaults *Overrides, validator Validator, typ ConfigType, expandEnv bool, enableLegacy bool) func(r io.Reader) (interface{}, error) {
 	// var is outside closure to ensure it's not recreated on each call
 	var lastLegacyWarn time.Time
 	return func(r io.Reader) (interface{}, error) {
-		overrides := &perTenantOverrides{}
+		overrides := &perTenantOverrides{defaults: defaults}
 
 		if expandEnv {
 			rr := r.(*bytes.Reader)
@@ -176,7 +291,7 @@ func newRuntimeConfigOverrides(cfg Config, validator Validator, registerer prome
 		runtimeCfg := runtimeconfig.Config{
 			LoadPath:     []string{cfg.PerTenantOverrideConfig},
 			ReloadPeriod: time.Duration(cfg.PerTenantOverridePeriod),
-			Loader:       loadPerTenantOverrides(validator, cfg.ConfigType, cfg.ExpandEnv, cfg.EnableLegacyOverrides),
+			Loader:       loadPerTenantOverrides(&cfg.Defaults, validator, cfg.ConfigType, cfg.ExpandEnv, cfg.EnableLegacyOverrides),
 		}
 		runtimeCfgMgr, err := runtimeconfig.New(runtimeCfg, "overrides", prometheus.WrapRegistererWithPrefix("tempo_", registerer), log.Logger)
 		if err != nil {

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -27,7 +27,7 @@ import (
 func TestRuntimeConfigOverrides_loadPerTenantOverrides(t *testing.T) {
 	validator := &mockValidator{}
 
-	loader := loadPerTenantOverrides(validator, ConfigTypeNew, false, false)
+	loader := loadPerTenantOverrides(nil, validator, ConfigTypeNew, false, false)
 
 	perTenantOverrides := perTenantOverrides{
 		TenantLimits: map[string]*Overrides{
@@ -745,10 +745,15 @@ func TestIngestionRetryInfoEnabled(t *testing.T) {
 }
 
 func TestMetricsGeneratorMaxCardinalityPerLabel(t *testing.T) {
+	// Fixtures use raw YAML text rather than a *perTenantOverrides Go value marshaled through
+	// toYamlBytes: MaxCardinalityPerLabel (and its enclosing MetricsGenerator section) both carry
+	// `omitempty`, so marshaling a struct that explicitly sets it to 0 would silently drop the
+	// field/section — indistinguishable from not setting it at all. Raw text preserves the
+	// explicit "0" in the input Tempo actually parses.
 	tests := []struct {
 		name               string
 		defaultLimits      Overrides
-		perTenantOverrides *perTenantOverrides
+		perTenantOverrides string
 		expected           map[string]uint64
 	}{
 		{
@@ -763,15 +768,12 @@ func TestMetricsGeneratorMaxCardinalityPerLabel(t *testing.T) {
 		{
 			name:          "default disabled, tenant enables",
 			defaultLimits: Overrides{},
-			perTenantOverrides: &perTenantOverrides{
-				TenantLimits: map[string]*Overrides{
-					"user1": {
-						MetricsGenerator: MetricsGeneratorOverrides{
-							MaxCardinalityPerLabel: 50,
-						},
-					},
-				},
-			},
+			perTenantOverrides: `
+overrides:
+  user1:
+    metrics_generator:
+      max_cardinality_per_label: 50
+`,
 			expected: map[string]uint64{"user1": 50, "user2": 0},
 		},
 		{
@@ -781,15 +783,12 @@ func TestMetricsGeneratorMaxCardinalityPerLabel(t *testing.T) {
 					MaxCardinalityPerLabel: 100,
 				},
 			},
-			perTenantOverrides: &perTenantOverrides{
-				TenantLimits: map[string]*Overrides{
-					"user1": {
-						MetricsGenerator: MetricsGeneratorOverrides{
-							MaxCardinalityPerLabel: 0,
-						},
-					},
-				},
-			},
+			perTenantOverrides: `
+overrides:
+  user1:
+    metrics_generator:
+      max_cardinality_per_label: 0
+`,
 			expected: map[string]uint64{"user1": 0, "user2": 100},
 		},
 		{
@@ -799,22 +798,23 @@ func TestMetricsGeneratorMaxCardinalityPerLabel(t *testing.T) {
 					MaxCardinalityPerLabel: 100,
 				},
 			},
-			perTenantOverrides: &perTenantOverrides{
-				TenantLimits: map[string]*Overrides{
-					"user1": {
-						MetricsGenerator: MetricsGeneratorOverrides{
-							MaxCardinalityPerLabel: 500,
-						},
-					},
-				},
-			},
+			perTenantOverrides: `
+overrides:
+  user1:
+    metrics_generator:
+      max_cardinality_per_label: 500
+`,
 			expected: map[string]uint64{"user1": 500, "user2": 100},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides, cleanup := createAndInitializeRuntimeOverridesManager(t, tt.defaultLimits, toYamlBytes(t, tt.perTenantOverrides))
+			var perTenantBytes []byte
+			if tt.perTenantOverrides != "" {
+				perTenantBytes = []byte(tt.perTenantOverrides)
+			}
+			overrides, cleanup := createAndInitializeRuntimeOverridesManager(t, tt.defaultLimits, perTenantBytes)
 			defer cleanup()
 
 			for user, expected := range tt.expected {
@@ -822,6 +822,64 @@ func TestMetricsGeneratorMaxCardinalityPerLabel(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestPerTenantOverridesInheritUnsetSections reproduces
+// https://github.com/grafana/tempo/issues/7238: a tenant overriding one section (compaction)
+// must still inherit every other section (ingestion, global, ...) from the configured global
+// defaults, instead of those sections silently resetting to the Go zero value.
+func TestPerTenantOverridesInheritUnsetSections(t *testing.T) {
+	defaultLimits := Overrides{
+		Global: GlobalOverrides{
+			MaxBytesPerTrace: 20_000_000,
+		},
+		Ingestion: IngestionOverrides{
+			RateStrategy:   GlobalIngestionRateStrategy,
+			BurstSizeBytes: 70_000_000,
+			RateLimitBytes: 60_000_000,
+		},
+	}
+
+	perTenant := `
+overrides:
+  productteam-xxx-team1:
+    compaction:
+      block_retention: 48h
+`
+
+	overrides, cleanup := createAndInitializeRuntimeOverridesManager(t, defaultLimits, []byte(perTenant))
+	defer cleanup()
+
+	const tenant = "productteam-xxx-team1"
+
+	// explicitly overridden
+	require.Equal(t, 48*time.Hour, overrides.BlockRetention(tenant))
+
+	// everything else must still come from the global defaults, not reset to zero
+	require.Equal(t, 70_000_000, overrides.IngestionBurstSizeBytes(tenant))
+	require.Equal(t, float64(60_000_000), overrides.IngestionRateLimitBytes(tenant))
+	require.Equal(t, 20_000_000, overrides.MaxBytesPerTrace(tenant))
+}
+
+// TestOverridesSectionKeysKnown guards mergeOverridesSections against silently ignoring a
+// newly-added top-level field on Overrides: if a new yaml-tagged field is added to Overrides
+// without also adding a case for it in mergeOverridesSections, that field would always take the
+// default value for every tenant regardless of what the tenant's override file says. This test
+// fails the moment overridesSectionKeys() (derived by reflection from Overrides' yaml tags) drifts
+// from this hardcoded list, which mergeOverridesSections' if-chain must be kept in sync with.
+func TestOverridesSectionKeysKnown(t *testing.T) {
+	knownSections := map[string]struct{}{
+		"ingestion":         {},
+		"read":              {},
+		"compaction":        {},
+		"metrics_generator": {},
+		"forwarders":        {},
+		"global":            {},
+		"storage":           {},
+		"cost_attribution":  {},
+	}
+
+	require.Equal(t, knownSections, overridesSectionKeys())
 }
 
 func createAndInitializeRuntimeOverridesManager(t *testing.T, defaultLimits Overrides, perTenantOverrides []byte) (Service, func()) {

--- a/tempodb/blockselector/compaction_block_selector.go
+++ b/tempodb/blockselector/compaction_block_selector.go
@@ -49,6 +49,17 @@ type timeWindowBlockEntry struct {
 var _ CompactionBlockSelector = (*timeWindowBlockSelector)(nil)
 
 func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRange time.Duration, maxCompactionObjects int, maxBlockBytes uint64, minInputBlocks, maxInputBlocks, maxCompactionLevel int) CompactionBlockSelector {
+	return newTimeWindowBlockSelector(blocklist, maxCompactionRange, maxCompactionObjects, maxBlockBytes, minInputBlocks, maxInputBlocks, maxCompactionLevel, time.Now())
+}
+
+// newTimeWindowBlockSelector takes "now" as an explicit parameter (rather than calling time.Now()
+// itself) so tests can pass a fixed value. Blocks are windowed relative to now, so if a caller
+// computed its own "now" for building expectations and this function computed a second,
+// independent time.Now(), the two could land in different windows whenever real time ticks over
+// a window boundary between the two calls — flaky by construction, especially with the small
+// window sizes tests use. NewTimeWindowBlockSelector's production callers are unaffected: they
+// only ever call it once and don't compare against a separately-captured "now".
+func newTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRange time.Duration, maxCompactionObjects int, maxBlockBytes uint64, minInputBlocks, maxInputBlocks, maxCompactionLevel int, now time.Time) CompactionBlockSelector {
 	twbs := &timeWindowBlockSelector{
 		MinInputBlocks:       minInputBlocks,
 		MaxInputBlocks:       maxInputBlocks,
@@ -58,7 +69,6 @@ func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRan
 		MaxCompactionLevel:   uint32(maxCompactionLevel),
 	}
 
-	now := time.Now()
 	currWindow := twbs.windowForTime(now)
 	activeWindow := twbs.windowForTime(now.Add(-activeWindowDuration))
 

--- a/tempodb/blockselector/compaction_block_selector_test.go
+++ b/tempodb/blockselector/compaction_block_selector_test.go
@@ -915,7 +915,11 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				maxLevel = tt.maxCompactionLevel
 			}
 
-			selector := NewTimeWindowBlockSelector(tt.blocklist, time.Second, 100, maxSize, minBlocks, maxBlocks, maxLevel)
+			// Use the same "now" the test fixtures above were built from (rather than
+			// NewTimeWindowBlockSelector's own time.Now()) so windowing is deterministic: with
+			// a 1-second window, two independent time.Now() calls can straddle a window
+			// boundary and flake, particularly for the "last active window" cutoff case.
+			selector := newTimeWindowBlockSelector(tt.blocklist, time.Second, 100, maxSize, minBlocks, maxBlocks, maxLevel, now)
 
 			actual, hash := selector.BlocksToCompact()
 			assert.Equal(t, tt.expected, actual)


### PR DESCRIPTION
A tenant with any per-tenant override entry got that entry back wholesale from forUser(), completely bypassing overrides.defaults for that tenant instead of just for the fields the tenant actually set. Overriding only compaction.block_retention, for example, silently reset ingestion.rate_limit_bytes/burst_size_bytes to zero, rejecting all traffic for that tenant.

Per-tenant overrides now merge with defaults at top-level section granularity (ingestion, read, compaction, metrics_generator, global, storage, cost_attribution, forwarders): a section a tenant's block doesn't mention now inherits fully from defaults, matching how override files are conventionally written. Extensions merge key by key since each is its own mini-section.

Sections are always either the shared defaults reference (read-only) or the tenant's independently-decoded value, never merged in place, to avoid corrupting redacted secret fields or shared map state.

Fixes #7238

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)