### PR TITLE
CI: Add Workflow to Generate and Attach SBOM on Release

### DIFF
--- a/.chloggen/ci_socket-sbom-on-release.yaml
+++ b/.chloggen/ci_socket-sbom-on-release.yaml
@@ -18,4 +18,4 @@ issues: []
 subtext:
 
 # The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
-user:
+user: ezebunandu

--- a/.chloggen/ezebunandu_socket-sbom-on-release.yaml
+++ b/.chloggen/ezebunandu_socket-sbom-on-release.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: operations
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: "adds workflow to generate and attach an SBOM to release artifacts on release"
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user:

--- a/.github/workflows/sbom-on-release.yml
+++ b/.github/workflows/sbom-on-release.yml
@@ -1,0 +1,39 @@
+name: "SBOM on Release"
+
+on:
+  release:
+    types:
+      - published
+
+permissions: {}
+
+jobs:
+  export-sbom:
+    name: "Export SBOM and attach to release"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # to upload the SBOM as a release asset
+      id-token: write # to authenticate to Vault
+    steps:
+      - name: "Get Socket API token from Vault"
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
+        with:
+          common_secrets: |
+            SOCKET_API_TOKEN=socket:SOCKET_API_KEY
+
+      - name: "Export SPDX SBOM from Socket"
+        id: export-sbom
+        uses: grafana/shared-workflows/actions/socket-export-sbom@ff9aaa53f25716fcd6dde39f6d4e41c4e16fb5e1 # socket-export-sbom/v0.1.2
+        with:
+          socket_api_token: ${{ fromJSON(steps.vault-secrets.outputs.secrets).SOCKET_API_TOKEN }}
+          socket_org: grafana
+          output_file: ${{ github.event.repository.name }}-${{ github.event.release.tag_name }}.spdx.json
+
+      - name: "Upload SBOM to release"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+          SBOM_PATH: ${{ steps.export-sbom.outputs.path }}
+        run: gh release upload "$TAG" "$SBOM_PATH" --clobber

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,6 +21,7 @@
 /.github/update-make-docs.yml   @jdbaldry @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
 /.github/website-next.yml       @jdbaldry @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
 /.github/website-versioned.yml  @jdbaldry @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
+/.github/workflows/sbom-on-release.yml @grafana/security
 /docs/docs.mk                   @jdbaldry @knylander-grafana @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
 /docs/make-docs                 @jdbaldry @knylander-grafana @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg
 /docs/Makefile                  @jdbaldry @knylander-grafana @mdisibio @mapno @yvrhdn @zalegrala @electron0zero @ie-pham @stoewer @javiermolinar @carles-grafana @ruslan-mikhailov @mattdurham @zhxiaogg


### PR DESCRIPTION
Replicates grafana/grafana#128430: generates an SPDX SBOM via socket.dev on each published release and attaches it as a release asset.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
What this PR does / why we need it:
CI workflow for generating an SBOM on release, which is added to the release assets. SBOMs are generated using the socket.dev API.

Which issue(s) this PR fixes:
The GRC team semi-frequently gets requests for Software Bill of Materials (SBOMs) from contracted customers and prospects. Grafana's Open Source repos are enrolled in and scanned for dependencies by socket.dev, which also generates SBOMs. Currently, the GRC team generates SBOMs ad-hoc using Socket's API. Adding a standardized workflow for SBOM generation reduces the burden for the GRC team and also makes SBOMs available for consumption by members of our OSS community.


**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)