### PR TITLE
feat(querier): add querier_bytes_returned_total metric

### DIFF
--- a/.chloggen/querier-bytes-returned-metric.yaml
+++ b/.chloggen/querier-bytes-returned-metric.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: querier
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Add `tempo_querier_bytes_returned_total` metric, tracking the size of trace data assembled and returned per operation and tenant
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: zhxiaogg

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -63,6 +63,17 @@ func observeBackendProcessing(operation, tenant string, start time.Time) {
 	metricBackendProcessingDuration.WithLabelValues(operation, tenant).Observe(time.Since(start).Seconds())
 }
 
+// metricBytesReturned records the size of the trace this querier assembled
+// and handed back to its caller (frontend or another querier), independent
+// of InspectedBytes (which measures storage bytes read). It is a
+// per-request/per-job value, not summed or reconciled with any
+// frontend-level metric.
+var metricBytesReturned = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "tempo",
+	Name:      "querier_bytes_returned_total",
+	Help:      "Bytes of trace/span data this querier assembled and returned to its caller, by operation and tenant.",
+}, []string{"operation", "tenant"})
+
 type (
 	forEachFn        func(ctx context.Context, client tempopb.QuerierClient) (any, error)
 	forEachMetricsFn func(ctx context.Context, client tempopb.MetricsClient) (any, error)
@@ -315,6 +326,9 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 	}
 
 	completeTrace, _ := combiner.Result()
+	if completeTrace != nil {
+		metricBytesReturned.WithLabelValues(api.OpTraceByID, userID).Add(float64(completeTrace.Size()))
+	}
 	resp := &tempopb.TraceByIDResponse{
 		Trace:   completeTrace,
 		Metrics: metrics,

--- a/modules/querier/querier_test.go
+++ b/modules/querier/querier_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -229,4 +230,74 @@ func TestFindTraceByID_ExternalMode(t *testing.T) {
 	require.Len(t, resp.Trace.ResourceSpans[0].ScopeSpans, 1)
 	require.Len(t, resp.Trace.ResourceSpans[0].ScopeSpans[0].Spans, 1)
 	require.Equal(t, "external-span", resp.Trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Name)
+}
+
+func TestFindTraceByID_RecordsBytesReturnedMetric(t *testing.T) {
+	traceID := []byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20}
+	userID := "test-tenant-bytes-returned"
+
+	externalTrace := &tempopb.Trace{
+		ResourceSpans: []*v1_trace.ResourceSpans{
+			{
+				ScopeSpans: []*v1_trace.ScopeSpans{
+					{
+						Spans: []*v1_trace.Span{
+							{
+								TraceId: traceID,
+								SpanId:  []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+								Name:    "external-span",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	startTime := int64(1000)
+	endTime := int64(2000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceBytes, err := externalTrace.Marshal()
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", api.HeaderAcceptProtobuf)
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(traceBytes)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		TraceByID: TraceByIDConfig{
+			External: ExternalConfig{
+				Endpoint: server.URL,
+				Timeout:  10 * time.Second,
+			},
+		},
+		Worker: worker.Config{
+			GRPCClientConfig: grpcclient.Config{
+				MaxSendMsgSize: 16 * 1024 * 1024,
+			},
+		},
+	}
+
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.DefaultRegisterer)
+	require.NoError(t, err)
+
+	q, err := New(cfg, nil, livestore_client.Config{}, nil, true, nil, o)
+	require.NoError(t, err)
+
+	ctx := user.InjectOrgID(context.Background(), userID)
+
+	before := testutil.ToFloat64(metricBytesReturned.WithLabelValues(api.OpTraceByID, userID))
+
+	resp, err := q.FindTraceByID(ctx, &tempopb.TraceByIDRequest{
+		TraceID:   traceID,
+		QueryMode: QueryModeExternal,
+	}, time.Unix(startTime, 0), time.Unix(endTime, 0))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Trace)
+
+	after := testutil.ToFloat64(metricBytesReturned.WithLabelValues(api.OpTraceByID, userID))
+	require.Equal(t, float64(resp.Trace.Size()), after-before)
 }


### PR DESCRIPTION
**What this PR does**:
Adds `tempo_querier_bytes_returned_total`, a counter tracking the size (proto `Size()`) of the trace assembled and returned by the querier for each `FindTraceByID` call, labeled by operation and tenant. This is independent of the existing `InspectedBytes`-based metrics, which measure storage read cost, not returned-payload size.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)