### PR TITLE
docs: Add EOL note for 2.9 (main and 3.0)

### DIFF
--- a/docs/sources/tempo/release-notes/version-2/v2-9.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-9.md
@@ -20,7 +20,7 @@ Tempo 2.9 is approaching end of life (EOL).
 Tempo 2.9 continues to receive bug fixes and security patches through December 31, 2026.
 After that date, Tempo 2.9 reaches EOL and no longer receives any updates, including security patches.
 
-Upgrade to a [recommended version](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/recommended-versions/), such as Tempo 2.10 or 3.0, before the end of 2026.
+Upgrade to a recommended version, such as [Tempo 2.10](/docs/tempo/<TEMPO_VERSION>/release-notes/v2-10/) or [Tempo 3.0](/docs/tempo/<TEMPO_VERSION>/release-notes/v3-0/), before the end of 2026.
 For upgrade steps, refer to the [upgrade guide](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/upgrade/).
 {{< /admonition >}}
 

--- a/docs/sources/tempo/release-notes/version-2/v2-9.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-9.md
@@ -14,6 +14,16 @@ aliases:
 <!-- vale Grafana.Timeless = NO -->
 <!-- vale Grafana.Parentheses = NO -->
 
+{{< admonition type="caution" >}}
+Tempo 2.9 is approaching end of life (EOL).
+
+Tempo 2.9 continues to receive bug fixes and security patches through December 31, 2026.
+After that date, Tempo 2.9 reaches EOL and no longer receives any updates, including security patches.
+
+Upgrade to a [recommended version](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/recommended-versions/), such as Tempo 2.10 or 3.0, before the end of 2026.
+For upgrade steps, refer to the [upgrade guide](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/upgrade/).
+{{< /admonition >}}
+
 The Tempo team is pleased to announce the release of Tempo 2.9.
 
 This release gives you:


### PR DESCRIPTION
**What this PR does**:

Adds an end of life notice to the 2.9 release notes. Recommends that users move to either 2.10 or 3.0. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)