### PR TITLE
chore(parquetquery): generic chunk/page pruning + iterator-native stats

### DIFF
--- a/pkg/parquetquery/chunk_resetter.go
+++ b/pkg/parquetquery/chunk_resetter.go
@@ -20,9 +20,3 @@ func (p *OrPredicate) resetForChunk() {
 		}
 	}
 }
-
-func (p *InstrumentedPredicate) resetForChunk() {
-	if r, ok := p.Pred.(chunkResetter); ok {
-		r.resetForChunk()
-	}
-}

--- a/pkg/parquetquery/chunk_resetter.go
+++ b/pkg/parquetquery/chunk_resetter.go
@@ -1,0 +1,28 @@
+package parquetquery
+
+// chunkResetter is a TEMPORARY hook: regex/substring predicates memoize matches per
+// column chunk and clear that cache at each chunk boundary; composites cascade.
+// Removed once dictionary-index pushdown lands and predicate memoization goes away.
+type chunkResetter interface {
+	resetForChunk()
+}
+
+func (p *regexPredicate) resetForChunk() { p.matcher.Reset() }
+
+func (p *SubstringPredicate) resetForChunk() {
+	p.matches = make(map[string]bool, len(p.matches))
+}
+
+func (p *OrPredicate) resetForChunk() {
+	for _, sub := range p.preds {
+		if r, ok := sub.(chunkResetter); ok {
+			r.resetForChunk()
+		}
+	}
+}
+
+func (p *InstrumentedPredicate) resetForChunk() {
+	if r, ok := p.Pred.(chunkResetter); ok {
+		r.resetForChunk()
+	}
+}

--- a/pkg/parquetquery/chunk_resetter_test.go
+++ b/pkg/parquetquery/chunk_resetter_test.go
@@ -1,0 +1,40 @@
+package parquetquery
+
+import (
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubstringResetForChunk: resetForChunk clears the memoization populated by KeepValue.
+func TestSubstringResetForChunk(t *testing.T) {
+	sub := NewSubstringPredicate("b")
+	sub.KeepValue(parquet.ValueOf("abc"))
+	require.NotEmpty(t, sub.matches)
+
+	sub.resetForChunk()
+	require.Empty(t, sub.matches)
+}
+
+// TestResetForChunkCascades: a memoizing predicate wrapped in a composite must still be
+// reset, matching base where the reset rode along KeepColumnChunk through the tree.
+func TestResetForChunkCascades(t *testing.T) {
+	cases := []struct {
+		name string
+		wrap func(*SubstringPredicate) chunkResetter
+	}{
+		{"or", func(s *SubstringPredicate) chunkResetter { return &OrPredicate{preds: []Predicate{s}} }},
+		{"instrumented", func(s *SubstringPredicate) chunkResetter { return &InstrumentedPredicate{Pred: s} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sub := NewSubstringPredicate("b")
+			sub.KeepValue(parquet.ValueOf("abc"))
+			require.NotEmpty(t, sub.matches)
+
+			tc.wrap(sub).resetForChunk()
+			require.Empty(t, sub.matches, "reset must cascade to the wrapped predicate")
+		})
+	}
+}

--- a/pkg/parquetquery/chunk_resetter_test.go
+++ b/pkg/parquetquery/chunk_resetter_test.go
@@ -20,21 +20,11 @@ func TestSubstringResetForChunk(t *testing.T) {
 // TestResetForChunkCascades: a memoizing predicate wrapped in a composite must still be
 // reset, matching base where the reset rode along KeepColumnChunk through the tree.
 func TestResetForChunkCascades(t *testing.T) {
-	cases := []struct {
-		name string
-		wrap func(*SubstringPredicate) chunkResetter
-	}{
-		{"or", func(s *SubstringPredicate) chunkResetter { return &OrPredicate{preds: []Predicate{s}} }},
-		{"instrumented", func(s *SubstringPredicate) chunkResetter { return &InstrumentedPredicate{Pred: s} }},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			sub := NewSubstringPredicate("b")
-			sub.KeepValue(parquet.ValueOf("abc"))
-			require.NotEmpty(t, sub.matches)
+	sub := NewSubstringPredicate("b")
+	sub.KeepValue(parquet.ValueOf("abc"))
+	require.NotEmpty(t, sub.matches)
 
-			tc.wrap(sub).resetForChunk()
-			require.Empty(t, sub.matches, "reset must cascade to the wrapped predicate")
-		})
-	}
+	or := &OrPredicate{preds: []Predicate{sub}}
+	or.resetForChunk()
+	require.Empty(t, sub.matches, "reset must cascade to the wrapped predicate")
 }

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -466,7 +466,12 @@ type SyncIterator struct {
 	rgsMax     []RowNumber // Exclusive, row number of next one past the row group
 	readSize   int
 	filter     Predicate
-	sampler    Sampler
+	// pred is the predicate used for chunk/page skipping. It is filter unwrapped of
+	// any InstrumentedPredicate so the helpers' dictionary/null KeepValue calls do not
+	// inflate the wrapper's value counters; those chunk/page counts go through stats.
+	pred    Predicate
+	stats   *predicateStats
+	sampler Sampler
 
 	// Status
 	span            trace.Span
@@ -528,6 +533,15 @@ func NewSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, opts ..
 	// Apply options
 	for _, opt := range opts {
 		opt(i)
+	}
+
+	// Resolve the predicate used for chunk/page skipping. Unwrap InstrumentedPredicate
+	// so the helpers count chunk/page decisions via stats and leave its value counters
+	// to the per-row loop.
+	i.pred = i.filter
+	if ip, ok := i.filter.(*InstrumentedPredicate); ok {
+		i.pred = ip.Pred
+		i.stats = &ip.predicateStats
 	}
 
 	// Default value, always clone results until we have
@@ -602,11 +616,11 @@ func (c *SyncIterator) Next() (*IteratorResult, error) {
 // or equal to the given row number (and based on the given definition level)
 func (c *SyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResult, error) {
 	for {
-		if done := c.seekRowGroup(to, definitionLevel); done {
+		if done := c.seekRowGroup(to, definitionLevel, true); done {
 			return nil, nil
 		}
 
-		done, err := c.seekPages(to, definitionLevel)
+		done, err := c.seekPages(to, definitionLevel, true)
 		if err != nil {
 			return nil, err
 		}
@@ -654,7 +668,7 @@ func (c *SyncIterator) popRowGroup() (pq.RowGroup, RowNumber, RowNumber) {
 
 // seekRowGroup skips ahead to the row group that could contain the value at the
 // desired row number. Does nothing if the current row group is already the correct one.
-func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int) (done bool) {
+func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int, prune bool) (done bool) {
 	if c.currRowGroup != nil && CompareRowNumbers(definitionLevel, seekTo, c.currRowGroupMax) >= 0 {
 		// Done with this row group
 		c.closeCurrRowGroup()
@@ -672,7 +686,7 @@ func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int) (done
 		}
 
 		cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-		if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
+		if prune && !c.keepColumnChunk(cc) {
 			cc.Close()
 			continue
 		}
@@ -686,7 +700,7 @@ func (c *SyncIterator) seekRowGroup(seekTo RowNumber, definitionLevel int) (done
 
 // seekPages skips ahead in the current row group to the page that could contain the value at
 // the desired row number. Does nothing if the current page is already the correct one.
-func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bool, err error) {
+func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int, prune bool) (done bool, err error) {
 	if c.currPage != nil && CompareRowNumbers(definitionLevel, seekTo, c.currPageMax) >= 0 {
 		// Value not in this page
 		c.setPage(nil)
@@ -733,7 +747,7 @@ func (c *SyncIterator) seekPages(seekTo RowNumber, definitionLevel int) (done bo
 			}
 
 			// Skip based on filter?
-			if c.filter != nil && !c.filter.KeepPage(pg) {
+			if prune && c.filter != nil && !c.keepPage(pg) {
 				c.curr.Skip(pg.NumRows())
 				pq.Release(pg)
 				continue
@@ -830,7 +844,7 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-			if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
+			if !c.keepColumnChunk(cc) {
 				cc.Close()
 				continue
 			}
@@ -848,7 +862,7 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 				c.closeCurrRowGroup()
 				continue
 			}
-			if c.filter != nil && !c.filter.KeepPage(pg) {
+			if c.filter != nil && !c.keepPage(pg) {
 				// This page filtered out
 				c.curr.Skip(pg.NumRows())
 				pq.Release(pg)
@@ -906,6 +920,13 @@ func (c *SyncIterator) setRowGroup(rg pq.RowGroup, min, max RowNumber, cc *Colum
 	c.currRowGroupMin = min
 	c.currRowGroupMax = max
 	c.currChunk = cc
+
+	// TEMPORARY: reset per-chunk regex/substring memoization at each chunk boundary (both
+	// iterators enter here). c.filter is the full tree, so resets cascade. Removed with
+	// predicate memoization once dictionary-index pushdown lands.
+	if r, ok := c.filter.(chunkResetter); ok {
+		r.resetForChunk()
+	}
 }
 
 func (c *SyncIterator) setPage(pg pq.Page) {

--- a/pkg/parquetquery/iters.go
+++ b/pkg/parquetquery/iters.go
@@ -402,6 +402,14 @@ func SyncIteratorOptPredicate(p Predicate) SyncIteratorOpt {
 	}
 }
 
+// SyncIteratorOptStats collects chunk/page/value inspected/kept counts into s as the
+// iterator runs. The caller owns s and reads it after iteration; nil disables counting.
+func SyncIteratorOptStats(s *PredicateStats) SyncIteratorOpt {
+	return func(i *SyncIterator) {
+		i.stats = s
+	}
+}
+
 // SyncIteratorOptColumnName sets the column name for the iterator.
 // This is used for tracing and debugging only. All work is done
 // using the column index which is a required parameter on creation.
@@ -466,12 +474,8 @@ type SyncIterator struct {
 	rgsMax     []RowNumber // Exclusive, row number of next one past the row group
 	readSize   int
 	filter     Predicate
-	// pred is the predicate used for chunk/page skipping. It is filter unwrapped of
-	// any InstrumentedPredicate so the helpers' dictionary/null KeepValue calls do not
-	// inflate the wrapper's value counters; those chunk/page counts go through stats.
-	pred    Predicate
-	stats   *predicateStats
-	sampler Sampler
+	stats      *PredicateStats // optional; counts chunk/page/value decisions (SyncIteratorOptStats)
+	sampler    Sampler
 
 	// Status
 	span            trace.Span
@@ -533,15 +537,6 @@ func NewSyncIterator(ctx context.Context, rgs []pq.RowGroup, column int, opts ..
 	// Apply options
 	for _, opt := range opts {
 		opt(i)
-	}
-
-	// Resolve the predicate used for chunk/page skipping. Unwrap InstrumentedPredicate
-	// so the helpers count chunk/page decisions via stats and leave its value counters
-	// to the per-row loop.
-	i.pred = i.filter
-	if ip, ok := i.filter.(*InstrumentedPredicate); ok {
-		i.pred = ip.Pred
-		i.stats = &ip.predicateStats
 	}
 
 	// Default value, always clone results until we have
@@ -900,8 +895,16 @@ func (c *SyncIterator) next() (RowNumber, *pq.Value, error) {
 			c.currBufN++
 			c.currPageN++
 
-			if c.filter != nil && !c.filter.KeepValue(*v) {
-				continue
+			if c.filter != nil {
+				if c.stats != nil {
+					c.stats.InspectedValues++
+				}
+				if !c.filter.KeepValue(*v) {
+					continue
+				}
+				if c.stats != nil {
+					c.stats.KeptValues++
+				}
 			}
 
 			if c.sampler != nil && !c.sampler.Sample() {

--- a/pkg/parquetquery/nil_iter.go
+++ b/pkg/parquetquery/nil_iter.go
@@ -9,7 +9,9 @@ import (
 	pq "github.com/parquet-go/parquet-go"
 )
 
-// NilSyncIterator copies all functions of the sync iterator with just the next() function being different
+// NilSyncIterator copies all functions of the sync iterator with just the next() function
+// being different. It detects the ABSENCE of a matching value per scope, so next() and
+// SeekTo must not prune — pruning would drop the very scopes it needs to emit as nil.
 type NilSyncIterator struct {
 	SyncIterator
 	lastRowNumberReturned RowNumber
@@ -54,11 +56,11 @@ func (c *NilSyncIterator) Next() (*IteratorResult, error) {
 
 func (c *NilSyncIterator) SeekTo(to RowNumber, definitionLevel int) (*IteratorResult, error) {
 	for {
-		if done := c.seekRowGroup(to, definitionLevel); done {
+		if done := c.seekRowGroup(to, definitionLevel, false); done {
 			return nil, nil
 		}
 
-		done, err := c.seekPages(to, definitionLevel)
+		done, err := c.seekPages(to, definitionLevel, false)
 		if err != nil {
 			return nil, err
 		}
@@ -134,11 +136,6 @@ func (c *NilSyncIterator) next() (RowNumber, *pq.Value, error) {
 			}
 
 			cc := &ColumnChunkHelper{ColumnChunk: rg.ColumnChunks()[c.column]}
-			if c.filter != nil && !c.filter.KeepColumnChunk(cc) {
-				cc.Close()
-				continue
-			}
-
 			c.setRowGroup(rg, minRN, maxRN, cc)
 		}
 
@@ -150,12 +147,6 @@ func (c *NilSyncIterator) next() (RowNumber, *pq.Value, error) {
 			if pg == nil || errors.Is(err, io.EOF) {
 				// This row group is exhausted
 				c.closeCurrRowGroup()
-				continue
-			}
-			if c.filter != nil && !c.filter.KeepPage(pg) {
-				// This page filtered out
-				c.curr.Skip(pg.NumRows())
-				pq.Release(pg)
 				continue
 			}
 			c.setPage(pg)

--- a/pkg/parquetquery/predicate_pruning.go
+++ b/pkg/parquetquery/predicate_pruning.go
@@ -4,15 +4,16 @@ import (
 	pq "github.com/parquet-go/parquet-go"
 )
 
-// predicateStats counts the chunk/page pruning decisions made by keepColumnChunk /
-// keepPage. It is optional (nil-safe) and, when supplied via an InstrumentedPredicate,
-// lets callers report inspected/kept counts without the Predicate interface needing
-// chunk/page methods.
-type predicateStats struct {
+// PredicateStats counts the chunk/page/value decisions the iterator makes while
+// applying its predicate. It is optional (nil-safe): attach one via SyncIteratorOptStats
+// to collect inspected/kept counts for instrumentation.
+type PredicateStats struct {
 	InspectedColumnChunks int64
 	KeptColumnChunks      int64
 	InspectedPages        int64
 	KeptPages             int64
+	InspectedValues       int64
+	KeptValues            int64
 }
 
 // predicateNullValue returns the null pq.Value fed to KeepValue when deciding
@@ -21,7 +22,7 @@ type predicateStats struct {
 // with per-row evaluation.
 func predicateNullValue() pq.Value { return pq.Value{} }
 
-// keepColumnChunk reports whether any value in cc can match c.pred. The decision
+// keepColumnChunk reports whether any value in cc can match c.filter. The decision
 // combines a dictionary match for dict-encoded (string) columns, a column-index
 // range test via KeepRange, and a null-count test via KeepValue(null). Counts into
 // c.stats when set.
@@ -38,12 +39,12 @@ func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool) {
 		}()
 	}
 
-	keepNull := c.pred.KeepValue(predicateNullValue())
+	keepNull := c.filter.KeepValue(predicateNullValue())
 
 	if dict := cc.Dictionary(); dict != nil {
 		// Dict-encoded (string) chunk: any present value that matches lives in the
 		// dictionary; null rows are decided by keepNull since nulls are not stored there.
-		if keepDictionary(dict, c.pred.KeepValue) {
+		if keepDictionary(dict, c.filter.KeepValue) {
 			return true
 		}
 		return keepNull && chunkHasNulls(cc)
@@ -61,16 +62,16 @@ func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool) {
 			// All-null page: min/max are not recorded, so only the null decision (above) applies.
 			continue
 		}
-		if c.pred.KeepRange(ci.MinValue(i), ci.MaxValue(i)) {
+		if c.filter.KeepRange(ci.MinValue(i), ci.MaxValue(i)) {
 			return true
 		}
 	}
 	return false
 }
 
-// keepPage reports whether any value in pg can match c.pred, combining a page-bounds
+// keepPage reports whether any value in pg can match c.filter, combining a page-bounds
 // range test via KeepRange with a null test via KeepValue(null). Counts into c.stats
-// when set. The caller guards c.filter != nil, so c.pred is always non-nil here.
+// when set. The caller guards c.filter != nil, so it is always non-nil here.
 func (c *SyncIterator) keepPage(pg pq.Page) (keep bool) {
 	if c.stats != nil {
 		c.stats.InspectedPages++
@@ -81,7 +82,7 @@ func (c *SyncIterator) keepPage(pg pq.Page) (keep bool) {
 		}()
 	}
 
-	keepNull := c.pred.KeepValue(predicateNullValue())
+	keepNull := c.filter.KeepValue(predicateNullValue())
 	if keepNull && pg.NumNulls() > 0 {
 		return true
 	}
@@ -89,8 +90,15 @@ func (c *SyncIterator) keepPage(pg pq.Page) (keep bool) {
 		// No present values on this page; only the null decision (handled above) applies.
 		return false
 	}
-	if min, max, ok := pg.Bounds(); ok {
-		return c.pred.KeepRange(min, max)
+	if pg.Dictionary() != nil {
+		// Dict-encoded page: pg.Bounds() has no stored min/max to hand back, so it would
+		// rescan every value to recompute them - a second full pass over data the caller
+		// is about to read anyway. Chunk-level dictionary pruning already covers this
+		// column, so skip the range test rather than pay for it.
+		return true
+	}
+	if minV, maxV, ok := pg.Bounds(); ok {
+		return c.filter.KeepRange(minV, maxV)
 	}
 	return true // no bounds recorded: cannot skip
 }

--- a/pkg/parquetquery/predicate_pruning.go
+++ b/pkg/parquetquery/predicate_pruning.go
@@ -1,0 +1,119 @@
+package parquetquery
+
+import (
+	pq "github.com/parquet-go/parquet-go"
+)
+
+// predicateStats counts the chunk/page pruning decisions made by keepColumnChunk /
+// keepPage. It is optional (nil-safe) and, when supplied via an InstrumentedPredicate,
+// lets callers report inspected/kept counts without the Predicate interface needing
+// chunk/page methods.
+type predicateStats struct {
+	InspectedColumnChunks int64
+	KeptColumnChunks      int64
+	InspectedPages        int64
+	KeptPages             int64
+}
+
+// predicateNullValue returns the null pq.Value fed to KeepValue when deciding
+// whether null rows in a chunk/page could match. It must be the same null
+// representation the per-row value reader produces so the skip decision agrees
+// with per-row evaluation.
+func predicateNullValue() pq.Value { return pq.Value{} }
+
+// keepColumnChunk reports whether any value in cc can match c.pred. The decision
+// combines a dictionary match for dict-encoded (string) columns, a column-index
+// range test via KeepRange, and a null-count test via KeepValue(null). Counts into
+// c.stats when set.
+func (c *SyncIterator) keepColumnChunk(cc *ColumnChunkHelper) (keep bool) {
+	if c.filter == nil {
+		return true // no predicate: keep everything
+	}
+	if c.stats != nil {
+		c.stats.InspectedColumnChunks++
+		defer func() {
+			if keep {
+				c.stats.KeptColumnChunks++
+			}
+		}()
+	}
+
+	keepNull := c.pred.KeepValue(predicateNullValue())
+
+	if dict := cc.Dictionary(); dict != nil {
+		// Dict-encoded (string) chunk: any present value that matches lives in the
+		// dictionary; null rows are decided by keepNull since nulls are not stored there.
+		if keepDictionary(dict, c.pred.KeepValue) {
+			return true
+		}
+		return keepNull && chunkHasNulls(cc)
+	}
+
+	ci, err := cc.ColumnIndex()
+	if err != nil || ci == nil {
+		return true // no column index: cannot skip
+	}
+	for i := 0; i < ci.NumPages(); i++ {
+		if keepNull && ci.NullCount(i) > 0 {
+			return true
+		}
+		if ci.NullPage(i) {
+			// All-null page: min/max are not recorded, so only the null decision (above) applies.
+			continue
+		}
+		if c.pred.KeepRange(ci.MinValue(i), ci.MaxValue(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+// keepPage reports whether any value in pg can match c.pred, combining a page-bounds
+// range test via KeepRange with a null test via KeepValue(null). Counts into c.stats
+// when set. The caller guards c.filter != nil, so c.pred is always non-nil here.
+func (c *SyncIterator) keepPage(pg pq.Page) (keep bool) {
+	if c.stats != nil {
+		c.stats.InspectedPages++
+		defer func() {
+			if keep {
+				c.stats.KeptPages++
+			}
+		}()
+	}
+
+	keepNull := c.pred.KeepValue(predicateNullValue())
+	if keepNull && pg.NumNulls() > 0 {
+		return true
+	}
+	if pg.NumValues()-pg.NumNulls() <= 0 {
+		// No present values on this page; only the null decision (handled above) applies.
+		return false
+	}
+	if min, max, ok := pg.Bounds(); ok {
+		return c.pred.KeepRange(min, max)
+	}
+	return true // no bounds recorded: cannot skip
+}
+
+func chunkHasNulls(cc *ColumnChunkHelper) bool {
+	ci, err := cc.ColumnIndex()
+	if err != nil || ci == nil {
+		return true // unknown: assume nulls may be present
+	}
+	for i := 0; i < ci.NumPages(); i++ {
+		if ci.NullCount(i) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// keepDictionary reports whether any dictionary entry matches keepValue.
+func keepDictionary(dict pq.Dictionary, keepValue func(pq.Value) bool) bool {
+	for i, l := 0, dict.Len(); i < l; i++ {
+		if keepValue(dict.Index(int32(i))) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/parquetquery/predicate_pruning_test.go
+++ b/pkg/parquetquery/predicate_pruning_test.go
@@ -1,0 +1,192 @@
+package parquetquery
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/stretchr/testify/require"
+)
+
+type testOptString struct {
+	S *string `parquet:",dict,optional"`
+}
+
+func TestPredicateNullValueIsNull(t *testing.T) {
+	require.True(t, predicateNullValue().IsNull())
+}
+
+// TestKeepHelpersMatchValueOracle asserts the generic keepColumnChunk/keepPage
+// helpers agree with the authoritative per-row semantic: a chunk/page must be
+// kept iff some value in it (nulls included) satisfies KeepValue.
+func TestKeepHelpersMatchValueOracle(t *testing.T) {
+	sp := func(s string) *string { return &s }
+
+	cases := []struct {
+		name      string
+		predicate Predicate
+		writeData func(w *parquet.Writer) //nolint:all
+	}{
+		{
+			name:      "dict string IN, match present",
+			predicate: NewStringInPredicate([]string{"abc", "acd"}),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"acd"}))
+				require.NoError(t, w.Write(&testDictString{"cde"}))
+			},
+		},
+		{
+			name:      "dict string IN, no match (chunk skippable)",
+			predicate: NewStringInPredicate([]string{"x"}),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+			},
+		},
+		{
+			name:      "dict string substring match",
+			predicate: NewSubstringPredicate("b"),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"bcd"}))
+			},
+		},
+		{
+			name:      "dict string substring no match",
+			predicate: NewSubstringPredicate("zz"),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+				require.NoError(t, w.Write(&testDictString{"abc"}))
+			},
+		},
+		{
+			name:      "int between, no match",
+			predicate: NewIntBetweenPredicate(5, 10),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testInt{1}))
+				require.NoError(t, w.Write(&testInt{2}))
+				require.NoError(t, w.Write(&testInt{3}))
+			},
+		},
+		{
+			name:      "int between, match",
+			predicate: NewIntBetweenPredicate(2, 3),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testInt{1}))
+				require.NoError(t, w.Write(&testInt{2}))
+				require.NoError(t, w.Write(&testInt{3}))
+			},
+		},
+		{
+			name:      "nil value predicate, nulls present",
+			predicate: NewNilValuePredicate(),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testOptString{sp("abc")}))
+				require.NoError(t, w.Write(&testOptString{nil}))
+			},
+		},
+		{
+			name:      "nil value predicate, no nulls",
+			predicate: NewNilValuePredicate(),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testOptString{sp("abc")}))
+				require.NoError(t, w.Write(&testOptString{sp("def")}))
+			},
+		},
+		{
+			name:      "skip nils predicate, present values",
+			predicate: NewSkipNilsPredicate(),
+			writeData: func(w *parquet.Writer) { //nolint:all
+				require.NoError(t, w.Write(&testOptString{sp("abc")}))
+				require.NoError(t, w.Write(&testOptString{nil}))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := buildFile(t, tc.writeData)
+
+			oracle := oracleKeep(t, r, tc.predicate)
+
+			it := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptPredicate(tc.predicate))
+			defer it.Close()
+
+			cc := &ColumnChunkHelper{ColumnChunk: r.RowGroups()[0].ColumnChunks()[0]}
+			defer cc.Close()
+			require.Equal(t, oracle, it.keepColumnChunk(cc), "keepColumnChunk vs oracle")
+
+			ccPage := &ColumnChunkHelper{ColumnChunk: r.RowGroups()[0].ColumnChunks()[0]}
+			defer ccPage.Close()
+			pg, err := ccPage.NextPage()
+			require.NoError(t, err)
+			require.NotNil(t, pg)
+			// keepPage must never under-keep: whenever a value matches (oracle true)
+			// the page must be kept. It may conservatively over-keep for predicates
+			// with no usable page-level range (e.g. substring/regex), whose tight skip
+			// happens at the chunk level (dictionary) instead.
+			if oracle {
+				require.True(t, it.keepPage(pg), "keepPage must keep a matching page")
+			}
+		})
+	}
+}
+
+func TestKeepStatsCounters(t *testing.T) {
+	r := buildFile(t, func(w *parquet.Writer) { //nolint:all
+		require.NoError(t, w.Write(&testDictString{"abc"}))
+	})
+
+	// An InstrumentedPredicate sets c.stats, so keepColumnChunk counts into it.
+	keepIP := &InstrumentedPredicate{Pred: NewStringInPredicate([]string{"abc"})}
+	keepIt := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptPredicate(keepIP))
+	defer keepIt.Close()
+	ccKeep := &ColumnChunkHelper{ColumnChunk: r.RowGroups()[0].ColumnChunks()[0]}
+	defer ccKeep.Close()
+	require.True(t, keepIt.keepColumnChunk(ccKeep))
+	require.Equal(t, int64(1), keepIP.InspectedColumnChunks)
+	require.Equal(t, int64(1), keepIP.KeptColumnChunks)
+
+	skipIP := &InstrumentedPredicate{Pred: NewStringInPredicate([]string{"zzz"})}
+	skipIt := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptPredicate(skipIP))
+	defer skipIt.Close()
+	ccSkip := &ColumnChunkHelper{ColumnChunk: r.RowGroups()[0].ColumnChunks()[0]}
+	defer ccSkip.Close()
+	require.False(t, skipIt.keepColumnChunk(ccSkip))
+	require.Equal(t, int64(1), skipIP.InspectedColumnChunks)
+	require.Equal(t, int64(0), skipIP.KeptColumnChunks) // chunk skipped
+}
+
+func buildFile(t *testing.T, writeData func(w *parquet.Writer)) *parquet.File { //nolint:all
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf)
+	writeData(w)
+	require.NoError(t, w.Flush())
+	require.NoError(t, w.Close())
+	r, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+	return r
+}
+
+// oracleKeep enumerates every value in column 0 (nulls included) with an
+// unfiltered iterator and reports whether any satisfies pred.KeepValue.
+func oracleKeep(t *testing.T, r *parquet.File, pred Predicate) bool {
+	t.Helper()
+	it := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptSelectAs("v"))
+	defer it.Close()
+	for {
+		res, err := it.Next()
+		require.NoError(t, err)
+		if res == nil {
+			return false
+		}
+		for _, e := range res.Entries {
+			if pred.KeepValue(e.Value) {
+				return true
+			}
+		}
+	}
+}

--- a/pkg/parquetquery/predicate_pruning_test.go
+++ b/pkg/parquetquery/predicate_pruning_test.go
@@ -13,6 +13,12 @@ type testOptString struct {
 	S *string `parquet:",dict,optional"`
 }
 
+// testPlainInt is deliberately not dict-encoded, so pruning falls to the column index
+// and page bounds rather than the dictionary.
+type testPlainInt struct {
+	N int64
+}
+
 func TestPredicateNullValueIsNull(t *testing.T) {
 	require.True(t, predicateNullValue().IsNull())
 }
@@ -139,24 +145,88 @@ func TestKeepStatsCounters(t *testing.T) {
 		require.NoError(t, w.Write(&testDictString{"abc"}))
 	})
 
-	// An InstrumentedPredicate sets c.stats, so keepColumnChunk counts into it.
-	keepIP := &InstrumentedPredicate{Pred: NewStringInPredicate([]string{"abc"})}
-	keepIt := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptPredicate(keepIP))
+	// SyncIteratorOptStats attaches a PredicateStats, so keepColumnChunk counts into it.
+	var keepStats PredicateStats
+	keepIt := NewSyncIterator(context.TODO(), r.RowGroups(), 0,
+		SyncIteratorOptPredicate(NewStringInPredicate([]string{"abc"})), SyncIteratorOptStats(&keepStats))
 	defer keepIt.Close()
 	ccKeep := &ColumnChunkHelper{ColumnChunk: r.RowGroups()[0].ColumnChunks()[0]}
 	defer ccKeep.Close()
 	require.True(t, keepIt.keepColumnChunk(ccKeep))
-	require.Equal(t, int64(1), keepIP.InspectedColumnChunks)
-	require.Equal(t, int64(1), keepIP.KeptColumnChunks)
+	require.Equal(t, int64(1), keepStats.InspectedColumnChunks)
+	require.Equal(t, int64(1), keepStats.KeptColumnChunks)
 
-	skipIP := &InstrumentedPredicate{Pred: NewStringInPredicate([]string{"zzz"})}
-	skipIt := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptPredicate(skipIP))
+	var skipStats PredicateStats
+	skipIt := NewSyncIterator(context.TODO(), r.RowGroups(), 0,
+		SyncIteratorOptPredicate(NewStringInPredicate([]string{"zzz"})), SyncIteratorOptStats(&skipStats))
 	defer skipIt.Close()
 	ccSkip := &ColumnChunkHelper{ColumnChunk: r.RowGroups()[0].ColumnChunks()[0]}
 	defer ccSkip.Close()
 	require.False(t, skipIt.keepColumnChunk(ccSkip))
-	require.Equal(t, int64(1), skipIP.InspectedColumnChunks)
-	require.Equal(t, int64(0), skipIP.KeptColumnChunks) // chunk skipped
+	require.Equal(t, int64(1), skipStats.InspectedColumnChunks)
+	require.Equal(t, int64(0), skipStats.KeptColumnChunks) // chunk skipped
+}
+
+// TestKeepPagePrunesByBounds covers page-level KeepRange pruning on a plain (non-dict)
+// column, where the chunk is kept but individual pages are skippable by their bounds.
+// Dict-encoded columns skip at the chunk level instead, so they never reach this path.
+func TestKeepPagePrunesByBounds(t *testing.T) {
+	const rows = 2000
+
+	buf := new(bytes.Buffer)
+	w := parquet.NewWriter(buf, parquet.PageBufferSize(1024))
+	for i := 0; i < rows; i++ {
+		require.NoError(t, w.Write(&testPlainInt{int64(i)}))
+	}
+	require.NoError(t, w.Flush())
+	require.NoError(t, w.Close())
+	r, err := parquet.OpenFile(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	require.NoError(t, err)
+
+	// Matches only the tail of an ascending column, so the leading pages are out of range.
+	var stats PredicateStats
+	it := NewSyncIterator(context.TODO(), r.RowGroups(), 0,
+		SyncIteratorOptPredicate(NewIntBetweenPredicate(rows-5, rows)), SyncIteratorOptStats(&stats))
+	defer it.Close()
+	drain(t, it)
+
+	require.Equal(t, int64(1), stats.KeptColumnChunks, "chunk holds matching values, must be kept")
+	require.Greater(t, stats.InspectedPages, int64(1), "need multiple pages to exercise pruning")
+	require.Less(t, stats.KeptPages, stats.InspectedPages, "out-of-range pages must be pruned")
+	require.Equal(t, int64(5), stats.KeptValues)
+}
+
+// TestStatsCountOnlyRowValues pins the invariant that replaced InstrumentedPredicate's
+// inner-predicate unwrap: the null and dictionary KeepValue probes issued by
+// keepColumnChunk / keepPage must not inflate the value counters, which count rows only.
+func TestStatsCountOnlyRowValues(t *testing.T) {
+	r := buildFile(t, func(w *parquet.Writer) { //nolint:all
+		require.NoError(t, w.Write(&testDictString{"abc"}))
+		require.NoError(t, w.Write(&testDictString{"bcd"}))
+		require.NoError(t, w.Write(&testDictString{"cde"}))
+	})
+
+	var stats PredicateStats
+	it := NewSyncIterator(context.TODO(), r.RowGroups(), 0,
+		SyncIteratorOptPredicate(NewStringInPredicate([]string{"abc"})), SyncIteratorOptStats(&stats))
+	defer it.Close()
+	drain(t, it)
+
+	// Exactly one inspection per row: the 3-entry dictionary scan and the null probe
+	// that keepColumnChunk performed are not counted.
+	require.Equal(t, int64(3), stats.InspectedValues)
+	require.Equal(t, int64(1), stats.KeptValues)
+}
+
+func drain(t *testing.T, it Iterator) {
+	t.Helper()
+	for {
+		res, err := it.Next()
+		require.NoError(t, err)
+		if res == nil {
+			return
+		}
+	}
 }
 
 func buildFile(t *testing.T, writeData func(w *parquet.Writer)) *parquet.File { //nolint:all

--- a/pkg/parquetquery/predicates.gen.go
+++ b/pkg/parquetquery/predicates.gen.go
@@ -24,50 +24,18 @@ func (p IntEqualPredicate) String() string {
 	return fmt.Sprintf("IntEqualPredicate{%d}", p.value)
 }
 
-func (p IntEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Int64()
-			max := ci.MaxValue(i).Int64()
-
-			if min <= p.value && p.value <= max {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p IntEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.Int64()
-		max := maxV.Int64()
-
-		return min <= p.value && p.value <= max
-	}
-
-	return true
-}
-
 func (p IntEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Int64()
 	return vv == p.value
+}
+
+func (p IntEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Int64()
+	max := maxV.Int64()
+	return min <= p.value && p.value <= max
 }
 
 var _ Predicate = (*IntNotEqualPredicate)(nil)
@@ -84,50 +52,18 @@ func (p IntNotEqualPredicate) String() string {
 	return fmt.Sprintf("IntNotEqualPredicate{%d}", p.value)
 }
 
-func (p IntNotEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Int64()
-			max := ci.MaxValue(i).Int64()
-
-			if min != p.value || p.value != max {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p IntNotEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.Int64()
-		max := maxV.Int64()
-
-		return min != p.value || p.value != max
-	}
-
-	return true
-}
-
 func (p IntNotEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Int64()
 	return vv != p.value
+}
+
+func (p IntNotEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Int64()
+	max := maxV.Int64()
+	return min != p.value || p.value != max
 }
 
 var _ Predicate = (*IntGreaterPredicate)(nil)
@@ -144,49 +80,18 @@ func (p IntGreaterPredicate) String() string {
 	return fmt.Sprintf("IntGreaterPredicate{%d}", p.value)
 }
 
-func (p IntGreaterPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			max := ci.MaxValue(i).Int64()
-
-			if max > p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p IntGreaterPredicate) KeepPage(page pq.Page) bool {
-	_, maxV, ok := page.Bounds()
-	if ok {
-
-		max := maxV.Int64()
-
-		return max > p.value
-	}
-
-	return true
-}
-
 func (p IntGreaterPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Int64()
 	return vv > p.value
+}
+
+func (p IntGreaterPredicate) KeepRange(minV, maxV pq.Value) bool {
+
+	max := maxV.Int64()
+	return max > p.value
 }
 
 var _ Predicate = (*IntGreaterEqualPredicate)(nil)
@@ -203,49 +108,18 @@ func (p IntGreaterEqualPredicate) String() string {
 	return fmt.Sprintf("IntGreaterEqualPredicate{%d}", p.value)
 }
 
-func (p IntGreaterEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			max := ci.MaxValue(i).Int64()
-
-			if max >= p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p IntGreaterEqualPredicate) KeepPage(page pq.Page) bool {
-	_, maxV, ok := page.Bounds()
-	if ok {
-
-		max := maxV.Int64()
-
-		return max >= p.value
-	}
-
-	return true
-}
-
 func (p IntGreaterEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Int64()
 	return vv >= p.value
+}
+
+func (p IntGreaterEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+
+	max := maxV.Int64()
+	return max >= p.value
 }
 
 var _ Predicate = (*IntLessPredicate)(nil)
@@ -262,48 +136,18 @@ func (p IntLessPredicate) String() string {
 	return fmt.Sprintf("IntLessPredicate{%d}", p.value)
 }
 
-func (p IntLessPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Int64()
-
-			if min < p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p IntLessPredicate) KeepPage(page pq.Page) bool {
-	minV, _, ok := page.Bounds()
-	if ok {
-		min := minV.Int64()
-
-		return min < p.value
-	}
-
-	return true
-}
-
 func (p IntLessPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Int64()
 	return vv < p.value
+}
+
+func (p IntLessPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Int64()
+
+	return min < p.value
 }
 
 var _ Predicate = (*IntLessEqualPredicate)(nil)
@@ -320,48 +164,18 @@ func (p IntLessEqualPredicate) String() string {
 	return fmt.Sprintf("IntLessEqualPredicate{%d}", p.value)
 }
 
-func (p IntLessEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Int64()
-
-			if min <= p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p IntLessEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, _, ok := page.Bounds()
-	if ok {
-		min := minV.Int64()
-
-		return min <= p.value
-	}
-
-	return true
-}
-
 func (p IntLessEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Int64()
 	return vv <= p.value
+}
+
+func (p IntLessEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Int64()
+
+	return min <= p.value
 }
 
 var _ Predicate = (*FloatEqualPredicate)(nil)
@@ -378,50 +192,18 @@ func (p FloatEqualPredicate) String() string {
 	return fmt.Sprintf("FloatEqualPredicate{%f}", p.value)
 }
 
-func (p FloatEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Double()
-			max := ci.MaxValue(i).Double()
-
-			if min <= p.value && p.value <= max {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p FloatEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.Double()
-		max := maxV.Double()
-
-		return min <= p.value && p.value <= max
-	}
-
-	return true
-}
-
 func (p FloatEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Double()
 	return vv == p.value
+}
+
+func (p FloatEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Double()
+	max := maxV.Double()
+	return min <= p.value && p.value <= max
 }
 
 var _ Predicate = (*FloatNotEqualPredicate)(nil)
@@ -438,50 +220,18 @@ func (p FloatNotEqualPredicate) String() string {
 	return fmt.Sprintf("FloatNotEqualPredicate{%f}", p.value)
 }
 
-func (p FloatNotEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Double()
-			max := ci.MaxValue(i).Double()
-
-			if min != p.value || p.value != max {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p FloatNotEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.Double()
-		max := maxV.Double()
-
-		return min != p.value || p.value != max
-	}
-
-	return true
-}
-
 func (p FloatNotEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Double()
 	return vv != p.value
+}
+
+func (p FloatNotEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Double()
+	max := maxV.Double()
+	return min != p.value || p.value != max
 }
 
 var _ Predicate = (*FloatGreaterPredicate)(nil)
@@ -498,49 +248,18 @@ func (p FloatGreaterPredicate) String() string {
 	return fmt.Sprintf("FloatGreaterPredicate{%f}", p.value)
 }
 
-func (p FloatGreaterPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			max := ci.MaxValue(i).Double()
-
-			if max > p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p FloatGreaterPredicate) KeepPage(page pq.Page) bool {
-	_, maxV, ok := page.Bounds()
-	if ok {
-
-		max := maxV.Double()
-
-		return max > p.value
-	}
-
-	return true
-}
-
 func (p FloatGreaterPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Double()
 	return vv > p.value
+}
+
+func (p FloatGreaterPredicate) KeepRange(minV, maxV pq.Value) bool {
+
+	max := maxV.Double()
+	return max > p.value
 }
 
 var _ Predicate = (*FloatGreaterEqualPredicate)(nil)
@@ -557,49 +276,18 @@ func (p FloatGreaterEqualPredicate) String() string {
 	return fmt.Sprintf("FloatGreaterEqualPredicate{%f}", p.value)
 }
 
-func (p FloatGreaterEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			max := ci.MaxValue(i).Double()
-
-			if max >= p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p FloatGreaterEqualPredicate) KeepPage(page pq.Page) bool {
-	_, maxV, ok := page.Bounds()
-	if ok {
-
-		max := maxV.Double()
-
-		return max >= p.value
-	}
-
-	return true
-}
-
 func (p FloatGreaterEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Double()
 	return vv >= p.value
+}
+
+func (p FloatGreaterEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+
+	max := maxV.Double()
+	return max >= p.value
 }
 
 var _ Predicate = (*FloatLessPredicate)(nil)
@@ -616,48 +304,18 @@ func (p FloatLessPredicate) String() string {
 	return fmt.Sprintf("FloatLessPredicate{%f}", p.value)
 }
 
-func (p FloatLessPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Double()
-
-			if min < p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p FloatLessPredicate) KeepPage(page pq.Page) bool {
-	minV, _, ok := page.Bounds()
-	if ok {
-		min := minV.Double()
-
-		return min < p.value
-	}
-
-	return true
-}
-
 func (p FloatLessPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Double()
 	return vv < p.value
+}
+
+func (p FloatLessPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Double()
+
+	return min < p.value
 }
 
 var _ Predicate = (*FloatLessEqualPredicate)(nil)
@@ -674,48 +332,18 @@ func (p FloatLessEqualPredicate) String() string {
 	return fmt.Sprintf("FloatLessEqualPredicate{%f}", p.value)
 }
 
-func (p FloatLessEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).Double()
-
-			if min <= p.value {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p FloatLessEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, _, ok := page.Bounds()
-	if ok {
-		min := minV.Double()
-
-		return min <= p.value
-	}
-
-	return true
-}
-
 func (p FloatLessEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Double()
 	return vv <= p.value
+}
+
+func (p FloatLessEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Double()
+
+	return min <= p.value
 }
 
 var _ Predicate = (*BoolEqualPredicate)(nil)
@@ -732,25 +360,16 @@ func (p BoolEqualPredicate) String() string {
 	return fmt.Sprintf("BoolEqualPredicate{%t}", p.value)
 }
 
-func (p BoolEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-
-	return true
-}
-
-func (p BoolEqualPredicate) KeepPage(page pq.Page) bool {
-
-	return true
-}
-
 func (p BoolEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Boolean()
 	return vv == p.value
+}
+
+func (p BoolEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	return true
 }
 
 var _ Predicate = (*BoolNotEqualPredicate)(nil)
@@ -767,25 +386,16 @@ func (p BoolNotEqualPredicate) String() string {
 	return fmt.Sprintf("BoolNotEqualPredicate{%t}", p.value)
 }
 
-func (p BoolNotEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-
-	return true
-}
-
-func (p BoolNotEqualPredicate) KeepPage(page pq.Page) bool {
-
-	return true
-}
-
 func (p BoolNotEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.Boolean()
 	return vv != p.value
+}
+
+func (p BoolNotEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	return true
 }
 
 var _ Predicate = (*StringGreaterPredicate)(nil)
@@ -802,49 +412,18 @@ func (p StringGreaterPredicate) String() string {
 	return fmt.Sprintf("StringGreaterPredicate{%s}", p.value)
 }
 
-func (p StringGreaterPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			max := ci.MaxValue(i).ByteArray()
-
-			if len(max) == 0 || bytes.Compare(max, p.value) > 0 {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p StringGreaterPredicate) KeepPage(page pq.Page) bool {
-	_, maxV, ok := page.Bounds()
-	if ok {
-
-		max := maxV.ByteArray()
-
-		return len(max) == 0 || bytes.Compare(max, p.value) > 0
-	}
-
-	return true
-}
-
 func (p StringGreaterPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.ByteArray()
 	return bytes.Compare(vv, p.value) > 0
+}
+
+func (p StringGreaterPredicate) KeepRange(minV, maxV pq.Value) bool {
+
+	max := maxV.ByteArray()
+	return len(max) == 0 || bytes.Compare(max, p.value) > 0
 }
 
 var _ Predicate = (*StringGreaterEqualPredicate)(nil)
@@ -861,49 +440,18 @@ func (p StringGreaterEqualPredicate) String() string {
 	return fmt.Sprintf("StringGreaterEqualPredicate{%s}", p.value)
 }
 
-func (p StringGreaterEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			max := ci.MaxValue(i).ByteArray()
-
-			if len(max) == 0 || bytes.Compare(max, p.value) >= 0 {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p StringGreaterEqualPredicate) KeepPage(page pq.Page) bool {
-	_, maxV, ok := page.Bounds()
-	if ok {
-
-		max := maxV.ByteArray()
-
-		return len(max) == 0 || bytes.Compare(max, p.value) >= 0
-	}
-
-	return true
-}
-
 func (p StringGreaterEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.ByteArray()
 	return bytes.Compare(vv, p.value) >= 0
+}
+
+func (p StringGreaterEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+
+	max := maxV.ByteArray()
+	return len(max) == 0 || bytes.Compare(max, p.value) >= 0
 }
 
 var _ Predicate = (*StringLessPredicate)(nil)
@@ -920,48 +468,18 @@ func (p StringLessPredicate) String() string {
 	return fmt.Sprintf("StringLessPredicate{%s}", p.value)
 }
 
-func (p StringLessPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).ByteArray()
-
-			if len(min) == 0 || bytes.Compare(min, p.value) < 0 {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p StringLessPredicate) KeepPage(page pq.Page) bool {
-	minV, _, ok := page.Bounds()
-	if ok {
-		min := minV.ByteArray()
-
-		return len(min) == 0 || bytes.Compare(min, p.value) < 0
-	}
-
-	return true
-}
-
 func (p StringLessPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.ByteArray()
 	return bytes.Compare(vv, p.value) < 0
+}
+
+func (p StringLessPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.ByteArray()
+
+	return len(min) == 0 || bytes.Compare(min, p.value) < 0
 }
 
 var _ Predicate = (*StringLessEqualPredicate)(nil)
@@ -978,48 +496,18 @@ func (p StringLessEqualPredicate) String() string {
 	return fmt.Sprintf("StringLessEqualPredicate{%s}", p.value)
 }
 
-func (p StringLessEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).ByteArray()
-
-			if len(min) == 0 || bytes.Compare(min, p.value) <= 0 {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p StringLessEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, _, ok := page.Bounds()
-	if ok {
-		min := minV.ByteArray()
-
-		return len(min) == 0 || bytes.Compare(min, p.value) <= 0
-	}
-
-	return true
-}
-
 func (p StringLessEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.ByteArray()
 	return bytes.Compare(vv, p.value) <= 0
+}
+
+func (p StringLessEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.ByteArray()
+
+	return len(min) == 0 || bytes.Compare(min, p.value) <= 0
 }
 
 var _ Predicate = (*ByteEqualPredicate)(nil)
@@ -1036,50 +524,18 @@ func (p ByteEqualPredicate) String() string {
 	return fmt.Sprintf("ByteEqualPredicate{%s}", p.value)
 }
 
-func (p ByteEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).ByteArray()
-			max := ci.MaxValue(i).ByteArray()
-
-			if (len(min) == 0 && len(max) == 0) || (bytes.Compare(p.value, min) >= 0 && bytes.Compare(p.value, max) <= 0) {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p ByteEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.ByteArray()
-		max := maxV.ByteArray()
-
-		return (len(min) == 0 && len(max) == 0) || (bytes.Compare(p.value, min) >= 0 && bytes.Compare(p.value, max) <= 0)
-	}
-
-	return true
-}
-
 func (p ByteEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.ByteArray()
 	return bytes.Equal(vv, p.value)
+}
+
+func (p ByteEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.ByteArray()
+	max := maxV.ByteArray()
+	return (len(min) == 0 && len(max) == 0) || (bytes.Compare(p.value, min) >= 0 && bytes.Compare(p.value, max) <= 0)
 }
 
 var _ Predicate = (*ByteNotEqualPredicate)(nil)
@@ -1096,50 +552,18 @@ func (p ByteNotEqualPredicate) String() string {
 	return fmt.Sprintf("ByteNotEqualPredicate{%s}", p.value)
 }
 
-func (p ByteNotEqualPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			min := ci.MinValue(i).ByteArray()
-			max := ci.MaxValue(i).ByteArray()
-
-			if (len(min) == 0 && len(max) == 0) || (!bytes.Equal(min, p.value) || !bytes.Equal(p.value, max)) {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p ByteNotEqualPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.ByteArray()
-		max := maxV.ByteArray()
-
-		return (len(min) == 0 && len(max) == 0) || (!bytes.Equal(min, p.value) || !bytes.Equal(p.value, max))
-	}
-
-	return true
-}
-
 func (p ByteNotEqualPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.ByteArray()
 	return !bytes.Equal(vv, p.value)
+}
+
+func (p ByteNotEqualPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.ByteArray()
+	max := maxV.ByteArray()
+	return (len(min) == 0 && len(max) == 0) || (!bytes.Equal(min, p.value) || !bytes.Equal(p.value, max))
 }
 
 var _ Predicate = (*IntInPredicate)(nil)
@@ -1154,41 +578,6 @@ func NewIntInPredicate(vals []int64) IntInPredicate {
 
 func (p IntInPredicate) String() string { return fmt.Sprintf("IntInPredicate{%v}", p.values) }
 
-func (p IntInPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			min := ci.MinValue(i).Int64()
-			max := ci.MaxValue(i).Int64()
-			for _, v := range p.values {
-				if min <= v && v <= max {
-					return true
-				}
-			}
-		}
-		return false
-	}
-	return true
-}
-
-func (p IntInPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.Int64()
-		max := maxV.Int64()
-		for _, v := range p.values {
-			if min <= v && v <= max {
-				return true
-			}
-		}
-		return false
-	}
-	return true
-}
-
 func (p IntInPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -1196,6 +585,17 @@ func (p IntInPredicate) KeepValue(v pq.Value) bool {
 	vv := v.Int64()
 	for _, x := range p.values {
 		if vv == x {
+			return true
+		}
+	}
+	return false
+}
+
+func (p IntInPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Int64()
+	max := maxV.Int64()
+	for _, v := range p.values {
+		if min <= v && v <= max {
 			return true
 		}
 	}
@@ -1216,17 +616,6 @@ func (p IntNotInPredicate) String() string {
 	return fmt.Sprintf("IntNotInPredicate{%v}", p.values)
 }
 
-func (p IntNotInPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	return true
-}
-
-func (p IntNotInPredicate) KeepPage(page pq.Page) bool {
-	return true
-}
-
 func (p IntNotInPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -1240,6 +629,8 @@ func (p IntNotInPredicate) KeepValue(v pq.Value) bool {
 	return true
 }
 
+func (p IntNotInPredicate) KeepRange(pq.Value, pq.Value) bool { return true }
+
 var _ Predicate = (*FloatInPredicate)(nil)
 
 type FloatInPredicate struct {
@@ -1252,41 +643,6 @@ func NewFloatInPredicate(vals []float64) FloatInPredicate {
 
 func (p FloatInPredicate) String() string { return fmt.Sprintf("FloatInPredicate{%v}", p.values) }
 
-func (p FloatInPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			min := ci.MinValue(i).Double()
-			max := ci.MaxValue(i).Double()
-			for _, v := range p.values {
-				if min <= v && v <= max {
-					return true
-				}
-			}
-		}
-		return false
-	}
-	return true
-}
-
-func (p FloatInPredicate) KeepPage(page pq.Page) bool {
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.Double()
-		max := maxV.Double()
-		for _, v := range p.values {
-			if min <= v && v <= max {
-				return true
-			}
-		}
-		return false
-	}
-	return true
-}
-
 func (p FloatInPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -1294,6 +650,17 @@ func (p FloatInPredicate) KeepValue(v pq.Value) bool {
 	vv := v.Double()
 	for _, x := range p.values {
 		if vv == x {
+			return true
+		}
+	}
+	return false
+}
+
+func (p FloatInPredicate) KeepRange(minV, maxV pq.Value) bool {
+	min := minV.Double()
+	max := maxV.Double()
+	for _, v := range p.values {
+		if min <= v && v <= max {
 			return true
 		}
 	}
@@ -1314,17 +681,6 @@ func (p FloatNotInPredicate) String() string {
 	return fmt.Sprintf("FloatNotInPredicate{%v}", p.values)
 }
 
-func (p FloatNotInPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	return true
-}
-
-func (p FloatNotInPredicate) KeepPage(page pq.Page) bool {
-	return true
-}
-
 func (p FloatNotInPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -1338,6 +694,8 @@ func (p FloatNotInPredicate) KeepValue(v pq.Value) bool {
 	return true
 }
 
+func (p FloatNotInPredicate) KeepRange(pq.Value, pq.Value) bool { return true }
+
 var _ Predicate = (*BoolInPredicate)(nil)
 
 type BoolInPredicate struct {
@@ -1350,17 +708,6 @@ func NewBoolInPredicate(vals []bool) BoolInPredicate {
 
 func (p BoolInPredicate) String() string { return fmt.Sprintf("BoolInPredicate{%v}", p.values) }
 
-func (p BoolInPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	return true
-}
-
-func (p BoolInPredicate) KeepPage(page pq.Page) bool {
-	return true
-}
-
 func (p BoolInPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -1372,6 +719,10 @@ func (p BoolInPredicate) KeepValue(v pq.Value) bool {
 		}
 	}
 	return false
+}
+
+func (p BoolInPredicate) KeepRange(minV, maxV pq.Value) bool {
+	return true
 }
 
 var _ Predicate = (*BoolNotInPredicate)(nil)
@@ -1388,17 +739,6 @@ func (p BoolNotInPredicate) String() string {
 	return fmt.Sprintf("BoolNotInPredicate{%v}", p.values)
 }
 
-func (p BoolNotInPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	return true
-}
-
-func (p BoolNotInPredicate) KeepPage(page pq.Page) bool {
-	return true
-}
-
 func (p BoolNotInPredicate) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -1411,3 +751,5 @@ func (p BoolNotInPredicate) KeepValue(v pq.Value) bool {
 	}
 	return true
 }
+
+func (p BoolNotInPredicate) KeepRange(pq.Value, pq.Value) bool { return true }

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -18,8 +18,8 @@ type Predicate interface {
 	fmt.Stringer
 
 	KeepValue(pq.Value) bool
-	// KeepRange reports whether any value in the inclusive [min,max] range could match.
-	KeepRange(min, max pq.Value) bool
+	// KeepRange reports whether any value in the inclusive [minV,maxV] range could match.
+	KeepRange(minV, maxV pq.Value) bool
 }
 
 // NewStringEqualPredicate is just an alias for the equivalent byte predicate
@@ -88,8 +88,8 @@ func (p *ByteInPredicate) KeepValue(v pq.Value) bool {
 	return false
 }
 
-func (p *ByteInPredicate) KeepRange(min, max pq.Value) bool {
-	lo, hi := min.ByteArray(), max.ByteArray()
+func (p *ByteInPredicate) KeepRange(minV, maxV pq.Value) bool {
+	lo, hi := minV.ByteArray(), maxV.ByteArray()
 	for _, s := range p.values {
 		if bytes.Compare(lo, s) <= 0 && bytes.Compare(hi, s) >= 0 {
 			return true
@@ -255,8 +255,8 @@ func (p *IntBetweenPredicate) KeepValue(v pq.Value) bool {
 	return p.min <= vv && vv <= p.max
 }
 
-func (p *IntBetweenPredicate) KeepRange(min, max pq.Value) bool {
-	return p.max >= min.Int64() && p.min <= max.Int64()
+func (p *IntBetweenPredicate) KeepRange(minV, maxV pq.Value) bool {
+	return p.max >= minV.Int64() && p.min <= maxV.Int64()
 }
 
 // GenericPredicate with callbacks to evaluate data of type T
@@ -286,11 +286,11 @@ func (p *GenericPredicate[T]) KeepValue(v pq.Value) bool {
 	return p.Fn(p.Extract(v))
 }
 
-func (p *GenericPredicate[T]) KeepRange(min, max pq.Value) bool {
+func (p *GenericPredicate[T]) KeepRange(minV, maxV pq.Value) bool {
 	if p.RangeFn == nil {
 		return true
 	}
-	return p.RangeFn(p.Extract(min), p.Extract(max))
+	return p.RangeFn(p.Extract(minV), p.Extract(maxV))
 }
 
 type OrPredicate struct {
@@ -331,51 +331,14 @@ func (p *OrPredicate) KeepValue(v pq.Value) bool {
 	return false
 }
 
-func (p *OrPredicate) KeepRange(min, max pq.Value) bool {
+func (p *OrPredicate) KeepRange(minV, maxV pq.Value) bool {
 	for _, sub := range p.preds {
-		if sub == nil || sub.KeepRange(min, max) {
+		if sub == nil || sub.KeepRange(minV, maxV) {
 			// Nil means all values are returned
 			return true
 		}
 	}
 	return false
-}
-
-type InstrumentedPredicate struct {
-	Pred Predicate // Optional, if missing then just keeps metrics with no filtering
-	// predicateStats holds the chunk/page counters (InspectedColumnChunks,
-	// KeptColumnChunks, InspectedPages, KeptPages), incremented by the iterator's
-	// keep* helpers which take &predicateStats. Promoted fields keep the public API.
-	predicateStats
-	InspectedValues int64
-	KeptValues      int64
-}
-
-var _ Predicate = (*InstrumentedPredicate)(nil)
-
-func (p *InstrumentedPredicate) String() string {
-	if p.Pred == nil {
-		return fmt.Sprintf("InstrumentedPredicate{%d, nil}", p.InspectedValues)
-	}
-	return fmt.Sprintf("InstrumentedPredicate{%d, %s}", p.InspectedValues, p.Pred)
-}
-
-func (p *InstrumentedPredicate) KeepValue(v pq.Value) bool {
-	p.InspectedValues++
-
-	if p.Pred == nil || p.Pred.KeepValue(v) {
-		p.KeptValues++
-		return true
-	}
-
-	return false
-}
-
-func (p *InstrumentedPredicate) KeepRange(min, max pq.Value) bool {
-	if p.Pred == nil {
-		return true
-	}
-	return p.Pred.KeepRange(min, max)
 }
 
 type SkipNilsPredicate struct{}

--- a/pkg/parquetquery/predicates.go
+++ b/pkg/parquetquery/predicates.go
@@ -10,14 +10,16 @@ import (
 	pq "github.com/parquet-go/parquet-go"
 )
 
-// Predicate is a pushdown predicate that can be applied at
-// the chunk, page, and value levels.
+// Predicate is a pushdown predicate evaluated at the value level (KeepValue) and,
+// for chunk/page skipping, at the value-range level (KeepRange). Chunk-, page-,
+// dictionary-, and null-level skipping are handled generically by the iterator
+// layer (keepColumnChunk / keepPage) using these two methods.
 type Predicate interface {
 	fmt.Stringer
 
-	KeepColumnChunk(*ColumnChunkHelper) bool
-	KeepPage(page pq.Page) bool
 	KeepValue(pq.Value) bool
+	// KeepRange reports whether any value in the inclusive [min,max] range could match.
+	KeepRange(min, max pq.Value) bool
 }
 
 // NewStringEqualPredicate is just an alias for the equivalent byte predicate
@@ -72,29 +74,6 @@ func (p *ByteInPredicate) String() string {
 	return fmt.Sprintf("ByteInPredicate{%s}", strs)
 }
 
-func (p *ByteInPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
-	if d := cc.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-
-	ci, err := cc.ColumnIndex()
-	if err != nil || ci == nil {
-		return true // no index: keep column chunk
-	}
-
-	for i := 0; i < ci.NumPages(); i++ {
-		minVal := ci.MinValue(i).ByteArray()
-		maxVal := ci.MaxValue(i).ByteArray()
-		for _, subs := range p.values {
-			if bytes.Compare(minVal, subs) <= 0 && bytes.Compare(maxVal, subs) >= 0 {
-				// At least one page in this chunk matches
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func (p *ByteInPredicate) KeepValue(v pq.Value) bool {
 	ba := v.ByteArray()
 	if p.valuesMap != nil {
@@ -109,9 +88,14 @@ func (p *ByteInPredicate) KeepValue(v pq.Value) bool {
 	return false
 }
 
-func (p *ByteInPredicate) KeepPage(pq.Page) bool {
-	// todo: check bounds
-	return true
+func (p *ByteInPredicate) KeepRange(min, max pq.Value) bool {
+	lo, hi := min.ByteArray(), max.ByteArray()
+	for _, s := range p.values {
+		if bytes.Compare(lo, s) <= 0 && bytes.Compare(hi, s) >= 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // ByteNotInPredicate checks for any of the given strings. Case-sensitive exact byte matching
@@ -152,14 +136,6 @@ func (p *ByteNotInPredicate) String() string {
 	return fmt.Sprintf("ByteNotInPredicate{%s}", strs)
 }
 
-func (p *ByteNotInPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
-	if d := cc.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-
-	return true
-}
-
 func (p *ByteNotInPredicate) KeepValue(v pq.Value) bool {
 	ba := v.ByteArray()
 	if p.valuesMap != nil {
@@ -174,10 +150,7 @@ func (p *ByteNotInPredicate) KeepValue(v pq.Value) bool {
 	return true
 }
 
-func (p *ByteNotInPredicate) KeepPage(pq.Page) bool {
-	// todo: check bounds
-	return true
-}
+func (p *ByteNotInPredicate) KeepRange(pq.Value, pq.Value) bool { return true }
 
 type regexPredicate struct {
 	matcher *regexp.Regexp
@@ -220,26 +193,11 @@ func (p *regexPredicate) keep(v *pq.Value) bool {
 	return p.matcher.Match(v.ByteArray())
 }
 
-func (p *regexPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
-	d := cc.Dictionary()
-
-	// should we do this?
-	p.matcher.Reset()
-
-	if d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-
-	return true
-}
-
 func (p *regexPredicate) KeepValue(v pq.Value) bool {
 	return p.keep(&v)
 }
 
-func (p *regexPredicate) KeepPage(pq.Page) bool {
-	return true
-}
+func (p *regexPredicate) KeepRange(pq.Value, pq.Value) bool { return true }
 
 type SubstringPredicate struct {
 	substring []byte
@@ -259,17 +217,6 @@ func (p *SubstringPredicate) String() string {
 	return fmt.Sprintf("SubstringPredicate{%s}", p.substring)
 }
 
-func (p *SubstringPredicate) KeepColumnChunk(cc *ColumnChunkHelper) bool {
-	// Reset match cache on each row group change
-	p.matches = make(map[string]bool, len(p.matches))
-
-	if d := cc.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-
-	return true
-}
-
 func (p *SubstringPredicate) KeepValue(v pq.Value) bool {
 	b := v.ByteArray()
 
@@ -286,9 +233,7 @@ func (p *SubstringPredicate) KeepValue(v pq.Value) bool {
 	return matched
 }
 
-func (p *SubstringPredicate) KeepPage(pq.Page) bool {
-	return true
-}
+func (p *SubstringPredicate) KeepRange(pq.Value, pq.Value) bool { return true }
 
 // IntBetweenPredicate checks for int between the bounds [min,max] inclusive
 type IntBetweenPredicate struct {
@@ -305,32 +250,13 @@ func (p *IntBetweenPredicate) String() string {
 	return fmt.Sprintf("IntBetweenPredicate{%d,%d}", p.min, p.max)
 }
 
-func (p *IntBetweenPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			minVal := ci.MinValue(i).Int64()
-			maxVal := ci.MaxValue(i).Int64()
-			if p.max >= minVal && p.min <= maxVal {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
 func (p *IntBetweenPredicate) KeepValue(v pq.Value) bool {
 	vv := v.Int64()
 	return p.min <= vv && vv <= p.max
 }
 
-func (p *IntBetweenPredicate) KeepPage(page pq.Page) bool {
-	if minVal, maxVal, ok := page.Bounds(); ok {
-		return p.max >= minVal.Int64() && p.min <= maxVal.Int64()
-	}
-	return true
+func (p *IntBetweenPredicate) KeepRange(min, max pq.Value) bool {
+	return p.max >= min.Int64() && p.min <= max.Int64()
 }
 
 // GenericPredicate with callbacks to evaluate data of type T
@@ -356,42 +282,15 @@ func (p *GenericPredicate[T]) String() string {
 	return "GenericPredicate{}"
 }
 
-func (p *GenericPredicate[T]) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
+func (p *GenericPredicate[T]) KeepValue(v pq.Value) bool {
+	return p.Fn(p.Extract(v))
+}
 
+func (p *GenericPredicate[T]) KeepRange(min, max pq.Value) bool {
 	if p.RangeFn == nil {
 		return true
 	}
-
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			minVal := p.Extract(ci.MinValue(i))
-			maxVal := p.Extract(ci.MaxValue(i))
-			if p.RangeFn(minVal, maxVal) {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
-}
-
-func (p *GenericPredicate[T]) KeepPage(page pq.Page) bool {
-	if p.RangeFn != nil {
-		if min, max, ok := page.Bounds(); ok {
-			return p.RangeFn(p.Extract(min), p.Extract(max))
-		}
-	}
-
-	return true
-}
-
-func (p *GenericPredicate[T]) KeepValue(v pq.Value) bool {
-	return p.Fn(p.Extract(v))
+	return p.RangeFn(p.Extract(min), p.Extract(max))
 }
 
 type OrPredicate struct {
@@ -418,36 +317,6 @@ func (p *OrPredicate) String() string {
 	return fmt.Sprintf("OrPredicate{%s}", strings.Join(preds, ","))
 }
 
-func (p *OrPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	ret := false
-	for _, p := range p.preds {
-		if p == nil {
-			// Nil means all values are returned
-			ret = ret || true
-			continue
-		}
-		if p.KeepColumnChunk(c) {
-			ret = ret || true
-		}
-	}
-
-	return ret
-}
-
-func (p *OrPredicate) KeepPage(page pq.Page) bool {
-	for _, p := range p.preds {
-		if p == nil {
-			// Nil means all values are returned
-			return true
-		}
-		if p.KeepPage(page) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func (p *OrPredicate) KeepValue(v pq.Value) bool {
 	for _, p := range p.preds {
 		if p == nil {
@@ -462,14 +331,24 @@ func (p *OrPredicate) KeepValue(v pq.Value) bool {
 	return false
 }
 
+func (p *OrPredicate) KeepRange(min, max pq.Value) bool {
+	for _, sub := range p.preds {
+		if sub == nil || sub.KeepRange(min, max) {
+			// Nil means all values are returned
+			return true
+		}
+	}
+	return false
+}
+
 type InstrumentedPredicate struct {
-	Pred                  Predicate // Optional, if missing then just keeps metrics with no filtering
-	InspectedColumnChunks int64
-	InspectedPages        int64
-	InspectedValues       int64
-	KeptColumnChunks      int64
-	KeptPages             int64
-	KeptValues            int64
+	Pred Predicate // Optional, if missing then just keeps metrics with no filtering
+	// predicateStats holds the chunk/page counters (InspectedColumnChunks,
+	// KeptColumnChunks, InspectedPages, KeptPages), incremented by the iterator's
+	// keep* helpers which take &predicateStats. Promoted fields keep the public API.
+	predicateStats
+	InspectedValues int64
+	KeptValues      int64
 }
 
 var _ Predicate = (*InstrumentedPredicate)(nil)
@@ -479,28 +358,6 @@ func (p *InstrumentedPredicate) String() string {
 		return fmt.Sprintf("InstrumentedPredicate{%d, nil}", p.InspectedValues)
 	}
 	return fmt.Sprintf("InstrumentedPredicate{%d, %s}", p.InspectedValues, p.Pred)
-}
-
-func (p *InstrumentedPredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	p.InspectedColumnChunks++
-
-	if p.Pred == nil || p.Pred.KeepColumnChunk(c) {
-		p.KeptColumnChunks++
-		return true
-	}
-
-	return false
-}
-
-func (p *InstrumentedPredicate) KeepPage(page pq.Page) bool {
-	p.InspectedPages++
-
-	if p.Pred == nil || p.Pred.KeepPage(page) {
-		p.KeptPages++
-		return true
-	}
-
-	return false
 }
 
 func (p *InstrumentedPredicate) KeepValue(v pq.Value) bool {
@@ -514,18 +371,11 @@ func (p *InstrumentedPredicate) KeepValue(v pq.Value) bool {
 	return false
 }
 
-// keepDictionary inspects all values using the callback and returns if any
-// matches were found.
-func keepDictionary(dict pq.Dictionary, keepValue func(pq.Value) bool) bool {
-	l := dict.Len()
-	for i := 0; i < l; i++ {
-		dictionaryEntry := dict.Index(int32(i))
-		if keepValue(dictionaryEntry) {
-			return true
-		}
+func (p *InstrumentedPredicate) KeepRange(min, max pq.Value) bool {
+	if p.Pred == nil {
+		return true
 	}
-
-	return false
+	return p.Pred.KeepRange(min, max)
 }
 
 type SkipNilsPredicate struct{}
@@ -540,17 +390,11 @@ func (p *SkipNilsPredicate) String() string {
 	return "SkipNilsPredicate{}"
 }
 
-func (p *SkipNilsPredicate) KeepColumnChunk(*ColumnChunkHelper) bool {
-	return true
-}
-
-func (p *SkipNilsPredicate) KeepPage(page pq.Page) bool {
-	return page.NumValues() > page.NumNulls()
-}
-
 func (p *SkipNilsPredicate) KeepValue(v pq.Value) bool {
 	return !v.IsNull()
 }
+
+func (p *SkipNilsPredicate) KeepRange(pq.Value, pq.Value) bool { return true }
 
 type CallbackPredicate struct {
 	cb func() bool
@@ -564,11 +408,9 @@ func NewCallbackPredicate(cb func() bool) *CallbackPredicate {
 
 func (m *CallbackPredicate) String() string { return "CallbackPredicate{}" }
 
-func (m *CallbackPredicate) KeepColumnChunk(*ColumnChunkHelper) bool { return m.cb() }
-
-func (m *CallbackPredicate) KeepPage(pq.Page) bool { return m.cb() }
-
 func (m *CallbackPredicate) KeepValue(pq.Value) bool { return m.cb() }
+
+func (m *CallbackPredicate) KeepRange(pq.Value, pq.Value) bool { return m.cb() }
 
 var _ Predicate = (*NilValuePredicate)(nil)
 
@@ -582,27 +424,11 @@ func (p NilValuePredicate) String() string {
 	return "NilValuePredicate{}"
 }
 
-func (p NilValuePredicate) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := range ci.NumPages() {
-			if ci.NullCount(i) > 0 {
-				// At least one page in this chunk matches
-				return true
-			}
-		}
-		return false
-	}
-	return true
-}
-
-func (p NilValuePredicate) KeepPage(page pq.Page) bool {
-	return page.NumNulls() > 0
-}
-
 func (p NilValuePredicate) KeepValue(v pq.Value) bool {
 	return v.IsNull()
 }
+
+func (p NilValuePredicate) KeepRange(pq.Value, pq.Value) bool { return false }
 
 type IncludeNilStringEqualPredicate struct {
 	value []byte
@@ -616,15 +442,9 @@ func (p IncludeNilStringEqualPredicate) String() string {
 	return "IncludeNilStringEqualPredicate{}"
 }
 
-func (p IncludeNilStringEqualPredicate) KeepColumnChunk(_ *ColumnChunkHelper) bool {
-	return true
-}
-
-func (p IncludeNilStringEqualPredicate) KeepPage(_ pq.Page) bool {
-	return true
-}
-
 func (p IncludeNilStringEqualPredicate) KeepValue(v pq.Value) bool {
 	vv := v.ByteArray()
 	return bytes.Equal(vv, p.value)
 }
+
+func (p IncludeNilStringEqualPredicate) KeepRange(pq.Value, pq.Value) bool { return true }

--- a/pkg/parquetquery/predicates_test.go
+++ b/pkg/parquetquery/predicates_test.go
@@ -17,10 +17,7 @@ type testInt struct {
 }
 
 type mockPredicate struct {
-	ret         bool
-	valCalled   bool
-	pageCalled  bool
-	chunkCalled bool
+	ret bool
 }
 
 type testDictString struct {
@@ -29,20 +26,22 @@ type testDictString struct {
 
 var _ Predicate = (*mockPredicate)(nil)
 
-func newAlwaysTruePredicate() *mockPredicate {
-	return &mockPredicate{ret: true}
+func (p *mockPredicate) String() string                              { return "mockPredicate{}" }
+func (p *mockPredicate) KeepValue(parquet.Value) bool                { return p.ret }
+func (p *mockPredicate) KeepRange(parquet.Value, parquet.Value) bool { return p.ret }
+
+func TestKeepRange(t *testing.T) {
+	i64 := func(v int64) parquet.Value { return parquet.Int64Value(v) }
+	ba := func(s string) parquet.Value { return parquet.ByteArrayValue([]byte(s)) }
+
+	require.True(t, NewIntBetweenPredicate(5, 10).KeepRange(i64(0), i64(7)))
+	require.False(t, NewIntBetweenPredicate(5, 10).KeepRange(i64(0), i64(4)))
+	require.True(t, NewByteInPredicate([][]byte{[]byte("m")}).KeepRange(ba("a"), ba("z")))
+	require.False(t, NewByteInPredicate([][]byte{[]byte("zz")}).KeepRange(ba("a"), ba("m")))
+	require.True(t, NewSubstringPredicate("x").KeepRange(ba("a"), ba("b"))) // unbounded → true
+	require.False(t, NilValuePredicate{}.KeepRange(ba("a"), ba("z")))       // never matches a present value
+	require.True(t, NewSkipNilsPredicate().KeepRange(ba("a"), ba("z")))
 }
-
-func newAlwaysFalsePredicate() *mockPredicate {
-	return &mockPredicate{ret: false}
-}
-
-func (p *mockPredicate) String() string               { return "mockPredicate{}" }
-func (p *mockPredicate) KeepValue(parquet.Value) bool { p.valCalled = true; return p.ret }
-
-func (p *mockPredicate) KeepPage(parquet.Page) bool { p.pageCalled = true; return p.ret }
-
-func (p *mockPredicate) KeepColumnChunk(*ColumnChunkHelper) bool { p.chunkCalled = true; return p.ret }
 
 type predicateTestCase struct {
 	testName   string
@@ -285,57 +284,6 @@ func TestNewRegexNotInPredicate(t *testing.T) {
 		t.Run(tC.testName, func(t *testing.T) {
 			testPredicate(t, tC)
 		})
-	}
-}
-
-// TestOrPredicateCallsKeepColumnChunk ensures that the OrPredicate calls
-// KeepColumnChunk on all of its children. This is important because the
-// Dictionary predicates rely on KeepColumnChunk always being called at the
-// beginning of a row group to reset their page.
-func TestOrPredicateCallsKeepColumnChunk(t *testing.T) {
-	tcs := []struct {
-		preds []*mockPredicate
-	}{
-		{},
-		{
-			preds: []*mockPredicate{
-				newAlwaysTruePredicate(),
-			},
-		},
-		{
-			preds: []*mockPredicate{
-				newAlwaysFalsePredicate(),
-			},
-		},
-		{
-			preds: []*mockPredicate{
-				newAlwaysFalsePredicate(),
-				newAlwaysTruePredicate(),
-			},
-		},
-		{
-			preds: []*mockPredicate{
-				newAlwaysTruePredicate(),
-				newAlwaysFalsePredicate(),
-			},
-		},
-	}
-
-	for _, tc := range tcs {
-		preds := make([]Predicate, 0, len(tc.preds)+1)
-		for _, pred := range tc.preds {
-			preds = append(preds, pred)
-		}
-
-		recordPred := &mockPredicate{}
-		preds = append(preds, recordPred)
-
-		p := NewOrPredicate(preds...)
-		p.KeepColumnChunk(nil)
-
-		for _, pred := range preds {
-			require.True(t, pred.(*mockPredicate).chunkCalled)
-		}
 	}
 }
 

--- a/pkg/parquetquery/predicates_test.go
+++ b/pkg/parquetquery/predicates_test.go
@@ -31,7 +31,7 @@ func (p *mockPredicate) KeepValue(parquet.Value) bool                { return p.
 func (p *mockPredicate) KeepRange(parquet.Value, parquet.Value) bool { return p.ret }
 
 func TestKeepRange(t *testing.T) {
-	i64 := func(v int64) parquet.Value { return parquet.Int64Value(v) }
+	i64 := parquet.Int64Value
 	ba := func(s string) parquet.Value { return parquet.ByteArrayValue([]byte(s)) }
 
 	require.True(t, NewIntBetweenPredicate(5, 10).KeepRange(i64(0), i64(7)))
@@ -301,9 +301,9 @@ func testPredicate(t *testing.T, tc predicateTestCase) {
 	r, err := parquet.OpenFile(file, int64(buf.Len()))
 	require.NoError(t, err)
 
-	p := InstrumentedPredicate{Pred: tc.predicate}
-
-	i := NewSyncIterator(context.TODO(), r.RowGroups(), 0, SyncIteratorOptPredicate(&p))
+	var stats PredicateStats
+	i := NewSyncIterator(context.TODO(), r.RowGroups(), 0,
+		SyncIteratorOptPredicate(tc.predicate), SyncIteratorOptStats(&stats))
 	for {
 		res, err := i.Next()
 		require.NoError(t, err)
@@ -312,9 +312,9 @@ func testPredicate(t *testing.T, tc predicateTestCase) {
 		}
 	}
 
-	require.Equal(t, tc.keptChunks, int(p.KeptColumnChunks), "keptChunks")
-	require.Equal(t, tc.keptPages, int(p.KeptPages), "keptPages")
-	require.Equal(t, tc.keptValues, int(p.KeptValues), "keptValues")
+	require.Equal(t, tc.keptChunks, int(stats.KeptColumnChunks), "keptChunks")
+	require.Equal(t, tc.keptPages, int(stats.KeptPages), "keptPages")
+	require.Equal(t, tc.keptValues, int(stats.KeptValues), "keptValues")
 }
 
 func BenchmarkSubstringPredicate(b *testing.B) {

--- a/pkg/parquetquerygen/predicates.go
+++ b/pkg/parquetquerygen/predicates.go
@@ -47,55 +47,22 @@ func (p {{ $structName }}) String() string {
 	return fmt.Sprintf("{{ $structName }}{{"{"}}{{ $pred.FormatModifier }}{{"}"}}", p.value)
 }
 
-func (p {{ $structName }}) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-
-	{{- if gt (.RangeCond | strlen) 0 }}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			if ci.NullPage(i) {
-				// This page only contains nulls so the min/max metadata is not
-				// recorded and this page does not contain any values.
-				continue
-			}
-
-			{{ if $minInRange }}min := ci.MinValue(i).{{ $pred.ParquetFunc }}{{end}}
-			{{ if $maxInRange }}max := ci.MaxValue(i).{{ $pred.ParquetFunc }}{{end}}
-
-			if {{ .RangeCond }} {
-				return true
-			}
-		}
-		return false
-	}
-	{{- end }}
-
-	return true
-}
-
-func (p {{ $structName }}) KeepPage(page pq.Page) bool {
-	{{- if gt (.RangeCond | strlen) 0 }}
-	{{ if $minInRange }}minV{{else}}_{{end}}, {{ if $maxInRange }}maxV{{else}}_{{end}}, ok := page.Bounds()
-	if ok {
-		{{ if $minInRange }}min := minV.{{ $pred.ParquetFunc }}{{end}}
-		{{ if $maxInRange }}max := maxV.{{ $pred.ParquetFunc }}{{end}}
-
-		return {{ .RangeCond }}
-	}
-	{{- end }}
-
-	return true
-}
-
 func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
 	}
 	vv := v.{{ $pred.ParquetFunc }}
 	return {{ .CompareCond }}
+}
+
+func (p {{ $structName }}) KeepRange(minV, maxV pq.Value) bool {
+	{{- if gt (.RangeCond | strlen) 0 }}
+	{{ if $minInRange }}min := minV.{{ $pred.ParquetFunc }}{{end}}
+	{{ if $maxInRange }}max := maxV.{{ $pred.ParquetFunc }}{{end}}
+	return {{ .RangeCond }}
+	{{- else }}
+	return true
+	{{- end }}
 }
 {{- end }}
 {{- end }}
@@ -117,45 +84,6 @@ func New{{ $structName }}(vals []{{$pred.Type}}) {{ $structName }} {
 
 func (p {{ $structName }}) String() string { return fmt.Sprintf("{{ $structName }}{%v}", p.values) }
 
-func (p {{ $structName }}) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	{{- if or (eq $pred.Name "Int") (eq $pred.Name "Float") }}
-	ci, err := c.ColumnIndex()
-	if err == nil && ci != nil {
-		for i := 0; i < ci.NumPages(); i++ {
-			min := ci.MinValue(i).{{ $pred.ParquetFunc }}
-			max := ci.MaxValue(i).{{ $pred.ParquetFunc }}
-			for _, v := range p.values {
-				if min <= v && v <= max {
-					return true
-				}
-			}
-		}
-		return false
-	}
-	{{- end }}
-	return true
-}
-
-func (p {{ $structName }}) KeepPage(page pq.Page) bool {
-	{{- if or (eq $pred.Name "Int") (eq $pred.Name "Float") }}
-	minV, maxV, ok := page.Bounds()
-	if ok {
-		min := minV.{{ $pred.ParquetFunc }}
-		max := maxV.{{ $pred.ParquetFunc }}
-		for _, v := range p.values {
-			if min <= v && v <= max {
-				return true
-			}
-		}
-		return false
-	}
-	{{- end }}
-	return true
-}
-
 func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -167,6 +95,21 @@ func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 		}
 	}
 	return false
+}
+
+func (p {{ $structName }}) KeepRange(minV, maxV pq.Value) bool {
+	{{- if or (eq $pred.Name "Int") (eq $pred.Name "Float") }}
+	min := minV.{{ $pred.ParquetFunc }}
+	max := maxV.{{ $pred.ParquetFunc }}
+	for _, v := range p.values {
+		if min <= v && v <= max {
+			return true
+		}
+	}
+	return false
+	{{- else }}
+	return true
+	{{- end }}
 }
 
 {{- $structName := printf "%sNotInPredicate" $pred.Name }}
@@ -184,17 +127,6 @@ func (p {{ $structName }}) String() string {
 	return fmt.Sprintf("{{ $structName }}{%v}", p.values)
 }
 
-func (p {{ $structName }}) KeepColumnChunk(c *ColumnChunkHelper) bool {
-	if d := c.Dictionary(); d != nil {
-		return keepDictionary(d, p.KeepValue)
-	}
-	return true
-}
-
-func (p {{ $structName }}) KeepPage(page pq.Page) bool { 
-	return true
-}
-
 func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 	if v.IsNull() {
 		return false
@@ -207,6 +139,8 @@ func (p {{ $structName }}) KeepValue(v pq.Value) bool {
 	}
 	return true
 }
+
+func (p {{ $structName }}) KeepRange(pq.Value, pq.Value) bool { return true }
 {{- end }}
 {{- end }}
 `

--- a/tempodb/encoding/vparquet3/block_search.go
+++ b/tempodb/encoding/vparquet3/block_search.go
@@ -436,46 +436,21 @@ func (r *reportValuesPredicate) String() string {
 	return "reportValuesPredicate{}"
 }
 
-// KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
-// and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column.
+// KeepValue reports every present value to r.cb and returns false so the iterator
+// does no extra work. The generic keepColumnChunk helper drives this over the
+// column-chunk dictionary when present (reporting each distinct value once, then
+// skipping the pages) and over each value otherwise.
 //
-// Once cb has asked to stop we return true instead, so the iterator produces a match and
-// hands control back to the caller rather than walking every remaining row group.
-func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
-	if r.stop {
-		return true
-	}
-
-	if d := cc.Dictionary(); d != nil {
-		for i := 0; i < d.Len(); i++ {
-			v := d.Index(int32(i))
-			if callback(r.cb, v) {
-				r.stop = true
-				return true
-			}
-		}
-
-		// No need to check the pages since this was a dictionary
-		// column.
-		return false
-	}
-
-	return true
-}
-
-// KeepPage always returns true because if we get this far we need to
-// inspect each individual value.
-func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
-	return true
-}
-
-// KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator does not do any extra work. Once cb has asked to stop we
-// return true so the iterator yields a match and the caller can abandon the scan.
+// Once cb has asked to stop we return true so the iterator yields a match and the
+// caller can abandon the scan. The null probe keepColumnChunk/keepPage use to test
+// null rows is not a reportable value, so it is skipped.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 	if r.stop {
 		return true
+	}
+
+	if v.IsNull() {
+		return false
 	}
 
 	if callback(r.cb, v) {
@@ -485,6 +460,11 @@ func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 
 	return false
 }
+
+// KeepRange keeps everything: this predicate reports all present values rather
+// than filtering by range. Dictionary reporting happens via KeepValue over the
+// dictionary in the generic chunk helper.
+func (r *reportValuesPredicate) KeepRange(parquet.Value, parquet.Value) bool { return true }
 
 func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {

--- a/tempodb/encoding/vparquet3/block_search.go
+++ b/tempodb/encoding/vparquet3/block_search.go
@@ -433,39 +433,21 @@ func (r *reportValuesPredicate) String() string {
 	return "reportValuesPredicate{}"
 }
 
-// KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
-// and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column
-func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
-	if d := cc.Dictionary(); d != nil {
-		for i := 0; i < d.Len(); i++ {
-			v := d.Index(int32(i))
-			if callback(r.cb, v) {
-				break
-			}
-		}
-
-		// No need to check the pages since this was a dictionary
-		// column.
-		return false
-	}
-
-	return true
-}
-
-// KeepPage always returns true because if we get this far we need to
-// inspect each individual value.
-func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
-	return true
-}
-
-// KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator do any extra work.
+// KeepValue reports every present value to r.cb and returns false so the iterator
+// does no extra work. The generic keepColumnChunk helper drives this over the
+// column-chunk dictionary when present (reporting each distinct value once, then
+// skipping the pages) and over each value otherwise.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
-	callback(r.cb, v)
-
+	if !v.IsNull() {
+		callback(r.cb, v)
+	}
 	return false
 }
+
+// KeepRange keeps everything: this predicate reports all present values rather
+// than filtering by range. Dictionary reporting happens via KeepValue over the
+// dictionary in the generic chunk helper.
+func (r *reportValuesPredicate) KeepRange(parquet.Value, parquet.Value) bool { return true }
 
 func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -443,39 +443,21 @@ func (r *reportValuesPredicate) String() string {
 	return "reportValuesPredicate{}"
 }
 
-// KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
-// and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column
-func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
-	if d := cc.Dictionary(); d != nil {
-		for i := 0; i < d.Len(); i++ {
-			v := d.Index(int32(i))
-			if callback(r.cb, v) {
-				break
-			}
-		}
-
-		// No need to check the pages since this was a dictionary
-		// column.
-		return false
-	}
-
-	return true
-}
-
-// KeepPage always returns true because if we get this far we need to
-// inspect each individual value.
-func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
-	return true
-}
-
-// KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator do any extra work.
+// KeepValue reports every present value to r.cb and returns false so the iterator
+// does no extra work. The generic keepColumnChunk helper drives this over the
+// column-chunk dictionary when present (reporting each distinct value once, then
+// skipping the pages) and over each value otherwise.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
-	callback(r.cb, v)
-
+	if !v.IsNull() {
+		callback(r.cb, v)
+	}
 	return false
 }
+
+// KeepRange keeps everything: this predicate reports all present values rather
+// than filtering by range. Dictionary reporting happens via KeepValue over the
+// dictionary in the generic chunk helper.
+func (r *reportValuesPredicate) KeepRange(parquet.Value, parquet.Value) bool { return true }
 
 func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -446,46 +446,21 @@ func (r *reportValuesPredicate) String() string {
 	return "reportValuesPredicate{}"
 }
 
-// KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
-// and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column.
+// KeepValue reports every present value to r.cb and returns false so the iterator
+// does no extra work. The generic keepColumnChunk helper drives this over the
+// column-chunk dictionary when present (reporting each distinct value once, then
+// skipping the pages) and over each value otherwise.
 //
-// Once cb has asked to stop we return true instead, so the iterator produces a match and
-// hands control back to the caller rather than walking every remaining row group.
-func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
-	if r.stop {
-		return true
-	}
-
-	if d := cc.Dictionary(); d != nil {
-		for i := 0; i < d.Len(); i++ {
-			v := d.Index(int32(i))
-			if callback(r.cb, v) {
-				r.stop = true
-				return true
-			}
-		}
-
-		// No need to check the pages since this was a dictionary
-		// column.
-		return false
-	}
-
-	return true
-}
-
-// KeepPage always returns true because if we get this far we need to
-// inspect each individual value.
-func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
-	return true
-}
-
-// KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator does not do any extra work. Once cb has asked to stop we
-// return true so the iterator yields a match and the caller can abandon the scan.
+// Once cb has asked to stop we return true so the iterator yields a match and the
+// caller can abandon the scan. The null probe keepColumnChunk/keepPage use to test
+// null rows is not a reportable value, so it is skipped.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 	if r.stop {
 		return true
+	}
+
+	if v.IsNull() {
+		return false
 	}
 
 	if callback(r.cb, v) {
@@ -495,6 +470,11 @@ func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 
 	return false
 }
+
+// KeepRange keeps everything: this predicate reports all present values rather
+// than filtering by range. Dictionary reporting happens via KeepValue over the
+// dictionary in the generic chunk helper.
+func (r *reportValuesPredicate) KeepRange(parquet.Value, parquet.Value) bool { return true }
 
 func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -1609,14 +1609,12 @@ func BenchmarkIterators(b *testing.B) {
 	rgs := pf.RowGroups()
 	rgs = rgs[3:5]
 
-	var instrPred *parquetquery.InstrumentedPredicate
+	var stats *parquetquery.PredicateStats
 	makeIterInternal := makeIterFunc(ctx, rgs, pf)
 	makeIter := func(columnName string, predicate parquetquery.Predicate, selectAs string) parquetquery.Iterator {
-		instrPred = &parquetquery.InstrumentedPredicate{
-			Pred: predicate,
-		}
+		stats = &parquetquery.PredicateStats{}
 
-		return makeIterInternal(columnName, predicate, selectAs)
+		return makeIterInternal(columnName, predicate, selectAs, parquetquery.SyncIteratorOptStats(stats))
 	}
 
 	b.ResetTimer()
@@ -1634,14 +1632,14 @@ func BenchmarkIterators(b *testing.B) {
 			count++
 		}
 		iter.Close()
-		if instrPred != nil {
+		if stats != nil {
 			b.ReportMetric(float64(count), "count")
-			b.ReportMetric(float64(instrPred.InspectedColumnChunks), "stats_cc")
-			b.ReportMetric(float64(instrPred.KeptColumnChunks), "stats_cc_kept")
-			b.ReportMetric(float64(instrPred.InspectedPages), "stats_ip")
-			b.ReportMetric(float64(instrPred.KeptPages), "stats_ip_kept")
-			b.ReportMetric(float64(instrPred.InspectedValues), "stats_v")
-			b.ReportMetric(float64(instrPred.KeptValues), "stats_v_kept")
+			b.ReportMetric(float64(stats.InspectedColumnChunks), "stats_cc")
+			b.ReportMetric(float64(stats.KeptColumnChunks), "stats_cc_kept")
+			b.ReportMetric(float64(stats.InspectedPages), "stats_ip")
+			b.ReportMetric(float64(stats.KeptPages), "stats_ip_kept")
+			b.ReportMetric(float64(stats.InspectedValues), "stats_v")
+			b.ReportMetric(float64(stats.KeptValues), "stats_v_kept")
 		}
 	}
 }

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -429,39 +429,21 @@ func (r *reportValuesPredicate) String() string {
 	return "reportValuesPredicate{}"
 }
 
-// KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
-// and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column
-func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
-	if d := cc.Dictionary(); d != nil {
-		for i := 0; i < d.Len(); i++ {
-			v := d.Index(int32(i))
-			if callback(r.cb, v) {
-				break
-			}
-		}
-
-		// No need to check the pages since this was a dictionary
-		// column.
-		return false
-	}
-
-	return true
-}
-
-// KeepPage always returns true because if we get this far we need to
-// inspect each individual value.
-func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
-	return true
-}
-
-// KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator do any extra work.
+// KeepValue reports every present value to r.cb and returns false so the iterator
+// does no extra work. The generic keepColumnChunk helper drives this over the
+// column-chunk dictionary when present (reporting each distinct value once, then
+// skipping the pages) and over each value otherwise.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
-	callback(r.cb, v)
-
+	if !v.IsNull() {
+		callback(r.cb, v)
+	}
 	return false
 }
+
+// KeepRange keeps everything: this predicate reports all present values rather
+// than filtering by range. Dictionary reporting happens via KeepValue over the
+// dictionary in the generic chunk helper.
+func (r *reportValuesPredicate) KeepRange(parquet.Value, parquet.Value) bool { return true }
 
 func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -432,46 +432,21 @@ func (r *reportValuesPredicate) String() string {
 	return "reportValuesPredicate{}"
 }
 
-// KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
-// and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column.
+// KeepValue reports every present value to r.cb and returns false so the iterator
+// does no extra work. The generic keepColumnChunk helper drives this over the
+// column-chunk dictionary when present (reporting each distinct value once, then
+// skipping the pages) and over each value otherwise.
 //
-// Once cb has asked to stop we return true instead, so the iterator produces a match and
-// hands control back to the caller rather than walking every remaining row group.
-func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
-	if r.stop {
-		return true
-	}
-
-	if d := cc.Dictionary(); d != nil {
-		for i := 0; i < d.Len(); i++ {
-			v := d.Index(int32(i))
-			if callback(r.cb, v) {
-				r.stop = true
-				return true
-			}
-		}
-
-		// No need to check the pages since this was a dictionary
-		// column.
-		return false
-	}
-
-	return true
-}
-
-// KeepPage always returns true because if we get this far we need to
-// inspect each individual value.
-func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
-	return true
-}
-
-// KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator does not do any extra work. Once cb has asked to stop we
-// return true so the iterator yields a match and the caller can abandon the scan.
+// Once cb has asked to stop we return true so the iterator yields a match and the
+// caller can abandon the scan. The null probe keepColumnChunk/keepPage use to test
+// null rows is not a reportable value, so it is skipped.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 	if r.stop {
 		return true
+	}
+
+	if v.IsNull() {
+		return false
 	}
 
 	if callback(r.cb, v) {
@@ -481,6 +456,11 @@ func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
 
 	return false
 }
+
+// KeepRange keeps everything: this predicate reports all present values rather
+// than filtering by range. Dictionary reporting happens via KeepValue over the
+// dictionary in the generic chunk helper.
+func (r *reportValuesPredicate) KeepRange(parquet.Value, parquet.Value) bool { return true }
 
 func callback(cb common.TagValuesCallbackV2, v parquet.Value) (stop bool) {
 	switch v.Kind() {

--- a/tempodb/encoding/vparquet5/block_traceql_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_test.go
@@ -1828,14 +1828,12 @@ func BenchmarkIterators(b *testing.B) {
 	rgs := pf.RowGroups()
 	rgs = rgs[3:5]
 
-	var instrPred *pq.InstrumentedPredicate
+	var stats *pq.PredicateStats
 	makeIterInternal := makeIterFunc(ctx, rgs, pf)
 	makeIter := func(columnName string, predicate pq.Predicate, selectAs string) pq.Iterator {
-		instrPred = &pq.InstrumentedPredicate{
-			Pred: predicate,
-		}
+		stats = &pq.PredicateStats{}
 
-		return makeIterInternal(columnName, predicate, selectAs)
+		return makeIterInternal(columnName, predicate, selectAs, pq.SyncIteratorOptStats(stats))
 	}
 
 	b.ResetTimer()
@@ -1866,14 +1864,14 @@ func BenchmarkIterators(b *testing.B) {
 			count++
 		}
 		iter.Close()
-		if instrPred != nil {
+		if stats != nil {
 			b.ReportMetric(float64(count), "count")
-			b.ReportMetric(float64(instrPred.InspectedColumnChunks), "stats_cc")
-			b.ReportMetric(float64(instrPred.KeptColumnChunks), "stats_cc_kept")
-			b.ReportMetric(float64(instrPred.InspectedPages), "stats_ip")
-			b.ReportMetric(float64(instrPred.KeptPages), "stats_ip_kept")
-			b.ReportMetric(float64(instrPred.InspectedValues), "stats_v")
-			b.ReportMetric(float64(instrPred.KeptValues), "stats_v_kept")
+			b.ReportMetric(float64(stats.InspectedColumnChunks), "stats_cc")
+			b.ReportMetric(float64(stats.KeptColumnChunks), "stats_cc_kept")
+			b.ReportMetric(float64(stats.InspectedPages), "stats_ip")
+			b.ReportMetric(float64(stats.KeptPages), "stats_ip_kept")
+			b.ReportMetric(float64(stats.InspectedValues), "stats_v")
+			b.ReportMetric(float64(stats.KeptValues), "stats_v_kept")
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does**:

Two internal cleanups to `pkg/parquetquery`, one commit each. No behavior change; prep for generic dictionary-index pushdown (#7536), which lands additively on top.

Generic chunk/page pruning:
- Shrinks `Predicate` to `{ String, KeepValue, KeepRange }` — `KeepColumnChunk`/`KeepPage` are dropped from the interface, all implementers, and the generator.
- Moves pruning into `*SyncIterator` helpers (`predicate_pruning.go`) driven by `KeepValue` + `KeepRange`; the skip decision was already derivable from those two, so the per-predicate methods were redundant (~1000 lines removed, mostly generated).
- Nil iterator drives the shared seek path with `prune=false` — it detects value *absence*, so it must scan every chunk/page.
- `reportValuesPredicate` (vparquet3/4/5) reports via the generic dictionary path, and keeps the `TagValuesCallbackV2` stop latch from #7696 in `KeepValue`.
- Page-level range pruning is skipped on dict-encoded pages: `pg.Bounds()` has no stored min/max there and would rescan every value, and chunk-level dictionary pruning already covers those columns. This keeps the string predicates (whose old `KeepPage` was `return true`) at parity — without it they regressed 50-73% on full scans. Numeric predicates, whose old `KeepPage` did test bounds, keep their page pruning.
- On *plain* (non-dict) columns the generic `keepPage` does apply the bounds test to string predicates, which `ByteInPredicate.KeepPage` never did (it was `return true` behind a `// todo: check bounds`). That is where the trace-by-ID win below comes from. Note this is a trade rather than a free win: no page type stores min/max, so `pg.Bounds()` is an O(n) scan (`byteArrayPage.bounds()` is a `bytes.Compare` per value) — the same objection that motivates skipping it on dict pages also applies here, and it pays off only because it replaces an even more expensive per-value path.

Iterator-native stats:
- Exports `PredicateStats` with added `InspectedValues`/`KeptValues`, attached via a new `SyncIteratorOptStats`; the iterator counts values in its per-row loop and chunk/page decisions in `keepColumnChunk`/`keepPage`.
- Removes `InstrumentedPredicate`, which had no production callers, along with the `pred` field and constructor unwrap it required.
- Fixes a latent bug in `BenchmarkIterators` (vparquet4/5): it built an `InstrumentedPredicate` but passed the raw predicate to the iterator, so every `stats_*` metric reported 0.

**Benchmarks**:

`pkg/parquetquery` microbenchmarks driving `SyncIterator` directly (no TraceQL engine) over columns of a production vParquet5 block — 2.29M traces, 2.39 GB, compaction level 2 — over row groups `[3:5]`. `benchstat`, n=10, old/new interleaved so machine drift is not attributed to the change. Harness is local and throwaway (block path via env var), so nothing is added to the tree.

| benchmark | shape | old | new | delta |
|---|---|---:|---:|---:|
| `RealNilControl` | no predicate (control) | 19.92m | 19.97m | ~ (p=0.353) |
| `RealChunkSkip` | dictionary proves no match, chunk pruned | 5.931m | 6.157m | +3.81% |
| `RealFullScan` | matches a real dictionary entry, full scan | 59.07m | 58.55m | ~ (p=0.165) |
| `RealPageSkip` | single trace ID against the block sort key | 994.6µ | 691.6µ | **-30.46%** |
| `RealIntFullScan` | range spanning every span start time | 23.96m | 24.24m | +1.18% |
| geomean | | 11.07m | 10.38m | **-6.21%** |

Deltas are p=0.000 unless noted. `RealPageSkip` also drops allocations 14% (99 → 85/op).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated — `TestKeepHelpersMatchValueOracle` checks `keepColumnChunk`/`keepPage` against a per-value oracle for every predicate type; `TestKeepPagePrunesByBounds` covers page-level pruning on a plain (non-dict) column; `TestStatsCountOnlyRowValues` pins that helper probes don't inflate the value counters; plus `TestKeepRange`, `TestKeepStatsCounters`, `TestResetForChunkCascades`
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` — internal refactor, no user-facing change
