### PR TITLE
Skip predicate evaluation while seeking parquet iterators to a target row

### DIFF
--- a/.chloggen/synciterator-seek-skip-filter.yaml
+++ b/.chloggen/synciterator-seek-skip-filter.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: querier
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Skip predicate evaluation for values scanned past during parquet iterator seeks, speeding up TraceQL join queries.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mapno

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -612,7 +612,14 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 	if !rn.Valid() {
 		return nil, nil
 	}
-	return c.makeResult(rn, v), nil
+
+	if c.filter == nil || c.filter.KeepValue(*v) {
+		return c.makeResult(rn, v), nil
+	}
+
+	// The value at the seek target didn't pass the filter, continue as a
+	// normal filtered read.
+	return c.Next()
 }
 
 func (c *SyncIterator) popRowGroup() (pq.RowGroup, RowNumber, RowNumber) {
@@ -827,10 +834,11 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 	}
 }
 
-// nextSeek is like next but for use while seeking: values before the seek
-// target are discarded without evaluating the filter, since SeekTo drops
-// them regardless of the filter's decision. Values at or past the target are
-// filtered as usual.
+// nextSeek is like next but for use while seeking: it returns the first
+// value at or past the seek target without evaluating the filter. Values
+// before the target are discarded unfiltered, since SeekTo drops them
+// regardless of the filter's decision. The caller is responsible for
+// filtering the returned value.
 func (c *SyncIterator) nextSeek(to RowNumber, definitionLevel int) (RowNumber, *pq.Value, error) {
 	for {
 		// Consume current buffer until empty
@@ -844,10 +852,6 @@ func (c *SyncIterator) nextSeek(to RowNumber, definitionLevel int) (RowNumber, *
 			c.currPageN++
 
 			if CompareRowNumbers(definitionLevel, c.curr, to) < 0 {
-				continue
-			}
-
-			if c.filter != nil && !c.filter.KeepValue(*v) {
 				continue
 			}
 

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -806,8 +806,8 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 // Next() is because it doesn't wrap the results in an IteratorResult, which is more efficient
 // when being called multiple times and throwing away the results like in SeekTo().
 //
-// If seekTo is non-nil, values before it are discarded without evaluating
-// the filter, since SeekTo drops them regardless of the filter's decision.
+// If seekTo is non-nil, values before it are discarded without evaluating the filter,
+// since SeekTo drops them regardless of the filter's decision.
 func (c *SyncIterator) next(seekTo *RowNumber, definitionLevel int) (RowNumber, *pq.Value, error) {
 	seeking := seekTo != nil
 	if seeking {
@@ -892,8 +892,8 @@ func (c *SyncIterator) next(seekTo *RowNumber, definitionLevel int) (RowNumber, 
 	}
 }
 
-// beforeSeekTarget returns true if the iterator's current position is before
-// the seek target. It compares the row numbers in place and is inlineable,
+// beforeSeekTarget returns true if the iterator's current position is before the seek target.
+// It compares the row numbers in place and is inlineable,
 // which keeps the hot loop in next() free of 32-byte RowNumber copies.
 func (c *SyncIterator) beforeSeekTarget() bool {
 	for i := 0; i <= c.seekDefinitionLevel; i++ {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -605,19 +605,14 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 
 	// The row group and page have been selected to where this value is possibly
 	// located. Now scan through the page and look for it.
-	for {
-		rn, v, err := c.next()
-		if err != nil {
-			return nil, err
-		}
-		if !rn.Valid() {
-			return nil, nil
-		}
-
-		if CompareRowNumbers(definitionLevel, rn, to) >= 0 {
-			return c.makeResult(rn, v), nil
-		}
+	rn, v, err := c.nextSeek(to, definitionLevel)
+	if err != nil {
+		return nil, err
 	}
+	if !rn.Valid() {
+		return nil, nil
+	}
+	return c.makeResult(rn, v), nil
 }
 
 func (c *SyncIterator) popRowGroup() (pq.RowGroup, RowNumber, RowNumber) {
@@ -807,10 +802,75 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 // when being called multiple times and throwing away the results like in SeekTo().
 func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 	for {
+		// Consume current buffer until empty
+		for c.currBufN < len(c.currBuf) {
+			v := &c.currBuf[c.currBufN]
+
+			// Inspect all values to track the current row number,
+			// even if the value is filtered out next.
+			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
+			c.currBufN++
+			c.currPageN++
+
+			if c.filter != nil && !c.filter.KeepValue(*v) {
+				continue
+			}
+
+			return c.curr, v, nil
+		}
+
+		// Buffer exhausted, refill it, advancing pages and row groups as needed.
+		ok, err := c.fill()
+		if !ok || err != nil {
+			return EmptyRowNumber(), nil, err
+		}
+	}
+}
+
+// nextSeek is like next but for use while seeking: values before the seek
+// target are discarded without evaluating the filter, since SeekTo drops
+// them regardless of the filter's decision. Values at or past the target are
+// filtered as usual.
+func (c *SyncIterator) nextSeek(to RowNumber, definitionLevel int) (RowNumber, *pq.Value, error) {
+	for {
+		// Consume current buffer until empty
+		for c.currBufN < len(c.currBuf) {
+			v := &c.currBuf[c.currBufN]
+
+			// Inspect all values to track the current row number,
+			// even if the value is filtered out next.
+			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
+			c.currBufN++
+			c.currPageN++
+
+			if CompareRowNumbers(definitionLevel, c.curr, to) < 0 {
+				continue
+			}
+
+			if c.filter != nil && !c.filter.KeepValue(*v) {
+				continue
+			}
+
+			return c.curr, v, nil
+		}
+
+		// Buffer exhausted, refill it, advancing pages and row groups as needed.
+		ok, err := c.fill()
+		if !ok || err != nil {
+			return EmptyRowNumber(), nil, err
+		}
+	}
+}
+
+// fill ensures the current buffer contains unconsumed values, advancing to
+// the next page and row group as needed. It returns false when the iterator
+// is exhausted.
+func (c *SyncIterator) fill() (bool, error) {
+	for c.currBuf == nil || c.currBufN >= len(c.currBuf) {
 		if c.currRowGroup == nil {
 			rg, minRN, maxRN := c.popRowGroup()
 			if rg == nil {
-				return EmptyRowNumber(), nil, nil
+				return false, nil
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
@@ -825,7 +885,7 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 		if c.currPage == nil {
 			pg, err := c.currChunk.NextPage()
 			if err != nil && !errors.Is(err, io.EOF) {
-				return EmptyRowNumber(), nil, err
+				return false, err
 			}
 			if pg == nil || errors.Is(err, io.EOF) {
 				// This row group is exhausted
@@ -845,38 +905,21 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 		if c.currBuf == nil {
 			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
 		}
-		if c.currBufN >= len(c.currBuf) || len(c.currBuf) == 0 {
-			c.currBuf = c.currBuf[:cap(c.currBuf)]
-			n, err := c.currValues.ReadValues(c.currBuf)
-			if err != nil && !errors.Is(err, io.EOF) {
-				return EmptyRowNumber(), nil, err
-			}
-			c.currBuf = c.currBuf[:n]
-			c.currBufN = 0
-			if n == 0 {
-				// This value reader and page are exhausted.
-				c.setPage(nil)
-				continue
-			}
+		c.currBuf = c.currBuf[:cap(c.currBuf)]
+		n, err := c.currValues.ReadValues(c.currBuf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, err
 		}
-
-		// Consume current buffer until empty
-		for c.currBufN < len(c.currBuf) {
-			v := &c.currBuf[c.currBufN]
-
-			// Inspect all values to track the current row number,
-			// even if the value is filtered out next.
-			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
-			c.currBufN++
-			c.currPageN++
-
-			if c.filter != nil && !c.filter.KeepValue(*v) {
-				continue
-			}
-
-			return c.curr, v, nil
+		c.currBuf = c.currBuf[:n]
+		c.currBufN = 0
+		if n == 0 {
+			// This value reader and page are exhausted.
+			c.setPage(nil)
+			continue
 		}
 	}
+
+	return true, nil
 }
 
 func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *ColumnChunkHelper) {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -816,6 +816,59 @@ func (c *SyncIterator) next(seekTo *RowNumber, definitionLevel int) (RowNumber, 
 	}
 
 	for {
+		if c.currRowGroup == nil {
+			rg, minRN, maxRN := c.popRowGroup()
+			if rg == nil {
+				return EmptyRowNumber(), nil, nil
+			}
+
+			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
+			if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
+				cc.Close()
+				continue
+			}
+
+			c.setRowGroup(rg, minRN, maxRN, cc)
+		}
+
+		if c.currPage == nil {
+			pg, err := c.currChunk.NextPage()
+			if err != nil && !errors.Is(err, io.EOF) {
+				return EmptyRowNumber(), nil, err
+			}
+			if pg == nil || errors.Is(err, io.EOF) {
+				// This row group is exhausted
+				c.closeCurrRowGroup()
+				continue
+			}
+			if c.filter != nil && !c.filter.KeepPage(pg) {
+				// This page filtered out
+				c.curr.Skip(pg.NumRows())
+				pq.Release(pg)
+				continue
+			}
+			c.setPage(pg)
+		}
+
+		// Read next batch of values if needed
+		if c.currBuf == nil {
+			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
+		}
+		if c.currBufN >= len(c.currBuf) || len(c.currBuf) == 0 {
+			c.currBuf = c.currBuf[:cap(c.currBuf)]
+			n, err := c.currValues.ReadValues(c.currBuf)
+			if err != nil && !errors.Is(err, io.EOF) {
+				return EmptyRowNumber(), nil, err
+			}
+			c.currBuf = c.currBuf[:n]
+			c.currBufN = 0
+			if n == 0 {
+				// This value reader and page are exhausted.
+				c.setPage(nil)
+				continue
+			}
+		}
+
 		// Consume current buffer until empty
 		for c.currBufN < len(c.currBuf) {
 			v := &c.currBuf[c.currBufN]
@@ -836,15 +889,12 @@ func (c *SyncIterator) next(seekTo *RowNumber, definitionLevel int) (RowNumber, 
 
 			return c.curr, v, nil
 		}
-
-		// Buffer exhausted, refill it, advancing pages and row groups as needed.
-		ok, err := c.fill()
-		if !ok || err != nil {
-			return EmptyRowNumber(), nil, err
-		}
 	}
 }
 
+// beforeSeekTarget returns true if the iterator's current position is before
+// the seek target. It compares the row numbers in place and is inlineable,
+// which keeps the hot loop in next() free of 32-byte RowNumber copies.
 func (c *SyncIterator) beforeSeekTarget() bool {
 	for i := 0; i <= c.seekDefinitionLevel; i++ {
 		if c.curr[i] < c.seekTo[i] {
@@ -855,66 +905,6 @@ func (c *SyncIterator) beforeSeekTarget() bool {
 		}
 	}
 	return false
-}
-
-// fill ensures the current buffer contains unconsumed values, advancing to
-// the next page and row group as needed. It returns false when the iterator
-// is exhausted.
-func (c *SyncIterator) fill() (bool, error) {
-	for c.currBuf == nil || c.currBufN >= len(c.currBuf) {
-		if c.currRowGroup == nil {
-			rg, minRN, maxRN := c.popRowGroup()
-			if rg == nil {
-				return false, nil
-			}
-
-			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-			if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
-				cc.Close()
-				continue
-			}
-
-			c.setRowGroup(rg, minRN, maxRN, cc)
-		}
-
-		if c.currPage == nil {
-			pg, err := c.currChunk.NextPage()
-			if err != nil && !errors.Is(err, io.EOF) {
-				return false, err
-			}
-			if pg == nil || errors.Is(err, io.EOF) {
-				// This row group is exhausted
-				c.closeCurrRowGroup()
-				continue
-			}
-			if c.filter != nil && !c.filter.KeepPage(pg) {
-				// This page filtered out
-				c.curr.Skip(pg.NumRows())
-				pq.Release(pg)
-				continue
-			}
-			c.setPage(pg)
-		}
-
-		// Read next batch of values if needed
-		if c.currBuf == nil {
-			c.currBuf = syncIteratorPoolGet(c.readSize, 0)
-		}
-		c.currBuf = c.currBuf[:cap(c.currBuf)]
-		n, err := c.currValues.ReadValues(c.currBuf)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return false, err
-		}
-		c.currBuf = c.currBuf[:n]
-		c.currBufN = 0
-		if n == 0 {
-			// This value reader and page are exhausted.
-			c.setPage(nil)
-			continue
-		}
-	}
-
-	return true, nil
 }
 
 func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *ColumnChunkHelper) {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -468,6 +468,11 @@ type SyncIterator struct {
 	currPageN       int
 	at              IteratorResult // Current value pointed at by iterator. Returned by call Next and SeekTo, valid until next call.
 
+	// Seek scratch state owned by next(). Copied from its arguments so the
+	// hot loop can compare in place without growing next's stack frame.
+	seekTo              RowNumber
+	seekDefinitionLevel int
+
 	maxDefinitionLevel int
 
 	interner   *intern.Interner
@@ -572,7 +577,7 @@ func (c *SyncIterator) String() string {
 }
 
 func (c *SyncIterator) Next() (*IteratorResult, error) {
-	rn, v, err := c.next()
+	rn, v, err := c.next(nil, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -605,21 +610,14 @@ func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResul
 
 	// The row group and page have been selected to where this value is possibly
 	// located. Now scan through the page and look for it.
-	rn, v, err := c.nextSeek(to, definitionLevel)
+	rn, v, err := c.next(&to, definitionLevel)
 	if err != nil {
 		return nil, err
 	}
 	if !rn.Valid() {
 		return nil, nil
 	}
-
-	if c.filter == nil || c.filter.KeepValue(*v) {
-		return c.makeResult(rn, v), nil
-	}
-
-	// The value at the seek target didn't pass the filter, continue as a
-	// normal filtered read.
-	return c.Next()
+	return c.makeResult(rn, v), nil
 }
 
 func (c *SyncIterator) popRowGroup() (pq.RowGroup, RowNumber, RowNumber) {
@@ -807,7 +805,16 @@ func (c *SyncIterator) seekWithinPage(to RowNumber, definitionLevel int) {
 // we run out of things to inspect, it returns nil. The reason this method is distinct from
 // Next() is because it doesn't wrap the results in an IteratorResult, which is more efficient
 // when being called multiple times and throwing away the results like in SeekTo().
-func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
+//
+// If seekTo is non-nil, values before it are discarded without evaluating
+// the filter, since SeekTo drops them regardless of the filter's decision.
+func (c *SyncIterator) next(seekTo *RowNumber, definitionLevel int) (RowNumber, *pq.Value, error) {
+	seeking := seekTo != nil
+	if seeking {
+		c.seekTo = *seekTo
+		c.seekDefinitionLevel = definitionLevel
+	}
+
 	for {
 		// Consume current buffer until empty
 		for c.currBufN < len(c.currBuf) {
@@ -818,6 +825,10 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
 			c.currBufN++
 			c.currPageN++
+
+			if seeking && c.beforeSeekTarget() {
+				continue
+			}
 
 			if c.filter != nil && !c.filter.KeepValue(*v) {
 				continue
@@ -834,36 +845,16 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 	}
 }
 
-// nextSeek is like next but for use while seeking: it returns the first
-// value at or past the seek target without evaluating the filter. Values
-// before the target are discarded unfiltered, since SeekTo drops them
-// regardless of the filter's decision. The caller is responsible for
-// filtering the returned value.
-func (c *SyncIterator) nextSeek(to RowNumber, definitionLevel int) (RowNumber, *pq.Value, error) {
-	for {
-		// Consume current buffer until empty
-		for c.currBufN < len(c.currBuf) {
-			v := &c.currBuf[c.currBufN]
-
-			// Inspect all values to track the current row number,
-			// even if the value is filtered out next.
-			c.curr.Next(v.RepetitionLevel(), v.DefinitionLevel(), c.maxDefinitionLevel)
-			c.currBufN++
-			c.currPageN++
-
-			if CompareRowNumbers(definitionLevel, c.curr, to) < 0 {
-				continue
-			}
-
-			return c.curr, v, nil
+func (c *SyncIterator) beforeSeekTarget() bool {
+	for i := 0; i <= c.seekDefinitionLevel; i++ {
+		if c.curr[i] < c.seekTo[i] {
+			return true
 		}
-
-		// Buffer exhausted, refill it, advancing pages and row groups as needed.
-		ok, err := c.fill()
-		if !ok || err != nil {
-			return EmptyRowNumber(), nil, err
+		if c.curr[i] > c.seekTo[i] {
+			return false
 		}
 	}
+	return false
 }
 
 // fill ensures the current buffer contains unconsumed values, advancing to

--- a/pkg/parquetquery/iters_test.go
+++ b/pkg/parquetquery/iters_test.go
@@ -2,6 +2,7 @@ package parquetquery
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -172,6 +173,90 @@ func testColumnIteratorSeek(t *testing.T, makeIter makeTestIterFn) {
 	}
 }
 
+// TestColumnIteratorSeekToFilter verifies how SeekTo interacts with the
+// column predicate: values scanned past on the way to the seek target are
+// discarded regardless of the filter's decision and must not be evaluated,
+// while values at/after the target are still filtered.
+func TestColumnIteratorSeekToFilter(t *testing.T) {
+	t.Run("filter not evaluated before target", func(t *testing.T) {
+		count := 10_000
+		pf := createTestFile(t, count)
+
+		pred := &InstrumentedPredicate{}
+		idx, _, _ := GetColumnIndexByPath(pf, "A")
+		iter := NewSyncIterator(context.TODO(), pf.RowGroups(), idx, SyncIteratorOptSelectAs("A"), SyncIteratorOptPredicate(pred), SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel))
+		defer iter.Close()
+
+		// Seek in steps below the page-reslice threshold so the iterator
+		// scans value-by-value toward each target.
+		var inspectedBefore int64
+		for _, seekTo := range []int32{900, 1800, 2700} {
+			rn := EmptyRowNumber()
+			rn[0] = seekTo
+			res, err := iter.SeekTo(rn, 0)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+			require.Equal(t, RowNumber{seekTo, -1, -1, -1, -1, -1, -1, -1}, res.RowNumber)
+			require.Equal(t, seekTo, res.ToMap()["A"][0].Int32())
+
+			require.Equal(t, int64(1), pred.InspectedValues-inspectedBefore, "only the value at the seek target should be inspected by the filter")
+			inspectedBefore = pred.InspectedValues
+		}
+	})
+
+	t.Run("filter applies at and after target", func(t *testing.T) {
+		count := 10_000
+		pf := createTestFile(t, count)
+
+		pred := NewIntBetweenPredicate(5000, 5010)
+		idx, _, _ := GetColumnIndexByPath(pf, "A")
+		iter := NewSyncIterator(context.TODO(), pf.RowGroups(), idx, SyncIteratorOptSelectAs("A"), SyncIteratorOptPredicate(pred), SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel))
+		defer iter.Close()
+
+		// The value at the seek target fails the filter; the result must be
+		// the first value at/after the target that passes it.
+		rn := EmptyRowNumber()
+		rn[0] = 900
+		res, err := iter.SeekTo(rn, 0)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, RowNumber{5000, -1, -1, -1, -1, -1, -1, -1}, res.RowNumber)
+		require.Equal(t, int32(5000), res.ToMap()["A"][0].Int32())
+	})
+
+	t.Run("nested column", func(t *testing.T) {
+		type testSpan struct {
+			ID int64
+		}
+		type testTrace struct {
+			Spans []testSpan `parquet:",list"`
+		}
+
+		traces := make([]testTrace, 100)
+		for i := range traces {
+			traces[i].Spans = make([]testSpan, 100)
+			for j := range traces[i].Spans {
+				traces[i].Spans[j].ID = int64(i*1000 + j)
+			}
+		}
+		pf := createFileWith(t, context.Background(), traces)
+
+		pred := &InstrumentedPredicate{}
+		iter := NewSyncIterator(context.TODO(), pf.RowGroups(), 0, SyncIteratorOptSelectAs("ID"), SyncIteratorOptPredicate(pred), SyncIteratorOptMaxDefinitionLevel(1))
+		defer iter.Close()
+
+		// Seek to trace 5, span 50 at definition level 1.
+		to := EmptyRowNumber()
+		to[0], to[1] = 5, 50
+		res, err := iter.SeekTo(to, 1)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, RowNumber{5, 50, -1, -1, -1, -1, -1, -1}, res.RowNumber)
+		require.Equal(t, int64(5*1000+50), res.ToMap()["ID"][0].Int64())
+		require.Equal(t, int64(1), pred.InspectedValues, "only the value at the seek target should be inspected by the filter")
+	})
+}
+
 func TestColumnIteratorPredicate(t *testing.T) {
 	for _, tc := range iterTestCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -202,6 +287,64 @@ func testColumnIteratorPredicate(t *testing.T, makeIter makeTestIterFn) {
 		require.NotNil(t, res)
 		require.Equal(t, RowNumber{expectedResult, -1, -1, -1, -1, -1, -1, -1}, res.RowNumber)
 		require.Equal(t, expectedResult, res.ToMap()["A"][0].Int32())
+	}
+}
+
+// BenchmarkSyncIteratorSeekTo models the join-iterator access pattern:
+// repeated forward seeks with strides below the page-reslice threshold, so
+// the iterator scans values toward each target.
+func BenchmarkSyncIteratorSeekTo(b *testing.B) {
+	count := 100_000
+	type T struct {
+		A int64  `parquet:",delta"`
+		S string `parquet:",dict"`
+	}
+	rows := make([]T, count)
+	for i := range rows {
+		rows[i] = T{A: int64(i), S: fmt.Sprintf("span-name-%d", i%100)}
+	}
+	pf := createFileWith(b, context.Background(), rows)
+
+	aIdx, _, _ := GetColumnIndexByPath(pf, "A")
+	sIdx, _, _ := GetColumnIndexByPath(pf, "S")
+
+	testCases := []struct {
+		name     string
+		column   int
+		makePred func() Predicate
+	}{
+		{"int/nopred", aIdx, func() Predicate { return nil }},
+		{"int/between", aIdx, func() Predicate { return NewIntBetweenPredicate(0, int64(count)) }},
+		{"string/regex", sIdx, func() Predicate {
+			pred, err := NewRegexInPredicate([]string{"span-name-[0-4].*"})
+			require.NoError(b, err)
+			return pred
+		}},
+	}
+
+	for _, tc := range testCases {
+		for _, stride := range []int32{10, 500} {
+			b.Run(fmt.Sprintf("%s/stride=%d", tc.name, stride), func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					iter := NewSyncIterator(context.TODO(), pf.RowGroups(), tc.column,
+						SyncIteratorOptSelectAs("v"), SyncIteratorOptPredicate(tc.makePred()), SyncIteratorOptMaxDefinitionLevel(MaxDefinitionLevel))
+					pos := int32(0)
+					for {
+						rn := EmptyRowNumber()
+						rn[0] = pos
+						res, err := iter.SeekTo(rn, 0)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if res == nil {
+							break
+						}
+						pos = res.RowNumber[0] + stride
+					}
+					iter.Close()
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does**:

Skips predicate evaluation for values scanned past during `SyncIterator.SeekTo`.

`SeekTo` scans toward the seek target by calling `next()`, which evaluates the column predicate on every value — only for `SeekTo` to discard everything before the target.

When seeking, `next` skips values before the target without evaluating the filter, then filters normally from the target onward — one loop, no separate seek path. The target is kept as iterator scratch state and compared in place by an inlineable helper, keeping 32-byte `RowNumber` copies out of the hot loop. Results are identical.

- Filtered metrics query (`{span.http.host != `` && span.http.flavor=`2`} | rate() by (...)`): **−18.3%**
- Plain `Next()` iteration and unfiltered scans: unchanged

<details>
<summary>benchstat: vParquet5 block benchmarks (main vs PR, n=10)</summary>

```
                                                                                                        │ /tmp/final_macro_main.txt │       /tmp/final_macro_pr.txt       │
                                                                                                        │          sec/op           │   sec/op     vs base                │
BackendBlockTraceQL/spanAttValMatch-12                                                                                  1.969m ± 8%   1.959m ± 2%        ~ (p=0.684 n=10)
BackendBlockTraceQL/mixedValMixedMatchAnd-12                                                                            431.5µ ± 3%   433.8µ ± 2%        ~ (p=0.436 n=10)
BackendBlockTraceQL/struct-12                                                                                           59.77m ± 1%   59.71m ± 0%        ~ (p=1.000 n=10)
BackendBlockQueryRange/{span.http.host_!=_``_&&_span.http.flavor=`2`}_|_rate()_by_(span.http.flavor)-12                 62.50m ± 2%   51.10m ± 1%  -18.25% (p=0.000 n=10)
geomean                                                                                                                 7.505m        7.136m        -4.93%
```

</details>

<details>
<summary>benchstat: BenchmarkSyncIteratorSeekTo (main vs PR, n=8)</summary>

```
                                              │ /tmp/final_micro_main.txt │      /tmp/final_micro_pr.txt       │
                                              │          sec/op           │   sec/op     vs base               │
SyncIteratorSeekTo/int/nopred/stride=10-12                  1568.6µ ± 12%   908.4µ ± 2%  -42.09% (p=0.000 n=8)
SyncIteratorSeekTo/int/nopred/stride=500-12                 1438.4µ ± 11%   707.4µ ± 2%  -50.82% (p=0.000 n=8)
SyncIteratorSeekTo/int/between/stride=10-12                  1.479m ±  1%   1.009m ± 1%  -31.80% (p=0.000 n=8)
SyncIteratorSeekTo/int/between/stride=500-12                1273.9µ ±  2%   765.9µ ± 2%  -39.88% (p=0.000 n=8)
SyncIteratorSeekTo/string/regex/stride=10-12                 3.102m ±  1%   2.092m ± 3%  -32.57% (p=0.000 n=8)
SyncIteratorSeekTo/string/regex/stride=500-12               2873.3µ ±  2%   716.5µ ± 2%  -75.06% (p=0.000 n=8)
geomean                                                      1.833m         951.9µ       -48.06%
```

</details>

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
