### PR TITLE
Add agent guidance: PR template usage and changelog note style

### DIFF
--- a/.agents/guidance/precommit.md
+++ b/.agents/guidance/precommit.md
@@ -86,6 +86,20 @@ make test-e2e-clean
 
 ---
 
+## PR Description
+
+When opening a PR,
+read [`.github/pull_request_template.md`](../../.github/pull_request_template.md)
+and use it as the structure for the PR body,
+filling in each section and checklist item.
+
+Note for non-interactive tooling:
+passing an explicit body to `gh pr create` (`--body` / `--body-file`)
+bypasses GitHub's template auto-fill,
+so the template must be applied manually.
+
+---
+
 ## Pushing to a PR Under Review
 
 Once a PR has received a review,

--- a/.chloggen/README.md
+++ b/.chloggen/README.md
@@ -50,6 +50,21 @@ entry without a PR link.
 [`config.yaml`](./config.yaml); `chlog-validate` rejects anything else. Adding a
 new component? Add it to that list in the same PR.
 
+## Writing the note
+
+Keep the note brief — one or two sentences at most —
+and focus on user impact.
+Internals of how the change is made are rarely relevant;
+when they are, the note should still open with the user impact,
+and extra implementation detail belongs in `subtext`, not the note.
+
+For example, for a change that adds predicate pushdown to the parquet iterators:
+
+- ✅ `Improve read performance by pushing down predicates to the parquet iterators.`
+- ❌ `Add support for pushdown predicates in the parquet iterators.`
+
+The note is about what users get, not the technical improvement itself.
+
 ## Validate / preview
 
 ```bash


### PR DESCRIPTION
**What this PR does**:

Adds two pieces of agent/contributor guidance:

- `.agents/guidance/precommit.md`: new **PR Description** section — PR bodies must follow `.github/pull_request_template.md`, filling in each section and checklist item. Includes a note that passing an explicit body to `gh pr create` (`--body` / `--body-file`) bypasses GitHub's template auto-fill, so non-interactive tooling must apply the template manually.
- `.chloggen/README.md`: new **Writing the note** section — changelog notes must be brief (one or two sentences), open with user impact, and keep implementation detail in `subtext` rather than the note. Includes a ✅/❌ example.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated — N/A, guidance/docs only
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` — N/A, internal agent guidance, not user-facing (Skip Changelog)
