### PR TITLE
fix(mixin): damp TempoUserConfigurableOverridesReloadFailing sensitivity

### DIFF
--- a/.chloggen/7638-user-configurable-overrides-alert-for.yaml
+++ b/.chloggen/7638-user-configurable-overrides-alert-for.yaml
@@ -1,0 +1,6 @@
+change_type: change
+component: operations
+note: Add a 15m `for` duration to the `TempoUserConfigurableOverridesReloadFailing` alert so brief transient failures don't page, and fix its runbook link.
+issues: []
+subtext:
+user: zhxiaogg

--- a/operations/tempo-mixin-compiled/alerts.yaml
+++ b/operations/tempo-mixin-compiled/alerts.yaml
@@ -87,10 +87,11 @@
   - "alert": "TempoUserConfigurableOverridesReloadFailing"
     "annotations":
       "message": "Greater than 5 user-configurable overides reloads failed in the past hour."
-      "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoTenantIndexFailures"
+      "runbook_url": "https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoUserConfigurableOverridesReloadFailing"
     "expr": |
       sum by (cluster, namespace) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total{}[1h])) > 5 and
       sum by (cluster, namespace) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total{}[5m])) > 0
+    "for": "15m"
     "labels":
       "severity": "critical"
   - "alert": "TempoCompactionTooManyOutstandingBlocks"

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -138,12 +138,13 @@
               sum by (%s) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total{}[1h])) > %s and
               sum by (%s) (increase(tempo_overrides_user_configurable_overrides_reload_failed_total{}[5m])) > 0
             ||| % [$._config.group_by_cluster, $._config.alerts.user_configurable_overrides_polls_per_hour_failed, $._config.group_by_cluster],
+            'for': '15m',
             labels: {
               severity: 'critical',
             },
             annotations: {
               message: 'Greater than %s user-configurable overides reloads failed in the past hour.' % $._config.alerts.user_configurable_overrides_polls_per_hour_failed,
-              runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoTenantIndexFailures',
+              runbook_url: 'https://github.com/grafana/tempo/tree/main/operations/tempo-mixin/runbook.md#TempoUserConfigurableOverridesReloadFailing',
             },
           },
           // compaction scheduler / workers


### PR DESCRIPTION
**What this PR does**:
Adds a `for: 15m` duration to the `TempoUserConfigurableOverridesReloadFailing` alert. The rule sums reload failures across every pod and tenant in a cell, so a handful of pods each hitting one transient failure (e.g. a brief backend blip) is enough to cross the hourly threshold and page, even without any single sustained problem. A `for` duration (already used by the sibling `TempoBadOverrides` alert) requires the elevated condition to persist before paging, filtering out short self-healing blips.

Also fixes `runbook_url`, which pointed at `#TempoTenantIndexFailures` instead of this alert's own runbook section.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated (n/a, alerting rule)
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`