### PR TITLE
docs: restructure introduction architecture page

### DIFF
--- a/docs/sources/tempo/introduction/_index.md
+++ b/docs/sources/tempo/introduction/_index.md
@@ -97,10 +97,10 @@ This data helps you locate problem areas, often in places you never would have a
 
 To continue learning about traces and Tempo, refer to:
 
-- [Traces and telemetry](./telemetry): how traces relate to metrics, logs, and profiles.
-- [Trace structure](./trace-structure): the parts of a span and the attributes you can query.
-- [Tempo architecture](./architecture): how Tempo ingests, stores, and queries traces.
-- [Tempo and AI](./tempo-and-ai): query traces with AI agents through the MCP server and LLM-optimized APIs.
-- [Glossary](./glossary): definitions of common tracing terms.
+- [Traces and telemetry](./telemetry/): how traces relate to metrics, logs, and profiles.
+- [Trace structure](./trace-structure/): the parts of a span and the attributes you can query.
+- [Tempo architecture](./architecture/): how Tempo ingests, stores, and queries traces.
+- [Tempo and AI](./tempo-and-ai/): query traces with AI agents through the MCP server and LLM-optimized APIs.
+- [Glossary](./glossary/): definitions of common tracing terms.
 
-For real-world examples, refer to [User journeys: How tracing can help you](../solutions-with-traces) elsewhere in the Tempo documentation.
+For real-world examples, refer to [User journeys: How tracing can help you](../solutions-with-traces/) elsewhere in the Tempo documentation.

--- a/docs/sources/tempo/introduction/_index.md
+++ b/docs/sources/tempo/introduction/_index.md
@@ -73,7 +73,7 @@ That same trace ID applies to every span as the request and response generate ac
 The trace ID lets you trace, or follow, a request as it flows from node to node, service to microservice to lambda function to wherever it goes in your chaotic, cloud computing system and back again.
 This is recorded and displayed as spans.
 
-Here's an example showing two pages in Grafana Cloud.
+Here's an example showing two pages in Grafana.
 The first, numbered 1, shows a query using the **Explore** feature.
 In the query results, you can see a **TraceID** field that was added to an application.
 That field contains a **Tempo** trace ID.
@@ -95,8 +95,12 @@ This data helps you locate problem areas, often in places you never would have a
 
 ## Learn more
 
-For more information about traces, refer to:
+To continue learning about traces and Tempo, the following pages follow a natural reading order:
 
-- [Traces and telemetry](./telemetry)
-- [User journeys: How tracing can help you](../solutions-with-traces)
-- [Glossary](./glossary)
+- [Traces and telemetry](./telemetry): how traces relate to metrics, logs, and profiles.
+- [Trace structure](./trace-structure): the parts of a span and the attributes you can query.
+- [Tempo architecture](./architecture): how Tempo ingests, stores, and queries traces.
+- [Tempo and AI](./tempo-and-ai): query traces with AI agents through the MCP server and LLM-optimized APIs.
+- [Glossary](./glossary): definitions of common tracing terms.
+
+For real-world examples, refer to [User journeys: How tracing can help you](../solutions-with-traces) elsewhere in the Tempo documentation.

--- a/docs/sources/tempo/introduction/_index.md
+++ b/docs/sources/tempo/introduction/_index.md
@@ -95,7 +95,7 @@ This data helps you locate problem areas, often in places you never would have a
 
 ## Learn more
 
-To continue learning about traces and Tempo, the following pages follow a natural reading order:
+To continue learning about traces and Tempo, refer to:
 
 - [Traces and telemetry](./telemetry): how traces relate to metrics, logs, and profiles.
 - [Trace structure](./trace-structure): the parts of a span and the attributes you can query.

--- a/docs/sources/tempo/introduction/architecture.md
+++ b/docs/sources/tempo/introduction/architecture.md
@@ -30,7 +30,7 @@ For in-depth operational detail, refer to the [Tempo architecture reference](htt
 
 The Tempo architecture is built around a few goals that shape how it ingests, stores, and queries traces.
 
-- Cost-efficient storage: Tempo stores all trace data in object storage and doesn't require a separate database or index tier.
+- Cost-efficient storage: Tempo stores all trace data in object storage.
 - Independent scaling: In microservices mode, Tempo separates the write path from the read path, so you can scale ingestion and query capacity independently.
 - Durability without extra replication: In microservices mode, a Kafka-compatible queue acts as a write-ahead log (WAL). After Kafka acknowledges a write, the data is durable, so Tempo doesn't replicate data across instances on the write path and can operate with a replication factor of 1 (RF1), which reduces cost.
 - Efficient attribute queries: Tempo stores blocks in Apache Parquet, a columnar format, so a query reads only the columns it needs instead of scanning entire traces.
@@ -65,6 +65,7 @@ The following steps describe the write path in microservices mode. In monolithic
 
 4. **Live-stores** consume from Kafka and make data available for recent queries.
 5. **Block-builders** consume from Kafka and build blocks for long-term object storage.
+6. **Metrics-generators** (optional) consume from Kafka to derive metrics from traces.
 
 ### Lifecycle of a read
 

--- a/docs/sources/tempo/introduction/architecture.md
+++ b/docs/sources/tempo/introduction/architecture.md
@@ -1,6 +1,11 @@
 ---
 title: Tempo architecture
-description: Learn about Tempo architectural decisions and operational implications.
+description: Learn how Grafana Tempo ingests, stores, and queries trace data.
+keywords:
+  - Grafana Tempo
+  - architecture
+  - components
+  - traces
 aliases:
   - ../architecture # https://grafana.com/docs/tempo/<TEMPO_VERSION>/architecture/
   - ../operations/architecture/ # /docs/tempo/latest/operations/architecture/
@@ -9,184 +14,182 @@ weight: 400
 
 # Tempo architecture
 
-The journey of a trace is usually from an instrumented application, to a trace receiver/collector,
-to a trace backend store, and then those traces being retrieved and visualized in a tool like Grafana.
+The journey of a trace is usually from an instrumented application, to a trace receiver/collector, to a trace backend store, and then those traces are retrieved and visualized in a tool like Grafana.
 
 Grafana Tempo acts in two major capacities:
 
-- Ingesting trace spans, sorting the span resources and attributes into columns in an Apache Parquet schema,
-  before sending them to object storage for long-term retention.
-- Retrieving trace data from storage, either by specific trace ID or by search parameters via TraceQL.
+- Ingesting trace spans, sorting the span resources and attributes into columns in an Apache Parquet schema, before sending them to object storage for long-term retention.
+- Retrieving trace data from storage, either by specific trace ID or by search parameters using TraceQL.
 
-Tempo has a microservices-based architecture.
-All components are compiled into the same binary, and the `-target` parameter controls which component is started.
-This allows Tempo to run in two modes:
-
-- **Monolithic mode**: All components run in a single process. Recommended for getting started.
-- **Microservices mode**: Each component runs as a separate process, allowing independent scaling.
-
-Refer to the [example setups](https://grafana.com/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/example-demo-app/)
-or [deployment options](https://grafana.com/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/deploy/) for help deploying.
+This page gives a high-level overview of how Tempo works: how it ingests, stores, and queries trace data, and the components that make up a Tempo deployment.
+For in-depth operational detail, refer to the [Tempo architecture reference](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/).
 
 ![Tempo architecture diagram](/media/docs/tempo/tempo_arch_3.0.png)
 
-## Components
+## Design goals
 
-Tempo is made up of the following components.
+The Tempo architecture is built around a few goals that shape how it ingests, stores, and queries traces.
 
-### Distributor
+- Cost-efficient storage: Tempo stores all trace data in object storage and doesn't require a separate database or index tier.
+- Independent scaling: In microservices mode, Tempo separates the write path from the read path, so you can scale ingestion and query capacity independently.
+- Durability without extra replication: In microservices mode, a Kafka-compatible queue acts as a write-ahead log (WAL). After Kafka acknowledges a write, the data is durable, so Tempo doesn't replicate data across instances on the write path and can operate with a replication factor of 1 (RF1), which reduces cost.
+- Efficient attribute queries: Tempo stores blocks in Apache Parquet, a columnar format, so a query reads only the columns it needs instead of scanning entire traces.
 
-The distributor accepts spans in multiple formats including Jaeger, OpenTelemetry, Zipkin.
-It uses the receiver layer from the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector).
-For best performance, it's recommended to ingest [OpenTelemetry Proto](https://github.com/open-telemetry/opentelemetry-proto).
-For this reason, [Grafana Alloy](https://github.com/grafana/alloy/) uses the OTLP exporter/receiver to send spans to Tempo.
+## Deployment modes
 
-Once data is received, the distributor validates the request against limits, shards traces by hashing the `traceID`, and writes records to Kafka.
-The distributor uses the partition ring to determine which partitions are active and routes data accordingly.
-A write is only acknowledged to the client after Kafka has confirmed receipt of the data.
+All Tempo components are compiled into the same binary; the `-target` parameter controls which components run in a given process, whether that's one process running everything or many processes each running one component.
+This lets you run Tempo in two modes:
 
-### Kafka-compatible system
+- Monolithic mode: All required components run in a single process (`-target=all`, the default). No Kafka is required; the distributor pushes trace data in-process to the live-store and metrics-generator.
+- Microservices mode: Each component runs as a separate process with its own `-target`. This mode requires a Kafka-compatible system and is recommended for production.
 
-Tempo uses a Kafka-compatible system (such as Apache Kafka or WarpStream) as a durable queue between distributors and downstream components.
-This serves as a write-ahead log (WAL) that enables the decoupling of write and read paths.
+Object storage is recommended for production in both modes; a local filesystem backend is available for development and testing.
 
-When distributors receive trace data, they shard traces by trace ID and write records to Kafka partitions.
-Once Kafka acknowledges the write, the distributor returns a response to the client.
-From this point, the write and read paths diverge:
+For more information, refer to [Deployment modes](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/deployment-modes/) and [Set up for tracing](https://grafana.com/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/deploy/).
 
-- **Block-builders** consume from Kafka to build blocks for long-term object storage.
-- **Live-stores** consume from Kafka to serve recent data queries.
+## How data flows
 
-Because traces are sharded by trace ID to specific partitions, both block-builders and live-stores consume unique data without requiring deduplication.
-This enables Tempo to operate with a replication factor of 1 (RF1) while maintaining durability through Kafka.
+Tempo separates the write path, which gets trace data into storage, from the read path, which serves queries.
 
-### Block-builder
+### Lifecycle of a write
 
-The Block-builder is responsible for building blocks which are sent to long-term storage.
-It does so by consuming from one or more Kafka partitions where distributors have sent trace spans to.
-The Block-builder organizes spans into blocks based on a configurable time window, for example, 5 minutes.
-
-### Live-store
-
-The live-store is a read-path component responsible for serving recent trace data.
-It consumes trace data from Kafka and makes it available for queries, typically covering the last 30 minutes to 1 hour of data depending on configuration.
-
-Live-stores own the partition lifecycle within Tempo.
-While Kafka has its own concept of partitions, Tempo maintains a separate partition ring that tracks which Tempo 
-partitions are active and which live-stores own them.
-Tempo partitions map to Kafka partitions, but they are logically distinct. 
-The partition ring lets Tempo control partition states and ownership independently of Kafka's internal partition management.
-
-Partitions have three states:
-
-- Pending: No writes or reads. This is the initial state when a new partition is created, waiting for live-stores to be added as owners.
-- Active: Normal read-write mode. Distributors send data to active partitions, and queriers read from them.
-- Inactive: Read-only mode. Inactive partitions are eventually deleted after a configured period of time.
-
-When a live-store starts, it checks if its partition already exists. If it does, the live-store joins as an owner. If not, it creates a new partition in pending state, waits for memberlist to propagate, then switches it to active.
-Scaling down requires first marking the partition as inactive while the live-store is still running. After enough 
-time has passed for data to be available in object storage, the partition and live-store can be removed.
-
-For high availability, live-stores are typically deployed across multiple availability zones.
-Each Tempo partition is owned by one live-store per zone, so if a live-store in one zone becomes unavailable, the 
-live-store in the other zone can continue serving queries.
-While this setup replicates data across zones (RF2), the read quorum is 1—queriers only need a response from one 
-live-store per partition.
-This provides high availability without requiring data deduplication on the read path.
-
-### Query Frontend
-
-The Query Frontend is the component called by, for example, Grafana when a user wishes to retrieve a specific trace via a trace ID, or carry out a search via a TraceQL filter (for example, all incoming requests for traces).
-The Query Frontend is responsible for calling one or more Queriers to carry out examination of potential blocks of data where span data for matching traces may exist in parallel, to speed up result response time (dependent on multiple Queriers being configured).
-Requests by the Query Frontend can be split across multiple Queriers, which all work in parallel to retrieve results quickly.
-The more Queriers available, generally the quicker a result response.
-When Queriers have returned enough responses, the Query Frontend is responsible for concatenating all of the span data returned by each individual Querier together to send a response to the requester.
-
-The Query Frontend is responsible for sharding the search space for an incoming query.
-
-A simple HTTP endpoint exposes traces:
-`GET /api/traces/<traceID>`
-
-Internally, the Query Frontend splits the blockID space into a configurable number of shards and queues these requests.
-Queriers connect to the Query Frontend via a streaming gRPC connection to process these sharded queries.
-
-### Querier
-
-Queriers carry out the actual examination of block data in object storage to find any relevant span data based on the trace ID or TraceQL query given.
-As well as object storage, they also query live-stores for any recent span data that may have been processed but not 
-yet sent to object storage.
-This ensures that both historical and recent trace data is always available.
-
-The querier finds the requested trace ID in either the live-stores or the backend storage.
-Depending on parameters, the querier queries the live-stores for recently ingested traces and pulls the bloom 
-filters and indexes from the backend storage to efficiently locate the traces within object storage blocks.
-
-The querier exposes an HTTP endpoint at:
-`GET /querier/api/traces/<traceID>`, but it's not intended for direct use.
-
-Queries should be sent to the Query Frontend.
-
-### Compactor
-
-The compactor is responsible for ensuring that the stored data is both compressed and deduplicated (more on deduplication in the advanced course).
-The compactor is also responsible for expiring data after the retention period for that data has been reached.
-Compactors run on scheduled frequent intervals to deal with data that is not compacted and has been stored by the 
-block-builders.
-Compaction takes into account the data stored for specific traces to minimize search space on queries.
-
-### Backend scheduler and worker
-
-The scheduler is a forward-looking re-architecture of the compaction process, with the goal of improving the determinism and removing the duplication present in the current compaction process. The scheduler is responsible for the scheduling and tracking jobs which are assigned to workers for processing. The scheduler component, in combination with the worker, will eventually replace the current compactor component.
-
-The worker connects to the scheduler via gRPC to receive jobs for processing. Workers are responsible for executing jobs assigned to them by the scheduler and updating the job status back to the scheduler. These jobs currently include compaction and retention, but will likely include other kinds of jobs in the future.
-
-The workers currently have the additional responsibility of maintaining the blocklist for all tenants, which was previously handled by the compactor. The determination of which tenants to poll is coordinated through the ring, just as it is with the compactor.
-
-When transitioning from the compactor to the scheduler and worker architecture, some considerations need to be kept in mind:
-
-- Only one scheduler should be running at a time.
-- Workers should be scaled up at the same time the compactor is scaled to 0. This is to avoid conflicts between the two systems attempting to compact the same blocks.
-
-Since the worker is taking the role of the compactor when it comes to polling, some documentation may reference the compactor, and can instead be interpreted as the worker for environments where the worker has replaced the compactor.
-
-### Object storage
-
-Tempo uses object storage for storing all tracing data. It supports three major object storage APIs:
-
-- Amazon Simple Storage Service (S3)
-- Google Cloud Storage (GCS)
-- Microsoft Azure Storage (AS)
-
-### Metrics-generator
-
-This is an optional component that derives metrics from ingested traces and writes them to a metrics storage.
-Like live-stores, metrics-generators consume trace data from Kafka.
-Refer to the [metrics-generator documentation](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-generator/) to learn more.
-
-## Lifecycle of a write
+The following steps describe the write path in microservices mode. In monolithic mode, the distributor pushes data in-process to the live-store and metrics-generator instead of writing to Kafka.
 
 1. Trace data is sent from the tracing pipeline (OpenTelemetry Collector, Grafana Alloy) to a **distributor**.
 2. The distributor validates the request, shards traces by trace ID, and writes to **Kafka**.
-3. Kafka acknowledges the write
-4. And the distributor returns a response to the client.
-5. **Live-stores** consume from Kafka and make data available for recent queries.
-6. **Block-builders** consume from Kafka and build blocks for long-term object storage.
+3. Kafka acknowledges the write, and the distributor returns a response to the client.
 
-![Lifecycle of a write diagram](/media/docs/tempo/lifecycle-of-a-write.png)
+   ![The tracing pipeline sends spans to the distributor, which writes them to Kafka and returns a response to the client](/media/docs/tempo/lifecycle-of-a-write.png)
 
-## Lifecycle of a read
+   After the write is acknowledged, downstream components consume the data asynchronously:
 
-1. The **query frontend** receives a TraceQL query and shards it into jobs for recent data and long-term storage.
+4. **Live-stores** consume from Kafka and make data available for recent queries.
+5. **Block-builders** consume from Kafka and build blocks for long-term object storage.
+
+### Lifecycle of a read
+
+1. The **query frontend** receives a query and shards it into jobs for recent data and long-term storage.
 2. **Queriers** retrieve recent data from **live-stores**.
 3. For older data, queriers fetch blocks from **object storage**.
 4. Results are aggregated and returned to the user.
+
+## Components
+
+The following table summarizes the Tempo components and which deployment modes use them.
+
+| Component | Role | Used in |
+|---|---|---|
+| [Distributor](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/distributor/) | Receives and validates spans, then routes them to the write path | Both modes |
+| [Kafka-compatible queue](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/kafka/) | Durable write-ahead log between the distributor and downstream consumers | Microservices mode |
+| [Block-builder](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/block-builder/) | Builds Apache Parquet blocks and flushes them to object storage | Microservices mode |
+| [Live-store](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/live-store/) | Serves recent trace data for queries | Both modes |
+| [Query frontend](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/query-frontend/) | Receives queries and shards them into parallel jobs | Both modes |
+| [Querier](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/querier/) | Executes query jobs against live-stores and object storage | Both modes |
+| [Backend scheduler and worker](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/compaction/) | Handles compaction, retention, and blocklist maintenance | Both modes |
+| [Metrics-generator](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/metrics-generator/) | Optional; derives request rate, error rate, and duration (RED) metrics and service graphs from traces | Both modes |
+| [Object storage](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/object-storage/) | Long-term storage for all trace data | Both modes |
+
+## Storage
+
+Tempo stores all trace data in object storage. It supports three major object storage APIs:
+
+- Amazon S3 (and S3-compatible systems, such as MinIO)
+- Google Cloud Storage (GCS)
+- Microsoft Azure Blob Storage
+
+A local filesystem backend is available for development and testing.
+
+Trace data is stored in Apache Parquet blocks, a columnar format that lets queries read only the attributes they need. Backend workers enforce retention by expiring data in object storage after the configured retention period.
+
+For more information, refer to [Object storage](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/object-storage/) and [Block format](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/block-format/).
+
+## What you can query
+
+Tempo answers two kinds of read requests: lookups for a specific trace by trace ID, and searches across traces using [TraceQL](https://grafana.com/docs/tempo/<TEMPO_VERSION>/traceql/), the Tempo trace query language.
+You can also compute [TraceQL metrics](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-queries/) (for example, span rates and latency quantiles) directly from trace data, and use the optional metrics-generator to produce rate, error, and duration (RED) metrics and service graphs.
+
+Tempo ingests traces in OpenTelemetry (OTLP), Jaeger, and Zipkin formats.
+
+Tempo is multi-tenant: trace data is isolated per tenant at the storage level. For more information, refer to [multi-tenancy](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/multitenancy/).
+
+For the span fields and attributes you can query, refer to [Trace structure](https://grafana.com/docs/tempo/<TEMPO_VERSION>/introduction/trace-structure/).
+For AI-driven access to trace data through the MCP server and LLM-optimized APIs, refer to [Tempo and AI](https://grafana.com/docs/tempo/<TEMPO_VERSION>/introduction/tempo-and-ai/).
+
+## Component details
+
+The following sections describe each component in a little more detail. For full operational reference, follow the link at the end of each section.
+
+### Distributor
+
+The distributor is the entry point for trace data. It accepts spans in OTLP (recommended), Jaeger, and Zipkin formats and validates them against per-tenant ingestion limits.
+In microservices mode, it shards traces by trace ID and writes them to Kafka; in monolithic mode, it pushes data in-process to the live-store and metrics-generator.
+
+For more information, refer to [Distributor](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/distributor/).
+
+### Kafka-compatible queue
+
+In microservices mode, Tempo uses a Kafka-compatible system (such as Apache Kafka or WarpStream) as a durable write-ahead log between the distributor and downstream consumers.
+Because Kafka provides durability after it acknowledges a write, Tempo can operate at a replication factor of 1.
+Kafka isn't used in monolithic mode.
+
+For more information, refer to [Kafka](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/kafka/).
+
+### Block-builder
+
+The block-builder consumes trace data from Kafka, organizes spans into Apache Parquet blocks, and flushes them to object storage for long-term retention. It runs only in microservices mode; in monolithic mode, the live-store flushes blocks to object storage directly. For details, refer to [Block-builder](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/block-builder/).
+
+### Live-store
+
+The live-store serves recent trace data, holding traces in memory and in a local write-ahead log so they're queryable within seconds of ingestion.
+In microservices mode, it consumes trace data from Kafka; in monolithic mode, it receives data directly from the distributor.
+For high availability, live-stores can be deployed across availability zones.
+
+For more information, refer to [Live-store](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/live-store/).
+
+### Query frontend
+
+The query frontend is the entry point for queries.
+It receives TraceQL queries and trace ID lookups, shards each into parallel jobs that it distributes to queriers, and merges the returned results into a final response.
+
+For more information, refer to [Query frontend](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/query-frontend/).
+
+### Querier
+
+The querier executes the jobs dispatched by the query frontend.
+It fetches recent data from live-stores and historical data from object storage, then returns results to the query frontend for merging.
+
+For more information, refer to [Querier](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/querier/).
+
+### Backend scheduler and worker
+
+The backend scheduler and worker handle compaction, retention, and blocklist maintenance for data in object storage.
+The scheduler creates jobs and assigns them to workers, which compact small blocks into larger ones and expire data past its retention period. Together they replace the legacy compactor.
+
+For more information, refer to [Compaction](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/compaction/).
+
+### Metrics-generator
+
+The metrics-generator is an optional component that derives rate, error, and duration metrics and service graphs from traces and remote-writes them to a metrics backend such as Prometheus or Grafana Mimir.
+
+For more information, refer to [Metrics-generator](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/metrics-generator/).
+
+### Object storage
+
+Object storage is the long-term store for all trace data.
+Tempo supports Amazon S3 (and S3-compatible systems), Google Cloud Storage, and Azure Blob Storage, with a local filesystem backend for development and testing.
+
+For more information, refer to [Object storage](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/object-storage/).
 
 ## Things to keep in mind
 
 There are three fundamentally important things to keep in mind with traces:
 
-- There is no concept of the 'end' of a trace. A trace can start with any span which holds a unique trace ID that hasn't been seen by Tempo previously. However, spans can be continually added at any point in the future.
+- There's no concept of the 'end' of a trace. A trace can start with any span which holds a unique trace ID that hasn't been seen by Tempo previously. However, spans can be continually added at any point in the future.
+- When a trace ID is queried in Tempo, it returns all of the currently stored/ingested spans that belong to that trace and presents them in a mapped response (that is, a graph of parent/child/sibling relationships between spans) that allows, for example, Grafana to then visually render those traces.
+- TraceQL queries return all matching traces from Tempo for the filters presented to it. This doesn't necessarily mean in chronological order, as some queriers may return results more promptly than others. When the maximum trace limit for a TraceQL query has been hit, the query frontend returns a response with all the current traces and their spans at that point and ignores the outstanding queriers.
 
-- When a trace ID is queried in Tempo, it returns all of the currently stored/ingested spans that belong to that trace and present them in a mapped response (that is, a graph of parent/child/sibling relationships between spans) that allow, for example, Grafana to then visually render those traces.
+## Next steps
 
-- TraceQL queries return all matching traces from Tempo for the filters presented to it. This does not necessarily mean in chronological order, as some Queriers may return results more promptly than others. When the max trace limit for a TraceQL query has been hit, the Query Frontend will return a response with all the current traces and their spans at that point and ignore/cancel all outstanding Queriers.
+- Plan and deploy Tempo: [Set up for tracing](https://grafana.com/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/deploy/).
+- Explore the architecture in depth: [Tempo architecture reference](https://grafana.com/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/).
+- Learn the parts of a span: [Trace structure](https://grafana.com/docs/tempo/<TEMPO_VERSION>/introduction/trace-structure/).

--- a/docs/sources/tempo/introduction/architecture.md
+++ b/docs/sources/tempo/introduction/architecture.md
@@ -187,7 +187,7 @@ There are three fundamentally important things to keep in mind with traces:
 
 - There's no concept of the 'end' of a trace. A trace can start with any span which holds a unique trace ID that hasn't been seen by Tempo previously. However, spans can be continually added at any point in the future.
 - When a trace ID is queried in Tempo, it returns all of the currently stored/ingested spans that belong to that trace and presents them in a mapped response (that is, a graph of parent/child/sibling relationships between spans) that allows, for example, Grafana to then visually render those traces.
-- TraceQL queries return all matching traces from Tempo for the filters presented to it. This doesn't necessarily mean in chronological order, as some queriers may return results more promptly than others. When the maximum trace limit for a TraceQL query has been hit, the query frontend returns a response with all the current traces and their spans at that point and ignores the outstanding queriers.
+- TraceQL queries return all matching traces from Tempo for the filters presented to it. This doesn't necessarily mean in chronological order, as some queriers may return results more promptly than others. When the maximum trace limit for a TraceQL query has been hit, the query frontend returns a response with the traces and spans it has collected so far and stops waiting for outstanding queriers.
 
 ## Next steps
 

--- a/docs/sources/tempo/introduction/telemetry.md
+++ b/docs/sources/tempo/introduction/telemetry.md
@@ -1,7 +1,4 @@
 ---
-aliases:
-  - /docs/tempo/getting-started/traces
-  - /docs/tempo/traces
 description: "Traces and telemetry"
 keywords:
   - Grafana
@@ -36,7 +33,7 @@ Logs let you know what's happening to your application.
 
 ## Traces
 
-Traces add further to the observability picture by telling you what happens at each step or action in a data pathway. Traces provide the map--the where--something is going wrong.
+Traces add further to the observability picture by telling you what happens at each step or action in a data pathway. Traces provide the map to where something is going wrong.
 A trace provides a graphic representation of how long each step in the data flow pathway takes to complete. For example, how long a HTTP request, a database lookup, or a call to a third party service takes.
 It can show where requests initiate and finish, as well as how your system responds.
 This data helps you locate problem areas and assess their impact, often in places you never would have anticipated or found without this ability to trace the request flow.
@@ -50,7 +47,7 @@ This helps identify specific lines of code or functions to optimize and improve 
 
 Metrics in themselves aren't sufficient to find the root cause and solve complex issues.
 The same can be said for logs, which can contain a significant amount of information but lack the context of the interactions and dependencies between the different components of your complex environment.
-Each pillar of observability&mdash;metrics, logs, traces, profiles&mdash;has its own unique strength when it comes to root causing issues.
+Each pillar of observability has its own unique strength when it comes to root causing issues.
 To get the most value of your observability strategy, you need to be able to correlate them.
 
 Traces have the unique ability to show relationships between services.

--- a/docs/sources/tempo/introduction/telemetry.md
+++ b/docs/sources/tempo/introduction/telemetry.md
@@ -33,7 +33,7 @@ Logs let you know what's happening to your application.
 
 ## Traces
 
-Traces add further to the observability picture by telling you what happens at each step or action in a data pathway. Traces provide the map to where something is going wrong.
+Traces add further to the observability picture by telling you what happens at each step or action in a data pathway. Traces provide a map of where something is going wrong.
 A trace provides a graphic representation of how long each step in the data flow pathway takes to complete. For example, how long a HTTP request, a database lookup, or a call to a third party service takes.
 It can show where requests initiate and finish, as well as how your system responds.
 This data helps you locate problem areas and assess their impact, often in places you never would have anticipated or found without this ability to trace the request flow.


### PR DESCRIPTION
A docs audit flagged the introduction architecture page for mixing overview and reference depth, and the section landing page for weak orientation. This reworks the architecture page into a "how Tempo works" overview that links out to the reference pages for detail, and cleans up a few nearby issues.

- `architecture.md`: restructured into design goals, deployment modes, data flow, components, storage, and query capabilities. Fixed the Azure Blob Storage name, replaced a dead training link, and spelled out RED on first use. Checked against the reference pages and module code.
- `_index.md`: made the example product-neutral and turned "Learn more" into a reading order.
- `telemetry.md`: dropped duplicate aliases and fixed dashes.

Docs updated with the help of AI. 