### PR TITLE
fix(overrides): fall back to cluster default for unset retry_info_enabled

### DIFF
--- a/.chloggen/retry-info-enabled-default-merge.yaml
+++ b/.chloggen/retry-info-enabled-default-merge.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: overrides
+note: fix `retry_info_enabled` per-tenant override silently overriding the cluster default when unset
+issues: []
+subtext:
+user: zhxiaogg

--- a/cmd/tempo-cli/test-data/migrate-overrides-config/legacy-expected.yaml
+++ b/cmd/tempo-cli/test-data/migrate-overrides-config/legacy-expected.yaml
@@ -20,6 +20,7 @@ overrides:
       max_traces_per_user: 50000
       rate_limit_bytes: 5000000
       rate_strategy: global
+      retry_info_enabled: false
       tenant_shard_size: 3
     metrics_generator:
       collection_interval: 30s

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -2190,7 +2190,7 @@ func TestRetryInfoEnabled(t *testing.T) {
 			limits := overrides.Config{
 				Defaults: overrides.Overrides{
 					Ingestion: overrides.IngestionOverrides{
-						RetryInfoEnabled: tt.overrideRetryInfoEnabled,
+						RetryInfoEnabled: boolPtr(tt.overrideRetryInfoEnabled),
 					},
 				},
 			}
@@ -2288,4 +2288,8 @@ func TestTracePushMiddlewareFailsOpen(t *testing.T) {
 	// Call PushTraces - should succeed despite middleware error (fail open)
 	_, err = d.PushTraces(ctx, traces)
 	require.NoError(t, err, "PushTraces should succeed even when middleware returns an error")
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -2190,7 +2190,7 @@ func TestRetryInfoEnabled(t *testing.T) {
 			limits := overrides.Config{
 				Defaults: overrides.Overrides{
 					Ingestion: overrides.IngestionOverrides{
-						RetryInfoEnabled: boolPtr(tt.overrideRetryInfoEnabled),
+						RetryInfoEnabled: new(tt.overrideRetryInfoEnabled),
 					},
 				},
 			}
@@ -2288,8 +2288,4 @@ func TestTracePushMiddlewareFailsOpen(t *testing.T) {
 	// Call PushTraces - should succeed despite middleware error (fail open)
 	_, err = d.PushTraces(ctx, traces)
 	require.NoError(t, err, "PushTraces should succeed even when middleware returns an error")
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -82,13 +82,6 @@ type IngestionOverrides struct {
 	RetryInfoEnabled  *bool          `yaml:"retry_info_enabled,omitempty" json:"retry_info_enabled,omitempty"`
 }
 
-// boolPtr is a helper to distinguish "not set" (nil) from an explicit false
-// on *bool override fields, so per-tenant overrides can fall back to the
-// cluster default when the tenant doesn't mention the field at all.
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 type ForwarderOverrides struct {
 	QueueSize int `yaml:"queue_size,omitempty" json:"queue_size,omitempty"`
 	Workers   int `yaml:"workers,omitempty" json:"workers,omitempty"`
@@ -389,7 +382,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(f *flag.FlagSet) {
 	// Distributor LegacyOverrides
 	// enabled in overrides by default, only takes effect when
 	// distributor.retry_after_on_resource_exhausted is greater than 0.cluster level default is 5s.
-	c.Defaults.Ingestion.RetryInfoEnabled = boolPtr(true)
+	c.Defaults.Ingestion.RetryInfoEnabled = new(true)
 	f.StringVar(&c.Defaults.Ingestion.RateStrategy, "distributor.rate-limit-strategy", "local", "Whether the various ingestion rate limits should be applied individually to each distributor instance (local), or evenly shared across the cluster (global).")
 	f.IntVar(&c.Defaults.Ingestion.RateLimitBytes, "distributor.ingestion-rate-limit-bytes", 30e6, "Per-user ingestion rate limit in bytes per second.")
 	f.IntVar(&c.Defaults.Ingestion.BurstSizeBytes, "distributor.ingestion-burst-size-bytes", 30e6, "Per-user ingestion burst size in bytes. Should be set to the expected size (in bytes) of a single push request.")

--- a/modules/overrides/config.go
+++ b/modules/overrides/config.go
@@ -79,7 +79,14 @@ type IngestionOverrides struct {
 	TenantShardSize   int            `yaml:"tenant_shard_size,omitempty" json:"tenant_shard_size,omitempty"`
 	MaxAttributeBytes int            `yaml:"max_attribute_bytes,omitempty" json:"max_attribute_bytes,omitempty"`
 	ArtificialDelay   *time.Duration `yaml:"artificial_delay,omitempty" json:"artificial_delay,omitempty"`
-	RetryInfoEnabled  bool           `yaml:"retry_info_enabled,omitempty" json:"retry_info_enabled,omitempty"`
+	RetryInfoEnabled  *bool          `yaml:"retry_info_enabled,omitempty" json:"retry_info_enabled,omitempty"`
+}
+
+// boolPtr is a helper to distinguish "not set" (nil) from an explicit false
+// on *bool override fields, so per-tenant overrides can fall back to the
+// cluster default when the tenant doesn't mention the field at all.
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 type ForwarderOverrides struct {
@@ -382,7 +389,7 @@ func (c *Config) RegisterFlagsAndApplyDefaults(f *flag.FlagSet) {
 	// Distributor LegacyOverrides
 	// enabled in overrides by default, only takes effect when
 	// distributor.retry_after_on_resource_exhausted is greater than 0.cluster level default is 5s.
-	c.Defaults.Ingestion.RetryInfoEnabled = true
+	c.Defaults.Ingestion.RetryInfoEnabled = boolPtr(true)
 	f.StringVar(&c.Defaults.Ingestion.RateStrategy, "distributor.rate-limit-strategy", "local", "Whether the various ingestion rate limits should be applied individually to each distributor instance (local), or evenly shared across the cluster (global).")
 	f.IntVar(&c.Defaults.Ingestion.RateLimitBytes, "distributor.ingestion-rate-limit-bytes", 30e6, "Per-user ingestion rate limit in bytes per second.")
 	f.IntVar(&c.Defaults.Ingestion.BurstSizeBytes, "distributor.ingestion-burst-size-bytes", 30e6, "Per-user ingestion burst size in bytes. Should be set to the expected size (in bytes) of a single push request.")

--- a/modules/overrides/config_legacy.go
+++ b/modules/overrides/config_legacy.go
@@ -105,7 +105,7 @@ type LegacyOverrides struct {
 	IngestionTenantShardSize   int            `yaml:"ingestion_tenant_shard_size" json:"ingestion_tenant_shard_size"`
 	IngestionMaxAttributeBytes int            `yaml:"ingestion_max_attribute_bytes" json:"ingestion_max_attribute_bytes"`
 	IngestionArtificialDelay   *time.Duration `yaml:"ingestion_artificial_delay" json:"ingestion_artificial_delay"`
-	IngestionRetryInfoEnabled  bool           `yaml:"ingestion_retry_info_enabled" json:"ingestion_retry_info_enabled"`
+	IngestionRetryInfoEnabled  *bool          `yaml:"ingestion_retry_info_enabled" json:"ingestion_retry_info_enabled"`
 
 	// Ingester enforced limits.
 	MaxLocalTracesPerUser  int `yaml:"max_traces_per_user" json:"max_traces_per_user"`

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -395,7 +395,7 @@ func generateTestLegacyOverrides() LegacyOverrides {
 		IngestionTenantShardSize:   3,
 		IngestionMaxAttributeBytes: 1000,
 		IngestionArtificialDelay:   durationPtr(5 * time.Minute),
-		IngestionRetryInfoEnabled:  boolPtr(true),
+		IngestionRetryInfoEnabled:  new(true),
 
 		MaxLocalTracesPerUser:  1000,
 		MaxGlobalTracesPerUser: 2000,

--- a/modules/overrides/config_test.go
+++ b/modules/overrides/config_test.go
@@ -395,7 +395,7 @@ func generateTestLegacyOverrides() LegacyOverrides {
 		IngestionTenantShardSize:   3,
 		IngestionMaxAttributeBytes: 1000,
 		IngestionArtificialDelay:   durationPtr(5 * time.Minute),
-		IngestionRetryInfoEnabled:  true,
+		IngestionRetryInfoEnabled:  boolPtr(true),
 
 		MaxLocalTracesPerUser:  1000,
 		MaxGlobalTracesPerUser: 2000,

--- a/modules/overrides/runtime_config_overrides.go
+++ b/modules/overrides/runtime_config_overrides.go
@@ -382,7 +382,15 @@ func (o *runtimeConfigOverridesManager) IngestionArtificialDelay(userID string) 
 }
 
 func (o *runtimeConfigOverridesManager) IngestionRetryInfoEnabled(userID string) bool {
-	return o.getOverridesForUser(userID).Ingestion.RetryInfoEnabled
+	if v := o.getOverridesForUser(userID).Ingestion.RetryInfoEnabled; v != nil {
+		return *v
+	}
+	// Tenant override exists but doesn't mention this field: fall back to the
+	// cluster default instead of the bool zero-value.
+	if v := o.defaultLimits.Ingestion.RetryInfoEnabled; v != nil {
+		return *v
+	}
+	return false
 }
 
 // MaxBytesPerTrace returns the maximum size of a single trace in bytes allowed for a user.

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -684,6 +684,59 @@ func TestNativeHistogramOverrides(t *testing.T) {
 	}
 }
 
+func TestIngestionRetryInfoEnabled(t *testing.T) {
+	tests := []struct {
+		name               string
+		defaultLimits      Overrides
+		perTenantOverrides *perTenantOverrides
+		expected           bool
+	}{
+		{
+			name: "no tenant override: cluster default wins",
+			defaultLimits: Overrides{
+				Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(true)},
+			},
+			expected: true,
+		},
+		{
+			name: "tenant override explicitly disables it",
+			defaultLimits: Overrides{
+				Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(true)},
+			},
+			perTenantOverrides: &perTenantOverrides{
+				TenantLimits: map[string]*Overrides{
+					"user1": {Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(false)}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "tenant override exists but doesn't mention retry info: falls back to cluster default",
+			defaultLimits: Overrides{
+				Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(true)},
+			},
+			perTenantOverrides: &perTenantOverrides{
+				TenantLimits: map[string]*Overrides{
+					"user1": {Ingestion: IngestionOverrides{RateLimitBytes: 600_000_000}},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			overrides, cleanup := createAndInitializeRuntimeOverridesManager(t, tt.defaultLimits, toYamlBytes(t, tt.perTenantOverrides))
+			defer cleanup()
+
+			assert.Equal(t, tt.expected, overrides.IngestionRetryInfoEnabled("user1"))
+
+			err := services.StopAndAwaitTerminated(context.TODO(), overrides)
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestMetricsGeneratorMaxCardinalityPerLabel(t *testing.T) {
 	tests := []struct {
 		name               string

--- a/modules/overrides/runtime_config_overrides_test.go
+++ b/modules/overrides/runtime_config_overrides_test.go
@@ -694,18 +694,18 @@ func TestIngestionRetryInfoEnabled(t *testing.T) {
 		{
 			name: "no tenant override: cluster default wins",
 			defaultLimits: Overrides{
-				Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(true)},
+				Ingestion: IngestionOverrides{RetryInfoEnabled: new(true)},
 			},
 			expected: true,
 		},
 		{
 			name: "tenant override explicitly disables it",
 			defaultLimits: Overrides{
-				Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(true)},
+				Ingestion: IngestionOverrides{RetryInfoEnabled: new(true)},
 			},
 			perTenantOverrides: &perTenantOverrides{
 				TenantLimits: map[string]*Overrides{
-					"user1": {Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(false)}},
+					"user1": {Ingestion: IngestionOverrides{RetryInfoEnabled: new(false)}},
 				},
 			},
 			expected: false,
@@ -713,7 +713,7 @@ func TestIngestionRetryInfoEnabled(t *testing.T) {
 		{
 			name: "tenant override exists but doesn't mention retry info: falls back to cluster default",
 			defaultLimits: Overrides{
-				Ingestion: IngestionOverrides{RetryInfoEnabled: boolPtr(true)},
+				Ingestion: IngestionOverrides{RetryInfoEnabled: new(true)},
 			},
 			perTenantOverrides: &perTenantOverrides{
 				TenantLimits: map[string]*Overrides{
@@ -726,7 +726,14 @@ func TestIngestionRetryInfoEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			overrides, cleanup := createAndInitializeRuntimeOverridesManager(t, tt.defaultLimits, toYamlBytes(t, tt.perTenantOverrides))
+			// A nil perTenantOverrides marshals to a literal "null" document; writing that as
+			// the runtime overrides file makes the loader decode a nil *perTenantOverrides and
+			// panic. Pass a nil []byte instead so no runtime overrides file is created at all.
+			var perTenantBytes []byte
+			if tt.perTenantOverrides != nil {
+				perTenantBytes = toYamlBytes(t, tt.perTenantOverrides)
+			}
+			overrides, cleanup := createAndInitializeRuntimeOverridesManager(t, tt.defaultLimits, perTenantBytes)
 			defer cleanup()
 
 			assert.Equal(t, tt.expected, overrides.IngestionRetryInfoEnabled("user1"))

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -479,6 +479,10 @@ func (b *badClient) Delete(context.Context, string, backend.Version) error {
 func (b badClient) Shutdown() {
 }
 
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func mapBoolPtr(m map[string]bool) *map[string]bool {
 	return &m
 }

--- a/modules/overrides/user_configurable_overrides_test.go
+++ b/modules/overrides/user_configurable_overrides_test.go
@@ -479,10 +479,6 @@ func (b *badClient) Delete(context.Context, string, backend.Version) error {
 func (b badClient) Shutdown() {
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 func mapBoolPtr(m map[string]bool) *map[string]bool {
 	return &m
 }


### PR DESCRIPTION
**What this PR does**:

`RetryInfoEnabled` is a plain `bool`, so a per-tenant override that never mentions `retry_info_enabled` is indistinguishable from one that explicitly sets it to `false` — both unmarshal to the zero value. Since `getOverridesForUser` returns a tenant's override struct as-is with no per-field merge against `Defaults`, any tenant with *any* override at all silently gets `RetryInfoEnabled=false`, regardless of the cluster-level default (`true`).

This changes the field to `*bool`, mirroring the existing `ArtificialDelay *time.Duration` pattern in the same struct, so `nil` means "not set" and the code falls back to the cluster default in that case. An explicit `true`/`false` from the tenant still takes priority.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated (chloggen entry added)