### PR TITLE
Keep memcached connection pools warm and add connection tuning options

### DIFF
--- a/.chloggen/memcached-connection-options.yaml
+++ b/.chloggen/memcached-connection-options.yaml
@@ -1,0 +1,26 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: cache
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Add `connect_timeout` and `min_idle_conns_headroom_percentage` options to the memcached client for tuning connection behavior.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  `connect_timeout` bounds connection establishment separately from `timeout` (request
+  round trips) and defaults to `timeout` when unset. `min_idle_conns_headroom_percentage`
+  controls idle connection reaping: negative values (the default) never close idle
+  connections, positive values keep that percentage of idle connections open relative
+  to the number of recently used ones.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mapno

--- a/.chloggen/memcached-connection-tuning.yaml
+++ b/.chloggen/memcached-connection-tuning.yaml
@@ -1,0 +1,25 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: change
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: cache
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Keep memcached connection pools warm to reduce tail latency under bursty read load. Idle connections are no longer closed by default and the default `max_idle_conns` was raised from 16 to 100.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  Previously, connections idle for more than 2 minutes were always closed, so every burst of
+  reads (e.g. trace-by-ID lookups) began with a storm of new dials that inflated p99 latency
+  and produced client-side timeouts. Set `min_idle_conns_headroom_percentage` to a positive
+  value to re-enable idle connection reaping.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mapno

--- a/modules/cache/config_test.go
+++ b/modules/cache/config_test.go
@@ -3,13 +3,36 @@ package cache
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/grafana/tempo/modules/cache/memcached"
 	"github.com/grafana/tempo/modules/cache/redis"
 	"github.com/grafana/tempo/pkg/cache"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
 )
+
+func TestConfigUnmarshalAppliesMemcachedDefaults(t *testing.T) {
+	yamlCfg := `
+caches:
+- roles:
+  - bloom
+  memcached:
+    host: memcached.example.com
+`
+
+	cfg := &Config{}
+	require.NoError(t, yaml.UnmarshalStrict([]byte(yamlCfg), cfg))
+
+	require.Len(t, cfg.Caches, 1)
+	clientCfg := cfg.Caches[0].MemcachedConfig.ClientConfig
+	require.Equal(t, "memcached.example.com", clientCfg.Host)
+	require.Equal(t, 100, clientCfg.MaxIdleConns)
+	require.Equal(t, float64(-1), clientCfg.MinIdleConnsHeadroomPercentage)
+	require.Equal(t, 100*time.Millisecond, clientCfg.Timeout)
+	require.Equal(t, time.Minute, clientCfg.UpdateInterval)
+}
 
 func TestConfigValidation(t *testing.T) {
 	tcs := []struct {

--- a/modules/cache/memcached/memcached.go
+++ b/modules/cache/memcached/memcached.go
@@ -1,6 +1,7 @@
 package memcached
 
 import (
+	"flag"
 	"time"
 
 	"github.com/go-kit/log"
@@ -15,17 +16,29 @@ type Config struct {
 	TTL time.Duration `yaml:"ttl"`
 }
 
-func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, name string, logger log.Logger) cache.Cache {
-	if cfg.ClientConfig.MaxIdleConns == 0 {
-		cfg.ClientConfig.MaxIdleConns = 16
-	}
-	if cfg.ClientConfig.Timeout == 0 {
-		cfg.ClientConfig.Timeout = 100 * time.Millisecond
-	}
-	if cfg.ClientConfig.UpdateInterval == 0 {
-		cfg.ClientConfig.UpdateInterval = time.Minute
-	}
+// RegisterFlagsAndApplyDefaults applies the default values for this config.
+func (cfg *Config) RegisterFlagsAndApplyDefaults(_ string, _ *flag.FlagSet) {
+	// Size the idle connection pool for burst concurrency: idle connections are kept
+	// per memcached server, and a too-small pool forces a storm of new dials at the
+	// start of every request burst.
+	cfg.ClientConfig.MaxIdleConns = 100
+	// Never reap idle connections by default: keeping connection pools warm between
+	// request bursts avoids dial storms and the tail latency they cause. Set a
+	// positive headroom percentage to re-enable idle connection reaping.
+	cfg.ClientConfig.MinIdleConnsHeadroomPercentage = -1
+	cfg.ClientConfig.Timeout = 100 * time.Millisecond
+	cfg.ClientConfig.UpdateInterval = time.Minute
+}
 
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (cfg *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+
+	type rawConfig Config
+	return unmarshal((*rawConfig)(cfg))
+}
+
+func NewClient(cfg *Config, cfgBackground *cache.BackgroundConfig, name string, logger log.Logger) cache.Cache {
 	client := cache.NewMemcachedClient(cfg.ClientConfig, name, prometheus.DefaultRegisterer, logger)
 	memcachedCfg := cache.MemcachedConfig{
 		Expiration: cfg.TTL,

--- a/modules/cache/memcached/memcached_test.go
+++ b/modules/cache/memcached/memcached_test.go
@@ -1,0 +1,67 @@
+package memcached
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/grafana/tempo/pkg/cache"
+)
+
+func TestConfigAppliesDefaultsOnUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want cache.MemcachedClientConfig
+	}{
+		{
+			name: "empty config gets defaults",
+			yaml: `{}`,
+			want: cache.MemcachedClientConfig{
+				MaxIdleConns:                   100,
+				MinIdleConnsHeadroomPercentage: -1,
+				Timeout:                        100 * time.Millisecond,
+				UpdateInterval:                 time.Minute,
+			},
+		},
+		{
+			name: "explicit values override defaults",
+			yaml: `
+host: memcached.example.com
+max_idle_conns: 32
+min_idle_conns_headroom_percentage: 50
+timeout: 250ms
+connect_timeout: 50ms
+update_interval: 5m
+`,
+			want: cache.MemcachedClientConfig{
+				Host:                           "memcached.example.com",
+				MaxIdleConns:                   32,
+				MinIdleConnsHeadroomPercentage: 50,
+				Timeout:                        250 * time.Millisecond,
+				ConnectTimeout:                 50 * time.Millisecond,
+				UpdateInterval:                 5 * time.Minute,
+			},
+		},
+		{
+			name: "partial config keeps remaining defaults",
+			yaml: `timeout: 500ms`,
+			want: cache.MemcachedClientConfig{
+				MaxIdleConns:                   100,
+				MinIdleConnsHeadroomPercentage: -1,
+				Timeout:                        500 * time.Millisecond,
+				UpdateInterval:                 time.Minute,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			require.NoError(t, yaml.UnmarshalStrict([]byte(tt.yaml), &cfg))
+			require.Equal(t, tt.want, cfg.ClientConfig)
+		})
+	}
+}

--- a/pkg/cache/memcached_client.go
+++ b/pkg/cache/memcached_client.go
@@ -74,19 +74,25 @@ type memcachedClient struct {
 
 // MemcachedClientConfig defines how a MemcachedClient should be constructed.
 type MemcachedClientConfig struct {
-	Host           string             `yaml:"host"`
-	Service        string             `yaml:"service"`
-	Addresses      string             `yaml:"addresses"` // EXPERIMENTAL.
-	Timeout        time.Duration      `yaml:"timeout"`
-	MaxIdleConns   int                `yaml:"max_idle_conns"`
-	MaxItemSize    int                `yaml:"max_item_size"`
-	UpdateInterval time.Duration      `yaml:"update_interval"`
-	ConsistentHash bool               `yaml:"consistent_hash"`
-	CBFailures     uint               `yaml:"circuit_breaker_consecutive_failures"`
-	CBTimeout      time.Duration      `yaml:"circuit_breaker_timeout"`  // reset error count after this long
-	CBInterval     time.Duration      `yaml:"circuit_breaker_interval"` // remain closed for this long after CBFailures errors
-	TLSEnabled     bool               `yaml:"tls_enabled"`              // Enable connecting to Memcached with TLS.
-	TLS            dstls.ClientConfig `yaml:",inline"`                  // TLS to use to connect to the Memcached server.
+	Host           string        `yaml:"host"`
+	Service        string        `yaml:"service"`
+	Addresses      string        `yaml:"addresses"` // EXPERIMENTAL.
+	Timeout        time.Duration `yaml:"timeout"`
+	ConnectTimeout time.Duration `yaml:"connect_timeout"` // Maximum time to establish a connection. If 0, Timeout is used.
+	MaxIdleConns   int           `yaml:"max_idle_conns"`
+	// MinIdleConnsHeadroomPercentage is the percentage of idle connections to keep open,
+	// relative to the number of recently used connections, when reaping idle connections.
+	// If negative, idle connections are never closed. If 0, all connections idle for longer
+	// than 2 minutes are closed.
+	MinIdleConnsHeadroomPercentage float64            `yaml:"min_idle_conns_headroom_percentage"`
+	MaxItemSize                    int                `yaml:"max_item_size"`
+	UpdateInterval                 time.Duration      `yaml:"update_interval"`
+	ConsistentHash                 bool               `yaml:"consistent_hash"`
+	CBFailures                     uint               `yaml:"circuit_breaker_consecutive_failures"`
+	CBTimeout                      time.Duration      `yaml:"circuit_breaker_timeout"`  // reset error count after this long
+	CBInterval                     time.Duration      `yaml:"circuit_breaker_interval"` // remain closed for this long after CBFailures errors
+	TLSEnabled                     bool               `yaml:"tls_enabled"`              // Enable connecting to Memcached with TLS.
+	TLS                            dstls.ClientConfig `yaml:",inline"`                  // TLS to use to connect to the Memcached server.
 }
 
 // RegisterFlagsWithPrefix adds the flags required to config this to the given FlagSet
@@ -94,8 +100,10 @@ func (cfg *MemcachedClientConfig) RegisterFlagsWithPrefix(prefix, description st
 	f.StringVar(&cfg.Host, prefix+"memcached.hostname", "", description+"Hostname for memcached service to use. If empty and if addresses is unset, no memcached will be used.")
 	f.StringVar(&cfg.Service, prefix+"memcached.service", "memcached", description+"SRV service used to discover memcache servers.")
 	f.StringVar(&cfg.Addresses, prefix+"memcached.addresses", "", description+"EXPERIMENTAL: Comma separated addresses list in DNS Service Discovery format: https://cortexmetrics.io/docs/configuration/arguments/#dns-service-discovery")
-	f.IntVar(&cfg.MaxIdleConns, prefix+"memcached.max-idle-conns", 16, description+"Maximum number of idle connections in pool.")
+	f.IntVar(&cfg.MaxIdleConns, prefix+"memcached.max-idle-conns", 100, description+"Maximum number of idle connections in pool per memcached server. Set higher than peak parallel requests to keep connections warm across request bursts.")
+	f.Float64Var(&cfg.MinIdleConnsHeadroomPercentage, prefix+"memcached.min-idle-conns-headroom-percentage", -1, description+"Percentage of idle connections to keep open when reaping idle connections, relative to the number of recently used connections. If negative, idle connections are never closed.")
 	f.DurationVar(&cfg.Timeout, prefix+"memcached.timeout", 100*time.Millisecond, description+"Maximum time to wait before giving up on memcached requests.")
+	f.DurationVar(&cfg.ConnectTimeout, prefix+"memcached.connect-timeout", 0, description+"Maximum time to wait for a connection to a memcached server to be established. If 0, the value of timeout is used.")
 	f.DurationVar(&cfg.UpdateInterval, prefix+"memcached.update-interval", 1*time.Minute, description+"Period with which to poll DNS for memcache servers.")
 	f.BoolVar(&cfg.ConsistentHash, prefix+"memcached.consistent-hash", true, description+"Use consistent hashing to distribute to memcache servers.")
 	f.UintVar(&cfg.CBFailures, prefix+"memcached.circuit-breaker-consecutive-failures", 10, description+"Trip circuit-breaker after this number of consecutive dial failures (if zero then circuit-breaker is disabled).")
@@ -118,6 +126,11 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 
 	client := memcache.NewFromSelector(selector)
 	client.Timeout = cfg.Timeout
+	client.ConnectTimeout = cfg.ConnectTimeout
+	if client.ConnectTimeout == 0 {
+		client.ConnectTimeout = cfg.Timeout
+	}
+	client.MinIdleConnsHeadroomPercentage = cfg.MinIdleConnsHeadroomPercentage
 	client.MaxIdleConns = cfg.MaxIdleConns
 
 	dnsProviderRegisterer := prometheus.WrapRegistererWithPrefix("tempo_", prometheus.WrapRegistererWith(prometheus.Labels{
@@ -187,8 +200,15 @@ func NewMemcachedClient(cfg MemcachedClientConfig, name string, r prometheus.Reg
 		level.Error(logger).Log("msg", "error setting memcache servers to host", "host", cfg.Host, "err", err)
 	}
 
+	// Guard against a zero interval: this client is also constructed from configs
+	// built programmatically, without going through config defaulting.
+	updateInterval := cfg.UpdateInterval
+	if updateInterval <= 0 {
+		updateInterval = time.Minute
+	}
+
 	newClient.wait.Add(1)
-	go newClient.updateLoop(cfg.UpdateInterval)
+	go newClient.updateLoop(updateInterval)
 	return newClient
 }
 

--- a/pkg/cache/memcached_client_config_test.go
+++ b/pkg/cache/memcached_client_config_test.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMemcachedClientAppliesConfig(t *testing.T) {
+	tests := []struct {
+		name               string
+		cfg                MemcachedClientConfig
+		wantTimeout        time.Duration
+		wantConnectTimeout time.Duration
+		wantMaxIdleConns   int
+		wantHeadroom       float64
+	}{
+		{
+			name: "connect timeout falls back to timeout",
+			cfg: MemcachedClientConfig{
+				Timeout:        200 * time.Millisecond,
+				MaxIdleConns:   16,
+				UpdateInterval: time.Minute,
+			},
+			wantTimeout:        200 * time.Millisecond,
+			wantConnectTimeout: 200 * time.Millisecond,
+			wantMaxIdleConns:   16,
+			wantHeadroom:       0,
+		},
+		{
+			name: "explicit values applied",
+			cfg: MemcachedClientConfig{
+				Timeout:                        100 * time.Millisecond,
+				ConnectTimeout:                 50 * time.Millisecond,
+				MaxIdleConns:                   42,
+				MinIdleConnsHeadroomPercentage: -1,
+				UpdateInterval:                 time.Minute,
+			},
+			wantTimeout:        100 * time.Millisecond,
+			wantConnectTimeout: 50 * time.Millisecond,
+			wantMaxIdleConns:   42,
+			wantHeadroom:       -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewMemcachedClient(tt.cfg, "test", prometheus.NewRegistry(), log.NewNopLogger())
+
+			mc, ok := c.(*memcachedClient)
+			require.True(t, ok)
+			defer mc.Stop()
+			defer mc.Close()
+
+			require.Equal(t, tt.wantTimeout, mc.Timeout)
+			require.Equal(t, tt.wantConnectTimeout, mc.ConnectTimeout)
+			require.Equal(t, tt.wantMaxIdleConns, mc.MaxIdleConns)
+			require.Equal(t, tt.wantHeadroom, mc.MinIdleConnsHeadroomPercentage)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Tunes the memcached client's connection behaviour after observing cache degradation during query surges. This is structured as two changes:

1. Keep connection pools warm between bursts (change):

- Idle connections are no longer closed by default (`min_idle_conns_headroom_percentage` defaults to `-1`). Previously the client closed every connection idle for more than 2 minutes, so pools drained between bursts and every surge began with a dial storm.
- The default `max_idle_conns` was raised from 16 to 100. The idle pool cap is what a burst leaves behind: with 16, connections opened during a surge were torn down right after it, recreating the cold-pool problem for the next one. The new default is sized for burst concurrency rather than steady state.

**2. New connection tuning options (enhancement)**

- `connect_timeout` bounds connection establishment separately from `timeout` (request round trips). Previously dials were always capped at the library's hardcoded 100ms default regardless of the configured `timeout`; it now defaults to `timeout` when unset and can be tuned independently, since dial+read stacking is exactly where the burst-onset tail comes from.
- `min_idle_conns_headroom_percentage` exposes the idle-connection reaping knob: negative values (the default) never close idle connections, positive values keep that percentage of idle connections open relative to recently used ones.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
