### PR TITLE
Fix intrinsic filtering in tag-value autocomplete; simplify lenient parser

### DIFF
--- a/.chloggen/lenient-parser-intrinsic-filtering.yaml
+++ b/.chloggen/lenient-parser-intrinsic-filtering.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: traceql
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Fix tag-value autocomplete ignoring query filters when the incomplete matcher targets an intrinsic (e.g. `{ resource.service.name = "foo" && name = }`)
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mapno

--- a/pkg/traceql/lenient_extract.go
+++ b/pkg/traceql/lenient_extract.go
@@ -17,7 +17,7 @@ const emptyQuery = "{}"
 const DefaultMaxConditionGroupsPerTagQuery = 100
 
 // ExtractConditionGroups parses a query string using the lenient parser and returns
-// groups of conditions. Conditions with OpNone (from incomplete matchers) are filtered out.
+// groups of conditions. Conditions with OpNone (bare attributes) are filtered out.
 //
 // Returns nil if the query is empty or parsing fails completely.
 // Returns nil, ErrMaxConditionGroupsPerTagQueryReached if the number of groups exceeds maxGroups.
@@ -61,7 +61,11 @@ func ExtractConditionGroups(query string, maxGroups int) ([][]Condition, error) 
 			}
 		}
 
-		// if even one group has zero conditions after filtering, treat the whole query as empty (e.g. `{.attr || .foo}`)
+		// If even one group has zero conditions after filtering, treat the whole query as
+		// match-all: that group places no constraint on spans, so no other group can narrow
+		// the result. This covers empty filters (`{}`), bare attributes (`{.attr || .foo}`)
+		// and OR branches with an incomplete matcher (`{.a = "x" || .b = }`, which the
+		// lenient parser rewrites to `{.a = "x" || true}`).
 		if len(conditions) == 0 {
 			return nil, nil
 		}
@@ -181,15 +185,10 @@ func splitReqConditions(expr FieldExpression, maxGroups int) ([][]Condition, boo
 		}
 	}
 
-	// Drop empty groups (e.g. from an empty filter `{}`).
-	result := conditionGroups[:0]
-	for _, g := range conditionGroups {
-		if len(g) > 0 {
-			result = append(result, g)
-		}
-	}
-
-	return result, reachedMaxGroups
+	// Empty groups are kept: they come from match-all branches (`true` leaves, e.g. an
+	// empty filter `{}` or an incomplete matcher rewritten by the lenient parser) and
+	// signal to the caller that the whole query is match-all.
+	return conditionGroups, reachedMaxGroups
 }
 
 // deduplicateConditionBranches removes duplicate branches from an OR group.

--- a/pkg/traceql/lenient_extract_test.go
+++ b/pkg/traceql/lenient_extract_test.go
@@ -198,6 +198,10 @@ func TestExtractConditionGroups(t *testing.T) {
 		// An OR branch with an incomplete matcher matches anything, so the whole
 		// query is match-all (no groups).
 		{name: "incomplete OR branch", query: `{ .foo = "bar" || .baz = }`, count: 0},
+		// Attribute-to-attribute comparisons extract only OpNone fetch hints,
+		// so the group collapses to match-all.
+		{name: "attribute comparison with incomplete", query: `{ .a = .b && .c = }`, count: 0},
+		{name: "attribute comparison plus condition with incomplete", query: `{ .a = .b && .service = "x" && .c = }`, count: 1},
 		{name: "explicit true OR branch", query: `{ .foo = "bar" || true }`, count: 0},
 	}
 	for _, tc := range testCases {

--- a/pkg/traceql/lenient_extract_test.go
+++ b/pkg/traceql/lenient_extract_test.go
@@ -33,7 +33,7 @@ func TestCanonicalQuery(t *testing.T) {
 		{
 			name:     "incomplete query",
 			query:    `{ .http.status_code = 200 && .http.method = }`,
-			expected: "{(.http.status_code = 200) && .http.method}",
+			expected: "{(.http.status_code = 200) && true}",
 		},
 		{
 			name:     "reversed operands with missing closing bracket",
@@ -43,12 +43,12 @@ func TestCanonicalQuery(t *testing.T) {
 		{
 			name:     "long query",
 			query:    `{.service_name = "foo" && .http.status_code = 200 && .http.method = "GET" && .cluster = }`,
-			expected: `{(((.service_name = "foo") && (.http.status_code = 200)) && (.http.method = "GET")) && .cluster}`,
+			expected: `{(((.service_name = "foo") && (.http.status_code = 200)) && (.http.method = "GET")) && true}`,
 		},
 		{
 			name:     "query with duration a boolean",
 			query:    `{ duration > 5s && .success = true && .cluster = }`,
-			expected: `{((duration > 5s) && (.success = true)) && .cluster}`,
+			expected: `{((duration > 5s) && (.success = true)) && true}`,
 		},
 		{
 			name:     "query with three selectors with AND",
@@ -83,12 +83,12 @@ func TestCanonicalQuery(t *testing.T) {
 		{
 			name:     "query with missing closing bracket",
 			query:    `{resource.service_name = "foo" && span.http.target=`,
-			expected: `{(resource.service_name = "foo") && span.http.target}`,
+			expected: `{(resource.service_name = "foo") && true}`,
 		},
 		{
 			name:     "uncommon characters",
 			query:    `{ span.foo = "<>:b5[]" && resource.service.name = }`,
-			expected: `{(span.foo = "<>:b5[]") && resource.service.name}`,
+			expected: `{(span.foo = "<>:b5[]") && true}`,
 		},
 		{
 			name:     "kind",
@@ -138,7 +138,7 @@ func TestCanonicalQuery(t *testing.T) {
 		{
 			name:     "structural operators with incomplete in first matcher",
 			query:    `{ .foo = "bar" && .baaz = } >> { .bar = "foo" }`,
-			expected: `({ (.foo = "bar") && .baaz }) >> ({ .bar = "foo" })`,
+			expected: `({ (.foo = "bar") && true }) >> ({ .bar = "foo" })`,
 		},
 		{
 			name:     "structural operators with incomplete in second matcher",
@@ -148,22 +148,22 @@ func TestCanonicalQuery(t *testing.T) {
 		{
 			name:     "metrics query",
 			query:    `{.service_name = "foo" && .foo=} | rate() by (.bar)`,
-			expected: `{(.service_name = "foo") && .foo} | rate() by (.bar)`,
+			expected: `{(.service_name = "foo") && true} | rate() by (.bar)`,
 		},
 		{
 			name:     "query with select",
 			query:    `{.service_name = "foo" && .foo=} | select(.bar, .baz)`,
-			expected: `{(.service_name = "foo") && .foo} | select(.bar, .baz)`,
+			expected: `{(.service_name = "foo") && true} | select(.bar, .baz)`,
 		},
 		{
 			name:     "query with parentheses and incomplete matcher",
 			query:    `{ (resource.foo = "bar" && .baz = ) && .qux = "quux" }`,
-			expected: `{((resource.foo = "bar") && .baz) && (.qux = "quux")}`,
+			expected: `{((resource.foo = "bar") && true) && (.qux = "quux")}`,
 		},
 		{
 			name:     "query with parentheses containing all incomplete matchers",
 			query:    `{ (resource.foo =  && .baz = ) && .qux = "quux" }`,
-			expected: `{(resource.foo && .baz) && (.qux = "quux")}`,
+			expected: `{true && (.qux = "quux")}`,
 		},
 	}
 	for _, tc := range testCases {
@@ -192,6 +192,13 @@ func TestExtractConditionGroups(t *testing.T) {
 		{name: "OR conditions", query: `{ (.foo = "bar" || .baz = "qux") }`, count: 2},
 		{name: "structural", query: `{ .foo = "bar" } >> { .bar = "baz" }`, count: 0},
 		{name: "multiple conditions", query: `{.a = 1 && .b = "two" && .c > 3}`, count: 1},
+		// Regression: an incomplete intrinsic matcher must not discard the other
+		// AND conditions (it used to fail validation and return zero groups).
+		{name: "incomplete intrinsic", query: `{.a = 1 && .b = "two" && name = }`, count: 1},
+		// An OR branch with an incomplete matcher matches anything, so the whole
+		// query is match-all (no groups).
+		{name: "incomplete OR branch", query: `{ .foo = "bar" || .baz = }`, count: 0},
+		{name: "explicit true OR branch", query: `{ .foo = "bar" || true }`, count: 0},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -323,6 +330,20 @@ func TestSplitReqConditionGroups(t *testing.T) {
 		{
 			name:     "one OR is opnone query",
 			query:    `{.attr || .foo = "bar" }`,
+			expected: nil,
+		},
+		{
+			name:  "incomplete intrinsic matcher keeps other conditions",
+			query: `{ .service = "b" && name = }`,
+			expected: [][]Condition{
+				{
+					newCondition(NewAttribute("service"), OpEqual, NewStaticString("b")),
+				},
+			},
+		},
+		{
+			name:     "incomplete matcher in OR branch is match-all",
+			query:    `{ .service = "b" || .env = }`,
 			expected: nil,
 		},
 		{

--- a/pkg/traceql/lenient_parser.go
+++ b/pkg/traceql/lenient_parser.go
@@ -25,6 +25,14 @@ import (
 // it contributes no conditions in an AND chain,
 // and as an OR branch it correctly collapses the query to match-all
 // (see ExtractConditionGroups in lenient_extract.go).
+//
+// Scope: the only supported input shape is a valid query except for
+// incomplete matchers and a not-yet-typed closing brace —
+// exactly what completion requests produce.
+// Anything else (e.g. a dangling connector like `{ .a = 1 && }`)
+// intentionally returns the original parse error,
+// and callers degrade to unfiltered results.
+// This is not a general TraceQL repair tool; do not widen the shape.
 
 // ParseLenient attempts to parse a query string.
 // If parsing succeeds, the result is returned as-is.

--- a/pkg/traceql/lenient_parser.go
+++ b/pkg/traceql/lenient_parser.go
@@ -7,19 +7,38 @@ import (
 	"text/scanner"
 )
 
-// ParseLenient attempts to parse a query string. If parsing succeeds, the result
-// is returned as-is. If parsing fails (e.g. due to incomplete matchers like `.foo=`),
-// it removes the comparison operator from incomplete matchers, leaving just the
-// attribute (e.g. `.foo`), while preserving the original query structure (ORs, ANDs,
-// pipes, structural operators, etc.) and re-parses the cleaned-up query.
+// This file implements lenient parsing of incomplete TraceQL queries,
+// used by the tag-name and tag-value autocomplete endpoints
+// where clients (e.g. Grafana) send partially-typed queries such as `{ .foo = "bar" && name = }`.
+//
+// The approach is deliberately a single string-level transformation:
+//
+//  1. Tokenize the query with the regular TraceQL lexer.
+//  2. Replace each incomplete matcher (attribute + comparison operator with no value, e.g. `name =`)
+//     with the literal `true`.
+//  3. Rebuild the query string (balancing unclosed braces) and re-parse it with the strict parser.
+//
+// Replacing incomplete matchers with `true` — rather than deleting tokens —
+// keeps the expression structurally complete and boolean-typed by construction:
+// no dangling `&&`/`||` connectors, no empty parentheses, no type errors from leftover bare attributes.
+// `true` is also semantically right for condition extraction:
+// it contributes no conditions in an AND chain,
+// and as an OR branch it correctly collapses the query to match-all
+// (see ExtractConditionGroups in lenient_extract.go).
+
+// ParseLenient attempts to parse a query string.
+// If parsing succeeds, the result is returned as-is.
+// If parsing fails (e.g. due to incomplete matchers like `.foo =`),
+// incomplete matchers are replaced with `true` and the cleaned query is re-parsed.
+// The original query structure (ORs, ANDs, pipes, structural operators, etc.) is preserved.
 func ParseLenient(s string) (*RootExpr, error) {
 	expr, err := ParseNoOptimizations(s)
 	if err == nil {
 		return expr, nil
 	}
 
-	// Remove incomplete matchers and try again.
-	cleaned := removeIncompleteMatchers(s)
+	// Replace incomplete matchers and try again.
+	cleaned := replaceIncompleteMatchers(s)
 	if cleaned == "" {
 		return nil, err
 	}
@@ -28,72 +47,7 @@ func ParseLenient(s string) (*RootExpr, error) {
 	if cleanedErr != nil {
 		return nil, err // return original parse error
 	}
-	removeBareAttributes(result)
 	return result, nil
-}
-
-// removeBareAttributes walks the AST and replaces bare Attribute expressions
-// inside SpansetFilters with `true`. These are leftovers from incomplete matchers
-// (e.g. { event:name = } cleaned to { event:name }) that wouldn't pass validation.
-// After mutation, pipeline map keys and expression tree leaf keys are rebuilt
-// to stay consistent with the changed pipeline string representations.
-func removeBareAttributes(root *RootExpr) {
-	keyMap := make(map[string]string, len(root.Pipeline))
-	newPipelines := make(map[string]Pipeline, len(root.Pipeline))
-	for k, p := range root.Pipeline {
-		removeBareAttrsInPipeline(p)
-		newKey := p.String()
-		if sp, ok := root.BatchSpanProcessor[k]; ok {
-			newKey += " | " + sp.(Element).String()
-		}
-		newPipelines[newKey] = p
-		keyMap[k] = newKey
-	}
-	root.Pipeline = newPipelines
-	root.expression = root.expression.RewriteKeys(keyMap)
-
-	if len(root.BatchSpanProcessor) > 0 {
-		newSpanProcs := make(map[string]spanProcessor, len(root.BatchSpanProcessor))
-		for k, v := range root.BatchSpanProcessor {
-			newSpanProcs[keyMap[k]] = v
-		}
-		root.BatchSpanProcessor = newSpanProcs
-	}
-	if len(root.SeriesProcessor) > 0 {
-		newSeriesProcs := make(map[string]seriesProcessor, len(root.SeriesProcessor))
-		for k, v := range root.SeriesProcessor {
-			newSeriesProcs[keyMap[k]] = v
-		}
-		root.SeriesProcessor = newSeriesProcs
-	}
-}
-
-func removeBareAttrsInPipeline(p Pipeline) {
-	for _, e := range p.Elements {
-		switch v := e.(type) {
-		case *SpansetFilter:
-			if _, ok := v.Expression.(Attribute); ok {
-				v.Expression = NewStaticBool(true)
-			}
-		case SpansetOperation:
-			removeBareAttrsInElement(v.LHS)
-			removeBareAttrsInElement(v.RHS)
-		}
-	}
-}
-
-func removeBareAttrsInElement(e SpansetExpression) {
-	switch v := e.(type) {
-	case *SpansetFilter:
-		if _, ok := v.Expression.(Attribute); ok {
-			v.Expression = NewStaticBool(true)
-		}
-	case SpansetOperation:
-		removeBareAttrsInElement(v.LHS)
-		removeBareAttrsInElement(v.RHS)
-	case Pipeline:
-		removeBareAttrsInPipeline(v)
-	}
 }
 
 // token represents a lexed token with its type and string value.
@@ -102,42 +56,62 @@ type token struct {
 	str string
 }
 
-// removeIncompleteMatchers tokenizes the input, removes incomplete matchers
-// (attribute + comparison operator with no following value), cleans up dangling
-// connectors, and rebuilds the query string.
-// Only the part before the first pipe is cleaned — the cleanup logic doesn't
-// understand pipeline syntax (function calls like rate(), count(), grouping
-// like by()) and would mangle it. The pipeline is re-appended after cleanup.
-func removeIncompleteMatchers(s string) string {
+// replaceIncompleteMatchers tokenizes the input, replaces incomplete matchers
+// (attribute + comparison operator with no following value) with `true`, and rebuilds the query string.
+// Only the part before the first pipe is rewritten — the rewrite logic doesn't understand pipeline syntax
+// (function calls like rate(), count(), grouping like by()) and would mangle it.
+// The pipeline is re-appended after the rewrite.
+func replaceIncompleteMatchers(s string) string {
 	tokens := tokenize(s)
 	if len(tokens) == 0 {
 		return ""
 	}
 
-	// Split at the first pipe: clean matchers only, preserve pipeline as-is.
+	// Split at the first pipe: rewrite matchers only, preserve pipeline as-is.
 	var pipelineTokens []token
-	pipeIdx := -1
 	for i, t := range tokens {
 		if t.typ == PIPE {
-			pipeIdx = i
+			pipelineTokens = tokens[i:]
+			tokens = tokens[:i]
 			break
 		}
 	}
 
-	if pipeIdx != -1 {
-		pipelineTokens = tokens[pipeIdx:]
-		tokens = tokens[:pipeIdx]
+	out := make([]token, 0, len(tokens)+len(pipelineTokens))
+	for i := 0; i < len(tokens); {
+		if !isAttributeToken(tokens[i].typ) {
+			out = append(out, tokens[i])
+			i++
+			continue
+		}
+
+		attrStart := i
+		skipAttribute(tokens, &i)
+
+		// Complete matcher: attr + op + value → keep as-is.
+		if i+2 < len(tokens) && isComparisonOperator(tokens[i+1].typ) && isValueToken(tokens[i+2].typ) {
+			out = append(out, tokens[attrStart:i+3]...)
+			i += 3
+			continue
+		}
+
+		// Incomplete matcher: attr + op but no value → replace with `true`.
+		if i+1 < len(tokens) && isComparisonOperator(tokens[i+1].typ) {
+			out = append(out, token{typ: TRUE, str: "true"})
+			i += 2
+			continue
+		}
+
+		// Not a matcher pattern (just an attribute reference) → keep the token
+		// and rescan from the next one.
+		out = append(out, tokens[attrStart])
+		i = attrStart + 1
 	}
 
-	remove := make([]bool, len(tokens))
-	markIncompleteMatchers(tokens, remove)
-	cleanDanglingConnectorsAndParens(tokens, remove)
+	// Re-append the pipeline tokens (not subject to the rewrite).
+	out = append(out, pipelineTokens...)
 
-	// Re-append the pipeline tokens (not subject to cleanup).
-	tokens = append(tokens, pipelineTokens...)
-	remove = append(remove, make([]bool, len(pipelineTokens))...)
-
-	return rebuildQuery(tokens, remove)
+	return rebuildQuery(out)
 }
 
 // tokenize lexes the input into tokens, skipping END_ATTRIBUTE markers.
@@ -179,37 +153,6 @@ func tokenize(s string) []token {
 	return tokens
 }
 
-// markIncompleteMatchers finds attribute + comparison operator sequences with no
-// following value token and marks them for removal.
-func markIncompleteMatchers(tokens []token, remove []bool) {
-	i := 0
-	for i < len(tokens) {
-		if !isAttributeToken(tokens[i].typ) {
-			i++
-			continue
-		}
-
-		attrStart := i
-		skipAttribute(tokens, &i)
-
-		// Complete matcher: attr + op + value → keep
-		if i+2 < len(tokens) && isComparisonOperator(tokens[i+1].typ) && isValueToken(tokens[i+2].typ) {
-			i += 3
-			continue
-		}
-
-		// Incomplete matcher: attr + op but no value → mark operator for removal
-		if i+1 < len(tokens) && isComparisonOperator(tokens[i+1].typ) {
-			remove[i+1] = true
-			i += 2
-			continue
-		}
-
-		// Not a matcher pattern (just an attribute reference) → leave it
-		i = attrStart + 1
-	}
-}
-
 // skipAttribute advances idx past scope prefix tokens so it points to the
 // attribute name (IDENTIFIER or intrinsic). For bare intrinsics (e.g. statusMessage),
 // idx is not advanced since the intrinsic token is the attribute itself.
@@ -233,103 +176,15 @@ func skipAttribute(tokens []token, idx *int) {
 	*idx = i
 }
 
-// cleanDanglingConnectorsAndParens removes AND/OR tokens left dangling after
-// incomplete matcher removal (e.g. adjacent to braces or other connectors),
-// and removes parentheses pairs that contain only removed tokens.
-func cleanDanglingConnectorsAndParens(tokens []token, remove []bool) {
-	changed := true
-	for changed {
-		changed = false
-		for i := range tokens {
-			if remove[i] {
-				continue
-			}
-
-			switch tokens[i].typ {
-			case AND, OR:
-				// Remove connectors with no valid expression on either side
-				prev := findAdjacentToken(tokens, remove, i, -1)
-				next := findAdjacentToken(tokens, remove, i, 1)
-
-				if prev == -1 || tokens[prev].typ == OPEN_BRACE || tokens[prev].typ == OPEN_PARENS ||
-					next == -1 || tokens[next].typ == CLOSE_BRACE || tokens[next].typ == CLOSE_PARENS ||
-					isConnector(tokens[prev].typ) || isConnector(tokens[next].typ) {
-					remove[i] = true
-					changed = true
-				}
-			case OPEN_PARENS:
-				// check if all tokens inside the parens are removed, if so remove the parens too
-				closeParensIdx := findNextCloseParens(tokens, remove, i+1)
-				if closeParensIdx != -1 {
-					allRemoved := true
-					for j := i + 1; j < closeParensIdx; j++ {
-						if !remove[j] {
-							allRemoved = false
-							break
-						}
-					}
-					if allRemoved {
-						remove[i] = true
-						remove[closeParensIdx] = true
-						changed = true
-					}
-				}
-			default:
-				continue
-			}
-		}
-	}
-}
-
-func isConnector(typ int) bool {
-	return typ == AND || typ == OR
-}
-
-// findAdjacentToken returns the index of the nearest non-removed token in the
-// given direction (-1 for previous, +1 for next). Returns -1 if none found.
-func findAdjacentToken(tokens []token, remove []bool, from, dir int) int {
-	for j := from + dir; j >= 0 && j < len(tokens); j += dir {
-		if !remove[j] {
-			return j
-		}
-	}
-	return -1
-}
-
-func findNextCloseParens(tokens []token, remove []bool, from int) int {
-	depth := 0
-	for j := from; j < len(tokens); j++ {
-		if remove[j] {
-			continue
-		}
-		switch tokens[j].typ {
-		case OPEN_PARENS:
-			depth++
-		case CLOSE_PARENS:
-			if depth == 0 {
-				return j
-			}
-			depth--
-		}
-	}
-	return -1
-}
-
-// rebuildQuery reconstructs a query string from remaining (non-removed) tokens,
-// balancing any unclosed braces.
-func rebuildQuery(tokens []token, remove []bool) string {
+// rebuildQuery reconstructs a query string from tokens, balancing any unclosed braces.
+func rebuildQuery(tokens []token) string {
 	var b strings.Builder
-	prevIdx := -1
 	braceDepth := 0
 	for i, t := range tokens {
-		if remove[i] {
-			continue
-		}
-		if prevIdx >= 0 && !isScopeToken(tokens[prevIdx].typ) {
+		if i > 0 && !isScopeToken(tokens[i-1].typ) {
 			b.WriteString(" ")
 		}
 		b.WriteString(tokenRepr(t))
-		prevIdx = i
 		switch t.typ {
 		case OPEN_BRACE:
 			braceDepth++

--- a/pkg/traceql/lenient_parser.go
+++ b/pkg/traceql/lenient_parser.go
@@ -11,6 +11,10 @@ import (
 // used by the tag-name and tag-value autocomplete endpoints
 // where clients (e.g. Grafana) send partially-typed queries such as `{ .foo = "bar" && name = }`.
 //
+// Anything else (e.g. a dangling connector like `{ .a = 1 && }`) intentionally returns the original parse error,
+// and callers degrade to unfiltered results.
+// This is not a general TraceQL repair tool; do not widen the shape.
+//
 // The approach is deliberately a single string-level transformation:
 //
 //  1. Tokenize the query with the regular TraceQL lexer.
@@ -25,14 +29,6 @@ import (
 // it contributes no conditions in an AND chain,
 // and as an OR branch it correctly collapses the query to match-all
 // (see ExtractConditionGroups in lenient_extract.go).
-//
-// Scope: the only supported input shape is a valid query except for
-// incomplete matchers and a not-yet-typed closing brace —
-// exactly what completion requests produce.
-// Anything else (e.g. a dangling connector like `{ .a = 1 && }`)
-// intentionally returns the original parse error,
-// and callers degrade to unfiltered results.
-// This is not a general TraceQL repair tool; do not widen the shape.
 
 // ParseLenient attempts to parse a query string.
 // If parsing succeeds, the result is returned as-is.

--- a/pkg/traceql/lenient_parser.go
+++ b/pkg/traceql/lenient_parser.go
@@ -14,8 +14,8 @@ import (
 // The approach is deliberately a single string-level transformation:
 //
 //  1. Tokenize the query with the regular TraceQL lexer.
-//  2. Replace each incomplete matcher (attribute + comparison operator with no value, e.g. `name =`)
-//     with the literal `true`.
+//  2. Replace each incomplete matcher (attribute + comparison operator with nothing
+//     after it, e.g. `name =`; see isTerminator) with the literal `true`.
 //  3. Rebuild the query string (balancing unclosed braces) and re-parse it with the strict parser.
 //
 // Replacing incomplete matchers with `true` — rather than deleting tokens —
@@ -88,16 +88,18 @@ func replaceIncompleteMatchers(s string) string {
 		attrStart := i
 		skipAttribute(tokens, &i)
 
-		// Complete matcher: attr + op + value → keep as-is.
-		if i+2 < len(tokens) && isComparisonOperator(tokens[i+1].typ) && isValueToken(tokens[i+2].typ) {
-			out = append(out, tokens[attrStart:i+3]...)
-			i += 3
-			continue
-		}
-
-		// Incomplete matcher: attr + op but no value → replace with `true`.
+		// Matcher: attr + comparison operator. It is incomplete only when
+		// nothing follows the operator: end of input or a structural
+		// terminator. Anything else may be the RHS — keep it and let the
+		// strict re-parse decide whether it's valid.
 		if i+1 < len(tokens) && isComparisonOperator(tokens[i+1].typ) {
-			out = append(out, token{typ: TRUE, str: "true"})
+			if i+2 >= len(tokens) || isTerminator(tokens[i+2].typ) {
+				// Incomplete: no RHS → replace with `true`. tokenRepr renders
+				// the TRUE token via reverseTokenMap, so no str is needed.
+				out = append(out, token{typ: TRUE})
+			} else {
+				out = append(out, tokens[attrStart:i+2]...)
+			}
 			i += 2
 			continue
 		}
@@ -248,13 +250,13 @@ func isComparisonOperator(typ int) bool {
 		typ == GT || typ == GTE || typ == RE || typ == NRE
 }
 
-func isValueToken(typ int) bool {
-	return typ == STRING || typ == INTEGER || typ == FLOAT ||
-		typ == DURATION || typ == TRUE || typ == FALSE || typ == NIL ||
-		typ == STATUS_OK || typ == STATUS_ERROR || typ == STATUS_UNSET ||
-		typ == KIND_UNSPECIFIED || typ == KIND_INTERNAL || typ == KIND_SERVER ||
-		typ == KIND_CLIENT || typ == KIND_PRODUCER || typ == KIND_CONSUMER ||
-		typ == IDENTIFIER
+// isTerminator reports whether a token closes a matcher's slot in a filter:
+// a closing brace/paren or a connector. A comparison operator followed by one
+// of these (or by end of input) has no RHS, i.e. the matcher is incomplete.
+// This is deliberately a closed set: the pass only knows what "nothing" looks
+// like, so it needs no updates as the expression grammar grows.
+func isTerminator(typ int) bool {
+	return typ == CLOSE_BRACE || typ == CLOSE_PARENS || typ == AND || typ == OR
 }
 
 // lenientLexer is a lexer that doesn't stop on errors.

--- a/pkg/traceql/lenient_parser_test.go
+++ b/pkg/traceql/lenient_parser_test.go
@@ -42,9 +42,11 @@ func TestParseLenient(t *testing.T) {
 			expected: "{ true }",
 		},
 
-		// Incomplete matchers: operator removed, bare attribute replaced with true.
-		// A single bare attribute as the entire filter becomes { true } (match all).
-		// When part of a larger expression (e.g. && .b), it stays as-is.
+		// Incomplete matchers are replaced with `true`. A lone incomplete
+		// matcher becomes { true } (match all); inside a larger expression the
+		// `true` placeholder keeps the rest of the expression intact. The
+		// strict re-parse may constant-fold static booleans (e.g.
+		// `true && true` → `true`, `!true` → `false`).
 		{
 			name:     "single incomplete matcher",
 			in:       `{ .foo = }`,
@@ -53,22 +55,22 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "incomplete after complete",
 			in:       `{ .a = 1 && .b = }`,
-			expected: "{ (.a = 1) && .b }",
+			expected: "{ (.a = 1) && true }",
 		},
 		{
 			name:     "incomplete before complete",
 			in:       `{ .a = && .b = 1 }`,
-			expected: "{ .a && (.b = 1) }",
+			expected: "{ true && (.b = 1) }",
 		},
 		{
 			name:     "multiple incomplete matchers",
 			in:       `{ .a = && .b = && .c = 1 }`,
-			expected: "{ (.a && .b) && (.c = 1) }",
+			expected: "{ true && (.c = 1) }",
 		},
 		{
 			name:     "all matchers incomplete",
 			in:       `{ .a = && .b = }`,
-			expected: "{ .a && .b }",
+			expected: "{ true }",
 		},
 		{
 			name:     "incomplete not-equal",
@@ -78,7 +80,7 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "incomplete with negation",
 			in:       `{ !.foo = }`,
-			expected: "{ !.foo }",
+			expected: "{ false }",
 		},
 
 		// Scoped attributes.
@@ -90,7 +92,7 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "mixed scopes incomplete",
 			in:       `{ span.foo = "bar" && resource.baz = }`,
-			expected: "{ (span.foo = `bar`) && resource.baz }",
+			expected: "{ (span.foo = `bar`) && true }",
 		},
 		{
 			name:     "parent scoped incomplete",
@@ -218,17 +220,17 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "all comparison ops incomplete",
 			in:       `{ .a > && .b < }`,
-			expected: "{ .a && .b }",
+			expected: "{ true }",
 		},
 		{
 			name:     "all comparison ops incomplete gte lte",
 			in:       `{ .a >= && .b <= }`,
-			expected: "{ .a && .b }",
+			expected: "{ true }",
 		},
 		{
 			name:     "all comparison ops incomplete regex",
 			in:       `{ .a =~ && .b !~ }`,
-			expected: "{ .a && .b }",
+			expected: "{ true }",
 		},
 
 		// Value types preserved in complete matchers.
@@ -265,53 +267,53 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "nil value with incomplete",
 			in:       `{ .foo = nil && .bar = }`,
-			expected: "{ (.foo = nil) && .bar }",
+			expected: "{ (.foo = nil) && true }",
 		},
 		{
 			name:     "multiple nil values with incomplete",
 			in:       `{ .a = nil && .b = nil && .c = }`,
-			expected: "{ ((.a = nil) && (.b = nil)) && .c }",
+			expected: "{ ((.a = nil) && (.b = nil)) && true }",
 		},
 		{
 			name:     "existence check with incomplete",
 			in:       `{ .foo != nil && .bar = }`,
-			expected: "{ (.foo != nil) && .bar }",
+			expected: "{ (.foo != nil) && true }",
 		},
 
 		// OR with incomplete.
 		{
 			name:     "OR with incomplete",
 			in:       `{ .a = "foo" || .b = }`,
-			expected: "{ (.a = `foo`) || .b }",
+			expected: "{ (.a = `foo`) || true }",
 		},
 
 		// Parentheses cleanup.
 		{
 			name:     "parenthesized incomplete",
 			in:       `{ (.a = ) && .b = 1 }`,
-			expected: "{ .a && (.b = 1) }",
+			expected: "{ true && (.b = 1) }",
 		},
 		{
 			name:     "all incomplete inside parens",
 			in:       `{ (.a = && .b = ) && .c = 1 }`,
-			expected: "{ (.a && .b) && (.c = 1) }",
+			expected: "{ true && (.c = 1) }",
 		},
 		{
 			name:     "nested parens with incomplete",
 			in:       `{ ((.a = ) && .b = 1) || .c = 2 }`,
-			expected: "{ (.a && (.b = 1)) || (.c = 2) }",
+			expected: "{ (true && (.b = 1)) || (.c = 2) }",
 		},
 		{
 			name:     "inner parens incomplete",
 			in:       `{ (.a = 1 && (.b = )) && .c = 2 }`,
-			expected: "{ ((.a = 1) && .b) && (.c = 2) }",
+			expected: "{ ((.a = 1) && true) && (.c = 2) }",
 		},
 
 		// Missing closing brace.
 		{
 			name:     "missing closing brace with incomplete",
 			in:       `{ .a = 1 && .b =`,
-			expected: "{ (.a = 1) && .b }",
+			expected: "{ (.a = 1) && true }",
 		},
 		{
 			name:     "missing closing brace valid",
@@ -321,19 +323,19 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "missing closing brace gte incomplete",
 			in:       `{ .a = 1 && .b >=`,
-			expected: "{ (.a = 1) && .b }",
+			expected: "{ (.a = 1) && true }",
 		},
 		{
 			name:     "missing closing brace nre incomplete",
 			in:       `{ .a = 1 && .b !~`,
-			expected: "{ (.a = 1) && .b }",
+			expected: "{ (.a = 1) && true }",
 		},
 
 		// Structural operators preserved.
 		{
 			name:     "structural with incomplete in first",
 			in:       `{ .foo = "bar" && .baz = } >> { .bar = "qux" }`,
-			expected: "({ (.foo = `bar`) && .baz }) >> ({ .bar = `qux` })",
+			expected: "({ (.foo = `bar`) && true }) >> ({ .bar = `qux` })",
 		},
 		{
 			name:     "structural with incomplete in second",
@@ -360,12 +362,12 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "incomplete with rate pipeline",
 			in:       `{ .foo = "bar" && .baz = } | rate() by (.qux)`,
-			expected: "{ (.foo = `bar`) && .baz } | rate()by(.qux)",
+			expected: "{ (.foo = `bar`) && true } | rate()by(.qux)",
 		},
 		{
 			name:     "incomplete with select pipeline",
 			in:       `{ .foo = && .bar = "baz" } | select(.qux)`,
-			expected: "{ .foo && (.bar = `baz`) }|select(.qux)",
+			expected: "{ true && (.bar = `baz`) }|select(.qux)",
 		},
 		{
 			name:     "incomplete with count pipeline",
@@ -395,8 +397,8 @@ func TestParseLenient(t *testing.T) {
 			expected: "{ (.foo = `bar`) || (.baz = `qux`) }",
 		},
 
-		// Quoted attributes — complete matchers pass through, incomplete ones resolve to { true }
-		// or leave the bare quoted attribute in place when combined with other matchers.
+		// Quoted attributes — complete matchers pass through, incomplete ones
+		// are replaced with `true`.
 		{
 			name:     "quoted attribute name",
 			in:       `{ span."foo bar" = "baz" }`,
@@ -405,7 +407,7 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "quoted attributes with incomplete",
 			in:       `{ span."foo bar" = "baz" && resource."service name" = }`,
-			expected: "{ (span.\"foo bar\" = `baz`) && resource.\"service name\" }",
+			expected: "{ (span.\"foo bar\" = `baz`) && true }",
 		},
 		{
 			name:     "quoted attribute incomplete",
@@ -432,21 +434,51 @@ func TestParseLenient(t *testing.T) {
 		{
 			name:     "mixed regex and incomplete",
 			in:       `{ .foo =~ "(a|b)" && .bar = }`,
-			expected: "{ (.foo =~ `(a|b)`) && .bar }",
+			expected: "{ (.foo =~ `(a|b)`) && true }",
 		},
 
 		// Reversed operands.
 		{
 			name:     "reversed operands with incomplete",
 			in:       `{ 200 = .status_code && .method = }`,
-			expected: "{ (200 = .status_code) && .method }",
+			expected: "{ (200 = .status_code) && true }",
 		},
 
 		// Arithmetic in matchers.
 		{
 			name:     "arithmetic expression with incomplete",
 			in:       `{ .a + .b = 3 && .c = }`,
-			expected: "{ ((.a + .b) = 3) && .c }",
+			expected: "{ ((.a + .b) = 3) && true }",
+		},
+
+		// Typed intrinsics with incomplete matchers combined with other
+		// conditions. Regression tests: these used to leave a bare intrinsic
+		// behind (e.g. `{ ... && name }`), which failed type validation and
+		// made tag-value autocomplete fall back to unfiltered results.
+		{
+			name:     "incomplete name intrinsic after conditions",
+			in:       `{ resource.k8s.namespace.name = "tempo-ops-01" && resource.k8s.container.name = "query-frontend" && name = }`,
+			expected: "{ ((resource.k8s.namespace.name = `tempo-ops-01`) && (resource.k8s.container.name = `query-frontend`)) && true }",
+		},
+		{
+			name:     "incomplete status intrinsic after condition",
+			in:       `{ .a = 1 && status = }`,
+			expected: "{ (.a = 1) && true }",
+		},
+		{
+			name:     "incomplete kind intrinsic after condition",
+			in:       `{ .a = 1 && kind = }`,
+			expected: "{ (.a = 1) && true }",
+		},
+		{
+			name:     "incomplete duration intrinsic after condition",
+			in:       `{ .a = 1 && duration > }`,
+			expected: "{ (.a = 1) && true }",
+		},
+		{
+			name:     "incomplete scoped intrinsic after condition",
+			in:       `{ .a = 1 && event:name = }`,
+			expected: "{ (.a = 1) && true }",
 		},
 	}
 
@@ -505,7 +537,7 @@ func TestParseLenientKnownFailures(t *testing.T) {
 	}
 }
 
-func TestRemoveIncompleteMatchers(t *testing.T) {
+func TestReplaceIncompleteMatchers(t *testing.T) {
 	tests := []struct {
 		name     string
 		in       string
@@ -519,37 +551,37 @@ func TestRemoveIncompleteMatchers(t *testing.T) {
 		{
 			name:     "single incomplete",
 			in:       `{ .a = }`,
-			expected: `{ .a }`,
+			expected: `{ true }`,
 		},
 		{
 			name:     "trailing incomplete",
 			in:       `{ .a = 1 && .b = }`,
-			expected: `{ .a = 1 && .b }`,
+			expected: `{ .a = 1 && true }`,
 		},
 		{
 			name:     "leading incomplete",
 			in:       `{ .a = && .b = 1 }`,
-			expected: `{ .a && .b = 1 }`,
+			expected: `{ true && .b = 1 }`,
 		},
 		{
-			name:     "all incomplete removes connectors",
+			name:     "all incomplete",
 			in:       `{ .a = && .b = }`,
-			expected: `{ .a && .b }`,
+			expected: `{ true && true }`,
 		},
 		{
 			name:     "missing closing brace auto-closed",
 			in:       `{ .a = 1 && .b =`,
-			expected: `{ .a = 1 && .b }`,
+			expected: `{ .a = 1 && true }`,
 		},
 		{
 			name:     "pipeline preserved",
 			in:       `{ .a = } | rate ( ) by ( .b )`,
-			expected: `{ .a } | rate ( ) by ( .b )`,
+			expected: `{ true } | rate ( ) by ( .b )`,
 		},
 		{
-			name:     "parens with incomplete keep attribute",
+			name:     "parens with incomplete",
 			in:       `{ (.a = ) && .b = 1 }`,
-			expected: `{ ( .a ) && .b = 1 }`,
+			expected: `{ ( true ) && .b = 1 }`,
 		},
 		{
 			name:     "empty input",
@@ -559,23 +591,28 @@ func TestRemoveIncompleteMatchers(t *testing.T) {
 		{
 			name:     "scoped attribute",
 			in:       `{ resource.service.name = && span.foo = "bar" }`,
-			expected: `{ resource.service.name && span.foo = "bar" }`,
+			expected: `{ true && span.foo = "bar" }`,
+		},
+		{
+			name:     "incomplete intrinsic after complete matcher",
+			in:       `{ .a = 1 && name = }`,
+			expected: `{ .a = 1 && true }`,
 		},
 		{
 			name:     "structural operator passes through",
 			in:       `{ .a = } >> { .b = "foo" }`,
-			expected: `{ .a } >> { .b = "foo" }`,
+			expected: `{ true } >> { .b = "foo" }`,
 		},
 		{
 			name:     "OR connector preserved",
 			in:       `{ .a = "foo" || .b = }`,
-			expected: `{ .a = "foo" || .b }`,
+			expected: `{ .a = "foo" || true }`,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := removeIncompleteMatchers(tc.in)
+			actual := replaceIncompleteMatchers(tc.in)
 			require.Equal(t, tc.expected, actual)
 		})
 	}

--- a/pkg/traceql/lenient_parser_test.go
+++ b/pkg/traceql/lenient_parser_test.go
@@ -451,6 +451,24 @@ func TestParseLenient(t *testing.T) {
 			expected: "{ ((.a + .b) = 3) && true }",
 		},
 
+		// Comparisons whose RHS is not a literal value: the operand may be an
+		// attribute, a parenthesized expression, or start with a unary operator.
+		{
+			name:     "attribute-to-attribute comparison with incomplete",
+			in:       `{ .a = .b && .c = }`,
+			expected: "{ (.a = .b) && true }",
+		},
+		{
+			name:     "parenthesized RHS with incomplete",
+			in:       `{ .a = (.b + .c) && .d = }`,
+			expected: "{ (.a = (.b + .c)) && true }",
+		},
+		{
+			name:     "negative value with incomplete",
+			in:       `{ .a = -1 && .b = }`,
+			expected: "{ (.a = -1) && true }",
+		},
+
 		// Typed intrinsics with incomplete matchers combined with other
 		// conditions. Regression tests: these used to leave a bare intrinsic
 		// behind (e.g. `{ ... && name }`), which failed type validation and
@@ -597,6 +615,11 @@ func TestReplaceIncompleteMatchers(t *testing.T) {
 			name:     "incomplete intrinsic after complete matcher",
 			in:       `{ .a = 1 && name = }`,
 			expected: `{ .a = 1 && true }`,
+		},
+		{
+			name:     "attribute-to-attribute comparison preserved",
+			in:       `{ .a = .b && .c = }`,
+			expected: `{ .a = .b && true }`,
 		},
 		{
 			name:     "structural operator passes through",


### PR DESCRIPTION
**What this PR does**:

Tag-value autocomplete ignored query filters when the incomplete matcher targeted an intrinsic. For `{ resource.service.name = "foo" && name = }`, the lenient parser left a bare `name` behind, which failed type validation; `ExtractConditionGroups` swallowed the error and returned zero groups, so suggestions fell back to unfiltered results.

Fixed by simplifying the lenient parser to three steps:

1. Tokenize with the regular TraceQL lexer.
2. Replace each incomplete matcher with `true`.
3. Rebuild the query and re-parse with the strict parser.

`true` keeps the expression structurally complete and boolean-typed by construction, so the AST post-processing (`removeBareAttributes`) and connector/paren cleanup passes are deleted. `splitReqConditions` now keeps empty condition groups so an incomplete OR branch (`{ .a = "x" || .b = }`) still collapses to match-all, preserving existing OR semantics.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`