### PR TITLE
frontend/v1: fix requestBatch reuse race with the doneChan watcher

### DIFF
--- a/.chloggen/frontend-v1-request-batch-race.yaml
+++ b/.chloggen/frontend-v1-request-batch-race.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+
+component: query-frontend
+
+note: Fix a data race in the frontend v1 `Process` loop where the reused `requestBatch` was rewritten (`clear()`/`add()`) while the `doneChan` watcher goroutine still ranged over its backing array, and a secondary write/write race on `err` when the send/recv goroutine outlived `reportResponseUpstream`. Only affected batched queriers (`max_batch_size > 1`).
+
+issues: []
+
+subtext:
+
+user: aldernero

--- a/.chloggen/frontend-v1-request-batch-race.yaml
+++ b/.chloggen/frontend-v1-request-batch-race.yaml
@@ -2,7 +2,7 @@ change_type: bug_fix
 
 component: query-frontend
 
-note: Fix a data race in the frontend v1 `Process` loop where the reused `requestBatch` was rewritten (`clear()`/`add()`) while the `doneChan` watcher goroutine still ranged over its backing array, and a secondary write/write race on `err` when the send/recv goroutine outlived `reportResponseUpstream`. Only affected batched queriers (`max_batch_size > 1`).
+note: Fix a data race in the query frontend when dispatching request batches to queriers (`max_batch_size` > 1).
 
 issues: []
 

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -269,6 +269,13 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		resps := make(chan *frontendv1pb.ClientToFrontend, 1)
 		errs := make(chan error, 1)
 		go func() {
+			// Use a local err rather than the outer one: this goroutine can outlive
+			// reportResponseUpstream (e.g. still blocked in Send/Recv when the batch's
+			// contexts cancel), and writing the captured outer err would then race with
+			// the main loop's `err = reportResponseUpstream(...)`. Errors are handed back
+			// via the errs channel instead.
+			var err error
+
 			// todo: we are still sending the old Type_HTTP_REQUEST for backwards compat
 			// with queriers that don't support the new Type_HTTP_REQUEST_BATCH. this feature
 			// was introduced in 2.2. We should remove this in a few versions

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -269,11 +269,8 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		resps := make(chan *frontendv1pb.ClientToFrontend, 1)
 		errs := make(chan error, 1)
 		go func() {
-			// Use a local err rather than the outer one: this goroutine can outlive
-			// reportResponseUpstream (e.g. still blocked in Send/Recv when the batch's
-			// contexts cancel), and writing the captured outer err would then race with
-			// the main loop's `err = reportResponseUpstream(...)`. Errors are handed back
-			// via the errs channel instead.
+			// Local err: this goroutine can outlive reportResponseUpstream, so
+			// writing the outer err would race with it. Report via errs instead.
 			var err error
 
 			// todo: we are still sending the old Type_HTTP_REQUEST for backwards compat

--- a/modules/frontend/v1/frontend_test.go
+++ b/modules/frontend/v1/frontend_test.go
@@ -1,0 +1,124 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/httpgrpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+
+	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/frontend/v1/frontendv1pb"
+)
+
+// mockProcessServer is a minimal Frontend_ProcessServer that drives Process()
+// through the batching happy path: it completes the GET_ID handshake advertising
+// REQUEST_BATCHING, then answers every batch it is sent with a matching batch of
+// 200 responses. Once it has answered for totalRequests requests it cancels the
+// server context so the next GetNextRequestForQuerier unblocks Process's loop.
+type mockProcessServer struct {
+	grpc.ServerStream
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	totalRequests int
+
+	mu            sync.Mutex
+	recvCount     int
+	lastBatchSize int
+	served        int
+}
+
+func (m *mockProcessServer) Context() context.Context { return m.ctx }
+
+func (m *mockProcessServer) Send(msg *frontendv1pb.FrontendToClient) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	switch msg.Type {
+	case frontendv1pb.Type_HTTP_REQUEST:
+		m.lastBatchSize = 1
+	case frontendv1pb.Type_HTTP_REQUEST_BATCH:
+		m.lastBatchSize = len(msg.HttpRequestBatch)
+	default:
+		// GET_ID handshake, nothing to record.
+	}
+
+	return nil
+}
+
+func (m *mockProcessServer) Recv() (*frontendv1pb.ClientToFrontend, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.recvCount++
+	if m.recvCount == 1 {
+		// Handshake: advertise batching support so Process uses MaxBatchSize.
+		return &frontendv1pb.ClientToFrontend{
+			ClientID: "test-querier",
+			Features: int32(frontendv1pb.Feature_REQUEST_BATCHING),
+		}, nil
+	}
+
+	batch := make([]*httpgrpc.HTTPResponse, m.lastBatchSize)
+	for i := range batch {
+		batch[i] = &httpgrpc.HTTPResponse{Code: http.StatusOK}
+	}
+
+	m.served += m.lastBatchSize
+	if m.served >= m.totalRequests {
+		// No more work is coming; unblock the queue so Process returns.
+		m.cancel()
+	}
+
+	return &frontendv1pb.ClientToFrontend{HttpResponseBatch: batch}, nil
+}
+
+// TestProcessRequestBatchReuseRace exercises Process() with batching enabled and a
+// deep queue so nearly every iteration dispatches a len>1 batch. That path spawns
+// the doneChan watcher goroutine, which outlives reportResponseUpstream and races
+// with the next iteration's reqBatch.clear()+add() over the reused backing array.
+// Run with -race to detect the data race.
+func TestProcessRequestBatchReuseRace(t *testing.T) {
+	cfg := Config{
+		MaxOutstandingPerTenant: 100000,
+		MaxBatchSize:            8,
+	}
+	f, err := New(cfg, log.NewNopLogger(), prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	const totalRequests = 4000
+
+	// Enqueue everything up front so the queue stays deep and GetNextRequestForQuerier
+	// returns full (len>1) batches.
+	noopSpan := trace.SpanFromContext(context.Background())
+	for i := 0; i < totalRequests; i++ {
+		httpReq := httptest.NewRequest("GET", "http://example.com", nil)
+		r := &request{
+			request:   pipeline.NewHTTPRequest(httpReq),
+			queueSpan: noopSpan,
+			err:       make(chan error, 1),
+			response:  make(chan *http.Response, 1),
+		}
+		require.NoError(t, f.requestQueue.EnqueueRequest("test-tenant", r))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := &mockProcessServer{
+		ctx:           ctx,
+		cancel:        cancel,
+		totalRequests: totalRequests,
+	}
+
+	err = f.Process(srv)
+	require.ErrorIs(t, err, context.Canceled)
+	require.GreaterOrEqual(t, srv.served, totalRequests)
+}

--- a/modules/frontend/v1/request_batch.go
+++ b/modules/frontend/v1/request_batch.go
@@ -82,13 +82,22 @@ func (b *requestBatch) doneChan(stop <-chan struct{}) <-chan struct{} {
 		return b.pipelineRequests[0].OriginalContext().Done()
 	}
 
+	// Snapshot the requests before spawning the watcher. Process reuses this
+	// requestBatch across loop iterations (clear()+add() rewrite the same backing
+	// array), and the watcher below outlives this call: reportResponseUpstream
+	// closes stop and returns without waiting for the watcher to exit. Ranging over
+	// b.pipelineRequests directly would let the watcher read the backing array while
+	// the next iteration overwrites it. Copying the (pointer-sized) slice keeps the
+	// watcher on its own array.
+	reqs := append([]*request(nil), b.pipelineRequests...)
+
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		// tests each request context and only closes done if all are done.
 		// technically it is only testing one a time, but the loop will only complete
 		// if all are done.
-		for _, r := range b.pipelineRequests {
+		for _, r := range reqs {
 			select {
 			case <-r.OriginalContext().Done():
 			case <-stop:

--- a/modules/frontend/v1/request_batch.go
+++ b/modules/frontend/v1/request_batch.go
@@ -82,13 +82,10 @@ func (b *requestBatch) doneChan(stop <-chan struct{}) <-chan struct{} {
 		return b.pipelineRequests[0].OriginalContext().Done()
 	}
 
-	// Snapshot the requests before spawning the watcher. Process reuses this
-	// requestBatch across loop iterations (clear()+add() rewrite the same backing
-	// array), and the watcher below outlives this call: reportResponseUpstream
-	// closes stop and returns without waiting for the watcher to exit. Ranging over
-	// b.pipelineRequests directly would let the watcher read the backing array while
-	// the next iteration overwrites it. Copying the (pointer-sized) slice keeps the
-	// watcher on its own array.
+	// Snapshot the requests before spawning the watcher. The watcher outlives this
+	// call, and Process reuses this requestBatch across iterations (clear()+add()
+	// rewrite the same backing array), so ranging over b.pipelineRequests directly
+	// would race with the next iteration. The copy keeps the watcher on its own array.
 	reqs := append([]*request(nil), b.pipelineRequests...)
 
 	done := make(chan struct{})


### PR DESCRIPTION
## What this PR does

`Frontend.Process()` reuses a single `requestBatch` per querier stream, resetting it each iteration via `clear()`+`add()`. For batches with `len > 1`, `doneChan` spawns a watcher goroutine that ranges over `pipelineRequests` and exits asynchronously once `reportResponseUpstream` closes its `stop` channel.

On the batched happy path (`max_batch_size > 1`), `reportResponseUpstream` returns as soon as the querier responds — it signals `stop` but never waits for the watcher to actually exit. The main loop then immediately runs the next iteration's `clear()`+`add()`, rewriting the same backing array the watcher may still be reading. That is an unsynchronized read/write pair on every batched happy-path iteration, flagged by `-race`.

There is a secondary write/write race with the same root cause: the send/recv goroutine assigns to the captured outer `err`, which can outlive `reportResponseUpstream` (e.g. still blocked in `Send`/`Recv` when the batch's contexts cancel) and race with the main loop's `err = reportResponseUpstream(...)`.

Batch size 1 is unaffected — `doneChan` returns the request context's `Done()` directly, with no goroutine.

## Fix

- **`doneChan`**: snapshot the (pointer-sized) request slice before spawning the watcher, so it reads its own array instead of the reused backing array.
- **send/recv goroutine**: use a local `err` and report failures solely via the `errs` channel, removing the write to the shared outer `err`.

## Testing

Adds `TestProcessRequestBatchReuseRace`, which drives `Process` with batching enabled and a deep queue so nearly every iteration dispatches a `len > 1` batch. It fails under `-race` before the fix (racing `requestBatch.clear()`/`add()` against the watcher's read) and passes after.

- `go test -race ./modules/frontend/v1/` — clean
- `go vet ./modules/frontend/v1/` — clean