### PR TITLE
feat(frontend): compute returnedBytes for trace-by-id responses

### DIFF
--- a/.chloggen/trace-by-id-returned-bytes.yaml
+++ b/.chloggen/trace-by-id-returned-bytes.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: query-frontend
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Add `returnedBytes` to trace-by-id's additional metrics, the size of the trace actually returned to the client, complementing the existing `inspectedBytes` (storage bytes read)
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: zhxiaogg

--- a/modules/frontend/combiner/trace_by_id.go
+++ b/modules/frontend/combiner/trace_by_id.go
@@ -142,6 +142,11 @@ func (c *TraceByIDCombiner) HTTPFinal() (*http.Response, error) {
 		}
 	}
 
+	if c.MetricsCombiner.Metrics.AdditionalMetrics == nil {
+		c.MetricsCombiner.Metrics.AdditionalMetrics = map[string]int64{}
+	}
+	c.MetricsCombiner.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes] = int64(traceResult.Size())
+
 	// marshal in the requested format
 	var buff []byte
 	var err error

--- a/modules/frontend/combiner/trace_by_id_test.go
+++ b/modules/frontend/combiner/trace_by_id_test.go
@@ -115,6 +115,75 @@ func TestTraceByIDRedactorHidesTrace(t *testing.T) {
 	require.Empty(t, body)
 }
 
+func TestTraceByIDReturnedBytes(t *testing.T) {
+	trace1 := test.MakeTrace(2, []byte{0x21, 0x22})
+
+	c := NewTypedTraceByID(0, api.HeaderAcceptProtobuf, nil)
+	err := c.AddResponse(toHTTPProtoResponse(t, &tempopb.TraceByIDResponse{
+		Trace:   trace1,
+		Metrics: &tempopb.TraceByIDMetrics{},
+	}, 200))
+	require.NoError(t, err)
+
+	_, err = c.HTTPFinal()
+	require.NoError(t, err)
+
+	require.Equal(t, int64(trace1.Size()), c.MetricsCombiner.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes])
+}
+
+func TestTraceByIDReturnedBytesDedupesOverlappingShards(t *testing.T) {
+	trace1 := test.MakeTrace(2, []byte{0x23, 0x24})
+
+	c := NewTypedTraceByID(0, api.HeaderAcceptProtobuf, nil)
+	// two shards return the exact same trace, simulating live-store/backend overlap.
+	// each AddResponse call marshals/unmarshals its own independent copy.
+	for i := 0; i < 2; i++ {
+		err := c.AddResponse(toHTTPProtoResponse(t, &tempopb.TraceByIDResponse{
+			Trace:   trace1,
+			Metrics: &tempopb.TraceByIDMetrics{},
+		}, 200))
+		require.NoError(t, err)
+	}
+
+	resp, err := c.HTTPFinal()
+	require.NoError(t, err)
+
+	actual := &tempopb.Trace{}
+	buff, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, proto.Unmarshal(buff, actual))
+
+	returnedBytes := c.MetricsCombiner.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes]
+	require.Equal(t, int64(actual.Size()), returnedBytes)
+	// proves dedup happened: two identical shards must not double the byte count
+	require.Less(t, returnedBytes, int64(2*trace1.Size()))
+}
+
+func TestTraceByIDReturnedBytesComputedOnCacheHit(t *testing.T) {
+	trace1 := test.MakeTrace(2, []byte{0x2b, 0x2c})
+	body, err := proto.Marshal(&tempopb.TraceByIDResponse{
+		Trace:   trace1,
+		Metrics: &tempopb.TraceByIDMetrics{},
+	})
+	require.NoError(t, err)
+
+	c := NewTypedTraceByID(0, api.HeaderAcceptProtobuf, nil)
+	err = c.AddResponse(&testPipelineResponse{r: &http.Response{
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		StatusCode: 200,
+		Header:     http.Header{TempoCacheHeader: {TempoCacheHit}},
+	}})
+	require.NoError(t, err)
+
+	_, err = c.HTTPFinal()
+	require.NoError(t, err)
+
+	// returnedBytes must be populated even though the per-job response was a cache
+	// hit (unlike InspectedBytes/other AdditionalMetrics, which skip cache hits in
+	// Combine()) — the bytes returned to the client are the same either way.
+	require.Equal(t, int64(trace1.Size()), c.MetricsCombiner.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes])
+}
+
 func toHTTPProtoResponse(t *testing.T, pb proto.Message, statusCode int) PipelineResponse {
 	var body []byte
 

--- a/modules/frontend/combiner/trace_by_id_v2.go
+++ b/modules/frontend/combiner/trace_by_id_v2.go
@@ -72,6 +72,11 @@ func NewTraceByIDV2(maxBytes int, marshalingFormat api.MarshallingFormat, traceR
 				}
 			}
 
+			if metricsCombiner.Metrics.AdditionalMetrics == nil {
+				metricsCombiner.Metrics.AdditionalMetrics = map[string]int64{}
+			}
+			metricsCombiner.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes] = int64(traceResult.Size())
+
 			resp.Trace = traceResult
 			resp.Metrics = metricsCombiner.Metrics
 

--- a/modules/frontend/combiner/trace_by_id_v2_test.go
+++ b/modules/frontend/combiner/trace_by_id_v2_test.go
@@ -174,6 +174,28 @@ func TestNewTraceByIDV2(t *testing.T) {
 	})
 }
 
+func TestTraceByIDV2ReturnedBytes(t *testing.T) {
+	testTrace := test.MakeTrace(2, []byte{0x25, 0x26})
+	resBytes, err := proto.Marshal(&tempopb.TraceByIDResponse{
+		Trace:   testTrace,
+		Metrics: &tempopb.TraceByIDMetrics{},
+	})
+	require.NoError(t, err)
+	response := http.Response{
+		StatusCode: 200,
+		Header:     map[string][]string{"Content-Type": {"application/protobuf"}},
+		Body:       io.NopCloser(bytes.NewReader(resBytes)),
+	}
+
+	combiner := NewTypedTraceByIDV2(100_000, api.HeaderAcceptProtobuf, nil, TraceByIDV2Options{})
+	require.NoError(t, combiner.AddResponse(MockResponse{&response}))
+
+	resp, err := combiner.GRPCFinal()
+	require.NoError(t, err)
+
+	require.Equal(t, int64(resp.Trace.Size()), resp.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes])
+}
+
 // TestNewTraceByIDV2WithSpanPruning mimics TestPruneTrace_BasicAggregation from
 // pkg/spanpruning to verify that the combiner actually invokes span pruning: 3 identical
 // leaf spans below a parent should collapse into a single summary span.

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -65,8 +65,10 @@ func newTraceIDHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pipe
 		elapsed := time.Since(start)
 
 		var inspectBytes uint64
+		var returnedBytes int64
 		if comb.MetricsCombiner != nil && comb.MetricsCombiner.Metrics != nil {
 			inspectBytes = comb.MetricsCombiner.Metrics.InspectedBytes
+			returnedBytes = comb.MetricsCombiner.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes]
 		}
 		postSLOHook(resp, tenant, inspectBytes, elapsed, err)
 
@@ -79,6 +81,7 @@ func newTraceIDHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pipe
 			"path", req.URL.Path,
 			"duration_seconds", elapsed.Seconds(),
 			"inspected_bytes", inspectBytes,
+			"returned_bytes", returnedBytes,
 			"request_throughput", float64(inspectBytes)/elapsed.Seconds(),
 			"err", err,
 		)
@@ -155,9 +158,11 @@ func newTraceIDV2Handler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pi
 		elapsed := time.Since(start)
 
 		var bytesProcessed uint64
+		var returnedBytes int64
 		findResp, _ := comb.GRPCFinal()
 		if findResp != nil && findResp.Metrics != nil {
 			bytesProcessed = findResp.Metrics.InspectedBytes
+			returnedBytes = findResp.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes]
 		}
 
 		postSLOHook(resp, tenant, bytesProcessed, elapsed, err)
@@ -170,6 +175,7 @@ func newTraceIDV2Handler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pi
 			"traceID", traceID,
 			"path", req.URL.Path,
 			"inspected_bytes", bytesProcessed,
+			"returned_bytes", returnedBytes,
 			"request_throughput", float64(bytesProcessed)/elapsed.Seconds(),
 			"duration_seconds", elapsed.Seconds(),
 			"span_pruning_enabled", spanPruningEnabled,

--- a/modules/frontend/traceid_handlers_test.go
+++ b/modules/frontend/traceid_handlers_test.go
@@ -595,3 +595,43 @@ func TestTraceByIDHandlerV2CachedMetrics(t *testing.T) {
 	// Verify the backend was called again (callCount should be 4)
 	require.Equal(t, 4, callCount)
 }
+
+func TestTraceIDHandlerV2ReturnedBytes(t *testing.T) {
+	testTrace := test.MakeTrace(2, []byte{0x27, 0x28})
+
+	next := pipeline.RoundTripperFunc(func(_ pipeline.Request) (*http.Response, error) {
+		resBytes, err := proto.Marshal(&tempopb.TraceByIDResponse{
+			Trace:   testTrace,
+			Metrics: &tempopb.TraceByIDMetrics{},
+		})
+		require.NoError(t, err)
+		return &http.Response{
+			Body:       io.NopCloser(bytes.NewReader(resBytes)),
+			StatusCode: 200,
+			Header:     map[string][]string{"Content-Type": {"application/protobuf"}},
+		}, nil
+	})
+
+	f := frontendWithSettings(t, next, nil, config, nil)
+
+	req := httptest.NewRequest("GET", "/api/v2/traces/1234", nil)
+	ctx := user.InjectOrgID(req.Context(), "blerg")
+	req = req.WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{"traceID": "1234"})
+	req.Header.Set("Accept", "application/protobuf")
+
+	httpResp := httptest.NewRecorder()
+	f.TraceByIDHandlerV2.ServeHTTP(httpResp, req)
+	resp := httpResp.Result()
+	require.Equal(t, 200, resp.StatusCode)
+
+	actualResp := &tempopb.TraceByIDResponse{}
+	bytesTrace, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, proto.Unmarshal(bytesTrace, actualResp))
+
+	// config.TraceByID.QueryShards == 2; both shards return the same trace, so the
+	// response must reflect the single deduped copy, not the sum of both shards.
+	require.Equal(t, int64(actualResp.Trace.Size()), actualResp.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes])
+	require.Less(t, actualResp.Metrics.AdditionalMetrics[tempopb.AdditionalMetricReturnedBytes], int64(2*testTrace.Size()))
+}

--- a/pkg/tempopb/additional_metrics_keys.go
+++ b/pkg/tempopb/additional_metrics_keys.go
@@ -15,4 +15,11 @@ const (
 	AdditionalMetricCacheHits          = "cacheHits"
 	AdditionalMetricCacheMisses        = "cacheMisses"
 	AdditionalMetricCacheBytes         = "cacheBytes"
+
+	// AdditionalMetricReturnedBytes is the proto Size() of the final,
+	// deduped trace-by-id response actually returned to the caller. Unlike
+	// the other keys in this file, it is computed once per request at the
+	// point the final result is assembled, and is NOT additive across
+	// per-job/per-shard responses.
+	AdditionalMetricReturnedBytes = "returnedBytes"
 )


### PR DESCRIPTION
**What this PR does**:
Adds `returnedBytes` to trace-by-id's `AdditionalMetrics` (both `/api/traces/{id}` and `/api/v2/traces/{id}`): the proto `Size()` of the final, deduped, redacted (and pruned, where span pruning is enabled) trace actually returned to the caller.

Computed once per request at the point the final result is assembled, not accumulated per-shard — unlike `InspectedBytes`, which sums storage bytes read across every queried shard, a trace can be present in more than one queried source (for example, briefly in both live-store and a freshly-flushed backend block), and summing per-shard sizes would double-count overlapping spans even though the client only receives them once. Always computed, including on cache hits, since the bytes returned to the client are the same regardless of how the response was produced.

Adds a `returned_bytes` field to the existing structured request logs. No new Prometheus metric in this PR (follow-up).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)