### PR TITLE
docs: Add EOL note for 2.9 (2.10 and 2.9)

### DIFF
--- a/docs/sources/tempo/release-notes/v2-9.md
+++ b/docs/sources/tempo/release-notes/v2-9.md
@@ -12,6 +12,16 @@ weight: 15
 <!-- vale Grafana.Timeless = NO -->
 <!-- vale Grafana.Parentheses = NO -->
 
+{{< admonition type="caution" >}}
+Tempo 2.9 is approaching end of life (EOL).
+
+Tempo 2.9 continues to receive bug fixes and security patches through December 31, 2026.
+After that date, Tempo 2.9 reaches EOL and no longer receives any updates, including security patches.
+
+Upgrade to a recommended version, such as Tempo 2.10 or 3.0, before the end of 2026.
+For upgrade steps, refer to the [upgrade guide](/docs/tempo/<TEMPO_VERSION>/set-up-for-tracing/setup-tempo/upgrade/).
+{{< /admonition >}}
+
 The Tempo team is pleased to announce the release of Tempo 2.9.
 
 This release gives you:


### PR DESCRIPTION
Adds an end-of-life (EOL) admonition to the Tempo 2.9 release notes, backported to the 2.10 release branch.

The note states that 2.9 continues to receive bug fixes and security patches through December 31, 2026, reaches EOL after that date, and recommends upgrading to Tempo 2.10 or 3.0.

Backport of the same change on main (#7676). Ref: grafana/technical-documentation#1068.