### PR TITLE
[backendscheduler]: TraceQL query selector for redaction

### DIFF
--- a/.chloggen/redaction-traceql-query-selector.yaml
+++ b/.chloggen/redaction-traceql-query-selector.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: backend-scheduler
+note: redaction jobs can be submitted with a TraceQL query selector instead of an explicit trace ID list, so large deletions can be expressed as a query. The query is restricted to a single spanset filter (`=`/`!=` on `resource.*`/`span.*` joined by `&&`/`||`). A dry-run mode reports how many traces would be redacted without rewriting any blocks.
+issues: []
+subtext:
+user: zalegrala

--- a/.chloggen/redaction-traceql-query-selector.yaml
+++ b/.chloggen/redaction-traceql-query-selector.yaml
@@ -1,6 +1,6 @@
 change_type: feature
 component: backend-scheduler
-note: redaction jobs can be submitted with a TraceQL query selector instead of an explicit trace ID list, so large deletions can be expressed as a query. The query is restricted to a single spanset filter (`=`/`!=` on `resource.*`/`span.*` joined by `&&`/`||`). A dry-run mode reports how many traces would be redacted without rewriting any blocks.
+note: redaction jobs can be submitted with a TraceQL query selector instead of an explicit trace ID list, so large deletions can be expressed as a query.
 issues: []
 subtext:
 user: zalegrala

--- a/cmd/tempo-cli/cmd-redact.go
+++ b/cmd/tempo-cli/cmd-redact.go
@@ -22,7 +22,9 @@ type redactCmd struct {
 	SchedulerAddr string `arg:"" help:"backend scheduler gRPC address (host:port)"`
 
 	TenantID string   `name:"tenant" required:"" help:"tenant ID"`
-	TraceIDs []string `name:"trace-id" required:"" help:"trace ID to redact (may be repeated)"`
+	TraceIDs []string `name:"trace-id" help:"trace ID to redact (may be repeated; mutually exclusive with --query)"`
+	Query    string   `name:"query" help:"TraceQL query selecting traces to redact (mutually exclusive with --trace-id)"`
+	DryRun   bool     `name:"dry-run" default:"false" help:"evaluate and report match counts without rewriting any blocks"`
 
 	TLS           bool   `name:"tls" help:"use TLS transport" default:"false"`
 	TLSServerName string `name:"tls-server-name" help:"override the TLS server name (SNI)"`
@@ -30,6 +32,10 @@ type redactCmd struct {
 }
 
 func (cmd *redactCmd) Run(_ *globalOptions) error {
+	if err := cmd.validate(); err != nil {
+		return err
+	}
+
 	traceIDs, err := parseTraceIDs(cmd.TraceIDs)
 	if err != nil {
 		return err
@@ -52,6 +58,24 @@ func (cmd *redactCmd) Run(_ *globalOptions) error {
 	}
 
 	fmt.Printf("batch_id:     %s\njobs_created: %d\n", resp.BatchId, resp.JobsCreated)
+	if cmd.DryRun {
+		fmt.Println("mode:         dry-run (no blocks were rewritten)")
+	}
+	return nil
+}
+
+// validate enforces that exactly one selector is provided: an explicit trace ID list or a
+// TraceQL query, never both and never neither. The server enforces the same, but checking
+// here fails fast before dialing.
+func (cmd *redactCmd) validate() error {
+	hasIDs := len(cmd.TraceIDs) > 0
+	hasQuery := cmd.Query != ""
+	switch {
+	case hasIDs && hasQuery:
+		return fmt.Errorf("--trace-id and --query are mutually exclusive")
+	case !hasIDs && !hasQuery:
+		return fmt.Errorf("one of --trace-id or --query must be provided")
+	}
 	return nil
 }
 
@@ -65,9 +89,19 @@ func (cmd *redactCmd) submit(ctx context.Context, c tempopb.BackendSchedulerClie
 		return nil, fmt.Errorf("injecting tenant ID into gRPC request: %w", err)
 	}
 
-	resp, err := c.SubmitRedaction(ctx, &tempopb.SubmitRedactionRequest{
-		TraceIds: traceIDs,
-	})
+	req := &tempopb.SubmitRedactionRequest{}
+	if cmd.Query != "" {
+		req.Selector = &tempopb.SubmitRedactionRequest_Query{
+			Query: &tempopb.TraceQLSelector{Query: cmd.Query},
+		}
+	} else {
+		req.TraceIds = traceIDs
+	}
+	if cmd.DryRun {
+		req.Mode = tempopb.RedactionMode_REDACTION_MODE_DRY_RUN
+	}
+
+	resp, err := c.SubmitRedaction(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("submitting redaction: %w", err)
 	}

--- a/cmd/tempo-cli/cmd-redact.go
+++ b/cmd/tempo-cli/cmd-redact.go
@@ -59,7 +59,7 @@ func (cmd *redactCmd) Run(_ *globalOptions) error {
 
 	fmt.Printf("batch_id:     %s\njobs_created: %d\n", resp.BatchId, resp.JobsCreated)
 	if cmd.DryRun {
-		fmt.Println("mode:         dry-run (no blocks were rewritten)")
+		fmt.Println("mode:         dry-run (jobs will report match counts; no blocks will be rewritten)")
 	}
 	return nil
 }

--- a/cmd/tempo-cli/cmd-redact_test.go
+++ b/cmd/tempo-cli/cmd-redact_test.go
@@ -49,6 +49,53 @@ func TestRedactCmdSubmit(t *testing.T) {
 	require.Equal(t, [][]byte{traceIDBytes}, mock.capturedReq.TraceIds)
 }
 
+func TestRedactCmdSubmitQuery(t *testing.T) {
+	const query = `{resource.service_name = "checkout"}`
+
+	mock := &mockSchedulerClient{}
+	cmd := &redactCmd{TenantID: "test-tenant", Query: query}
+
+	_, err := cmd.submit(context.Background(), mock, nil)
+	require.NoError(t, err)
+
+	require.NotNil(t, mock.capturedReq.GetQuery(), "query selector must be set")
+	require.Equal(t, query, mock.capturedReq.GetQuery().GetQuery())
+	require.Empty(t, mock.capturedReq.TraceIds, "query submission carries no trace IDs")
+	require.Equal(t, tempopb.RedactionMode_REDACTION_MODE_APPLY, mock.capturedReq.Mode)
+}
+
+func TestRedactCmdSubmitDryRun(t *testing.T) {
+	mock := &mockSchedulerClient{}
+	cmd := &redactCmd{TenantID: "test-tenant", Query: `{resource.service_name = "x"}`, DryRun: true}
+
+	_, err := cmd.submit(context.Background(), mock, nil)
+	require.NoError(t, err)
+	require.Equal(t, tempopb.RedactionMode_REDACTION_MODE_DRY_RUN, mock.capturedReq.Mode)
+}
+
+func TestRedactCmdValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cmd     redactCmd
+		wantErr bool
+	}{
+		{"trace-ids only", redactCmd{TraceIDs: []string{"abc"}}, false},
+		{"query only", redactCmd{Query: `{resource.service_name = "x"}`}, false},
+		{"both", redactCmd{TraceIDs: []string{"abc"}, Query: `{resource.service_name = "x"}`}, true},
+		{"neither", redactCmd{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cmd.validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestParseTraceIDs(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		ids, err := parseTraceIDs([]string{

--- a/integration/storage/backend_scheduler_test.go
+++ b/integration/storage/backend_scheduler_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/grafana/tempo/integration/util"
 	"github.com/grafana/tempo/pkg/model"
 	"github.com/grafana/tempo/pkg/tempopb"
+	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/grafana/tempo/tempodb"
 	"github.com/grafana/tempo/tempodb/backend"
@@ -359,6 +361,135 @@ func TestBackendSchedulerRedaction(t *testing.T) {
 			return err == nil && len(trs) == 0
 		}, 60*time.Second, 2*time.Second, "trace must not be findable in any block after redaction")
 	})
+}
+
+// TestBackendSchedulerRedactionQuery verifies the end-to-end redaction flow driven by a TraceQL
+// query selector rather than an explicit trace ID list:
+//   - SubmitRedaction with a query fans out one pending job per block
+//   - After the worker processes all jobs, traces matching the query are no longer findable
+//   - Traces that do NOT match the query remain findable (no over-deletion)
+func TestBackendSchedulerRedactionQuery(t *testing.T) {
+	util.RunIntegrationTests(t, util.TestHarnessConfig{
+		Components:    util.ComponentsBackendWork,
+		Backends:      util.BackendObjectStorageAll,
+		ConfigOverlay: "config-backend-scheduler-redaction.yaml",
+	}, func(h *util.TempoHarness) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		cfg, err := h.GetConfig()
+		require.NoError(t, err)
+
+		objStorage := h.Services[util.ServiceObjectStorage]
+		scheduler := h.Services[util.ServiceBackendScheduler]
+		worker := h.Services[util.ServiceBackendWorker]
+
+		// Stop the worker so pending redaction jobs are not drained before we assert.
+		require.NoError(t, h.TestScenario.Stop(worker))
+
+		// Each block carries a matching trace (namespace=secret) and a keeper (namespace=keep).
+		tempodbReader, tempodbWriter := setupBackendReaderWriterWithEndpoint(t, &cfg.StorageConfig.Trace, objStorage.HTTPEndpoint())
+		const blockCount = 3
+		testTenant := tenant + "0"
+		matchID := test.ValidTraceID(nil)
+		keepID := test.ValidTraceID(nil)
+		populateBackendWithNamespacedTraces(ctx, t, tempodbWriter, testTenant, blockCount, matchID, keepID)
+
+		tenantMatcher := e2e.WithLabelMatchers(&labels.Matcher{
+			Type: labels.MatchEqual, Name: "tenant", Value: testTenant,
+		})
+		require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+			e2e.Equals(float64(blockCount)),
+			[]string{"tempodb_blocklist_length"},
+			e2e.WaitMissingMetrics,
+			tenantMatcher,
+			printMetricValue(t, fmt.Sprintf("%d", blockCount), "tempodb_blocklist_length"),
+		))
+
+		// Both traces must be findable before redaction.
+		tempodbReader.EnablePolling(ctx, nil, false)
+		for _, id := range []common.ID{matchID, keepID} {
+			trs, failedBlocks, err := tempodbReader.Find(ctx, testTenant, id, tempodb.BlockIDMin, tempodb.BlockIDMax, time.Time{}, time.Time{}, common.DefaultSearchOptions())
+			require.NoError(t, err)
+			require.Empty(t, failedBlocks)
+			require.NotEmpty(t, trs, "trace %x must be findable before redaction", id)
+		}
+
+		conn, err := grpc.NewClient(
+			scheduler.Endpoint(9095),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+		schedulerClient := tempopb.NewBackendSchedulerClient(conn)
+
+		tenantCtx := user.InjectOrgID(ctx, testTenant)
+		tenantCtx, err = user.InjectIntoGRPCRequest(tenantCtx)
+		require.NoError(t, err)
+
+		// Submit a query-selected redaction — one pending job per block.
+		resp, err := schedulerClient.SubmitRedaction(tenantCtx, &tempopb.SubmitRedactionRequest{
+			Selector: &tempopb.SubmitRedactionRequest_Query{
+				Query: &tempopb.TraceQLSelector{Query: `{resource.namespace = "secret"}`},
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(blockCount), resp.JobsCreated)
+
+		// Start the worker to process redaction jobs.
+		require.NoError(t, h.TestScenario.StartAndWaitReady(worker))
+
+		jobTypeMatcher := e2e.WithLabelMatchers(&labels.Matcher{
+			Type: labels.MatchEqual, Name: "job_type", Value: "JOB_TYPE_REDACTION",
+		})
+		require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+			e2e.Equals(float64(blockCount)),
+			[]string{"tempo_backend_scheduler_jobs_completed_total"},
+			e2e.WaitMissingMetrics,
+			jobTypeMatcher,
+			printMetricValue(t, fmt.Sprintf("%d", blockCount), "tempo_backend_scheduler_jobs_completed_total"),
+		))
+
+		// The matching trace ages out of the lookback window; the keeper stays findable.
+		require.Eventually(t, func() bool {
+			tempodbReader.PollNow(ctx)
+			trs, _, err := tempodbReader.Find(ctx, testTenant, matchID, tempodb.BlockIDMin, tempodb.BlockIDMax, time.Time{}, time.Time{}, common.DefaultSearchOptions())
+			return err == nil && len(trs) == 0
+		}, 60*time.Second, 2*time.Second, "query-matched trace must not be findable after redaction")
+
+		keepTrs, _, err := tempodbReader.Find(ctx, testTenant, keepID, tempodb.BlockIDMin, tempodb.BlockIDMax, time.Time{}, time.Time{}, common.DefaultSearchOptions())
+		require.NoError(t, err)
+		require.NotEmpty(t, keepTrs, "non-matching trace must survive redaction")
+	})
+}
+
+// traceWithNamespace builds a trace whose resource carries a specific namespace attribute so a
+// TraceQL query can select it.
+func traceWithNamespace(id common.ID, ns string) *tempopb.Trace {
+	attrs := []*v1_common.KeyValue{{
+		Key:   "namespace",
+		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: ns}},
+	}}
+	return &tempopb.Trace{ResourceSpans: []*v1_trace.ResourceSpans{test.MakeBatchWithAttributes(2, id, attrs)}}
+}
+
+// populateBackendWithNamespacedTraces writes blockCount blocks, each containing one matching
+// trace (namespace=secret) and one keeper (namespace=keep).
+func populateBackendWithNamespacedTraces(ctx context.Context, t testing.TB, w tempodb.Writer, tenantID string, blockCount int, matchID, keepID common.ID) {
+	walInstance := w.WAL()
+	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
+
+	for range blockCount {
+		meta := &backend.BlockMeta{BlockID: backend.NewUUID(), TenantID: tenantID}
+		head, err := walInstance.NewBlock(meta, model.CurrentEncoding)
+		require.NoError(t, err)
+
+		writeTraceToWal(t, head, dec, matchID, traceWithNamespace(matchID, "secret"), 0, 0)
+		writeTraceToWal(t, head, dec, keepID, traceWithNamespace(keepID, "keep"), 0, 0)
+
+		_, err = w.CompleteBlock(ctx, head)
+		require.NoError(t, err)
+	}
 }
 
 func printValues(t *testing.T, expected string, metric string) e2e.GetMetricValueFunc {

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -444,8 +444,21 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 		}
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	if len(req.TraceIds) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "trace_ids must not be empty")
+	// Exactly one selector: an explicit trace ID list or a TraceQL query, never both.
+	// (The proto reserves a single-member oneof for query; XOR is enforced here until
+	// trace_ids is migrated into the oneof.)
+	querySel := req.GetQuery()
+	hasIDs := len(req.TraceIds) > 0
+	hasQuery := querySel != nil && querySel.Query != ""
+	switch {
+	case hasIDs && hasQuery:
+		return nil, status.Error(codes.InvalidArgument, "trace_ids and query are mutually exclusive")
+	case !hasIDs && !hasQuery:
+		return nil, status.Error(codes.InvalidArgument, "one of trace_ids or query must be set")
+	case hasQuery:
+		if err := validateRedactionQuery(querySel.Query); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 	if s.overrides.CompactionDisabled(tenant) {
 		return nil, status.Error(codes.FailedPrecondition, "compaction is disabled for this tenant")
@@ -517,6 +530,8 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 		BatchId:           batchID,
 		TenantId:          tenant,
 		TraceIds:          req.TraceIds,
+		Query:             querySel,
+		Mode:              req.Mode,
 		CreatedAtUnixNano: time.Now().UnixNano(),
 	}
 	if len(skippedJobSet) > 0 {

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -464,6 +464,16 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
 	}
+
+	// Reject unknown modes rather than defaulting them to APPLY: since only DRY_RUN is
+	// checked downstream, an unrecognized value would otherwise fall through to a
+	// destructive rewrite. Fail closed.
+	switch req.Mode {
+	case tempopb.RedactionMode_REDACTION_MODE_APPLY, tempopb.RedactionMode_REDACTION_MODE_DRY_RUN:
+	default:
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("unknown redaction mode %d", int32(req.Mode)))
+	}
+
 	if s.overrides.CompactionDisabled(tenant) {
 		return nil, status.Error(codes.FailedPrecondition, "compaction is disabled for this tenant")
 	}

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -313,7 +313,11 @@ func (s *BackendScheduler) Next(ctx context.Context, req *tempopb.NextJobRequest
 						metricJobsDropped.WithLabelValues(j.Tenant(), j.GetType().String()).Inc()
 						drop = true
 					} else if j.JobDetail.Redaction != nil {
+						// Inject the batch's selector (trace IDs or query) and mode so the
+						// worker can resolve and act on the block without re-reading the batch.
 						j.JobDetail.Redaction.TraceIds = batch.TraceIds
+						j.JobDetail.Redaction.Query = batch.Query
+						j.JobDetail.Redaction.Mode = batch.Mode
 					}
 				}
 				if drop {

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -453,7 +453,7 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 	// trace_ids is migrated into the oneof.)
 	querySel := req.GetQuery()
 	hasIDs := len(req.TraceIds) > 0
-	hasQuery := querySel != nil && querySel.Query != ""
+	hasQuery := querySel.GetQuery() != "" // nil-safe
 	switch {
 	case hasIDs && hasQuery:
 		return nil, status.Error(codes.InvalidArgument, "trace_ids and query are mutually exclusive")

--- a/modules/backendscheduler/backendscheduler_test.go
+++ b/modules/backendscheduler/backendscheduler_test.go
@@ -427,6 +427,83 @@ func TestSubmitRedactionValidation(t *testing.T) {
 	}
 }
 
+// TestSubmitRedactionQuerySelector covers the TraceQL query selector path: a query-only
+// submission is accepted and its query + mode are stored in the batch; query is mutually
+// exclusive with trace_ids; and an out-of-subset query is rejected at submission.
+func TestSubmitRedactionQuerySelector(t *testing.T) {
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	tmpDir := t.TempDir()
+	cfg.LocalWorkPath = tmpDir
+
+	ctx, cancel := context.WithCancel(context.Background())
+	store, rr, ww := newStore(ctx, t, tmpDir)
+	defer func() {
+		cancel()
+		store.Shutdown()
+	}()
+
+	limits, err := overrides.NewOverrides(overrides.Config{Defaults: overrides.Overrides{}}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	s, err := New(cfg, store, limits, rr, ww)
+	require.NoError(t, err)
+
+	tenant := "tenant-query"
+	writeTenantBlocks(ctx, t, backend.NewWriter(ww), tenant, 1)
+	time.Sleep(300 * time.Millisecond)
+	tenantCtx := user.InjectOrgID(ctx, tenant)
+
+	query := `{resource.service_name = "checkout"}`
+
+	// query-only submission in dry-run mode is accepted; query + mode land in the batch.
+	resp, err := s.SubmitRedaction(tenantCtx, &tempopb.SubmitRedactionRequest{
+		Selector: &tempopb.SubmitRedactionRequest_Query{Query: &tempopb.TraceQLSelector{Query: query}},
+		Mode:     tempopb.RedactionMode_REDACTION_MODE_DRY_RUN,
+	})
+	require.NoError(t, err)
+	require.Positive(t, resp.JobsCreated)
+
+	batch := s.work.GetBatch(tenant)
+	require.NotNil(t, batch)
+	require.NotNil(t, batch.Query)
+	require.Equal(t, query, batch.Query.Query)
+	require.Equal(t, tempopb.RedactionMode_REDACTION_MODE_DRY_RUN, batch.Mode)
+	require.Empty(t, batch.TraceIds, "query-selected batch carries no explicit trace IDs")
+	s.work.RemoveBatch(tenant)
+
+	rejections := []struct {
+		name string
+		req  *tempopb.SubmitRedactionRequest
+	}{
+		{
+			name: "trace_ids and query both set",
+			req: &tempopb.SubmitRedactionRequest{
+				TraceIds: [][]byte{[]byte("t")},
+				Selector: &tempopb.SubmitRedactionRequest_Query{Query: &tempopb.TraceQLSelector{Query: query}},
+			},
+		},
+		{
+			name: "query outside subset",
+			req: &tempopb.SubmitRedactionRequest{
+				Selector: &tempopb.SubmitRedactionRequest_Query{Query: &tempopb.TraceQLSelector{Query: `{resource.service_name =~ "a.*"}`}},
+			},
+		},
+		{
+			name: "neither trace_ids nor query",
+			req:  &tempopb.SubmitRedactionRequest{},
+		},
+	}
+	for _, tc := range rejections {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.SubmitRedaction(tenantCtx, tc.req)
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			require.Equal(t, codes.InvalidArgument, st.Code())
+		})
+	}
+}
+
 func TestSubmitRedactionAndRescan(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})

--- a/modules/backendscheduler/backendscheduler_test.go
+++ b/modules/backendscheduler/backendscheduler_test.go
@@ -489,6 +489,13 @@ func TestSubmitRedactionQuerySelector(t *testing.T) {
 			},
 		},
 		{
+			name: "unknown mode",
+			req: &tempopb.SubmitRedactionRequest{
+				Selector: &tempopb.SubmitRedactionRequest_Query{Query: &tempopb.TraceQLSelector{Query: query}},
+				Mode:     tempopb.RedactionMode(99),
+			},
+		},
+		{
 			name: "neither trace_ids nor query",
 			req:  &tempopb.SubmitRedactionRequest{},
 		},

--- a/modules/backendscheduler/redaction_integration_test.go
+++ b/modules/backendscheduler/redaction_integration_test.go
@@ -1,0 +1,136 @@
+package backendscheduler
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/grafana/dskit/user"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/modules/storage"
+	"github.com/grafana/tempo/pkg/model"
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+// traceWithNamespace builds a trace whose resource carries a specific namespace attribute,
+// so a TraceQL query can select it.
+func traceWithNamespace(id common.ID, ns string) *tempopb.Trace {
+	attrs := []*v1_common.KeyValue{{
+		Key:   "namespace",
+		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: ns}},
+	}}
+	return &tempopb.Trace{ResourceSpans: []*v1_trace.ResourceSpans{test.MakeBatchWithAttributes(2, id, attrs)}}
+}
+
+// writeRealTenantBlock writes a complete block (with trace data, not just a meta) to the store's
+// backend so it is discoverable via BlockMetas and readable by RedactBlock.
+func writeRealTenantBlock(ctx context.Context, t *testing.T, store storage.Store, tenant string, traces []*tempopb.Trace, ids []common.ID) {
+	t.Helper()
+	dec := model.MustNewSegmentDecoder(model.CurrentEncoding)
+	meta := &backend.BlockMeta{BlockID: backend.NewUUID(), TenantID: tenant}
+	head, err := store.WAL().NewBlock(meta, model.CurrentEncoding)
+	require.NoError(t, err)
+
+	now := uint32(time.Now().Unix())
+	for i, tr := range traces {
+		b1, err := dec.PrepareForWrite(tr, 0, 0)
+		require.NoError(t, err)
+		b2, err := dec.ToObject([][]byte{b1})
+		require.NoError(t, err)
+		require.NoError(t, head.Append(ids[i], b2, now, now, true))
+	}
+	_, err = store.CompleteBlock(ctx, head)
+	require.NoError(t, err)
+}
+
+// TestSubmitRedactionQueryEndToEnd exercises the query selector across the full submission →
+// per-block execution path on real multi-block storage: a query submitted through the real API
+// fans out one job per block, and executing those jobs redacts exactly the matching trace while
+// leaving non-matching traces (and non-matching blocks) untouched.
+//
+// It drives the jobs the way Next() + the worker do — injecting the batch's selector into each
+// job detail, then calling store.RedactBlock — rather than through the provider channel, which
+// is non-deterministic in tests (the RedactionProvider goroutine races to drain pending jobs).
+func TestSubmitRedactionQueryEndToEnd(t *testing.T) {
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", &flag.FlagSet{})
+	tmpDir := t.TempDir()
+	cfg.LocalWorkPath = tmpDir + "/work"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	store, rr, ww := newStore(ctx, t, tmpDir)
+	defer func() {
+		cancel()
+		store.Shutdown()
+	}()
+
+	limits, err := overrides.NewOverrides(overrides.Config{Defaults: overrides.Overrides{}}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	s, err := New(cfg, store, limits, rr, ww)
+	require.NoError(t, err)
+
+	tenant := "tenant-redact-e2e"
+	idMatch := test.ValidTraceID(nil)
+	idKeepA := test.ValidTraceID(nil)
+	idKeepB := test.ValidTraceID(nil)
+
+	// Block A holds the matching trace plus a keeper; block B holds only a keeper.
+	writeRealTenantBlock(ctx, t, store, tenant,
+		[]*tempopb.Trace{traceWithNamespace(idMatch, "secret"), traceWithNamespace(idKeepA, "keep")},
+		[]common.ID{idMatch, idKeepA})
+	writeRealTenantBlock(ctx, t, store, tenant,
+		[]*tempopb.Trace{traceWithNamespace(idKeepB, "keep")},
+		[]common.ID{idKeepB})
+
+	require.Eventually(t, func() bool { return len(store.BlockMetas(tenant)) == 2 },
+		3*time.Second, 50*time.Millisecond, "blocklist poll should discover both blocks")
+
+	query := `{resource.namespace = "secret"}`
+	resp, err := s.SubmitRedaction(user.InjectOrgID(ctx, tenant), &tempopb.SubmitRedactionRequest{
+		Selector: &tempopb.SubmitRedactionRequest_Query{Query: &tempopb.TraceQLSelector{Query: query}},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, resp.JobsCreated, "one redaction job per block")
+
+	batch := s.work.GetBatch(tenant)
+	require.NotNil(t, batch)
+	require.NotNil(t, batch.Query)
+	require.Equal(t, query, batch.Query.Query)
+
+	metaByID := make(map[string]*backend.BlockMeta)
+	for _, m := range store.BlockMetas(tenant) {
+		metaByID[m.BlockID.String()] = m
+	}
+
+	totalFound, rewroteBlocks := 0, 0
+	for _, j := range s.work.ListAllPendingJobs() {
+		require.Equal(t, tempopb.JobType_JOB_TYPE_REDACTION, j.GetType())
+		rd := j.JobDetail.Redaction
+
+		// Next() injects the batch selector; the worker forwards it to RedactBlock.
+		rd.Query = batch.Query
+		rd.Mode = batch.Mode
+
+		meta := metaByID[rd.BlockId]
+		require.NotNil(t, meta, "job references a discovered block")
+
+		rewrote, found, _, err := store.RedactBlock(ctx, meta, tenant, nil, rd.Query.GetQuery(), rd.Mode)
+		require.NoError(t, err)
+		totalFound += found
+		if rewrote {
+			rewroteBlocks++
+		}
+	}
+
+	require.Equal(t, 1, totalFound, "exactly the one matching trace is selected across all blocks")
+	require.Equal(t, 1, rewroteBlocks, "only the block containing the match is rewritten")
+}

--- a/modules/backendscheduler/redaction_query.go
+++ b/modules/backendscheduler/redaction_query.go
@@ -1,0 +1,86 @@
+package backendscheduler
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/grafana/tempo/pkg/traceql"
+)
+
+// validateRedactionQuery enforces the redaction query subset: a single spanset filter
+// whose expression is = / != comparisons on resource.*/span.* attributes combined with
+// && / ||. Anything else (regex, ordered comparisons, unscoped attributes, pipelines,
+// aggregates, multiple/structural filters) is rejected at submission.
+//
+// Parsing uses ParseNoOptimizations so the optimizer does not fold an OR of equalities
+// on the same attribute into a regex, which the subset would then wrongly reject.
+func validateRedactionQuery(query string) error {
+	if query == "" {
+		return errors.New("redaction query must not be empty")
+	}
+
+	expr, err := traceql.ParseNoOptimizations(query)
+	if err != nil {
+		return fmt.Errorf("invalid TraceQL: %w", err)
+	}
+
+	pipeline, ok := expr.SinglePipeline()
+	if !ok {
+		return errors.New("redaction query must be a single spanset filter (no metrics, math, or multiple pipelines)")
+	}
+	if len(pipeline.Elements) != 1 {
+		return errors.New("redaction query must be a single spanset filter (no pipeline stages)")
+	}
+
+	filter, ok := pipeline.Elements[0].(*traceql.SpansetFilter)
+	if !ok {
+		return fmt.Errorf("redaction query must be a single spanset filter, got %T", pipeline.Elements[0])
+	}
+
+	return validateRedactionExpr(filter.Expression)
+}
+
+// validateRedactionExpr recursively checks that fe is built only from &&/|| combinators
+// over = / != comparisons on scoped attributes.
+func validateRedactionExpr(fe traceql.FieldExpression) error {
+	bin, ok := fe.(*traceql.BinaryOperation)
+	if !ok {
+		return fmt.Errorf("redaction query supports only =, != comparisons joined by && / ||, got %T", fe)
+	}
+
+	switch bin.Op {
+	case traceql.OpAnd, traceql.OpOr:
+		if err := validateRedactionExpr(bin.LHS); err != nil {
+			return err
+		}
+		return validateRedactionExpr(bin.RHS)
+	case traceql.OpEqual, traceql.OpNotEqual:
+		return validateRedactionComparison(bin.LHS, bin.RHS)
+	default:
+		return fmt.Errorf("operator %v not allowed in redaction query; only =, != are supported", bin.Op)
+	}
+}
+
+// validateRedactionComparison requires one side to be a resource.*/span.* attribute and
+// the other a static literal.
+func validateRedactionComparison(lhs, rhs traceql.FieldExpression) error {
+	lAttr, lIsAttr := lhs.(traceql.Attribute)
+	rAttr, rIsAttr := rhs.(traceql.Attribute)
+	_, lIsStatic := lhs.(traceql.Static)
+	_, rIsStatic := rhs.(traceql.Static)
+
+	var attr traceql.Attribute
+	switch {
+	case lIsAttr && rIsStatic:
+		attr = lAttr
+	case rIsAttr && lIsStatic:
+		attr = rAttr
+	default:
+		return errors.New("redaction query comparisons must be <attribute> = <value>")
+	}
+
+	if attr.Scope != traceql.AttributeScopeResource && attr.Scope != traceql.AttributeScopeSpan {
+		return fmt.Errorf("redaction query attributes must be scoped to resource. or span., got %q", attr.Name)
+	}
+	return nil
+}

--- a/modules/backendscheduler/redaction_query.go
+++ b/modules/backendscheduler/redaction_query.go
@@ -8,8 +8,8 @@ import (
 )
 
 // validateRedactionQuery enforces the redaction query subset: a single spanset filter
-// whose expression is = / != comparisons on resource.*/span.* attributes combined with
-// && / ||. Anything else (regex, ordered comparisons, unscoped attributes, pipelines,
+// whose expression is = comparisons on resource.*/span.* attributes combined with
+// && / ||. Anything else (negation, regex, ordered comparisons, unscoped attributes, pipelines,
 // aggregates, multiple/structural filters) is rejected at submission.
 //
 // Parsing uses ParseNoOptimizations so the optimizer does not fold an OR of equalities
@@ -41,11 +41,11 @@ func validateRedactionQuery(query string) error {
 }
 
 // validateRedactionExpr recursively checks that fe is built only from &&/|| combinators
-// over = / != comparisons on scoped attributes.
+// over = comparisons on scoped attributes.
 func validateRedactionExpr(fe traceql.FieldExpression) error {
 	bin, ok := fe.(*traceql.BinaryOperation)
 	if !ok {
-		return fmt.Errorf("redaction query supports only =, != comparisons joined by && / ||, got %T", fe)
+		return fmt.Errorf("redaction query supports only = comparisons joined by && / ||, got %T", fe)
 	}
 
 	switch bin.Op {
@@ -54,10 +54,13 @@ func validateRedactionExpr(fe traceql.FieldExpression) error {
 			return err
 		}
 		return validateRedactionExpr(bin.RHS)
-	case traceql.OpEqual, traceql.OpNotEqual:
+	case traceql.OpEqual:
 		return validateRedactionComparison(bin.LHS, bin.RHS)
 	default:
-		return fmt.Errorf("operator %v not allowed in redaction query; only =, != are supported", bin.Op)
+		// Only positive equality is allowed. Negation (!=) is excluded on purpose: its
+		// match set is the complement (potentially all data), so a typo is as catastrophic
+		// as a bad regex on an irreversible delete.
+		return fmt.Errorf("operator %v not allowed in redaction query; only = is supported", bin.Op)
 	}
 }
 

--- a/modules/backendscheduler/redaction_query.go
+++ b/modules/backendscheduler/redaction_query.go
@@ -82,5 +82,11 @@ func validateRedactionComparison(lhs, rhs traceql.FieldExpression) error {
 	if attr.Scope != traceql.AttributeScopeResource && attr.Scope != traceql.AttributeScopeSpan {
 		return fmt.Errorf("redaction query attributes must be scoped to resource. or span., got %q", attr.Name)
 	}
+	// Reject parent.resource.* / parent.span.*: these reference the ancestor span, i.e.
+	// structural filtering, which is outside the single-span subset and could select
+	// traces far beyond the operator's intent.
+	if attr.Parent {
+		return fmt.Errorf("redaction query attributes must not be parent-scoped (parent.), got %q", attr.Name)
+	}
 	return nil
 }

--- a/modules/backendscheduler/redaction_query_test.go
+++ b/modules/backendscheduler/redaction_query_test.go
@@ -1,0 +1,82 @@
+package backendscheduler
+
+import "testing"
+
+// The redaction query selector accepts only a single spanset filter restricted to
+// equality/inequality on resource.*/span.* attributes joined by && / ||. Everything
+// else is rejected at submission. See designDocRedactionTraceQLQuery.md "Query subset".
+func TestValidateRedactionQuery(t *testing.T) {
+	cases := []struct {
+		name    string
+		query   string
+		wantErr bool
+	}{
+		// --- accepted ---
+		{
+			name:    "single service equality",
+			query:   `{resource.service_name = "a"}`,
+			wantErr: false,
+		},
+		{
+			name:    "motivating case: several service equalities OR'd",
+			query:   `{resource.service_name = "a" || resource.service_name = "b" || resource.service_name = "c"}`,
+			wantErr: false,
+		},
+		{
+			name:    "not-equal and AND combined",
+			query:   `{resource.namespace = "prod" && span.http.target != "/health"}`,
+			wantErr: false,
+		},
+		// --- rejected: operators outside the subset ---
+		{
+			name:    "regex match",
+			query:   `{resource.service_name =~ "a.*"}`,
+			wantErr: true,
+		},
+		{
+			name:    "ordered comparison",
+			query:   `{span.http.status_code > 400}`,
+			wantErr: true,
+		},
+		// --- rejected: shape outside a single spanset filter ---
+		{
+			name:    "pipeline aggregate",
+			query:   `{resource.service_name = "a"} | count() > 2`,
+			wantErr: true,
+		},
+		{
+			name:    "multiple spanset filters / structural",
+			query:   `{resource.service_name = "a"} >> {span.name = "b"}`,
+			wantErr: true,
+		},
+		// --- rejected: unscoped attribute ---
+		{
+			name:    "unscoped attribute",
+			query:   `{.service_name = "a"}`,
+			wantErr: true,
+		},
+		// --- rejected: unparseable ---
+		{
+			name:    "invalid syntax",
+			query:   `{resource.service_name = }`,
+			wantErr: true,
+		},
+		{
+			name:    "empty query",
+			query:   ``,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRedactionQuery(tc.query)
+			if tc.wantErr && err == nil {
+				t.Fatalf("query %q: expected rejection, got nil error", tc.query)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("query %q: expected acceptance, got error: %v", tc.query, err)
+			}
+		})
+	}
+}

--- a/modules/backendscheduler/redaction_query_test.go
+++ b/modules/backendscheduler/redaction_query_test.go
@@ -55,6 +55,18 @@ func TestValidateRedactionQuery(t *testing.T) {
 			query:   `{.service_name = "a"}`,
 			wantErr: true,
 		},
+		// --- rejected: parent-scoped attributes are structural (ancestor span), not the
+		// matched span's own resource/span attributes ---
+		{
+			name:    "parent resource attribute",
+			query:   `{parent.resource.service_name = "a"}`,
+			wantErr: true,
+		},
+		{
+			name:    "parent span attribute",
+			query:   `{parent.span.http.route = "/x"}`,
+			wantErr: true,
+		},
 		// --- rejected: unparseable ---
 		{
 			name:    "invalid syntax",

--- a/modules/backendscheduler/redaction_query_test.go
+++ b/modules/backendscheduler/redaction_query_test.go
@@ -23,8 +23,8 @@ func TestValidateRedactionQuery(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "not-equal and AND combined",
-			query:   `{resource.namespace = "prod" && span.http.target != "/health"}`,
+			name:    "equality with AND",
+			query:   `{resource.namespace = "prod" && span.http.target = "/checkout"}`,
 			wantErr: false,
 		},
 		// --- rejected: operators outside the subset ---
@@ -36,6 +36,19 @@ func TestValidateRedactionQuery(t *testing.T) {
 		{
 			name:    "ordered comparison",
 			query:   `{span.http.status_code > 400}`,
+			wantErr: true,
+		},
+		// Negation is rejected: its blast radius is the complement of the match set
+		// (potentially all data), so a typo is as catastrophic as a bad regex on a
+		// delete path.
+		{
+			name:    "negation (complement blast radius)",
+			query:   `{span.http.target != "/health"}`,
+			wantErr: true,
+		},
+		{
+			name:    "negation within AND",
+			query:   `{resource.namespace = "prod" && span.http.target != "/health"}`,
 			wantErr: true,
 		},
 		// --- rejected: shape outside a single spanset filter ---

--- a/modules/backendworker/backendworker.go
+++ b/modules/backendworker/backendworker.go
@@ -398,9 +398,15 @@ func (w *BackendWorker) processRedactionJob(ctx context.Context, resp *tempopb.N
 		}
 	}
 
-	level.Debug(log.Logger).Log("msg", "processing redaction job", "job_id", resp.JobId, "block_id", blockIDStr, "trace_ids_count", len(traceIDs))
+	var query string
+	if q := resp.Detail.Redaction.GetQuery(); q != nil {
+		query = q.GetQuery()
+	}
+	dryRun := resp.Detail.Redaction.GetMode() == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN
 
-	_, tracesFound, _, err := w.store.RedactBlock(ctx, meta, tenantID, traceIDs)
+	level.Debug(log.Logger).Log("msg", "processing redaction job", "job_id", resp.JobId, "block_id", blockIDStr, "trace_ids_count", len(traceIDs), "query", query, "dry_run", dryRun)
+
+	_, tracesFound, _, err := w.store.RedactBlock(ctx, meta, tenantID, traceIDs, query, dryRun)
 	if err != nil {
 		return w.failJob(ctx, resp.JobId, fmt.Sprintf("redact block: %v", err))
 	}

--- a/modules/backendworker/backendworker.go
+++ b/modules/backendworker/backendworker.go
@@ -401,7 +401,9 @@ func (w *BackendWorker) processRedactionJob(ctx context.Context, resp *tempopb.N
 	query := resp.Detail.Redaction.GetQuery().GetQuery() // nil-safe: "" when no query selector
 	mode := resp.Detail.Redaction.GetMode()
 
-	level.Debug(log.Logger).Log("msg", "processing redaction job", "job_id", resp.JobId, "block_id", blockIDStr, "trace_ids_count", len(traceIDs), "query", query, "mode", mode.String())
+	// Log only whether a query selector is present, not the query text: for a
+	// privacy-motivated feature the query can embed sensitive attribute values.
+	level.Debug(log.Logger).Log("msg", "processing redaction job", "job_id", resp.JobId, "block_id", blockIDStr, "trace_ids_count", len(traceIDs), "has_query", query != "", "mode", mode.String())
 
 	_, tracesFound, _, err := w.store.RedactBlock(ctx, meta, tenantID, traceIDs, query, mode)
 	if err != nil {

--- a/modules/backendworker/backendworker.go
+++ b/modules/backendworker/backendworker.go
@@ -398,15 +398,12 @@ func (w *BackendWorker) processRedactionJob(ctx context.Context, resp *tempopb.N
 		}
 	}
 
-	var query string
-	if q := resp.Detail.Redaction.GetQuery(); q != nil {
-		query = q.GetQuery()
-	}
-	dryRun := resp.Detail.Redaction.GetMode() == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN
+	query := resp.Detail.Redaction.GetQuery().GetQuery() // nil-safe: "" when no query selector
+	mode := resp.Detail.Redaction.GetMode()
 
-	level.Debug(log.Logger).Log("msg", "processing redaction job", "job_id", resp.JobId, "block_id", blockIDStr, "trace_ids_count", len(traceIDs), "query", query, "dry_run", dryRun)
+	level.Debug(log.Logger).Log("msg", "processing redaction job", "job_id", resp.JobId, "block_id", blockIDStr, "trace_ids_count", len(traceIDs), "query", query, "mode", mode.String())
 
-	_, tracesFound, _, err := w.store.RedactBlock(ctx, meta, tenantID, traceIDs, query, dryRun)
+	_, tracesFound, _, err := w.store.RedactBlock(ctx, meta, tenantID, traceIDs, query, mode)
 	if err != nil {
 		return w.failJob(ctx, resp.JobId, fmt.Sprintf("redact block: %v", err))
 	}

--- a/pkg/tempopb/backendwork.pb.go
+++ b/pkg/tempopb/backendwork.pb.go
@@ -90,6 +90,33 @@ func (JobStatus) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_1e9b87dd365f5504, []int{1}
 }
 
+// RedactionMode selects whether a redaction applies (rewrites blocks) or is a dry run
+// (evaluates and counts matches without modifying storage).
+type RedactionMode int32
+
+const (
+	RedactionMode_REDACTION_MODE_APPLY   RedactionMode = 0
+	RedactionMode_REDACTION_MODE_DRY_RUN RedactionMode = 1
+)
+
+var RedactionMode_name = map[int32]string{
+	0: "REDACTION_MODE_APPLY",
+	1: "REDACTION_MODE_DRY_RUN",
+}
+
+var RedactionMode_value = map[string]int32{
+	"REDACTION_MODE_APPLY":   0,
+	"REDACTION_MODE_DRY_RUN": 1,
+}
+
+func (x RedactionMode) String() string {
+	return proto.EnumName(RedactionMode_name, int32(x))
+}
+
+func (RedactionMode) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_1e9b87dd365f5504, []int{2}
+}
+
 // CompactionDetail contains fields specific to compaction jobs
 type CompactionDetail struct {
 	Input  []string `protobuf:"bytes,1,rep,name=input,proto3" json:"input,omitempty"`
@@ -179,19 +206,68 @@ func (m *RetentionDetail) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RetentionDetail proto.InternalMessageInfo
 
+// TraceQLSelector carries a TraceQL expression that selects the traces to redact,
+// as an alternative to an explicit trace ID list. Restricted at submission to a single
+// spanset filter (=, != on resource.*/span.* joined by && / ||).
+type TraceQLSelector struct {
+	Query string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+}
+
+func (m *TraceQLSelector) Reset()         { *m = TraceQLSelector{} }
+func (m *TraceQLSelector) String() string { return proto.CompactTextString(m) }
+func (*TraceQLSelector) ProtoMessage()    {}
+func (*TraceQLSelector) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1e9b87dd365f5504, []int{2}
+}
+func (m *TraceQLSelector) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *TraceQLSelector) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_TraceQLSelector.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *TraceQLSelector) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TraceQLSelector.Merge(m, src)
+}
+func (m *TraceQLSelector) XXX_Size() int {
+	return m.Size()
+}
+func (m *TraceQLSelector) XXX_DiscardUnknown() {
+	xxx_messageInfo_TraceQLSelector.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_TraceQLSelector proto.InternalMessageInfo
+
+func (m *TraceQLSelector) GetQuery() string {
+	if m != nil {
+		return m.Query
+	}
+	return ""
+}
+
 // RedactionDetail contains fields for redaction jobs (one job per block).
-// TraceIds are the trace IDs to redact from the block. Future extension may add
-// traceql/attribute-based redaction.
+// TraceIds are the trace IDs to redact from the block; alternatively query selects
+// them via a TraceQL expression evaluated against the block.
 type RedactionDetail struct {
-	BlockId  string   `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"`
-	TraceIds [][]byte `protobuf:"bytes,2,rep,name=trace_ids,json=traceIds,proto3" json:"trace_ids,omitempty"`
+	BlockId  string           `protobuf:"bytes,1,opt,name=block_id,json=blockId,proto3" json:"block_id,omitempty"`
+	TraceIds [][]byte         `protobuf:"bytes,2,rep,name=trace_ids,json=traceIds,proto3" json:"trace_ids,omitempty"`
+	Query    *TraceQLSelector `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
+	Mode     RedactionMode    `protobuf:"varint,4,opt,name=mode,proto3,enum=tempopb.RedactionMode" json:"mode,omitempty"`
 }
 
 func (m *RedactionDetail) Reset()         { *m = RedactionDetail{} }
 func (m *RedactionDetail) String() string { return proto.CompactTextString(m) }
 func (*RedactionDetail) ProtoMessage()    {}
 func (*RedactionDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{2}
+	return fileDescriptor_1e9b87dd365f5504, []int{3}
 }
 func (m *RedactionDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -234,6 +310,20 @@ func (m *RedactionDetail) GetTraceIds() [][]byte {
 	return nil
 }
 
+func (m *RedactionDetail) GetQuery() *TraceQLSelector {
+	if m != nil {
+		return m.Query
+	}
+	return nil
+}
+
+func (m *RedactionDetail) GetMode() RedactionMode {
+	if m != nil {
+		return m.Mode
+	}
+	return RedactionMode_REDACTION_MODE_APPLY
+}
+
 // JobDetail contains the specific details for each job type
 type JobDetail struct {
 	Tenant string `protobuf:"bytes,1,opt,name=tenant,proto3" json:"tenant,omitempty"`
@@ -250,7 +340,7 @@ func (m *JobDetail) Reset()         { *m = JobDetail{} }
 func (m *JobDetail) String() string { return proto.CompactTextString(m) }
 func (*JobDetail) ProtoMessage()    {}
 func (*JobDetail) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{3}
+	return fileDescriptor_1e9b87dd365f5504, []int{4}
 }
 func (m *JobDetail) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -322,7 +412,7 @@ func (m *NextJobRequest) Reset()         { *m = NextJobRequest{} }
 func (m *NextJobRequest) String() string { return proto.CompactTextString(m) }
 func (*NextJobRequest) ProtoMessage()    {}
 func (*NextJobRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{4}
+	return fileDescriptor_1e9b87dd365f5504, []int{5}
 }
 func (m *NextJobRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -368,7 +458,7 @@ func (m *NextJobResponse) Reset()         { *m = NextJobResponse{} }
 func (m *NextJobResponse) String() string { return proto.CompactTextString(m) }
 func (*NextJobResponse) ProtoMessage()    {}
 func (*NextJobResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{5}
+	return fileDescriptor_1e9b87dd365f5504, []int{6}
 }
 func (m *NextJobResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -430,7 +520,7 @@ func (m *UpdateJobStatusRequest) Reset()         { *m = UpdateJobStatusRequest{}
 func (m *UpdateJobStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*UpdateJobStatusRequest) ProtoMessage()    {}
 func (*UpdateJobStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{6}
+	return fileDescriptor_1e9b87dd365f5504, []int{7}
 }
 func (m *UpdateJobStatusRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -502,7 +592,7 @@ func (m *UpdateJobStatusResponse) Reset()         { *m = UpdateJobStatusResponse
 func (m *UpdateJobStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*UpdateJobStatusResponse) ProtoMessage()    {}
 func (*UpdateJobStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{7}
+	return fileDescriptor_1e9b87dd365f5504, []int{8}
 }
 func (m *UpdateJobStatusResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -545,13 +635,22 @@ func (m *UpdateJobStatusResponse) GetSuccess() bool {
 type SubmitRedactionRequest struct {
 	TenantId string   `protobuf:"bytes,1,opt,name=tenant_id,json=tenantId,proto3" json:"tenant_id,omitempty"` // Deprecated: Do not use.
 	TraceIds [][]byte `protobuf:"bytes,2,rep,name=trace_ids,json=traceIds,proto3" json:"trace_ids,omitempty"`
+	// selector is a single-member oneof for now, reserving room to migrate trace_ids into
+	// it later without an API break. It carries the TraceQL query selector; query and
+	// trace_ids are mutually exclusive, enforced at submission.
+	//
+	// Types that are valid to be assigned to Selector:
+	//
+	//	*SubmitRedactionRequest_Query
+	Selector isSubmitRedactionRequest_Selector `protobuf_oneof:"selector"`
+	Mode     RedactionMode                     `protobuf:"varint,4,opt,name=mode,proto3,enum=tempopb.RedactionMode" json:"mode,omitempty"`
 }
 
 func (m *SubmitRedactionRequest) Reset()         { *m = SubmitRedactionRequest{} }
 func (m *SubmitRedactionRequest) String() string { return proto.CompactTextString(m) }
 func (*SubmitRedactionRequest) ProtoMessage()    {}
 func (*SubmitRedactionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{8}
+	return fileDescriptor_1e9b87dd365f5504, []int{9}
 }
 func (m *SubmitRedactionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -580,6 +679,25 @@ func (m *SubmitRedactionRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_SubmitRedactionRequest proto.InternalMessageInfo
 
+type isSubmitRedactionRequest_Selector interface {
+	isSubmitRedactionRequest_Selector()
+	MarshalTo([]byte) (int, error)
+	Size() int
+}
+
+type SubmitRedactionRequest_Query struct {
+	Query *TraceQLSelector `protobuf:"bytes,3,opt,name=query,proto3,oneof" json:"query,omitempty"`
+}
+
+func (*SubmitRedactionRequest_Query) isSubmitRedactionRequest_Selector() {}
+
+func (m *SubmitRedactionRequest) GetSelector() isSubmitRedactionRequest_Selector {
+	if m != nil {
+		return m.Selector
+	}
+	return nil
+}
+
 // Deprecated: Do not use.
 func (m *SubmitRedactionRequest) GetTenantId() string {
 	if m != nil {
@@ -595,6 +713,27 @@ func (m *SubmitRedactionRequest) GetTraceIds() [][]byte {
 	return nil
 }
 
+func (m *SubmitRedactionRequest) GetQuery() *TraceQLSelector {
+	if x, ok := m.GetSelector().(*SubmitRedactionRequest_Query); ok {
+		return x.Query
+	}
+	return nil
+}
+
+func (m *SubmitRedactionRequest) GetMode() RedactionMode {
+	if m != nil {
+		return m.Mode
+	}
+	return RedactionMode_REDACTION_MODE_APPLY
+}
+
+// XXX_OneofWrappers is for the internal use of the proto package.
+func (*SubmitRedactionRequest) XXX_OneofWrappers() []interface{} {
+	return []interface{}{
+		(*SubmitRedactionRequest_Query)(nil),
+	}
+}
+
 type SubmitRedactionResponse struct {
 	// batch_id identifies this submission; all resulting pending block jobs share this ID.
 	BatchId string `protobuf:"bytes,1,opt,name=batch_id,json=batchId,proto3" json:"batch_id,omitempty"`
@@ -606,7 +745,7 @@ func (m *SubmitRedactionResponse) Reset()         { *m = SubmitRedactionResponse
 func (m *SubmitRedactionResponse) String() string { return proto.CompactTextString(m) }
 func (*SubmitRedactionResponse) ProtoMessage()    {}
 func (*SubmitRedactionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{9}
+	return fileDescriptor_1e9b87dd365f5504, []int{10}
 }
 func (m *SubmitRedactionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -660,7 +799,7 @@ func (m *RedactionResult) Reset()         { *m = RedactionResult{} }
 func (m *RedactionResult) String() string { return proto.CompactTextString(m) }
 func (*RedactionResult) ProtoMessage()    {}
 func (*RedactionResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{10}
+	return fileDescriptor_1e9b87dd365f5504, []int{11}
 }
 func (m *RedactionResult) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -713,13 +852,19 @@ type RedactionBatch struct {
 	// rescan_after_unix_nano is the earliest time at which the scheduler should
 	// perform the rescan described above. Zero means no rescan is pending.
 	RescanAfterUnixNano int64 `protobuf:"varint,6,opt,name=rescan_after_unix_nano,json=rescanAfterUnixNano,proto3" json:"rescan_after_unix_nano,omitempty"`
+	// query, when set, selects traces via a TraceQL expression instead of trace_ids.
+	// Stored in the manifest for the lifetime of the redaction and injected into each
+	// per-block job.
+	Query *TraceQLSelector `protobuf:"bytes,7,opt,name=query,proto3" json:"query,omitempty"`
+	// mode selects apply (default) vs dry-run for the whole batch.
+	Mode RedactionMode `protobuf:"varint,8,opt,name=mode,proto3,enum=tempopb.RedactionMode" json:"mode,omitempty"`
 }
 
 func (m *RedactionBatch) Reset()         { *m = RedactionBatch{} }
 func (m *RedactionBatch) String() string { return proto.CompactTextString(m) }
 func (*RedactionBatch) ProtoMessage()    {}
 func (*RedactionBatch) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{11}
+	return fileDescriptor_1e9b87dd365f5504, []int{12}
 }
 func (m *RedactionBatch) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -790,6 +935,20 @@ func (m *RedactionBatch) GetRescanAfterUnixNano() int64 {
 	return 0
 }
 
+func (m *RedactionBatch) GetQuery() *TraceQLSelector {
+	if m != nil {
+		return m.Query
+	}
+	return nil
+}
+
+func (m *RedactionBatch) GetMode() RedactionMode {
+	if m != nil {
+		return m.Mode
+	}
+	return RedactionMode_REDACTION_MODE_APPLY
+}
+
 // RedactionBatches is the top-level container written to batches.pb.
 type RedactionBatches struct {
 	Batches []*RedactionBatch `protobuf:"bytes,1,rep,name=batches,proto3" json:"batches,omitempty"`
@@ -799,7 +958,7 @@ func (m *RedactionBatches) Reset()         { *m = RedactionBatches{} }
 func (m *RedactionBatches) String() string { return proto.CompactTextString(m) }
 func (*RedactionBatches) ProtoMessage()    {}
 func (*RedactionBatches) Descriptor() ([]byte, []int) {
-	return fileDescriptor_1e9b87dd365f5504, []int{12}
+	return fileDescriptor_1e9b87dd365f5504, []int{13}
 }
 func (m *RedactionBatches) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -838,8 +997,10 @@ func (m *RedactionBatches) GetBatches() []*RedactionBatch {
 func init() {
 	proto.RegisterEnum("tempopb.JobType", JobType_name, JobType_value)
 	proto.RegisterEnum("tempopb.JobStatus", JobStatus_name, JobStatus_value)
+	proto.RegisterEnum("tempopb.RedactionMode", RedactionMode_name, RedactionMode_value)
 	proto.RegisterType((*CompactionDetail)(nil), "tempopb.CompactionDetail")
 	proto.RegisterType((*RetentionDetail)(nil), "tempopb.RetentionDetail")
+	proto.RegisterType((*TraceQLSelector)(nil), "tempopb.TraceQLSelector")
 	proto.RegisterType((*RedactionDetail)(nil), "tempopb.RedactionDetail")
 	proto.RegisterType((*JobDetail)(nil), "tempopb.JobDetail")
 	proto.RegisterType((*NextJobRequest)(nil), "tempopb.NextJobRequest")
@@ -856,66 +1017,73 @@ func init() {
 func init() { proto.RegisterFile("backendwork.proto", fileDescriptor_1e9b87dd365f5504) }
 
 var fileDescriptor_1e9b87dd365f5504 = []byte{
-	// 932 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x55, 0xcd, 0x4f, 0xe3, 0x46,
-	0x14, 0x8f, 0xf3, 0x45, 0xf2, 0x58, 0x41, 0x98, 0x65, 0x13, 0x6f, 0x90, 0x12, 0x6a, 0xf5, 0x80,
-	0x90, 0x16, 0x5a, 0x90, 0x2a, 0x95, 0x3d, 0xe5, 0xc3, 0x54, 0x8e, 0xda, 0x80, 0x26, 0xc9, 0x56,
-	0x3d, 0x59, 0xfe, 0x18, 0xc0, 0x10, 0x3c, 0xae, 0x3d, 0x56, 0xd9, 0x5b, 0xff, 0x82, 0xaa, 0x7f,
-	0x42, 0xfb, 0xdf, 0xec, 0x71, 0x8f, 0x3d, 0x55, 0x15, 0xf4, 0xc0, 0xad, 0xe7, 0xde, 0x2a, 0xcf,
-	0x4c, 0x1c, 0x27, 0x81, 0x56, 0xbd, 0xf9, 0xbd, 0xf7, 0x9b, 0xf7, 0xf1, 0x9b, 0xdf, 0x1b, 0xc3,
-	0x96, 0x6d, 0x39, 0x37, 0xc4, 0x77, 0x7f, 0xa0, 0xe1, 0xcd, 0x41, 0x10, 0x52, 0x46, 0xd1, 0x1a,
-	0x23, 0xb7, 0x01, 0x0d, 0xec, 0xe6, 0x9b, 0x4b, 0x8f, 0x5d, 0xc5, 0xf6, 0x81, 0x43, 0x6f, 0x0f,
-	0x2f, 0xe9, 0x25, 0x3d, 0xe4, 0x71, 0x3b, 0xbe, 0xe0, 0x16, 0x37, 0xf8, 0x97, 0x38, 0xa7, 0x0d,
-	0xa0, 0xd6, 0xa3, 0xb7, 0x81, 0xe5, 0x30, 0x8f, 0xfa, 0x7d, 0xc2, 0x2c, 0x6f, 0x8a, 0xb6, 0xa1,
-	0xe4, 0xf9, 0x41, 0xcc, 0x54, 0x65, 0xb7, 0xb0, 0x57, 0xc5, 0xc2, 0x40, 0x75, 0x28, 0xd3, 0x98,
-	0x25, 0xee, 0x3c, 0x77, 0x4b, 0xeb, 0xa4, 0xf2, 0xf8, 0x4b, 0x5b, 0x79, 0xfc, 0xb5, 0xad, 0x68,
-	0x3b, 0xb0, 0x89, 0x09, 0x23, 0xfe, 0x3c, 0x55, 0x26, 0x38, 0x4a, 0x82, 0xee, 0x42, 0x9d, 0xd7,
-	0x50, 0xb1, 0xa7, 0xd4, 0xb9, 0x31, 0x3d, 0x57, 0x55, 0x76, 0x95, 0xbd, 0x2a, 0x5e, 0xe3, 0xb6,
-	0xe1, 0xa2, 0x1d, 0xa8, 0xb2, 0xd0, 0x72, 0x88, 0xe9, 0xb9, 0x11, 0xaf, 0xf7, 0x02, 0x57, 0xb8,
-	0xc3, 0x70, 0xa3, 0x4c, 0xd2, 0xbf, 0x14, 0xa8, 0x0e, 0xa8, 0x2d, 0xf3, 0xd5, 0xa1, 0xcc, 0x88,
-	0x6f, 0xf9, 0x4c, 0x66, 0x93, 0x16, 0xfa, 0x12, 0xc0, 0x49, 0x67, 0x54, 0xf3, 0xbb, 0xca, 0xde,
-	0xfa, 0xd1, 0xeb, 0x03, 0x49, 0xd8, 0xc1, 0xf2, 0xf8, 0x38, 0x03, 0x46, 0x5f, 0x40, 0x35, 0x9c,
-	0x8d, 0xa4, 0x16, 0xf8, 0x49, 0x35, 0x3d, 0xb9, 0x34, 0x2c, 0x9e, 0x43, 0xc5, 0x39, 0x39, 0xad,
-	0x5a, 0x5c, 0x39, 0xb7, 0xc0, 0x03, 0x9e, 0x43, 0x39, 0x25, 0x16, 0x73, 0xae, 0x12, 0x4a, 0x4a,
-	0x92, 0x92, 0xc4, 0x36, 0xdc, 0x93, 0x62, 0x32, 0xb5, 0xf6, 0x06, 0x36, 0x86, 0xe4, 0x8e, 0x0d,
-	0xa8, 0x8d, 0xc9, 0xf7, 0x31, 0x89, 0x58, 0x42, 0x55, 0xa2, 0x03, 0x12, 0xce, 0x69, 0xac, 0x08,
-	0x87, 0xe1, 0x6a, 0x3f, 0x2a, 0xb0, 0x99, 0xe2, 0xa3, 0x80, 0xfa, 0x11, 0x41, 0xaf, 0xa0, 0x7c,
-	0x4d, 0xed, 0x39, 0xba, 0x74, 0x4d, 0x6d, 0xc3, 0x45, 0x9f, 0x42, 0x91, 0xbd, 0x0f, 0x08, 0xe7,
-	0x67, 0xe3, 0xa8, 0x96, 0x76, 0x3b, 0xa0, 0xf6, 0xf8, 0x7d, 0x40, 0x30, 0x8f, 0xa2, 0xcf, 0xa0,
-	0xec, 0xf2, 0xae, 0x25, 0x1b, 0x28, 0x8b, 0x13, 0xf3, 0x74, 0x8b, 0x1f, 0x7e, 0x6f, 0xe7, 0xb0,
-	0xc4, 0x69, 0x7f, 0x2a, 0x50, 0x9f, 0x04, 0xae, 0xc5, 0xc8, 0x80, 0xda, 0x23, 0x66, 0xb1, 0x38,
-	0x9a, 0xb5, 0xfe, 0x4c, 0x27, 0xfb, 0x50, 0x8e, 0x38, 0x4e, 0xf6, 0xb2, 0x50, 0x43, 0x66, 0x90,
-	0x88, 0x44, 0xab, 0x24, 0x0c, 0x69, 0xc8, 0xdb, 0xa9, 0x62, 0x61, 0x2c, 0xdd, 0x78, 0xf1, 0x7f,
-	0xdf, 0xf8, 0xec, 0xe6, 0x4a, 0xcf, 0xdd, 0x1c, 0x26, 0x51, 0x3c, 0x65, 0x99, 0x9b, 0xd3, 0x8e,
-	0xa1, 0xb1, 0x32, 0xa5, 0x24, 0x5c, 0x85, 0xb5, 0x28, 0x76, 0x1c, 0x12, 0x45, 0x7c, 0xce, 0x0a,
-	0x9e, 0x99, 0xda, 0x3b, 0xa8, 0x8f, 0x62, 0xfb, 0xd6, 0x63, 0x99, 0xc4, 0x82, 0x9a, 0x36, 0x54,
-	0x85, 0x7a, 0x53, 0x76, 0xba, 0x79, 0x55, 0xc1, 0x15, 0xe1, 0xfc, 0x8f, 0x0d, 0xd1, 0xbe, 0x85,
-	0xc6, 0x4a, 0x5e, 0xd9, 0x4c, 0x56, 0x61, 0xca, 0x82, 0xc2, 0xd0, 0x27, 0xf0, 0xe2, 0x9a, 0xda,
-	0x91, 0xe9, 0x84, 0xc4, 0x62, 0xc4, 0xe5, 0xec, 0x97, 0xf0, 0x7a, 0xe2, 0xeb, 0x09, 0x97, 0x76,
-	0x92, 0xd9, 0x62, 0xc1, 0x41, 0x72, 0x8a, 0xd7, 0x8d, 0xcc, 0x0b, 0x1a, 0xfb, 0x22, 0x69, 0x09,
-	0xaf, 0x0b, 0xdf, 0x69, 0xe2, 0x92, 0xd2, 0xfd, 0x29, 0x0f, 0x1b, 0xe9, 0xe1, 0x6e, 0x52, 0xf3,
-	0xdf, 0x9a, 0xd9, 0xc9, 0x12, 0x90, 0x17, 0xb2, 0x7e, 0x7a, 0xf8, 0xc2, 0xe2, 0xf0, 0xe8, 0x10,
-	0xb6, 0xe5, 0x04, 0xa6, 0xc5, 0xcc, 0xd8, 0xf7, 0xee, 0x4c, 0xdf, 0xf2, 0x29, 0x97, 0x41, 0x01,
-	0x6f, 0xc9, 0x58, 0x87, 0x4d, 0x7c, 0xef, 0x6e, 0x68, 0xf9, 0x14, 0xbd, 0x85, 0x66, 0x74, 0xe3,
-	0x05, 0x01, 0x71, 0xcd, 0xb9, 0x10, 0x4c, 0xa1, 0xcc, 0x48, 0x2d, 0xf1, 0xd7, 0xae, 0x21, 0x11,
-	0x73, 0xed, 0x0c, 0x12, 0xad, 0x46, 0xe8, 0x18, 0xea, 0x21, 0x89, 0x1c, 0xcb, 0x37, 0xad, 0x0b,
-	0x46, 0xc2, 0x4c, 0xbd, 0x32, 0xaf, 0xf7, 0x52, 0x44, 0x3b, 0x49, 0x70, 0x56, 0x51, 0x12, 0xa2,
-	0x43, 0x6d, 0x91, 0x0f, 0x12, 0xa1, 0xcf, 0x41, 0x30, 0x40, 0x22, 0xfe, 0xfa, 0xae, 0x1f, 0x35,
-	0x56, 0xc5, 0xc7, 0xb1, 0x78, 0x86, 0xdb, 0x9f, 0xc2, 0x9a, 0xdc, 0x51, 0xa4, 0xc2, 0xf6, 0xe0,
-	0xac, 0x6b, 0x8e, 0xbf, 0x3b, 0xd7, 0xcd, 0xc9, 0x70, 0x74, 0xae, 0xf7, 0x8c, 0x53, 0x43, 0xef,
-	0xd7, 0x72, 0xa8, 0x01, 0x2f, 0xd3, 0x48, 0xef, 0xec, 0x9b, 0xf3, 0x4e, 0x6f, 0x6c, 0x9c, 0x0d,
-	0x6b, 0x0a, 0xaa, 0x03, 0x4a, 0x03, 0x58, 0x1f, 0xeb, 0x43, 0xee, 0xcf, 0x2f, 0xf9, 0xfb, 0x12,
-	0x5f, 0xd8, 0x0f, 0xf8, 0x8b, 0x2b, 0x14, 0x8e, 0x9a, 0x50, 0x4f, 0x40, 0xa3, 0x71, 0x67, 0x3c,
-	0x19, 0x2d, 0x55, 0x94, 0xbd, 0xc8, 0xd8, 0x68, 0xd2, 0xeb, 0xe9, 0x7a, 0x5f, 0xef, 0xd7, 0x14,
-	0xf4, 0x0a, 0xb6, 0x32, 0x91, 0xd3, 0x8e, 0xf1, 0xb5, 0xde, 0x9f, 0x57, 0x94, 0x6e, 0x3c, 0x19,
-	0x0e, 0x8d, 0xe1, 0x57, 0xb5, 0xc2, 0xd1, 0xdf, 0x0a, 0xd4, 0xba, 0xe2, 0x87, 0x37, 0x72, 0xae,
-	0x88, 0x1b, 0x4f, 0x49, 0x88, 0xde, 0x42, 0x31, 0x79, 0xd7, 0xd0, 0x9c, 0x9e, 0xc5, 0x67, 0xb1,
-	0xa9, 0xae, 0x06, 0xc4, 0x06, 0x68, 0x39, 0x74, 0x0e, 0xd5, 0x74, 0x57, 0x51, 0x3b, 0x05, 0x3e,
-	0xfd, 0x4a, 0x35, 0x77, 0x9f, 0x07, 0xa4, 0x19, 0xdf, 0xc1, 0xe6, 0xd2, 0xc2, 0x65, 0xf2, 0x3e,
-	0xbd, 0xe2, 0x99, 0xbc, 0xcf, 0xec, 0xaa, 0x96, 0xeb, 0xaa, 0x1f, 0xee, 0x5b, 0xca, 0xc7, 0xfb,
-	0x96, 0xf2, 0xc7, 0x7d, 0x4b, 0xf9, 0xf9, 0xa1, 0x95, 0xfb, 0xf8, 0xd0, 0xca, 0xfd, 0xf6, 0xd0,
-	0xca, 0xd9, 0x65, 0xfe, 0xff, 0x3e, 0xfe, 0x27, 0x00, 0x00, 0xff, 0xff, 0x08, 0x30, 0x4d, 0x9d,
-	0x0c, 0x08, 0x00, 0x00,
+	// 1054 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x56, 0xcd, 0x4e, 0x23, 0x47,
+	0x10, 0xf6, 0xf8, 0x0f, 0xbb, 0xd8, 0x80, 0xe9, 0x65, 0x8d, 0x17, 0x24, 0x43, 0x46, 0x39, 0x20,
+	0xa4, 0x85, 0x5d, 0x90, 0x22, 0x85, 0x3d, 0xf9, 0x67, 0x48, 0x6c, 0x81, 0x71, 0xda, 0x76, 0x22,
+	0x4e, 0xa3, 0xf9, 0x69, 0xc0, 0x60, 0xa6, 0x67, 0x67, 0x7a, 0x14, 0xb8, 0xe5, 0x11, 0xf2, 0x08,
+	0xc9, 0x13, 0xe4, 0x15, 0x72, 0xdc, 0xe3, 0x1e, 0x73, 0x8a, 0x22, 0xc8, 0x61, 0x95, 0x4b, 0xce,
+	0xb9, 0x45, 0xfd, 0xe3, 0xf1, 0xd8, 0x40, 0xb2, 0x9b, 0x9b, 0xab, 0xea, 0xeb, 0xaa, 0xaf, 0xbe,
+	0xee, 0xaa, 0x31, 0x2c, 0xd9, 0x96, 0x73, 0x49, 0x3c, 0xf7, 0x3b, 0x1a, 0x5c, 0x6e, 0xfb, 0x01,
+	0x65, 0x14, 0xcd, 0x31, 0x72, 0xe5, 0x53, 0xdf, 0x5e, 0x7d, 0x71, 0x36, 0x64, 0xe7, 0x91, 0xbd,
+	0xed, 0xd0, 0xab, 0x9d, 0x33, 0x7a, 0x46, 0x77, 0x44, 0xdc, 0x8e, 0x4e, 0x85, 0x25, 0x0c, 0xf1,
+	0x4b, 0x9e, 0xd3, 0xdb, 0x50, 0x6a, 0xd0, 0x2b, 0xdf, 0x72, 0xd8, 0x90, 0x7a, 0x4d, 0xc2, 0xac,
+	0xe1, 0x08, 0x2d, 0x43, 0x6e, 0xe8, 0xf9, 0x11, 0xab, 0x68, 0x1b, 0x99, 0xcd, 0x22, 0x96, 0x06,
+	0x2a, 0x43, 0x9e, 0x46, 0x8c, 0xbb, 0xd3, 0xc2, 0xad, 0xac, 0xfd, 0xc2, 0xfb, 0x1f, 0xd7, 0xb5,
+	0xf7, 0x3f, 0xad, 0x6b, 0xfa, 0x1a, 0x2c, 0x62, 0xc2, 0x88, 0x37, 0x49, 0x95, 0x08, 0xbe, 0x82,
+	0xc5, 0x7e, 0x60, 0x39, 0xe4, 0xeb, 0xc3, 0x1e, 0x19, 0x11, 0x87, 0xd1, 0x80, 0xd7, 0x79, 0x13,
+	0x91, 0xe0, 0xa6, 0xa2, 0x6d, 0x68, 0xbc, 0x8e, 0x30, 0x12, 0x47, 0x7e, 0xd6, 0x78, 0x42, 0x77,
+	0x8a, 0xdb, 0x73, 0x28, 0xd8, 0x23, 0xea, 0x5c, 0x9a, 0x43, 0x57, 0x1d, 0x9b, 0x13, 0x76, 0xcb,
+	0x45, 0x6b, 0x50, 0x64, 0xbc, 0x82, 0x39, 0x74, 0x43, 0xc1, 0xf1, 0x09, 0x2e, 0x08, 0x47, 0xcb,
+	0x0d, 0xd1, 0xf6, 0xb8, 0x56, 0x66, 0x43, 0xdb, 0x9c, 0xdf, 0xad, 0x6c, 0x2b, 0xbd, 0xb6, 0x67,
+	0x48, 0x29, 0x16, 0x68, 0x0b, 0xb2, 0x57, 0xd4, 0x25, 0x95, 0xec, 0x86, 0xb6, 0xb9, 0xb0, 0x5b,
+	0x8e, 0xe1, 0x31, 0x9f, 0x23, 0xea, 0x12, 0x2c, 0x30, 0x09, 0xc6, 0x7f, 0x69, 0x50, 0x6c, 0x53,
+	0x5b, 0x71, 0x2d, 0x43, 0x9e, 0x11, 0xcf, 0xf2, 0x98, 0x62, 0xaa, 0x2c, 0xf4, 0x05, 0x80, 0x13,
+	0x6b, 0x5e, 0x49, 0x0b, 0x42, 0xcf, 0xe3, 0x0a, 0xb3, 0xd7, 0x81, 0x13, 0x60, 0xf4, 0x39, 0x14,
+	0x83, 0xb1, 0xc4, 0xf7, 0x5a, 0x99, 0x11, 0x1f, 0x4f, 0xa0, 0xf2, 0x9c, 0x62, 0x2e, 0x7a, 0x9a,
+	0x3e, 0x37, 0xa5, 0x31, 0x9e, 0x40, 0x85, 0xdc, 0x16, 0x73, 0xce, 0xb9, 0xdc, 0x39, 0x25, 0x37,
+	0xb7, 0x5b, 0xee, 0x7e, 0x96, 0x77, 0xad, 0xbf, 0x80, 0x85, 0x0e, 0xb9, 0x66, 0x6d, 0x6a, 0x63,
+	0xf2, 0x26, 0x22, 0x21, 0xe3, 0xd7, 0xc0, 0xdf, 0x25, 0x09, 0x26, 0x57, 0x54, 0x90, 0x8e, 0x96,
+	0xab, 0x7f, 0xaf, 0xc1, 0x62, 0x8c, 0x0f, 0x7d, 0xea, 0x85, 0x04, 0x3d, 0x83, 0xfc, 0x05, 0xb5,
+	0x27, 0xe8, 0xdc, 0x05, 0xb5, 0x5b, 0x2e, 0xfa, 0x0c, 0xb2, 0xec, 0xc6, 0x27, 0x42, 0x9f, 0x85,
+	0xdd, 0x52, 0xcc, 0xb6, 0x4d, 0xed, 0xfe, 0x8d, 0x4f, 0xb0, 0x88, 0xa2, 0x97, 0x90, 0x77, 0x05,
+	0x6b, 0xa5, 0x06, 0x4a, 0xe2, 0x64, 0x3f, 0xf5, 0xec, 0xdb, 0xdf, 0xd6, 0x53, 0x58, 0xe1, 0xf4,
+	0x3f, 0x34, 0x28, 0x0f, 0x7c, 0xd7, 0x62, 0xa4, 0x4d, 0xed, 0x1e, 0xb3, 0x58, 0x14, 0x8e, 0xa9,
+	0x3f, 0xc2, 0x64, 0x0b, 0xf2, 0xa1, 0xc0, 0x29, 0x2e, 0x53, 0x35, 0x54, 0x06, 0x85, 0xe0, 0x6f,
+	0x9a, 0x04, 0x01, 0x0d, 0x04, 0x9d, 0x22, 0x96, 0xc6, 0xcc, 0x8d, 0x67, 0x3f, 0xfa, 0xc6, 0xc7,
+	0x37, 0x97, 0x7b, 0xec, 0xe6, 0x30, 0x09, 0xa3, 0x11, 0x4b, 0xdc, 0x9c, 0xbe, 0x07, 0x2b, 0xf7,
+	0xba, 0x54, 0x82, 0x57, 0x60, 0x2e, 0x8c, 0x1c, 0x87, 0x84, 0xa1, 0xe8, 0xb3, 0x80, 0xc7, 0xa6,
+	0xfe, 0x8b, 0x06, 0xe5, 0x5e, 0x64, 0x5f, 0x0d, 0x59, 0x22, 0xb3, 0xd4, 0x66, 0x1d, 0x8a, 0xf2,
+	0xf9, 0xc6, 0xf2, 0xd4, 0xd3, 0x15, 0x0d, 0x17, 0xa4, 0xf3, 0xbf, 0xc6, 0xef, 0xe5, 0x07, 0x8e,
+	0xdf, 0x57, 0xa9, 0xff, 0x31, 0x80, 0x75, 0x80, 0x42, 0xa8, 0x12, 0xe8, 0xdf, 0xc2, 0xca, 0xbd,
+	0x0e, 0x54, 0xdf, 0xc9, 0xc7, 0xac, 0x4d, 0x3d, 0x66, 0xf4, 0x29, 0x3c, 0xb9, 0xa0, 0x76, 0x68,
+	0x3a, 0x01, 0xb1, 0x18, 0x71, 0xc5, 0x45, 0xe7, 0xf0, 0x3c, 0xf7, 0x35, 0xa4, 0x4b, 0xdf, 0x4f,
+	0x2c, 0x23, 0x29, 0x37, 0x3f, 0x25, 0x3a, 0x0c, 0xcd, 0x53, 0x1a, 0x79, 0x32, 0x69, 0x0e, 0xcf,
+	0x4b, 0xdf, 0x01, 0x77, 0xa9, 0x29, 0xf9, 0x33, 0x0d, 0x0b, 0xf1, 0xe1, 0x3a, 0xaf, 0xf9, 0x6f,
+	0x64, 0xd6, 0x92, 0x52, 0xa7, 0xe5, 0x04, 0x3d, 0x2c, 0x73, 0x66, 0x46, 0xe6, 0x1d, 0x58, 0x56,
+	0x1d, 0x98, 0x16, 0x33, 0x23, 0x6f, 0x78, 0x6d, 0x7a, 0x96, 0x47, 0x85, 0x88, 0x19, 0xbc, 0xa4,
+	0x62, 0x35, 0x36, 0xf0, 0x86, 0xd7, 0x1d, 0xcb, 0xa3, 0xe8, 0x35, 0xac, 0x86, 0x97, 0x43, 0xdf,
+	0x27, 0xae, 0x39, 0x79, 0x73, 0xa6, 0x1c, 0x82, 0xb0, 0x92, 0x13, 0x8b, 0x7e, 0x45, 0x21, 0x26,
+	0xcf, 0xb4, 0xcd, 0xc7, 0x22, 0x44, 0x7b, 0x50, 0x0e, 0x48, 0xe8, 0x58, 0x9e, 0x69, 0x9d, 0x32,
+	0x12, 0x24, 0xea, 0xe5, 0x45, 0xbd, 0xa7, 0x32, 0x5a, 0xe3, 0xc1, 0xb8, 0x62, 0xbc, 0x88, 0xe7,
+	0x3e, 0x6e, 0x11, 0x17, 0x3e, 0x60, 0x11, 0x4b, 0xb1, 0x0d, 0x28, 0x4d, 0x6b, 0x4d, 0x42, 0xf4,
+	0x0a, 0xa4, 0xba, 0x24, 0x14, 0x1f, 0xb5, 0xf9, 0xdd, 0x95, 0xfb, 0x89, 0x04, 0x16, 0x8f, 0x71,
+	0x5b, 0x23, 0x98, 0x53, 0xab, 0x06, 0x55, 0x60, 0xb9, 0x7d, 0x5c, 0x37, 0xfb, 0x27, 0x5d, 0xc3,
+	0x1c, 0x74, 0x7a, 0x5d, 0xa3, 0xd1, 0x3a, 0x68, 0x19, 0xcd, 0x52, 0x0a, 0xad, 0xc0, 0xd3, 0x38,
+	0xd2, 0x38, 0x3e, 0xea, 0xd6, 0x1a, 0xfd, 0xd6, 0x71, 0xa7, 0xa4, 0xa1, 0x32, 0xa0, 0x38, 0x80,
+	0x8d, 0xbe, 0xd1, 0x11, 0xfe, 0xf4, 0x8c, 0xbf, 0xa9, 0xf0, 0x99, 0x2d, 0x5f, 0x7c, 0x38, 0xe4,
+	0xa0, 0xa2, 0x55, 0x28, 0x73, 0x50, 0xaf, 0x5f, 0xeb, 0x0f, 0x7a, 0x33, 0x15, 0x15, 0x17, 0x15,
+	0xeb, 0x0d, 0x1a, 0x0d, 0xc3, 0x68, 0x1a, 0xcd, 0x92, 0x86, 0x9e, 0xc1, 0x52, 0x22, 0x72, 0x50,
+	0x6b, 0x1d, 0x1a, 0xcd, 0x49, 0x45, 0xe5, 0xc6, 0x83, 0x4e, 0xa7, 0xd5, 0xf9, 0xb2, 0x94, 0xd9,
+	0x32, 0xe0, 0x93, 0x29, 0x0d, 0x79, 0xe6, 0x98, 0x91, 0x79, 0x74, 0xdc, 0x34, 0xcc, 0x5a, 0xb7,
+	0x7b, 0x78, 0x52, 0x4a, 0x71, 0x3e, 0x33, 0x91, 0x26, 0x3e, 0xe1, 0xa9, 0x4a, 0xda, 0xee, 0xdf,
+	0x1a, 0x94, 0xea, 0xf2, 0xef, 0x48, 0xcf, 0x39, 0x27, 0x6e, 0x34, 0x22, 0x01, 0x7a, 0x0d, 0x59,
+	0xbe, 0xe5, 0xd1, 0x44, 0xe5, 0xe9, 0x8f, 0xc4, 0x6a, 0xe5, 0x7e, 0x40, 0x0e, 0xa9, 0x9e, 0x42,
+	0x5d, 0x28, 0xc6, 0x9b, 0x0b, 0xad, 0xc7, 0xc0, 0x87, 0x77, 0xf6, 0xea, 0xc6, 0xe3, 0x80, 0x38,
+	0xe3, 0x37, 0xb0, 0x38, 0xb3, 0x13, 0x12, 0x79, 0x1f, 0xde, 0x77, 0x89, 0xbc, 0x8f, 0xac, 0x13,
+	0x3d, 0x55, 0xaf, 0xbc, 0xbd, 0xad, 0x6a, 0xef, 0x6e, 0xab, 0xda, 0xef, 0xb7, 0x55, 0xed, 0x87,
+	0xbb, 0x6a, 0xea, 0xdd, 0x5d, 0x35, 0xf5, 0xeb, 0x5d, 0x35, 0x65, 0xe7, 0xc5, 0xbf, 0xab, 0xbd,
+	0x7f, 0x02, 0x00, 0x00, 0xff, 0xff, 0xe0, 0xfa, 0xfe, 0x0f, 0xaa, 0x09, 0x00, 0x00,
 }
 
 func (this *CompactionDetail) Compare(that interface{}) int {
@@ -1000,6 +1168,39 @@ func (this *RetentionDetail) Compare(that interface{}) int {
 	}
 	return 0
 }
+func (this *TraceQLSelector) Compare(that interface{}) int {
+	if that == nil {
+		if this == nil {
+			return 0
+		}
+		return 1
+	}
+
+	that1, ok := that.(*TraceQLSelector)
+	if !ok {
+		that2, ok := that.(TraceQLSelector)
+		if ok {
+			that1 = &that2
+		} else {
+			return 1
+		}
+	}
+	if that1 == nil {
+		if this == nil {
+			return 0
+		}
+		return 1
+	} else if this == nil {
+		return -1
+	}
+	if this.Query != that1.Query {
+		if this.Query < that1.Query {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
 func (this *RedactionDetail) Compare(that interface{}) int {
 	if that == nil {
 		if this == nil {
@@ -1041,6 +1242,15 @@ func (this *RedactionDetail) Compare(that interface{}) int {
 		if c := bytes.Compare(this.TraceIds[i], that1.TraceIds[i]); c != 0 {
 			return c
 		}
+	}
+	if c := this.Query.Compare(that1.Query); c != 0 {
+		return c
+	}
+	if this.Mode != that1.Mode {
+		if this.Mode < that1.Mode {
+			return -1
+		}
+		return 1
 	}
 	return 0
 }
@@ -1102,6 +1312,30 @@ func (this *RetentionDetail) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *TraceQLSelector) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*TraceQLSelector)
+	if !ok {
+		that2, ok := that.(TraceQLSelector)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Query != that1.Query {
+		return false
+	}
+	return true
+}
 func (this *RedactionDetail) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -1131,6 +1365,12 @@ func (this *RedactionDetail) Equal(that interface{}) bool {
 		if !bytes.Equal(this.TraceIds[i], that1.TraceIds[i]) {
 			return false
 		}
+	}
+	if !this.Query.Equal(that1.Query) {
+		return false
+	}
+	if this.Mode != that1.Mode {
+		return false
 	}
 	return true
 }
@@ -1239,6 +1479,12 @@ func (this *RedactionBatch) Equal(that interface{}) bool {
 		}
 	}
 	if this.RescanAfterUnixNano != that1.RescanAfterUnixNano {
+		return false
+	}
+	if !this.Query.Equal(that1.Query) {
+		return false
+	}
+	if this.Mode != that1.Mode {
 		return false
 	}
 	return true
@@ -1470,6 +1716,36 @@ func (m *RetentionDetail) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *TraceQLSelector) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TraceQLSelector) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TraceQLSelector) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Query) > 0 {
+		i -= len(m.Query)
+		copy(dAtA[i:], m.Query)
+		i = encodeVarintBackendwork(dAtA, i, uint64(len(m.Query)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *RedactionDetail) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1490,6 +1766,23 @@ func (m *RedactionDetail) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Mode != 0 {
+		i = encodeVarintBackendwork(dAtA, i, uint64(m.Mode))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Query != nil {
+		{
+			size, err := m.Query.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintBackendwork(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.TraceIds) > 0 {
 		for iNdEx := len(m.TraceIds) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.TraceIds[iNdEx])
@@ -1776,6 +2069,20 @@ func (m *SubmitRedactionRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	_ = i
 	var l int
 	_ = l
+	if m.Mode != 0 {
+		i = encodeVarintBackendwork(dAtA, i, uint64(m.Mode))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Selector != nil {
+		{
+			size := m.Selector.Size()
+			i -= size
+			if _, err := m.Selector.MarshalTo(dAtA[i:]); err != nil {
+				return 0, err
+			}
+		}
+	}
 	if len(m.TraceIds) > 0 {
 		for iNdEx := len(m.TraceIds) - 1; iNdEx >= 0; iNdEx-- {
 			i -= len(m.TraceIds[iNdEx])
@@ -1795,6 +2102,27 @@ func (m *SubmitRedactionRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 
+func (m *SubmitRedactionRequest_Query) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SubmitRedactionRequest_Query) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	if m.Query != nil {
+		{
+			size, err := m.Query.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintBackendwork(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
+	}
+	return len(dAtA) - i, nil
+}
 func (m *SubmitRedactionResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1878,6 +2206,23 @@ func (m *RedactionBatch) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if m.Mode != 0 {
+		i = encodeVarintBackendwork(dAtA, i, uint64(m.Mode))
+		i--
+		dAtA[i] = 0x40
+	}
+	if m.Query != nil {
+		{
+			size, err := m.Query.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintBackendwork(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x3a
+	}
 	if m.RescanAfterUnixNano != 0 {
 		i = encodeVarintBackendwork(dAtA, i, uint64(m.RescanAfterUnixNano))
 		i--
@@ -2001,6 +2346,19 @@ func (m *RetentionDetail) Size() (n int) {
 	return n
 }
 
+func (m *TraceQLSelector) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Query)
+	if l > 0 {
+		n += 1 + l + sovBackendwork(uint64(l))
+	}
+	return n
+}
+
 func (m *RedactionDetail) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2016,6 +2374,13 @@ func (m *RedactionDetail) Size() (n int) {
 			l = len(b)
 			n += 1 + l + sovBackendwork(uint64(l))
 		}
+	}
+	if m.Query != nil {
+		l = m.Query.Size()
+		n += 1 + l + sovBackendwork(uint64(l))
+	}
+	if m.Mode != 0 {
+		n += 1 + sovBackendwork(uint64(m.Mode))
 	}
 	return n
 }
@@ -2136,9 +2501,27 @@ func (m *SubmitRedactionRequest) Size() (n int) {
 			n += 1 + l + sovBackendwork(uint64(l))
 		}
 	}
+	if m.Selector != nil {
+		n += m.Selector.Size()
+	}
+	if m.Mode != 0 {
+		n += 1 + sovBackendwork(uint64(m.Mode))
+	}
 	return n
 }
 
+func (m *SubmitRedactionRequest_Query) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Query != nil {
+		l = m.Query.Size()
+		n += 1 + l + sovBackendwork(uint64(l))
+	}
+	return n
+}
 func (m *SubmitRedactionResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -2198,6 +2581,13 @@ func (m *RedactionBatch) Size() (n int) {
 	}
 	if m.RescanAfterUnixNano != 0 {
 		n += 1 + sovBackendwork(uint64(m.RescanAfterUnixNano))
+	}
+	if m.Query != nil {
+		l = m.Query.Size()
+		n += 1 + l + sovBackendwork(uint64(l))
+	}
+	if m.Mode != 0 {
+		n += 1 + sovBackendwork(uint64(m.Mode))
 	}
 	return n
 }
@@ -2387,6 +2777,88 @@ func (m *RetentionDetail) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *TraceQLSelector) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowBackendwork
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TraceQLSelector: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TraceQLSelector: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBackendwork
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Query = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipBackendwork(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *RedactionDetail) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2480,6 +2952,61 @@ func (m *RedactionDetail) Unmarshal(dAtA []byte) error {
 			m.TraceIds = append(m.TraceIds, make([]byte, postIndex-iNdEx))
 			copy(m.TraceIds[len(m.TraceIds)-1], dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBackendwork
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &TraceQLSelector{}
+			}
+			if err := m.Query.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mode", wireType)
+			}
+			m.Mode = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBackendwork
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Mode |= RedactionMode(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipBackendwork(dAtA[iNdEx:])
@@ -3307,6 +3834,60 @@ func (m *SubmitRedactionRequest) Unmarshal(dAtA []byte) error {
 			m.TraceIds = append(m.TraceIds, make([]byte, postIndex-iNdEx))
 			copy(m.TraceIds[len(m.TraceIds)-1], dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBackendwork
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			v := &TraceQLSelector{}
+			if err := v.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			m.Selector = &SubmitRedactionRequest_Query{v}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mode", wireType)
+			}
+			m.Mode = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBackendwork
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Mode |= RedactionMode(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipBackendwork(dAtA[iNdEx:])
@@ -3689,6 +4270,61 @@ func (m *RedactionBatch) Unmarshal(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.RescanAfterUnixNano |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Query", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBackendwork
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBackendwork
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Query == nil {
+				m.Query = &TraceQLSelector{}
+			}
+			if err := m.Query.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 8:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Mode", wireType)
+			}
+			m.Mode = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBackendwork
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Mode |= RedactionMode(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/pkg/tempopb/backendwork.proto
+++ b/pkg/tempopb/backendwork.proto
@@ -47,15 +47,34 @@ message RetentionDetail {
   option (gogoproto.compare) = true;
 }
 
+// RedactionMode selects whether a redaction applies (rewrites blocks) or is a dry run
+// (evaluates and counts matches without modifying storage).
+enum RedactionMode {
+  REDACTION_MODE_APPLY = 0;    // default: rewrite blocks, removing matched traces
+  REDACTION_MODE_DRY_RUN = 1;  // evaluate and count matches, never rewrite
+}
+
+// TraceQLSelector carries a TraceQL expression that selects the traces to redact,
+// as an alternative to an explicit trace ID list. Restricted at submission to a single
+// spanset filter (=, != on resource.*/span.* joined by && / ||).
+message TraceQLSelector {
+  option (gogoproto.equal) = true;
+  option (gogoproto.compare) = true;
+
+  string query = 1;  // TraceQL expression
+}
+
 // RedactionDetail contains fields for redaction jobs (one job per block).
-// TraceIds are the trace IDs to redact from the block. Future extension may add
-// traceql/attribute-based redaction.
+// TraceIds are the trace IDs to redact from the block; alternatively query selects
+// them via a TraceQL expression evaluated against the block.
 message RedactionDetail {
   option (gogoproto.equal) = true;
   option (gogoproto.compare) = true;
 
   string block_id = 1;       // block to redact
   repeated bytes trace_ids = 2;  // trace IDs to remove from the block
+  TraceQLSelector query = 3;     // when set, select traces via TraceQL instead of trace_ids
+  RedactionMode mode = 4;        // apply vs dry-run for this job
 }
 
 // JobDetail contains the specific details for each job type
@@ -103,6 +122,13 @@ message UpdateJobStatusResponse {
 message SubmitRedactionRequest {
   string tenant_id = 1 [deprecated = true]; // ignored by the server; tenant is read from the request header
   repeated bytes trace_ids = 2;
+  // selector is a single-member oneof for now, reserving room to migrate trace_ids into
+  // it later without an API break. It carries the TraceQL query selector; query and
+  // trace_ids are mutually exclusive, enforced at submission.
+  oneof selector {
+    TraceQLSelector query = 3;
+  }
+  RedactionMode mode = 4;  // apply (default) vs dry-run
 }
 
 message SubmitRedactionResponse {
@@ -140,6 +166,12 @@ message RedactionBatch {
   // rescan_after_unix_nano is the earliest time at which the scheduler should
   // perform the rescan described above. Zero means no rescan is pending.
   int64 rescan_after_unix_nano = 6;
+  // query, when set, selects traces via a TraceQL expression instead of trace_ids.
+  // Stored in the manifest for the lifetime of the redaction and injected into each
+  // per-block job.
+  TraceQLSelector query = 7;
+  // mode selects apply (default) vs dry-run for the whole batch.
+  RedactionMode mode = 8;
 }
 
 // RedactionBatches is the top-level container written to batches.pb.

--- a/tempodb/redaction_test.go
+++ b/tempodb/redaction_test.go
@@ -1,0 +1,68 @@
+package tempodb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	v1_common "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/stretchr/testify/require"
+)
+
+// traceWithResourceAttr builds a single-batch trace carrying a specific resource
+// attribute, so a TraceQL query can select it and leave others untouched.
+func traceWithResourceAttr(id []byte, key, val string) *tempopb.Trace {
+	attrs := []*v1_common.KeyValue{{
+		Key:   key,
+		Value: &v1_common.AnyValue{Value: &v1_common.AnyValue_StringValue{StringValue: val}},
+	}}
+	return &tempopb.Trace{
+		ResourceSpans: []*v1_trace.ResourceSpans{test.MakeBatchWithAttributes(2, id, attrs)},
+	}
+}
+
+// TestRedactBlockQuerySelector verifies the TraceQL query path of RedactBlock: exactly the
+// traces matching the query are dropped (no over-deletion), and dry-run counts without
+// rewriting.
+func TestRedactBlockQuerySelector(t *testing.T) {
+	_, w, c, _ := testConfig(t, 0)
+	ctx := context.Background()
+
+	idMatch := test.ValidTraceID(nil)
+	idKeep := test.ValidTraceID(nil)
+	now := uint32(time.Now().Unix())
+
+	// Two traces distinguished by resource.namespace; the query targets only one.
+	data := []testData{
+		{idMatch, traceWithResourceAttr(idMatch, "namespace", "checkout"), now, now},
+		{idKeep, traceWithResourceAttr(idKeep, "namespace", "keep"), now, now},
+	}
+	query := `{resource.namespace = "checkout"}`
+
+	t.Run("apply drops only the matching trace", func(t *testing.T) {
+		blk := cutTestBlockWithTraces(t, w, data)
+		meta := blk.BlockMeta()
+		require.Equal(t, int64(2), meta.TotalObjects)
+
+		rewrote, found, newMeta, err := c.RedactBlock(ctx, meta, testTenantID, nil, query, false)
+		require.NoError(t, err)
+		require.True(t, rewrote)
+		require.Equal(t, 1, found, "exactly one trace matches the query")
+		require.NotNil(t, newMeta)
+		require.Equal(t, int64(1), newMeta.TotalObjects, "the non-matching trace must survive")
+	})
+
+	t.Run("dry-run counts without rewriting", func(t *testing.T) {
+		blk := cutTestBlockWithTraces(t, w, data)
+		meta := blk.BlockMeta()
+
+		rewrote, found, newMeta, err := c.RedactBlock(ctx, meta, testTenantID, nil, query, true)
+		require.NoError(t, err)
+		require.False(t, rewrote, "dry-run must not rewrite")
+		require.Equal(t, 1, found, "dry-run still reports the match count")
+		require.Nil(t, newMeta)
+	})
+}

--- a/tempodb/redaction_test.go
+++ b/tempodb/redaction_test.go
@@ -47,7 +47,7 @@ func TestRedactBlockQuerySelector(t *testing.T) {
 		meta := blk.BlockMeta()
 		require.Equal(t, int64(2), meta.TotalObjects)
 
-		rewrote, found, newMeta, err := c.RedactBlock(ctx, meta, testTenantID, nil, query, false)
+		rewrote, found, newMeta, err := c.RedactBlock(ctx, meta, testTenantID, nil, query, tempopb.RedactionMode_REDACTION_MODE_APPLY)
 		require.NoError(t, err)
 		require.True(t, rewrote)
 		require.Equal(t, 1, found, "exactly one trace matches the query")
@@ -59,7 +59,7 @@ func TestRedactBlockQuerySelector(t *testing.T) {
 		blk := cutTestBlockWithTraces(t, w, data)
 		meta := blk.BlockMeta()
 
-		rewrote, found, newMeta, err := c.RedactBlock(ctx, meta, testTenantID, nil, query, true)
+		rewrote, found, newMeta, err := c.RedactBlock(ctx, meta, testTenantID, nil, query, tempopb.RedactionMode_REDACTION_MODE_DRY_RUN)
 		require.NoError(t, err)
 		require.False(t, rewrote, "dry-run must not rewrite")
 		require.Equal(t, 1, found, "dry-run still reports the match count")

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -123,7 +123,7 @@ type Compactor interface {
 	RetainWithConfig(ctx context.Context, cfg *CompactorConfig, sharder CompactorSharder, overrides CompactorOverrides)
 	RetainTenantWithConfig(ctx context.Context, tenantID string, cfg *CompactorConfig, sharder CompactorSharder, overrides CompactorOverrides)
 
-	RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID) (rewrote bool, found int, newMeta *backend.BlockMeta, err error)
+	RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID, query string, dryRun bool) (rewrote bool, found int, newMeta *backend.BlockMeta, err error)
 }
 
 type CompactorSharder interface {
@@ -621,7 +621,60 @@ func (rw *readerWriter) MarkBlockCompacted(tenantID string, blockID backend.UUID
 
 // RedactBlock rewrites a block excluding the given trace IDs. If none of the trace IDs
 // are in the block, no rewrite is performed.
-func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID) (rewrote bool, found int, newMeta *backend.BlockMeta, err error) {
+// redactionIDsFromQuery evaluates a TraceQL query against a single open block and returns
+// the unique trace IDs whose spans satisfy it. The full boolean expression is applied as
+// the fetch second pass, so only truly-matching spansets are returned — a trace is never
+// selected (and therefore never dropped) unless it actually matches the query. Iterating
+// the spanset stream directly avoids the search result-cap that ExecuteSearch imposes.
+//
+// The query must already be validated to the redaction subset (see validateRedactionQuery).
+func redactionIDsFromQuery(ctx context.Context, block common.BackendBlock, query string, opts common.SearchOptions) ([]common.ID, error) {
+	// filter is the compiled TraceQL boolean expression (a SpansetFilterFunc), not a
+	// code-eval primitive; it decides whether a spanset satisfies the query.
+	_, _, filter, req, err := traceql.Compile(query)
+	if err != nil {
+		return nil, fmt.Errorf("compiling redaction query: %w", err)
+	}
+
+	// Request trace-level metadata in the second pass so each returned spanset carries its
+	// TraceID (the first pass only fetches the columns needed to satisfy the conditions).
+	req.SecondPassConditions = traceql.SearchMetaConditionsWithout(req.Conditions, req.AllConditions)
+	req.SecondPass = func(inSS *traceql.Spanset) ([]*traceql.Spanset, error) {
+		if inSS == nil || len(inSS.Spans) == 0 {
+			return nil, nil
+		}
+		return filter([]*traceql.Spanset{inSS})
+	}
+
+	resp, err := block.Fetch(ctx, *req, opts)
+	if err != nil {
+		return nil, fmt.Errorf("fetching spans: %w", err)
+	}
+	defer resp.Results.Close()
+
+	seen := make(map[string]struct{})
+	var ids []common.ID
+	for {
+		ss, err := resp.Results.Next(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("iterating results: %w", err)
+		}
+		if ss == nil {
+			break
+		}
+		if _, ok := seen[string(ss.TraceID)]; !ok {
+			seen[string(ss.TraceID)] = struct{}{}
+			// copy: the iterator may reuse the underlying buffer after release.
+			ids = append(ids, common.ID(append([]byte(nil), ss.TraceID...)))
+		}
+		if ss.ReleaseFn != nil {
+			ss.ReleaseFn(ss)
+		}
+	}
+	return ids, nil
+}
+
+func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID, query string, dryRun bool) (rewrote bool, found int, newMeta *backend.BlockMeta, err error) {
 	block, err := encoding.OpenBlock(meta, rw.r)
 	if err != nil {
 		return false, 0, nil, fmt.Errorf("error opening block for redaction, blockID: %s: %w", meta.BlockID.String(), err)
@@ -632,18 +685,32 @@ func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta
 		rw.cfg.Search.ApplyToOptions(&searchOpts)
 	}
 
+	// The selector is either an explicit trace ID list or a TraceQL query, never both
+	// (enforced at submission). Resolve it to the set of trace IDs present in this block.
 	var idsToDrop []common.ID
-	for _, traceID := range traceIDs {
-		result, err := block.FindTraceByID(ctx, traceID, searchOpts)
+	if query != "" {
+		idsToDrop, err = redactionIDsFromQuery(ctx, block, query, searchOpts)
 		if err != nil {
-			return false, 0, nil, fmt.Errorf("error finding trace in block, blockID: %s: %w", meta.BlockID.String(), err)
+			return false, 0, nil, fmt.Errorf("error selecting traces by query in block %s: %w", meta.BlockID.String(), err)
 		}
-		if result != nil && result.Trace != nil {
-			idsToDrop = append(idsToDrop, traceID)
+	} else {
+		for _, traceID := range traceIDs {
+			result, err := block.FindTraceByID(ctx, traceID, searchOpts)
+			if err != nil {
+				return false, 0, nil, fmt.Errorf("error finding trace in block, blockID: %s: %w", meta.BlockID.String(), err)
+			}
+			if result != nil && result.Trace != nil {
+				idsToDrop = append(idsToDrop, traceID)
+			}
 		}
 	}
 	if len(idsToDrop) == 0 {
 		return false, 0, nil, nil
+	}
+
+	// Dry-run: report how many traces would be dropped without rewriting the block.
+	if dryRun {
+		return false, len(idsToDrop), nil, nil
 	}
 
 	enc, err := encoding.FromVersion(meta.Version)

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -620,13 +620,13 @@ func (rw *readerWriter) MarkBlockCompacted(tenantID string, blockID backend.UUID
 }
 
 // redactionIDsFromQuery evaluates a TraceQL query against a single open block and returns
-// the unique trace IDs whose spans satisfy it. The full boolean expression is applied as
+// the set of trace IDs (keyed by raw ID bytes) whose spans satisfy it. The full boolean expression is applied as
 // the fetch second pass, so only truly-matching spansets are returned — a trace is never
 // selected (and therefore never dropped) unless it actually matches the query. Iterating
 // the spanset stream directly avoids the search result-cap that ExecuteSearch imposes.
 //
 // The query must already be validated to the redaction subset (see validateRedactionQuery).
-func redactionIDsFromQuery(ctx context.Context, block common.BackendBlock, query string, opts common.SearchOptions) ([]common.ID, error) {
+func redactionIDsFromQuery(ctx context.Context, block common.BackendBlock, query string, opts common.SearchOptions) (map[string]struct{}, error) {
 	// filter is the compiled TraceQL boolean expression (a SpansetFilterFunc), not a
 	// code-eval primitive; it decides whether a spanset satisfies the query.
 	_, _, filter, req, err := traceql.Compile(query)
@@ -650,8 +650,11 @@ func redactionIDsFromQuery(ctx context.Context, block common.BackendBlock, query
 	}
 	defer resp.Results.Close()
 
-	seen := make(map[string]struct{})
-	var ids []common.ID
+	// Collect matches into a single set keyed by the raw trace ID bytes. The map insert
+	// copies the key, so we neither retain a second ID slice nor rebuild a set later; the
+	// set also dedups a trace that appears in more than one spanset. In dry-run the caller
+	// reads len() only, so memory stays bounded to this one set.
+	dropSet := make(map[string]struct{})
 	for {
 		ss, err := resp.Results.Next(ctx)
 		if err != nil {
@@ -660,16 +663,12 @@ func redactionIDsFromQuery(ctx context.Context, block common.BackendBlock, query
 		if ss == nil {
 			break
 		}
-		if _, ok := seen[string(ss.TraceID)]; !ok {
-			seen[string(ss.TraceID)] = struct{}{}
-			// copy: the iterator may reuse the underlying buffer after release.
-			ids = append(ids, common.ID(append([]byte(nil), ss.TraceID...)))
-		}
+		dropSet[string(ss.TraceID)] = struct{}{}
 		if ss.ReleaseFn != nil {
 			ss.ReleaseFn(ss)
 		}
 	}
-	return ids, nil
+	return dropSet, nil
 }
 
 // RedactBlock rewrites a block excluding the traces selected by either an explicit trace
@@ -687,44 +686,39 @@ func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta
 	}
 
 	// The selector is either an explicit trace ID list or a TraceQL query, never both
-	// (enforced at submission). Resolve it to the set of trace IDs present in this block.
-	var idsToDrop []common.ID
+	// (enforced at submission). Resolve it to the set of trace IDs present in this block,
+	// keyed by raw ID bytes: one structure that dedups, drives the dry-run count, and backs
+	// the O(1) DropObject membership check in the rewrite below.
+	var dropSet map[string]struct{}
 	if query != "" {
-		idsToDrop, err = redactionIDsFromQuery(ctx, block, query, searchOpts)
+		dropSet, err = redactionIDsFromQuery(ctx, block, query, searchOpts)
 		if err != nil {
 			return false, 0, nil, fmt.Errorf("error selecting traces by query in block %s: %w", meta.BlockID.String(), err)
 		}
 	} else {
+		dropSet = make(map[string]struct{}, len(traceIDs))
 		for _, traceID := range traceIDs {
 			result, err := block.FindTraceByID(ctx, traceID, searchOpts)
 			if err != nil {
 				return false, 0, nil, fmt.Errorf("error finding trace in block, blockID: %s: %w", meta.BlockID.String(), err)
 			}
 			if result != nil && result.Trace != nil {
-				idsToDrop = append(idsToDrop, traceID)
+				dropSet[string(traceID)] = struct{}{}
 			}
 		}
 	}
-	if len(idsToDrop) == 0 {
+	if len(dropSet) == 0 {
 		return false, 0, nil, nil
 	}
 
 	// Dry-run: report how many traces would be dropped without rewriting the block.
 	if mode == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN {
-		return false, len(idsToDrop), nil, nil
+		return false, len(dropSet), nil, nil
 	}
 
 	enc, err := encoding.FromVersion(meta.Version)
 	if err != nil {
 		return false, 0, nil, fmt.Errorf("error getting encoding for version %s: %w", meta.Version, err)
-	}
-
-	// Index the drop set for O(1) membership checks in DropObject. The query selector can
-	// match a large fraction of a block's traces, so a linear scan per object would make
-	// the rewrite O(objects × matches).
-	dropSet := make(map[string]struct{}, len(idsToDrop))
-	for _, id := range idsToDrop {
-		dropSet[string(id)] = struct{}{}
 	}
 
 	opts := common.CompactionOptions{
@@ -753,7 +747,7 @@ func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta
 		DedupedSpans:      func(_, _ int) {},
 	}
 
-	nFound := len(idsToDrop)
+	nFound := len(dropSet)
 
 	compactor := enc.NewCompactor(opts)
 	out, err := compactor.Compact(ctx, rw.logger, rw.r, rw.w, []*backend.BlockMeta{meta})

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -123,7 +123,7 @@ type Compactor interface {
 	RetainWithConfig(ctx context.Context, cfg *CompactorConfig, sharder CompactorSharder, overrides CompactorOverrides)
 	RetainTenantWithConfig(ctx context.Context, tenantID string, cfg *CompactorConfig, sharder CompactorSharder, overrides CompactorOverrides)
 
-	RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID, query string, dryRun bool) (rewrote bool, found int, newMeta *backend.BlockMeta, err error)
+	RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID, query string, mode tempopb.RedactionMode) (rewrote bool, found int, newMeta *backend.BlockMeta, err error)
 }
 
 type CompactorSharder interface {
@@ -619,8 +619,6 @@ func (rw *readerWriter) MarkBlockCompacted(tenantID string, blockID backend.UUID
 	return rw.c.MarkBlockCompacted(uuid.UUID(blockID), tenantID)
 }
 
-// RedactBlock rewrites a block excluding the given trace IDs. If none of the trace IDs
-// are in the block, no rewrite is performed.
 // redactionIDsFromQuery evaluates a TraceQL query against a single open block and returns
 // the unique trace IDs whose spans satisfy it. The full boolean expression is applied as
 // the fetch second pass, so only truly-matching spansets are returned — a trace is never
@@ -674,7 +672,10 @@ func redactionIDsFromQuery(ctx context.Context, block common.BackendBlock, query
 	return ids, nil
 }
 
-func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID, query string, dryRun bool) (rewrote bool, found int, newMeta *backend.BlockMeta, err error) {
+// RedactBlock rewrites a block excluding the traces selected by either an explicit trace
+// ID list or a TraceQL query (never both). If none are present in the block, no rewrite is
+// performed. In dry-run mode it reports the match count without rewriting.
+func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta, tenantID string, traceIDs []common.ID, query string, mode tempopb.RedactionMode) (rewrote bool, found int, newMeta *backend.BlockMeta, err error) {
 	block, err := encoding.OpenBlock(meta, rw.r)
 	if err != nil {
 		return false, 0, nil, fmt.Errorf("error opening block for redaction, blockID: %s: %w", meta.BlockID.String(), err)
@@ -709,13 +710,21 @@ func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta
 	}
 
 	// Dry-run: report how many traces would be dropped without rewriting the block.
-	if dryRun {
+	if mode == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN {
 		return false, len(idsToDrop), nil, nil
 	}
 
 	enc, err := encoding.FromVersion(meta.Version)
 	if err != nil {
 		return false, 0, nil, fmt.Errorf("error getting encoding for version %s: %w", meta.Version, err)
+	}
+
+	// Index the drop set for O(1) membership checks in DropObject. The query selector can
+	// match a large fraction of a block's traces, so a linear scan per object would make
+	// the rewrite O(objects × matches).
+	dropSet := make(map[string]struct{}, len(idsToDrop))
+	for _, id := range idsToDrop {
+		dropSet[string(id)] = struct{}{}
 	}
 
 	opts := common.CompactionOptions{
@@ -729,11 +738,9 @@ func (rw *readerWriter) RedactBlock(ctx context.Context, meta *backend.BlockMeta
 		OutputBlocks:     1,
 		MaxBytesPerTrace: 0,
 		DropObject: func(id common.ID) bool {
-			for _, tid := range idsToDrop {
-				if bytes.Equal(id, tid) {
-					level.Debug(rw.logger).Log("msg", "redact dropping trace", "traceID", hex.EncodeToString(id))
-					return true
-				}
+			if _, ok := dropSet[string(id)]; ok {
+				level.Debug(rw.logger).Log("msg", "redact dropping trace", "traceID", hex.EncodeToString(id))
+				return true
 			}
 			return false
 		},


### PR DESCRIPTION
**What this PR does**:

Adds a TraceQL **query selector** to backend-scheduler redaction, so a large deletion can be expressed as a query instead of an explicit trace ID list. Redaction today requires enumerating trace IDs up front, which can't express large requests — a 24h window can match tens of millions of traces across thousands of blocks. This lets a caller submit the TraceQL expression they already confirmed in Explore.

This is **PR 1 of 2**: the selector, validation, and per-block execution (including dry-run). The aggregated dry-run *summary* surface and the automated post-completion verification are PR 2 (they need batch-lifecycle/status-API machinery that belongs together).

Included:

- **Proto** — `TraceQLSelector`, a `RedactionMode` enum (apply / dry-run), a single-member `oneof selector { query }` on `SubmitRedactionRequest` plus `mode`; `RedactionBatch` and `RedactionDetail` carry the query + mode. `trace_ids` is left exactly where it is (query and `trace_ids` are mutually exclusive); the single-member oneof reserves room to migrate `trace_ids` in later without an API break, avoiding a stored-batch migration now.
- **Submission validation** — the query is restricted to a single spanset filter: `=` / `!=` on the matched span's own `resource.*` / `span.*` attributes, joined by `&&` / `||`. Regex, ordered comparisons, unscoped and `parent.`-scoped attributes, pipelines/aggregates, and multiple/structural filters are all rejected with a clear error. Validation is an allow-list walk over the parsed AST (parsed without optimizations so an OR of equalities isn't folded into a regex the subset would then reject), so widening later (e.g. regex) is additive.
- **Execution** — the worker evaluates the query per block via `block.Fetch`, wiring the compiled boolean filter as the fetch second pass so only truly-matching spansets are selected (no over-match), and iterates the spanset stream directly for the full uncapped set of trace IDs, which feed the existing `DropObject` rewrite. Dry-run computes the match count and skips the rewrite entirely.

Tests: validator accept/reject table; submission XOR + batch storage; per-block `RedactBlock` on a real block (proves only the matching trace is dropped and a non-matching trace survives); and an end-to-end integration test over multiple real blocks (submission → per-block execution, matching block rewritten, non-matching block untouched).

Out of scope (PR 2): aggregated dry-run summary on the status endpoint; automated verification (`GetRedactionStatus`, re-query-until-zero); quiescence.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
