### PR TITLE
docs: remove multiple monolithic instances guidance

### DIFF
--- a/.chloggen/strike-multiple-monoliths.yaml
+++ b/.chloggen/strike-multiple-monoliths.yaml
@@ -1,0 +1,6 @@
+change_type: change
+component: docs
+note: remove guidance suggesting you run multiple monolithic instances.
+issues: [7637]
+subtext:
+user: mattdurham

--- a/.chloggen/strike-multiple-monoliths.yaml
+++ b/.chloggen/strike-multiple-monoliths.yaml
@@ -1,6 +1,6 @@
 change_type: change
 component: docs
-note: remove guidance suggesting you run multiple monolithic instances.
-issues: [7637]
+note: remove guidance on running multiple monolithic instances.
+issues: [7636]
 subtext:
 user: mattdurham

--- a/docs/sources/tempo/reference-tempo-architecture/deployment-modes.md
+++ b/docs/sources/tempo/reference-tempo-architecture/deployment-modes.md
@@ -37,7 +37,7 @@ Monolithic mode is suitable for getting started, development environments, and l
 
 ### Limitations
 
-Components share the same resource pool. A spike in query load can affect write throughput and vice versa. There is no independent scaling. You can run multiple monolithic instances, but each instance runs the same set of components. At higher volumes, memory pressure from collocated components, particularly the live-store and querier, can cause out-of-memory issues.
+Components share the same resource pool. A spike in query load can affect write throughput and vice versa. There is no independent scaling. At higher volumes, memory pressure from collocated components, particularly the live-store and querier, can cause out-of-memory issues.
 
 ### Resource considerations
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/plan/deployment-modes.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/plan/deployment-modes.md
@@ -22,7 +22,7 @@ Use monolithic mode when:
 
 Monolithic mode has some trade-offs to be aware of.
 All components share the same resource pool, so a spike in query load can affect write throughput and vice versa.
-There is no independent scaling: you can scale vertically or run multiple identical instances, but you cannot scale individual components separately.
+There is no independent scaling: you can scale vertically, but you cannot scale individual components separately.
 At higher volumes, memory pressure from collocated components can cause issues.
 
 ## Microservices mode
@@ -43,7 +43,7 @@ Microservices mode provides independent scaling for each component and isolated 
 | Consideration | Monolithic | Microservices |
 |---|---|---|
 | Kafka required | No | Yes |
-| Scaling | Single process; scale vertically or run multiple identical instances | Each component scales independently |
+| Scaling | Single process; scale vertically | Each component scales independently |
 | Failure isolation | All components share resources | Isolated failure domains per component |
 | Operational complexity | Low | Higher, with more processes to manage |
 | Best for | Getting started, development, up to 25-35 MB/s | Production, high volume, high availability |

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/plan/deployment-modes.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/plan/deployment-modes.md
@@ -23,6 +23,7 @@ Use monolithic mode when:
 Monolithic mode has some trade-offs to be aware of.
 All components share the same resource pool, so a spike in query load can affect write throughput and vice versa.
 There is no independent scaling: you can scale vertically, but you cannot scale individual components separately.
+Running more than one `target=all` instance isn't supported because the backend scheduler is a singleton; use microservices mode for high availability.
 At higher volumes, memory pressure from collocated components can cause issues.
 
 ## Microservices mode

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/plan/deployment-modes.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/plan/deployment-modes.md
@@ -23,7 +23,7 @@ Use monolithic mode when:
 Monolithic mode has some trade-offs to be aware of.
 All components share the same resource pool, so a spike in query load can affect write throughput and vice versa.
 There is no independent scaling: you can scale vertically, but you cannot scale individual components separately.
-Running more than one `target=all` instance isn't supported because the backend scheduler is a singleton; use microservices mode for high availability.
+Running more than one `-target=all` instance isn't supported because the backend scheduler is a singleton; use microservices mode for high availability.
 At higher volumes, memory pressure from collocated components can cause issues.
 
 ## Microservices mode


### PR DESCRIPTION
Running multiple independent monoliths just leads to failover and query distribution questions that end up rebuilding microservices. Better to not suggest it.

Closes #7636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)