### PR TITLE
ingest: fix stale per-partition lag metrics after partition handoff

### DIFF
--- a/.chloggen/ingest-prune-stale-partition-lag-metrics.yaml
+++ b/.chloggen/ingest-prune-stale-partition-lag-metrics.yaml
@@ -1,0 +1,11 @@
+change_type: bug_fix
+component: metrics-generator
+note: prune stale per-partition ingest lag metrics when a partition moves between consumers, and keep inactive partitions on their previous owner instead of reshuffling them on every rebalance.
+issues: []
+subtext: |
+  Fixes ever-growing tempo_ingest_group_partition_lag and tempo_ingest_group_partition_lag_seconds
+  reported by a former owner after a partition handoff. Affects consumers using the partition-ring
+  cooperative-active-sticky balancer (metrics-generator, block-builder, live-store). The
+  metrics-generator now also clears these metrics on OnPartitionsLost (e.g. session timeout or
+  fence), which previously left stale series behind.
+user: aldernero

--- a/modules/generator/generator.go
+++ b/modules/generator/generator.go
@@ -124,6 +124,9 @@ func (g *Generator) starting(ctx context.Context) error {
 			kgo.OnPartitionsRevoked(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
 				g.handlePartitionsRevoked(m)
 			}),
+			kgo.OnPartitionsLost(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
+				g.handlePartitionsLost(m)
+			}),
 		}
 		// When enabled, seek past stale backlog on startup instead of replaying
 		// from the committed offset (see adjustStartupOffsets).

--- a/modules/generator/generator_kafka.go
+++ b/modules/generator/generator_kafka.go
@@ -201,15 +201,31 @@ func (g *Generator) handlePartitionsAssigned(m map[string][]int32) {
 func (g *Generator) handlePartitionsRevoked(partitions map[string][]int32) {
 	revoked := partitions[g.cfg.Ingest.Kafka.Topic]
 	level.Info(g.logger).Log("msg", "partitions revoked", "partitions", formatInt32Slice(revoked))
+	g.dropPartitions(revoked)
+}
+
+// handlePartitionsLost is the OnPartitionsLost counterpart to handlePartitionsRevoked. Lost
+// partitions (e.g. after a session timeout or the member being fenced) do not go through the
+// cooperative revoke path, so without this callback their lag metrics would never be cleaned up
+// and would keep exporting stale, ever-growing values. The cleanup is identical to a revoke; we
+// deliberately do not commit offsets here (kgo warns against committing in OnPartitionsLost).
+func (g *Generator) handlePartitionsLost(partitions map[string][]int32) {
+	lost := partitions[g.cfg.Ingest.Kafka.Topic]
+	level.Warn(g.logger).Log("msg", "partitions lost", "partitions", formatInt32Slice(lost))
+	g.dropPartitions(lost)
+}
+
+// dropPartitions removes partitions from the assigned set and clears their exported lag metrics.
+// Shared by the revoke and lost callbacks.
+func (g *Generator) dropPartitions(partitions []int32) {
 	g.partitionMtx.Lock()
 	defer g.partitionMtx.Unlock()
 
-	sort.Slice(revoked, func(i, j int) bool { return revoked[i] < revoked[j] })
-	// Remove revoked partitions
-	g.assignedPartitions = revokePartitions(g.assignedPartitions, revoked)
+	sort.Slice(partitions, func(i, j int) bool { return partitions[i] < partitions[j] })
+	g.assignedPartitions = revokePartitions(g.assignedPartitions, partitions)
 	metricAssignedPartitions.Set(float64(len(g.assignedPartitions)))
 
-	ingest.ResetLagMetricsForRevokedPartitions(g.cfg.Ingest.Kafka.ConsumerGroup, revoked)
+	ingest.ResetLagMetricsForRevokedPartitions(g.cfg.Ingest.Kafka.ConsumerGroup, partitions)
 }
 
 // Helper function to format []int32 slice

--- a/modules/generator/generator_kafka_test.go
+++ b/modules/generator/generator_kafka_test.go
@@ -51,6 +51,21 @@ func TestHandlePartitionsRevoked_RemovesOnlyRevokedPartitions(t *testing.T) {
 	assert.Equal(t, []int32{0, 2, 4}, g.assignedPartitions)
 }
 
+// TestHandlePartitionsLost_RemovesLostPartitions verifies that partitions lost (e.g. after a
+// session timeout or fence) are removed from the assigned set, matching the revoke path. Without
+// wiring OnPartitionsLost their lag metrics would otherwise never be cleaned up.
+func TestHandlePartitionsLost_RemovesLostPartitions(t *testing.T) {
+	g := minimalGeneratorForKafkaTest()
+	g.assignedPartitions = []int32{0, 1, 2, 3, 4, 5}
+
+	g.handlePartitionsLost(map[string][]int32{"test-topic": {1, 3, 5}})
+	assert.Equal(t, []int32{0, 2, 4}, g.assignedPartitions)
+
+	// Partitions for an unrelated topic must not affect the tracked set.
+	g.handlePartitionsLost(map[string][]int32{"other-topic": {0, 2}})
+	assert.Equal(t, []int32{0, 2, 4}, g.assignedPartitions)
+}
+
 // TestHandlePartitionsAssigned_UnknownTopicIsIgnored verifies that assignment
 // callbacks for a different topic do not affect the tracked partitions.
 func TestHandlePartitionsAssigned_UnknownTopicIsIgnored(t *testing.T) {

--- a/pkg/ingest/balancer.go
+++ b/pkg/ingest/balancer.go
@@ -10,9 +10,24 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
+// topicPartition identifies a partition within a topic. Partition IDs are only unique per
+// topic, so inactive-owner tracking is keyed by both to avoid cross-topic collisions.
+type topicPartition struct {
+	topic     string
+	partition int32
+}
+
 type cooperativeActiveStickyBalancer struct {
 	kgo.GroupBalancer
 	partitionRing ring.PartitionRingReader
+
+	// prevInactiveOwners maps an inactive (topic, partition) to the member that owned it in the
+	// previous assignment. It is captured in MemberBalancer (before inactive partitions are
+	// filtered out of the member metadata) and consumed by Balance so that inactive partitions
+	// stay on their previous owner instead of being reshuffled round-robin on every rebalance.
+	// Keeping inactive partitions sticky avoids the churn that otherwise leaves stale
+	// per-partition metrics (and reader state) on former owners after a handoff.
+	prevInactiveOwners map[topicPartition]string
 }
 
 // NewCooperativeActiveStickyBalancer creates a balancer that combines Kafka's cooperative sticky balancing
@@ -23,10 +38,12 @@ type cooperativeActiveStickyBalancer struct {
 // 3. Applying cooperative sticky balancing only to the active partitions
 //
 // This ensures that:
-// - Active partitions are balanced evenly across consumers using sticky assignment for optimal processing
-// - Inactive partitions are still assigned and consumed in a round-robin fashion, but without sticky assignment
-// - All partitions are monitored even if inactive, allowing quick activation when needed
-// - Partition handoff happens cooperatively to avoid stop-the-world rebalances
+//   - Active partitions are balanced evenly across consumers using sticky assignment for optimal processing
+//   - Inactive partitions are still assigned and consumed; each is kept on its previous owner when that
+//     member is still present (sticky), falling back to round-robin only for partitions with no prior owner,
+//     so they are not reshuffled on every rebalance
+//   - All partitions are monitored even if inactive, allowing quick activation when needed
+//   - Partition handoff happens cooperatively to avoid stop-the-world rebalances
 //
 // This balancer should be used with [NewGroupClient] which monitors the partition ring and triggers
 // rebalancing when the set of active partitions changes. This ensures optimal partition distribution
@@ -49,6 +66,10 @@ func (b *cooperativeActiveStickyBalancer) MemberBalancer(members []kmsg.JoinGrou
 		activePartitions[id] = struct{}{}
 	}
 
+	// Record who currently owns each inactive partition, so Balance can keep it there
+	// (sticky) rather than reshuffling it round-robin. Rebuilt fresh every rebalance.
+	b.prevInactiveOwners = make(map[topicPartition]string)
+
 	// Filter member metadata to only include active partitions
 	filteredMembers := make([]kmsg.JoinGroupResponseMember, len(members))
 	for i, member := range members {
@@ -56,6 +77,15 @@ func (b *cooperativeActiveStickyBalancer) MemberBalancer(members []kmsg.JoinGrou
 		err := meta.ReadFrom(member.ProtocolMetadata)
 		if err != nil {
 			continue
+		}
+
+		// Remember inactive owned partitions before we strip them below.
+		for _, owned := range meta.OwnedPartitions {
+			for _, p := range owned.Partitions {
+				if _, isActive := activePartitions[p]; !isActive {
+					b.prevInactiveOwners[topicPartition{owned.Topic, p}] = member.MemberID
+				}
+			}
 		}
 
 		// Filter owned partitions to only include active ones
@@ -120,40 +150,69 @@ func (b *cooperativeActiveStickyBalancer) Balance(balancer *kgo.ConsumerBalancer
 	}
 	sort.Strings(members)
 
-	// Distribute inactive partitions round-robin
-	memberIdx := 0
+	// Nothing to assign to; return the active plan as-is.
+	if len(members) == 0 {
+		return syncAssignments(plan)
+	}
+
+	memberSet := make(map[string]struct{}, len(members))
+	for _, m := range members {
+		memberSet[m] = struct{}{}
+	}
+
+	// planIdx lets us append an inactive partition to a member's assignment by member ID.
+	planIdx := make(map[string]int, len(plan))
+	for i, m := range plan {
+		planIdx[m.MemberID] = i
+	}
+
+	assignInactive := func(topic string, memberID string, p int32) {
+		i, ok := planIdx[memberID]
+		if !ok {
+			return
+		}
+		var meta kmsg.ConsumerMemberAssignment
+		// A member with no active partitions may have an empty assignment; treat that as an
+		// empty ConsumerMemberAssignment rather than dropping the inactive partition. Only a
+		// genuinely malformed (non-empty) assignment is skipped.
+		if len(plan[i].MemberAssignment) > 0 {
+			if err := meta.ReadFrom(plan[i].MemberAssignment); err != nil {
+				return
+			}
+		}
+		found := false
+		for j := range meta.Topics {
+			if meta.Topics[j].Topic == topic {
+				meta.Topics[j].Partitions = append(meta.Topics[j].Partitions, p)
+				found = true
+				break
+			}
+		}
+		if !found {
+			meta.Topics = append(meta.Topics, kmsg.ConsumerMemberAssignmentTopic{
+				Topic:      topic,
+				Partitions: []int32{p},
+			})
+		}
+		plan[i].MemberAssignment = meta.AppendTo(nil)
+	}
+
+	// Distribute inactive partitions, keeping each on its previous owner when that member is
+	// still present (sticky). Partitions with no valid previous owner fall back to round-robin.
+	fallbackIdx := 0
 	for topic, numInactive := range inactiveTopics {
 		for p := int32(actives); p < int32(actives)+numInactive; p++ {
-			// Find the member's assignment
-			for i, m := range plan {
-				if m.MemberID == members[memberIdx] {
-					var meta kmsg.ConsumerMemberAssignment
-					err := meta.ReadFrom(m.MemberAssignment)
-					if err != nil {
-						continue
-					}
-
-					// Find or create topic assignment
-					found := false
-					for j, t := range meta.Topics {
-						if t.Topic == topic {
-							meta.Topics[j].Partitions = append(t.Partitions, p)
-							found = true
-							break
-						}
-					}
-					if !found {
-						meta.Topics = append(meta.Topics, kmsg.ConsumerMemberAssignmentTopic{
-							Topic:      topic,
-							Partitions: []int32{p},
-						})
-					}
-
-					plan[i].MemberAssignment = meta.AppendTo(nil)
-					break
+			target := ""
+			if owner, ok := b.prevInactiveOwners[topicPartition{topic, p}]; ok {
+				if _, stillMember := memberSet[owner]; stillMember {
+					target = owner
 				}
 			}
-			memberIdx = (memberIdx + 1) % len(members)
+			if target == "" {
+				target = members[fallbackIdx]
+				fallbackIdx = (fallbackIdx + 1) % len(members)
+			}
+			assignInactive(topic, target, p)
 		}
 	}
 

--- a/pkg/ingest/balancer_rebalance_test.go
+++ b/pkg/ingest/balancer_rebalance_test.go
@@ -1,0 +1,172 @@
+package ingest_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/tempo/pkg/ingest"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+const (
+	rebalanceTopic = "rebalance-topic"
+	rebalanceGroup = "rebalance-group"
+)
+
+// ownershipTracker records, per member, the partitions currently assigned to it, driven by the
+// OnPartitionsAssigned / OnPartitionsRevoked callbacks.
+type ownershipTracker struct {
+	mu    sync.Mutex
+	owned map[string]map[int32]struct{}
+}
+
+func newOwnershipTracker() *ownershipTracker {
+	return &ownershipTracker{owned: map[string]map[int32]struct{}{}}
+}
+
+func (o *ownershipTracker) assign(member, topic string, m map[string][]int32) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.owned[member] == nil {
+		o.owned[member] = map[int32]struct{}{}
+	}
+	for _, p := range m[topic] {
+		o.owned[member][p] = struct{}{}
+	}
+}
+
+func (o *ownershipTracker) revoke(member, topic string, m map[string][]int32) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for _, p := range m[topic] {
+		delete(o.owned[member], p)
+	}
+}
+
+func (o *ownershipTracker) snapshot(member string) map[int32]struct{} {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	out := make(map[int32]struct{}, len(o.owned[member]))
+	for p := range o.owned[member] {
+		out[p] = struct{}{}
+	}
+	return out
+}
+
+func mustRebalanceRing(t *testing.T, activeCount int32) ring.PartitionRingReader {
+	t.Helper()
+	partitions := make(map[int32]ring.PartitionDesc, activeCount)
+	for id := int32(0); id < activeCount; id++ {
+		partitions[id] = ring.PartitionDesc{Id: id, State: ring.PartitionActive}
+	}
+	r, err := ring.NewPartitionRing(ring.PartitionRingDesc{Partitions: partitions})
+	require.NoError(t, err)
+	return fakeRebalanceRingReader{r: r}
+}
+
+type fakeRebalanceRingReader struct{ r *ring.PartitionRing }
+
+func (f fakeRebalanceRingReader) PartitionRing() *ring.PartitionRing { return f.r }
+
+// TestCooperativeActiveStickyBalancer_InactivePartitionsStayOnOwnerAcrossRebalance drives two real
+// consumer-group members through kfake and asserts that when the second member joins, the inactive
+// partitions already owned by the first member stay with it (rather than being reshuffled), and no
+// partition is ever owned by both members. This guards against the stale duplicate-owner metrics
+// that the round-robin inactive distribution used to produce.
+func TestCooperativeActiveStickyBalancer_InactivePartitionsStayOnOwnerAcrossRebalance(t *testing.T) {
+	const totalPartitions = 4
+	const activePartitions = 2 // active: 0,1  inactive: 2,3
+
+	fake, err := kfake.NewCluster(kfake.NumBrokers(1), kfake.SeedTopics(totalPartitions, rebalanceTopic))
+	require.NoError(t, err)
+	t.Cleanup(fake.Close)
+	addr := fake.ListenAddrs()[0]
+
+	ringReader := mustRebalanceRing(t, activePartitions)
+	tracker := newOwnershipTracker()
+
+	cfg := ingest.KafkaConfig{
+		Address:                        addr,
+		Topic:                          rebalanceTopic,
+		ConsumerGroup:                  rebalanceGroup,
+		DisableKafkaTelemetry:          true,
+		LastProducedOffsetRetryTimeout: 5 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var wg sync.WaitGroup
+	var clients []*ingest.Client
+
+	// Always stop the poll-loop goroutines before closing the clients (and, registered earlier,
+	// the fake cluster), even if an assertion below fails early. t.Cleanup runs LIFO, so this
+	// runs ahead of fake.Close and closes clients only after the goroutines have exited.
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+		for _, c := range clients {
+			c.Close()
+		}
+	})
+
+	startMember := func(member string) {
+		client, err := ingest.NewGroupReaderClient(
+			cfg, ringReader, nil, log.NewNopLogger(),
+			kgo.OnPartitionsAssigned(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
+				tracker.assign(member, rebalanceTopic, m)
+			}),
+			kgo.OnPartitionsRevoked(func(_ context.Context, _ *kgo.Client, m map[string][]int32) {
+				tracker.revoke(member, rebalanceTopic, m)
+			}),
+		)
+		require.NoError(t, err)
+		clients = append(clients, client)
+
+		// A poll loop is required to drive the group protocol (join/sync/heartbeat).
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for ctx.Err() == nil {
+				client.PollFetches(ctx)
+			}
+		}()
+	}
+
+	// Member A joins alone and should own every partition (active via sticky, inactive via the
+	// round-robin fallback since no partition has a previous owner yet).
+	startMember("a")
+	require.Eventually(t, func() bool {
+		return len(tracker.snapshot("a")) == totalPartitions
+	}, 30*time.Second, 250*time.Millisecond, "member a should own all partitions while alone")
+
+	// Member B joins, forcing a rebalance.
+	startMember("b")
+
+	// Wait for the group to settle: all partitions assigned, ownership disjoint, and B has picked
+	// up at least one (active) partition.
+	require.Eventually(t, func() bool {
+		a, b := tracker.snapshot("a"), tracker.snapshot("b")
+		if len(a)+len(b) != totalPartitions {
+			return false
+		}
+		for p := range a {
+			if _, dup := b[p]; dup {
+				return false
+			}
+		}
+		return len(b) >= 1
+	}, 30*time.Second, 250*time.Millisecond, "group should settle with disjoint ownership after b joins")
+
+	// The fix: inactive partitions 2 and 3 remain on their previous owner (a) instead of being
+	// reshuffled to b.
+	a, b := tracker.snapshot("a"), tracker.snapshot("b")
+	require.Contains(t, a, int32(2), "inactive partition 2 must stay on a: a=%v b=%v", a, b)
+	require.Contains(t, a, int32(3), "inactive partition 3 must stay on a: a=%v b=%v", a, b)
+	require.NotContains(t, b, int32(2), "inactive partition 2 must not move to b: a=%v b=%v", a, b)
+	require.NotContains(t, b, int32(3), "inactive partition 3 must not move to b: a=%v b=%v", a, b)
+}

--- a/pkg/ingest/balancer_test.go
+++ b/pkg/ingest/balancer_test.go
@@ -1,0 +1,191 @@
+package ingest
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/grafana/dskit/ring"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/kmsg"
+)
+
+const balancerTestTopic = "t"
+
+type fakePartitionRingReader struct{ r *ring.PartitionRing }
+
+func (f fakePartitionRingReader) PartitionRing() *ring.PartitionRing { return f.r }
+
+// activeRing returns a ring reader whose ring contains partitions [0, activeCount)
+// all Active. The balancer treats partitions present in the ring as active and Kafka
+// partitions with an index >= the ring's partition count as inactive.
+func activeRing(t *testing.T, activeCount int32) fakePartitionRingReader {
+	t.Helper()
+	partitions := make(map[int32]ring.PartitionDesc, activeCount)
+	for id := int32(0); id < activeCount; id++ {
+		partitions[id] = ring.PartitionDesc{Id: id, State: ring.PartitionActive}
+	}
+	r, err := ring.NewPartitionRing(ring.PartitionRingDesc{Partitions: partitions})
+	require.NoError(t, err)
+	return fakePartitionRingReader{r: r}
+}
+
+// balancerMember builds a group member subscribed to the test topic that currently owns
+// the given partitions.
+func balancerMember(t *testing.T, id string, owned ...int32) kmsg.JoinGroupResponseMember {
+	t.Helper()
+	meta := kmsg.NewConsumerMemberMetadata()
+	meta.Version = 3
+	meta.Topics = []string{balancerTestTopic}
+	if len(owned) > 0 {
+		op := kmsg.NewConsumerMemberMetadataOwnedPartition()
+		op.Topic = balancerTestTopic
+		op.Partitions = append([]int32(nil), owned...)
+		meta.OwnedPartitions = []kmsg.ConsumerMemberMetadataOwnedPartition{op}
+	}
+	return kmsg.JoinGroupResponseMember{MemberID: id, ProtocolMetadata: meta.AppendTo(nil)}
+}
+
+// runBalance drives MemberBalancer then Balance for a topic with totalPartitions and returns
+// memberID -> sorted assigned partitions.
+func runBalance(t *testing.T, rr fakePartitionRingReader, totalPartitions int32, members []kmsg.JoinGroupResponseMember) map[string][]int32 {
+	t.Helper()
+	b := &cooperativeActiveStickyBalancer{
+		GroupBalancer: kgo.CooperativeStickyBalancer(),
+		partitionRing: rr,
+	}
+	gmb, _, err := b.MemberBalancer(members)
+	require.NoError(t, err)
+	cb, ok := gmb.(*kgo.ConsumerBalancer)
+	require.True(t, ok, "MemberBalancer must return a *kgo.ConsumerBalancer")
+
+	plan := b.Balance(cb, map[string]int32{balancerTestTopic: totalPartitions}).IntoSyncAssignment()
+
+	out := make(map[string][]int32, len(plan))
+	for _, m := range plan {
+		// A member with no active partitions has an empty assignment (a valid case the
+		// balancer handles); mirror that here instead of failing on ReadFrom.
+		if len(m.MemberAssignment) == 0 {
+			continue
+		}
+		var asg kmsg.ConsumerMemberAssignment
+		require.NoError(t, asg.ReadFrom(m.MemberAssignment))
+		for _, tp := range asg.Topics {
+			if tp.Topic != balancerTestTopic {
+				continue
+			}
+			ps := append([]int32(nil), tp.Partitions...)
+			sort.Slice(ps, func(i, j int) bool { return ps[i] < ps[j] })
+			out[m.MemberID] = ps
+		}
+	}
+	return out
+}
+
+// requireNoDoubleOwnership asserts no partition is assigned to more than one member. Active
+// partitions may be held back across a single cooperative round, so this does not require every
+// partition to be present; it only guards the invariant the fix protects: no duplicate ownership.
+func requireNoDoubleOwnership(t *testing.T, assignments map[string][]int32) {
+	t.Helper()
+	owner := make(map[int32]string)
+	for member, ps := range assignments {
+		for _, p := range ps {
+			prev, dup := owner[p]
+			require.Falsef(t, dup, "partition %d assigned to both %s and %s", p, prev, member)
+			owner[p] = member
+		}
+	}
+}
+
+// requireAssigned asserts each of the given partitions is assigned to exactly one member.
+func requireAssigned(t *testing.T, assignments map[string][]int32, partitions ...int32) {
+	t.Helper()
+	for _, p := range partitions {
+		count := 0
+		for _, ps := range assignments {
+			for _, got := range ps {
+				if got == p {
+					count++
+				}
+			}
+		}
+		require.Equalf(t, 1, count, "partition %d must be assigned to exactly one member: %v", p, assignments)
+	}
+}
+
+// ownsAll reports whether member's assignment contains all of the given partitions.
+func ownsAll(assignments map[string][]int32, member string, partitions ...int32) bool {
+	set := make(map[int32]struct{}, len(assignments[member]))
+	for _, p := range assignments[member] {
+		set[p] = struct{}{}
+	}
+	for _, p := range partitions {
+		if _, ok := set[p]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func ownsAny(assignments map[string][]int32, member string, partitions ...int32) bool {
+	set := make(map[int32]struct{}, len(assignments[member]))
+	for _, p := range assignments[member] {
+		set[p] = struct{}{}
+	}
+	for _, p := range partitions {
+		if _, ok := set[p]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Inactive partitions (2, 3) previously owned by a single member stay with that member
+// rather than being reshuffled round-robin to the other member.
+func TestBalancer_InactivePartitionsStickToSolePreviousOwner(t *testing.T) {
+	rr := activeRing(t, 2) // active: 0,1  inactive: 2,3
+	members := []kmsg.JoinGroupResponseMember{
+		balancerMember(t, "a", 0, 1, 2, 3),
+		balancerMember(t, "b"),
+	}
+
+	got := runBalance(t, rr, 4, members)
+
+	requireNoDoubleOwnership(t, got)
+	requireAssigned(t, got, 2, 3)
+	require.True(t, ownsAll(got, "a", 2, 3), "a must keep its inactive partitions: %v", got)
+	require.False(t, ownsAny(got, "b", 2, 3), "b must not receive a's inactive partitions: %v", got)
+}
+
+// Inactive partitions stay with their respective previous owners when spread across members.
+func TestBalancer_InactivePartitionsStickToRespectiveOwners(t *testing.T) {
+	rr := activeRing(t, 2) // active: 0,1  inactive: 2,3
+	members := []kmsg.JoinGroupResponseMember{
+		balancerMember(t, "a", 0, 2),
+		balancerMember(t, "b", 1, 3),
+	}
+
+	got := runBalance(t, rr, 4, members)
+
+	requireNoDoubleOwnership(t, got)
+	requireAssigned(t, got, 2, 3)
+	require.True(t, ownsAll(got, "a", 2), "a must keep inactive partition 2: %v", got)
+	require.True(t, ownsAll(got, "b", 3), "b must keep inactive partition 3: %v", got)
+}
+
+// Inactive partitions with no previous owner are distributed round-robin over sorted members.
+func TestBalancer_UnownedInactivePartitionsRoundRobin(t *testing.T) {
+	rr := activeRing(t, 2) // active: 0,1  inactive: 2,3
+	members := []kmsg.JoinGroupResponseMember{
+		balancerMember(t, "a", 0),
+		balancerMember(t, "b", 1),
+	}
+
+	got := runBalance(t, rr, 4, members)
+
+	requireNoDoubleOwnership(t, got)
+	requireAssigned(t, got, 2, 3)
+	// Sorted members are [a, b]; fallback round-robin assigns 2->a, 3->b.
+	require.True(t, ownsAll(got, "a", 2), "expected 2 on a: %v", got)
+	require.True(t, ownsAll(got, "b", 3), "expected 3 on b: %v", got)
+}

--- a/pkg/ingest/metrics.go
+++ b/pkg/ingest/metrics.go
@@ -41,9 +41,12 @@ var (
 // ExportPartitionLagMetrics in a background goroutine by periodically querying Kafka state
 // for the assigned and active partitions.  This exports the lag metric in number of records
 // which is different than the lag metric for age.
-// Call ResetLagMetricsForRevokedPartitions when partitions are revoked to prevent exporting
-// stale data. For efficiency this is not detected automatically from changes inthe assigned
-// partition callback.
+// Each tick also reconciles the exported series against the current assigned-partition set and
+// deletes series for partitions no longer assigned to this consumer. This is a safety net for
+// handoffs that do not deliver a clean OnPartitionsRevoked (e.g. the round-robin distribution of
+// inactive partitions in cooperativeActiveStickyBalancer), which otherwise leaves stale,
+// ever-growing lag on the previous owner. Callers may still call ResetLagMetricsForRevokedPartitions
+// on revoke for an immediate cleanup rather than waiting for the next tick.
 func ExportPartitionLagMetrics(ctx context.Context, kclient *kgo.Client, log log.Logger, cfg Config, getAssignedActivePartitions func() []int32, forceMetadataRefresh func()) {
 	go func() {
 		var (
@@ -57,6 +60,11 @@ func ExportPartitionLagMetrics(ctx context.Context, kclient *kgo.Client, log log
 			})
 			admClient       = kadm.NewClient(kclient)
 			partitionClient = NewPartitionOffsetClient(kclient, topic)
+
+			// trackedPartitions is the set of partitions for which we have exported lag
+			// metrics, used to prune series for partitions that are no longer assigned to
+			// this consumer so stale lag can't accumulate and trip alerts.
+			trackedPartitions = make(map[int32]struct{})
 		)
 
 		for {
@@ -67,6 +75,12 @@ func ExportPartitionLagMetrics(ctx context.Context, kclient *kgo.Client, log log
 					err error
 				)
 				assignedPartitions := getAssignedActivePartitions()
+
+				// Prune series for partitions moved off this consumer since the last tick, and
+				// record the current assigned set as tracked. This runs before the lag fetch so
+				// ownership changes are still reconciled even if getGroupLag fails for several ticks.
+				pruneUnassignedLagMetrics(group, assignedPartitions, trackedPartitions)
+
 				boff.Reset()
 				for boff.Ongoing() {
 					lag, err = getGroupLag(ctx, admClient, partitionClient, group, assignedPartitions)
@@ -81,6 +95,7 @@ func ExportPartitionLagMetrics(ctx context.Context, kclient *kgo.Client, log log
 					level.Error(log).Log("msg", "metric lag failed:", "err", err, "retries", boff.NumRetries())
 					continue
 				}
+
 				for _, p := range assignedPartitions {
 					l, ok := lag.Lookup(topic, p)
 					if ok {
@@ -108,6 +123,27 @@ func ResetLagMetricsForRevokedPartitions(group string, partitions []int32) {
 		l := strconv.Itoa(int(p))
 		metricPartitionLag.DeletePartialMatch(prometheus.Labels{labelGroup: group, labelPartition: l})
 		metricPartitionLagSeconds.DeletePartialMatch(prometheus.Labels{labelGroup: group, labelPartition: l})
+	}
+}
+
+// pruneUnassignedLagMetrics deletes exported lag series for partitions in tracked that are no
+// longer present in assignedPartitions, then records assignedPartitions as the new tracked set.
+// tracked is mutated in place. This reconciles the exported metrics with actual ownership each
+// tick, so a partition moved to another consumer stops exporting stale lag even if no clean
+// OnPartitionsRevoked was delivered for it.
+func pruneUnassignedLagMetrics(group string, assignedPartitions []int32, tracked map[int32]struct{}) {
+	assigned := make(map[int32]struct{}, len(assignedPartitions))
+	for _, p := range assignedPartitions {
+		assigned[p] = struct{}{}
+	}
+	for p := range tracked {
+		if _, ok := assigned[p]; !ok {
+			ResetLagMetricsForRevokedPartitions(group, []int32{p})
+			delete(tracked, p)
+		}
+	}
+	for _, p := range assignedPartitions {
+		tracked[p] = struct{}{}
 	}
 }
 

--- a/pkg/ingest/metrics_test.go
+++ b/pkg/ingest/metrics_test.go
@@ -1,0 +1,52 @@
+package ingest
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPruneUnassignedLagMetrics(t *testing.T) {
+	const group = "test-group"
+
+	metricPartitionLag.Reset()
+	metricPartitionLagSeconds.Reset()
+	t.Cleanup(func() {
+		metricPartitionLag.Reset()
+		metricPartitionLagSeconds.Reset()
+	})
+
+	// Export lag for three partitions, as the exporter goroutine and the fetch loop would.
+	for _, p := range []int32{0, 1, 2} {
+		metricPartitionLag.WithLabelValues(group, strconv.Itoa(int(p))).Set(float64(p) * 100)
+		SetPartitionLagSeconds(group, p, time.Duration(p)*time.Second)
+	}
+	require.Equal(t, 3, testutil.CollectAndCount(metricPartitionLag))
+	require.Equal(t, 3, testutil.CollectAndCount(metricPartitionLagSeconds))
+
+	tracked := map[int32]struct{}{0: {}, 1: {}, 2: {}}
+
+	// Partition 2 is no longer assigned: its series must be pruned from both gauges,
+	// and it must be dropped from the tracked set.
+	pruneUnassignedLagMetrics(group, []int32{0, 1}, tracked)
+
+	require.Equal(t, 2, testutil.CollectAndCount(metricPartitionLag))
+	require.Equal(t, 2, testutil.CollectAndCount(metricPartitionLagSeconds))
+	require.Equal(t, map[int32]struct{}{0: {}, 1: {}}, tracked)
+
+	// Still-assigned series keep their values untouched.
+	require.Equal(t, float64(100), testutil.ToFloat64(metricPartitionLag.WithLabelValues(group, "1")))
+
+	// A partition newly assigned this tick is recorded as tracked so it can be pruned later.
+	pruneUnassignedLagMetrics(group, []int32{0, 1, 3}, tracked)
+	require.Equal(t, map[int32]struct{}{0: {}, 1: {}, 3: {}}, tracked)
+
+	// Series for a different group are never touched by another group's reconcile.
+	metricPartitionLag.WithLabelValues("other-group", "0").Set(7)
+	pruneUnassignedLagMetrics(group, nil, tracked)
+	require.Empty(t, tracked)
+	require.Equal(t, float64(7), testutil.ToFloat64(metricPartitionLag.WithLabelValues("other-group", "0")))
+}


### PR DESCRIPTION
## What this fixes

The per-partition ingest lag gauges — `tempo_ingest_group_partition_lag` and `tempo_ingest_group_partition_lag_seconds` — can be left behind on a consumer after a partition moves to another pod. The former owner keeps exporting an ever-growing lag for a partition it no longer consumes, producing a phantom "high lag" that never recovers and makes pod-level lag alerting unusable (a single stale series fires even when every partition is healthy on its real owner).

Root cause is in the ring-aware `cooperativeActiveStickyBalancer`. Partitions beyond the ring's active count ("inactive") are:
- distributed **round-robin on every rebalance** (no stickiness), and
- **stripped from each member's `OwnedPartitions`** before the cooperative-sticky balancer runs.

Because the cooperative protocol never sees a member owning an inactive partition, no `OnPartitionsRevoked` is computed when it moves, so the losing member never cleans up — it silently keeps consuming and exporting stale per-partition state.

## Observed impact

On a production metrics-generator group (ring active count 200, topic with more partitions), dozens of "inactive" partitions were reported by two pods at once, with the lag on the stale pod growing unbounded while the partition was actually caught up on its true owner. 32 of 33 doubly-owned partitions were in the inactive (index ≥ active-count) range.

## Changes

1. **Sticky inactive assignment** (`pkg/ingest/balancer.go`): capture each inactive partition's previous owner in `MemberBalancer` (before filtering) and, in `Balance`, keep it on that owner when the member is still present — falling back to round-robin only for partitions with no valid previous owner. Active-partition balancing is unchanged. This removes the churn and the missed-revoke.

2. **Reconcile-prune safety net** (`pkg/ingest/metrics.go`): `ExportPartitionLagMetrics` now reconciles exported series against the current assigned-partition set each tick and deletes series for partitions no longer assigned (new `pruneUnassignedLagMetrics` helper). This bounds staleness to one tick regardless of how a partition left.

## Testing

- `pkg/ingest/balancer_test.go` — deterministic `MemberBalancer`/`Balance` cases: inactive partitions stick to their sole/respective previous owners, unowned inactive partitions round-robin, and no partition is ever assigned to two members.
- `pkg/ingest/balancer_rebalance_test.go` — kfake two-member rebalance: after a second member joins, inactive partitions stay on their original owner with disjoint ownership.
- `pkg/ingest/metrics_test.go` — the prune helper removes series for unassigned partitions from both gauges without touching still-assigned series or other consumer groups.

`gofmt`, `go vet`, and the full `pkg/ingest` suite pass; the balancer tests are stable across repeated runs.