### PR TITLE
docs: Add docs for PR 7671

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2879,9 +2879,25 @@ cache:
             [timeout: <duration>]
 
             # Optional
-            # Maximum number of idle connections in pool.
-            # (default: 16)
+            # Maximum time to wait for a connection to a memcached server to be
+            # established. If 0, the value of timeout is used.
+            # (default: 0s)
+            [connect_timeout: <duration>]
+
+            # Optional
+            # Maximum number of idle connections to keep open in the pool per
+            # memcached server. Set higher than the peak number of parallel
+            # requests to keep connections warm across request bursts.
+            # (default: 100)
             [max_idle_conns: <int>]
+
+            # Optional
+            # Percentage of idle connections to keep open when reaping idle
+            # connections, relative to the number of recently used connections.
+            # If negative, idle connections are never closed. If 0, connections
+            # idle for longer than two minutes are closed.
+            # (default: -1)
+            [min_idle_conns_headroom_percentage: <float>]
 
             # Optional
             # Period with which to poll DNS for memcache servers.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
@@ -134,6 +134,16 @@ cache:
         min_idle_conns: 0       # Minimum idle connections to maintain in the pool.
 ```
 
+### Memcached cache connection defaults
+
+Tempo changes the default connection behavior of the memcached cache client to keep connection pools warm across request bursts. If you do not use the memcached cache, no action is needed. [[PR 7671](https://github.com/grafana/tempo/pull/7671)]
+
+- The default `max_idle_conns` increases from `16` to `100`. Size it above your peak number of parallel requests so connections stay warm between bursts.
+- Idle connections are no longer closed by default. The new `min_idle_conns_headroom_percentage` defaults to `-1`, which keeps idle connections open. Set it to `0` to restore the previous behavior of closing connections idle for longer than two minutes.
+- A new `connect_timeout` bounds connection establishment separately from `timeout`. When unset (`0s`), it falls back to the value of `timeout`.
+
+These defaults raise the steady-state number of open connections per memcached server. To keep the previous behavior, set `max_idle_conns: 16` and `min_idle_conns_headroom_percentage: 0` in your cache configuration.
+
 ## Upgrade to Tempo 3.0
 
 Tempo 3.0 is a major release that replaces the ingester-based architecture with a new design that separates the read and write paths.


### PR DESCRIPTION
**What this PR does**:

Documents the memcached cache client changes introduced in #7671, which shipped without docs.
- Config reference (`configuration/_index.md`): adds `connect_timeout` and `min_idle_conns_headroom_percentage`, and corrects the `max_idle_conns` default (`16` → `100`).
- Upgrade guide (`set-up-for-tracing/setup-tempo/upgrade.md`): adds a "Memcached cache connection defaults" note under Tempo 3.1 explaining the changed defaults, the higher steady-state connection count, and how to restore the previous behavior.

All option names and defaults were verified against `pkg/cache/memcached_client.go` in #7671.

Make with the help of AI. 

**Which issue(s) this PR fixes**:
Documentation follow-up for #7671.

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)