### PR TITLE
fix: don't log/retry-count an idle scheduler as an error

### DIFF
--- a/.chloggen/fix_backendworker-idle-notfound-log-level.yaml
+++ b/.chloggen/fix_backendworker-idle-notfound-log-level.yaml
@@ -1,0 +1,24 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: backend-worker
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: stop logging an error and counting a retry every time the scheduler's job queue is empty
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  An empty queue (codes.NotFound from the scheduler's Next() long poll) is now logged at debug
+  level and excluded from backend_worker_call_retries_total, keeping error logs and
+  retry-based alerting meaningful for genuine scheduler problems.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: elinacse

--- a/modules/backendworker/backendworker.go
+++ b/modules/backendworker/backendworker.go
@@ -536,8 +536,15 @@ func (w *BackendWorker) callSchedulerWithBackoff(ctx context.Context, f func(con
 					return nil
 				}
 
-				level.Error(log.Logger).Log("msg", "error calling scheduler", "err", err, "backoff", b.NextDelay())
-				metricWorkerCallRetries.WithLabelValues().Inc()
+				if errStatus, ok := status.FromError(err); ok && errStatus.Code() == codes.NotFound {
+					// An empty job queue is the scheduler's normal answer to a long poll, not a
+					// failure — log it quietly and don't count it as a retry, so error logs and
+					// metricWorkerCallRetries stay meaningful for actual scheduler problems.
+					level.Debug(log.Logger).Log("msg", "no job available from scheduler", "err", err, "backoff", b.NextDelay())
+				} else {
+					level.Error(log.Logger).Log("msg", "error calling scheduler", "err", err, "backoff", b.NextDelay())
+					metricWorkerCallRetries.WithLabelValues().Inc()
+				}
 				// Add jitter so all workers don't all retry at once and cause a thundering herd.
 				time.Sleep(time.Duration(rand.Float32() * float32(1*time.Second)))
 				b.Wait()

--- a/modules/backendworker/backendworker_test.go
+++ b/modules/backendworker/backendworker_test.go
@@ -3,13 +3,16 @@ package backendworker
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"flag"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/gogo/status"
 	"github.com/google/uuid"
+	"github.com/grafana/dskit/backoff"
 	"github.com/grafana/dskit/flagext"
 	"github.com/grafana/dskit/kv"
 	"github.com/grafana/dskit/services"
@@ -30,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -274,6 +278,63 @@ func TestProcessRedactionJobMissingBlockObservable(t *testing.T) {
 	require.NoError(t, err, "a missing block must complete as a non-fatal no-op")
 	after := testutil.ToFloat64(metricRedactionBlockMissing.WithLabelValues(tenant))
 	require.Equal(t, before+1, after, "a missing redaction block must be counted, not silently dropped")
+}
+
+// TestCallSchedulerWithBackoff_NotFoundIsNotARetry verifies that an idle scheduler answering
+// "no jobs found" (codes.NotFound) doesn't get counted as a retry: an empty queue is the
+// scheduler's expected long-poll response, not a failure, so alerting on the retry metric should
+// stay meaningful for genuine scheduler problems.
+func TestCallSchedulerWithBackoff_NotFoundIsNotARetry(t *testing.T) {
+	w := &BackendWorker{
+		cfg: Config{
+			Backoff: backoff.Config{
+				MinBackoff: time.Millisecond,
+				MaxBackoff: time.Millisecond,
+				MaxRetries: 3,
+			},
+		},
+	}
+
+	before := testutil.ToFloat64(metricWorkerCallRetries.WithLabelValues())
+
+	var calls int
+	err := w.callSchedulerWithBackoff(context.Background(), func(context.Context) error {
+		calls++
+		return status.Error(codes.NotFound, "no jobs found")
+	})
+	require.Error(t, err, "exhausting retries on a persistently empty queue should still surface an error to the caller")
+	require.Positive(t, calls, "the callback should have run at least once")
+
+	after := testutil.ToFloat64(metricWorkerCallRetries.WithLabelValues())
+	require.Equal(t, before, after, "a NotFound response must not be counted as a retry")
+}
+
+// TestCallSchedulerWithBackoff_GenuineErrorIsARetry is the counterpart to
+// TestCallSchedulerWithBackoff_NotFoundIsNotARetry: real scheduler failures must still increment
+// the retry metric.
+func TestCallSchedulerWithBackoff_GenuineErrorIsARetry(t *testing.T) {
+	w := &BackendWorker{
+		cfg: Config{
+			Backoff: backoff.Config{
+				MinBackoff: time.Millisecond,
+				MaxBackoff: time.Millisecond,
+				MaxRetries: 3,
+			},
+		},
+	}
+
+	before := testutil.ToFloat64(metricWorkerCallRetries.WithLabelValues())
+
+	var calls int
+	err := w.callSchedulerWithBackoff(context.Background(), func(context.Context) error {
+		calls++
+		return errors.New("scheduler unavailable")
+	})
+	require.Error(t, err)
+	require.Positive(t, calls)
+
+	after := testutil.ToFloat64(metricWorkerCallRetries.WithLabelValues())
+	require.Equal(t, before+float64(calls), after, "every genuine failure must still be counted as a retry")
 }
 
 func TestIsSharded(t *testing.T) {


### PR DESCRIPTION
An empty job queue (codes.NotFound from Next()) is the scheduler's normal long-poll answer, not a failure. callSchedulerWithBackoff now logs it at debug and excludes it from backend_worker_call_retries_total, keeping error logs and retry-based alerting meaningful for genuine scheduler problems.

Fixes #7666 

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)