### PR TITLE
Point agent guidance at .chloggen instead of CHANGELOG.md

### DIFF
--- a/.agents/guidance/precommit.md
+++ b/.agents/guidance/precommit.md
@@ -81,6 +81,8 @@ make test-e2e-clean
 2. `make lint base=origin/main` — no new lint errors
 3. `make test` — all unit tests pass
 4. `go test -race ./...` (or `make test-with-cover`) — no races in changed packages
+5. `make chlog-validate` — a `.chloggen/` entry exists for user-facing changes
+   (never edit `CHANGELOG.md` directly; see `.chloggen/README.md`)
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # Tempo — Agent Guidance
 
+## Changelog Entries
+
+Never edit `CHANGELOG.md` directly. Every user-facing change adds a YAML entry
+under [`.chloggen/`](.chloggen/) instead — read [`.chloggen/README.md`](.chloggen/README.md)
+first, then create the entry with `make chlog-new` and validate it with
+`make chlog-validate`.
+
 ## Coding Standards
 
 Before writing or modifying Go code, read [`.agents/guidance/coding.md`](.agents/guidance/coding.md).


### PR DESCRIPTION
**What this PR does**:

Agent instructions never mentioned the chloggen workflow, so agents edited `CHANGELOG.md` directly. Adds a changelog section to `AGENTS.md` and a pre-commit checklist item pointing at `.chloggen/`.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`) — not needed, tooling/docs only