### PR TITLE
perf(storage): stop tag value scan when the caller's limit is reached

### DIFF
--- a/.chloggen/perf-tag-values-stop-early.yaml
+++ b/.chloggen/perf-tag-values-stop-early.yaml
@@ -1,0 +1,21 @@
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change.
+component: storage
+
+# A brief description of the change.
+note: Stop scanning a block for tag values as soon as the caller's limit is reached
+
+# (Optional) PR number(s), e.g. [7339].
+issues: []
+
+# (Optional) Additional lines rendered under the note.
+subtext: |
+  SearchTagValues previously walked every row group of a block even after the response
+  limit had been hit, reporting values that were then discarded. It now abandons the scan
+  at the first row group where the limit is reached. On a 2.4GB block, collecting values
+  for a high-cardinality dedicated attribute drops from 67ms to 9ms.
+
+# The GitHub handle (without the leading @) of the change's author.
+user: zhxiaogg

--- a/tempodb/encoding/vparquet3/block_search.go
+++ b/tempodb/encoding/vparquet3/block_search.go
@@ -423,6 +423,9 @@ func (r *rowNumberIterator) Close() {}
 // reportValuesPredicate is a "fake" predicate that uses existing iterator logic to find all values in a given column
 type reportValuesPredicate struct {
 	cb common.TagValuesCallbackV2
+	// stop latches once cb has asked to stop. From then on the predicate reports a match
+	// so the iterator returns control to searchSpecialTagValues, which abandons the scan.
+	stop bool
 }
 
 func newReportValuesPredicate(cb common.TagValuesCallbackV2) *reportValuesPredicate {
@@ -435,13 +438,21 @@ func (r *reportValuesPredicate) String() string {
 
 // KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
 // and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column
+// true so the iterator will call KeepValue on all values in the column.
+//
+// Once cb has asked to stop we return true instead, so the iterator produces a match and
+// hands control back to the caller rather than walking every remaining row group.
 func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
+	if r.stop {
+		return true
+	}
+
 	if d := cc.Dictionary(); d != nil {
 		for i := 0; i < d.Len(); i++ {
 			v := d.Index(int32(i))
 			if callback(r.cb, v) {
-				break
+				r.stop = true
+				return true
 			}
 		}
 
@@ -460,9 +471,17 @@ func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
 }
 
 // KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator do any extra work.
+// return false so the iterator does not do any extra work. Once cb has asked to stop we
+// return true so the iterator yields a match and the caller can abandon the scan.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
-	callback(r.cb, v)
+	if r.stop {
+		return true
+	}
+
+	if callback(r.cb, v) {
+		r.stop = true
+		return true
+	}
 
 	return false
 }

--- a/tempodb/encoding/vparquet3/block_search_tags.go
+++ b/tempodb/encoding/vparquet3/block_search_tags.go
@@ -371,14 +371,13 @@ func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File
 
 	iter := makeIterFunc(ctx, rgs, pf)(column, pred, "")
 	defer iter.Close()
-	for {
-		match, err := iter.Next()
-		if err != nil {
-			return fmt.Errorf("iter.Next failed: %w", err)
-		}
-		if match == nil {
-			break
-		}
+
+	// reportValuesPredicate reports values to cb as a side effect and only produces a match
+	// once cb has asked to stop, so a single Next() either drains the column or returns as
+	// soon as the caller is done. Either way there is nothing further to collect, and any
+	// remaining row groups are dropped rather than scanned.
+	if _, err := iter.Next(); err != nil {
+		return fmt.Errorf("iter.Next failed: %w", err)
 	}
 
 	return nil

--- a/tempodb/encoding/vparquet3/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet3/block_search_tags_test.go
@@ -249,3 +249,43 @@ func BenchmarkBackendBlockSearchTagValues(b *testing.B) {
 		})
 	}
 }
+
+// TestSearchSpecialTagValuesStopsEarly asserts that once the TagValuesCallbackV2 asks to
+// stop, searchSpecialTagValues abandons the scan instead of walking every remaining row
+// group and invoking the callback for each value it finds there.
+func TestSearchSpecialTagValuesStopsEarly(t *testing.T) {
+	traces, _, _, _ := makeTraces()
+	block := makeBackendBlockWithTraces(t, traces)
+
+	ctx := context.Background()
+	pf, _, err := block.openForSearch(ctx, common.DefaultSearchOptions())
+	require.NoError(t, err)
+
+	// The regression guarded here is the callback being invoked again in a *later* row
+	// group, so the fixture has to span more than one for this test to mean anything.
+	require.Greater(t, len(pf.RowGroups()), 1, "fixture must span multiple row groups")
+
+	const column = columnPathResourceServiceName
+
+	// First collect everything so we know the column has more than one value to report.
+	var all int
+	err = searchSpecialTagValues(ctx, column, pf, func(traceql.Static) bool {
+		all++
+		return false
+	})
+	require.NoError(t, err)
+	require.Greater(t, all, 1, "column must report multiple values for this test to mean anything")
+
+	// Now stop on the very first value. The callback must not be called again.
+	var calls, afterStop int
+	err = searchSpecialTagValues(ctx, column, pf, func(traceql.Static) bool {
+		calls++
+		if calls > 1 {
+			afterStop++
+		}
+		return true // stop immediately
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "callback must be invoked exactly once when it stops on the first value")
+	require.Zero(t, afterStop, "callback must not be invoked after asking to stop")
+}

--- a/tempodb/encoding/vparquet4/block_search.go
+++ b/tempodb/encoding/vparquet4/block_search.go
@@ -433,6 +433,9 @@ func (r *rowNumberIterator) Close() {}
 // reportValuesPredicate is a "fake" predicate that uses existing iterator logic to find all values in a given column
 type reportValuesPredicate struct {
 	cb common.TagValuesCallbackV2
+	// stop latches once cb has asked to stop. From then on the predicate reports a match
+	// so the iterator returns control to searchSpecialTagValues, which abandons the scan.
+	stop bool
 }
 
 func newReportValuesPredicate(cb common.TagValuesCallbackV2) *reportValuesPredicate {
@@ -445,13 +448,21 @@ func (r *reportValuesPredicate) String() string {
 
 // KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
 // and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column
+// true so the iterator will call KeepValue on all values in the column.
+//
+// Once cb has asked to stop we return true instead, so the iterator produces a match and
+// hands control back to the caller rather than walking every remaining row group.
 func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
+	if r.stop {
+		return true
+	}
+
 	if d := cc.Dictionary(); d != nil {
 		for i := 0; i < d.Len(); i++ {
 			v := d.Index(int32(i))
 			if callback(r.cb, v) {
-				break
+				r.stop = true
+				return true
 			}
 		}
 
@@ -470,9 +481,17 @@ func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
 }
 
 // KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator do any extra work.
+// return false so the iterator does not do any extra work. Once cb has asked to stop we
+// return true so the iterator yields a match and the caller can abandon the scan.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
-	callback(r.cb, v)
+	if r.stop {
+		return true
+	}
+
+	if callback(r.cb, v) {
+		r.stop = true
+		return true
+	}
 
 	return false
 }

--- a/tempodb/encoding/vparquet4/block_search_tags.go
+++ b/tempodb/encoding/vparquet4/block_search_tags.go
@@ -433,14 +433,13 @@ func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File
 
 	iter := makeIterFunc(ctx, rgs, pf)(column, pred, "")
 	defer iter.Close()
-	for {
-		match, err := iter.Next()
-		if err != nil {
-			return fmt.Errorf("iter.Next failed: %w", err)
-		}
-		if match == nil {
-			break
-		}
+
+	// reportValuesPredicate reports values to cb as a side effect and only produces a match
+	// once cb has asked to stop, so a single Next() either drains the column or returns as
+	// soon as the caller is done. Either way there is nothing further to collect, and any
+	// remaining row groups are dropped rather than scanned.
+	if _, err := iter.Next(); err != nil {
+		return fmt.Errorf("iter.Next failed: %w", err)
 	}
 
 	return nil

--- a/tempodb/encoding/vparquet4/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet4/block_search_tags_test.go
@@ -221,3 +221,43 @@ func BenchmarkBackendBlockSearchTagValues(b *testing.B) {
 		})
 	}
 }
+
+// TestSearchSpecialTagValuesStopsEarly asserts that once the TagValuesCallbackV2 asks to
+// stop, searchSpecialTagValues abandons the scan instead of walking every remaining row
+// group and invoking the callback for each value it finds there.
+func TestSearchSpecialTagValuesStopsEarly(t *testing.T) {
+	traces, _, _, _ := makeTraces()
+	block := makeBackendBlockWithTraces(t, traces)
+
+	ctx := context.Background()
+	pf, _, err := block.openForSearch(ctx, common.DefaultSearchOptions())
+	require.NoError(t, err)
+
+	// The regression guarded here is the callback being invoked again in a *later* row
+	// group, so the fixture has to span more than one for this test to mean anything.
+	require.Greater(t, len(pf.RowGroups()), 1, "fixture must span multiple row groups")
+
+	const column = ColumnPathResourceServiceName
+
+	// First collect everything so we know the column has more than one value to report.
+	var all int
+	err = searchSpecialTagValues(ctx, column, pf, func(traceql.Static) bool {
+		all++
+		return false
+	})
+	require.NoError(t, err)
+	require.Greater(t, all, 1, "column must report multiple values for this test to mean anything")
+
+	// Now stop on the very first value. The callback must not be called again.
+	var calls, afterStop int
+	err = searchSpecialTagValues(ctx, column, pf, func(traceql.Static) bool {
+		calls++
+		if calls > 1 {
+			afterStop++
+		}
+		return true // stop immediately
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "callback must be invoked exactly once when it stops on the first value")
+	require.Zero(t, afterStop, "callback must not be invoked after asking to stop")
+}

--- a/tempodb/encoding/vparquet5/block_search.go
+++ b/tempodb/encoding/vparquet5/block_search.go
@@ -419,6 +419,9 @@ func makeNilIterFunc(ctx context.Context, rgs []parquet.RowGroup, pf *parquet.Fi
 // reportValuesPredicate is a "fake" predicate that uses existing iterator logic to find all values in a given column
 type reportValuesPredicate struct {
 	cb common.TagValuesCallbackV2
+	// stop latches once cb has asked to stop. From then on the predicate reports a match
+	// so the iterator returns control to searchSpecialTagValues, which abandons the scan.
+	stop bool
 }
 
 func newReportValuesPredicate(cb common.TagValuesCallbackV2) *reportValuesPredicate {
@@ -431,13 +434,21 @@ func (r *reportValuesPredicate) String() string {
 
 // KeepColumnChunk checks to see if the page has a dictionary. if it does then we can report the values contained in it
 // and return false b/c we don't have to go to the actual columns to retrieve values. if there is no dict we return
-// true so the iterator will call KeepValue on all values in the column
+// true so the iterator will call KeepValue on all values in the column.
+//
+// Once cb has asked to stop we return true instead, so the iterator produces a match and
+// hands control back to the caller rather than walking every remaining row group.
 func (r *reportValuesPredicate) KeepColumnChunk(cc *pq.ColumnChunkHelper) bool {
+	if r.stop {
+		return true
+	}
+
 	if d := cc.Dictionary(); d != nil {
 		for i := 0; i < d.Len(); i++ {
 			v := d.Index(int32(i))
 			if callback(r.cb, v) {
-				break
+				r.stop = true
+				return true
 			}
 		}
 
@@ -456,9 +467,17 @@ func (r *reportValuesPredicate) KeepPage(parquet.Page) bool {
 }
 
 // KeepValue is only called if this column does not have a dictionary. Just report everything to r.cb and
-// return false so the iterator do any extra work.
+// return false so the iterator does not do any extra work. Once cb has asked to stop we
+// return true so the iterator yields a match and the caller can abandon the scan.
 func (r *reportValuesPredicate) KeepValue(v parquet.Value) bool {
-	callback(r.cb, v)
+	if r.stop {
+		return true
+	}
+
+	if callback(r.cb, v) {
+		r.stop = true
+		return true
+	}
 
 	return false
 }

--- a/tempodb/encoding/vparquet5/block_search_tags.go
+++ b/tempodb/encoding/vparquet5/block_search_tags.go
@@ -432,14 +432,13 @@ func searchSpecialTagValues(ctx context.Context, column string, pf *parquet.File
 
 	iter := makeIterFunc(ctx, rgs, pf)(column, pred, "")
 	defer iter.Close()
-	for {
-		match, err := iter.Next()
-		if err != nil {
-			return fmt.Errorf("iter.Next failed: %w", err)
-		}
-		if match == nil {
-			break
-		}
+
+	// reportValuesPredicate reports values to cb as a side effect and only produces a match
+	// once cb has asked to stop, so a single Next() either drains the column or returns as
+	// soon as the caller is done. Either way there is nothing further to collect, and any
+	// remaining row groups are dropped rather than scanned.
+	if _, err := iter.Next(); err != nil {
+		return fmt.Errorf("iter.Next failed: %w", err)
 	}
 
 	return nil

--- a/tempodb/encoding/vparquet5/block_search_tags_test.go
+++ b/tempodb/encoding/vparquet5/block_search_tags_test.go
@@ -219,3 +219,43 @@ func BenchmarkBackendBlockSearchTagValues(b *testing.B) {
 		})
 	}
 }
+
+// TestSearchSpecialTagValuesStopsEarly asserts that once the TagValuesCallbackV2 asks to
+// stop, searchSpecialTagValues abandons the scan instead of walking every remaining row
+// group and invoking the callback for each value it finds there.
+func TestSearchSpecialTagValuesStopsEarly(t *testing.T) {
+	traces, _, _, _ := makeTraces()
+	block := makeBackendBlockWithTraces(t, traces)
+
+	ctx := context.Background()
+	pf, _, err := block.openForSearch(ctx, common.DefaultSearchOptions())
+	require.NoError(t, err)
+
+	// The regression guarded here is the callback being invoked again in a *later* row
+	// group, so the fixture has to span more than one for this test to mean anything.
+	require.Greater(t, len(pf.RowGroups()), 1, "fixture must span multiple row groups")
+
+	const column = ColumnPathResourceServiceName
+
+	// First collect everything so we know the column has more than one value to report.
+	var all int
+	err = searchSpecialTagValues(ctx, column, pf, func(traceql.Static) bool {
+		all++
+		return false
+	})
+	require.NoError(t, err)
+	require.Greater(t, all, 1, "column must report multiple values for this test to mean anything")
+
+	// Now stop on the very first value. The callback must not be called again.
+	var calls, afterStop int
+	err = searchSpecialTagValues(ctx, column, pf, func(traceql.Static) bool {
+		calls++
+		if calls > 1 {
+			afterStop++
+		}
+		return true // stop immediately
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, calls, "callback must be invoked exactly once when it stops on the first value")
+	require.Zero(t, afterStop, "callback must not be invoked after asking to stop")
+}


### PR DESCRIPTION
**What this PR does**:

`SearchTagValues` keeps scanning a block after the caller has asked to stop. `TagValuesCallbackV2` returns `stop bool`, but `reportValuesPredicate` discarded it, so the iterator walked every remaining row group and kept invoking the callback for values that were then thrown away.

The predicate now latches the stop and reports a match, which is the only way to make `iter.Next()` return — because `reportValuesPredicate` never otherwise produces a match, a single `Next()` call today drains all row groups internally, leaving the caller no point at which to intervene. `searchSpecialTagValues` breaks on that match and drops the remaining row groups.

- `reportValuesPredicate` gains a `stop` latch, set when the callback asks to stop.
- `KeepColumnChunk` / `KeepValue` return `true` once stopped, instead of continuing to report.
- `searchSpecialTagValues` collapses its drain loop to a single `iter.Next()`, since that call either drains the column or returns as soon as the predicate signals stop.
- Applies to vparquet3, vparquet4 and vparquet5.

There is no behaviour change in what gets collected — only in how much work is done after the limit is hit.

**Benchmarks**

Against a real 2.4GB block (1.97M traces, 31 row groups) with the default `max_bytes_per_tag_values_query` of 1MB and no value-count cap. 5 interleaved rounds per side, `benchstat` vs `main`:

```
                                      │     main      │              this PR                │
                                      │    sec/op     │   sec/op     vs base                │
YieldStop/String03_veryHighCard-14        68.168m        9.162m       -86.56% (p=0.008 n=5)
YieldStop/SpanAttrsValue_highCard-14     242.856m        6.393m       -97.37% (p=0.008 n=5)
YieldStop/HttpUrl_midCard-14              23.765m        1.344m       -94.35% (p=0.008 n=5)
YieldStop/SpanName_lowCard-14             20.344m        8.544m       -58.00% (p=0.008 n=5)
YieldStop/ServiceName_lowCard-14           5.409m        5.359m             ~ (p=1.000 n=5)
geomean                                    33.67m        5.145m       -84.72%

                                      │     B/op      │  B/op        vs base                │
YieldStop/String03_veryHighCard-14       113.47Mi       22.77Mi      -79.94% (p=0.008 n=5)
YieldStop/SpanAttrsValue_highCard-14     566.60Mi       16.13Mi      -97.15% (p=0.008 n=5)
YieldStop/HttpUrl_midCard-14             55.137Mi       4.529Mi      -91.79% (p=0.008 n=5)
YieldStop/SpanName_lowCard-14             23.87Mi       12.40Mi      -48.03% (p=0.008 n=5)
YieldStop/ServiceName_lowCard-14          2.857Mi       2.868Mi            ~ (p=0.056 n=5)
geomean                                   47.50Mi       9.004Mi      -81.04%
```

`ServiceName` is unchanged, and that is the expected result: it has only 3,189 distinct values, never reaches the 1MB budget, so nothing stops early and the full dictionary walk still happens. Columns that do hit the budget stop after the row group that fills it instead of walking all 31.

For scale, on that block a `SearchTagValues` for the `String03` dedicated attribute previously reported 2,318,527 dictionary entries to the callback, 2,318,427 of them after it had already said stop.

Benchmarks were run on local disk with a warm page cache; against object storage the gain is larger, since skipping row groups also skips their dictionary page reads.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated — `TestSearchSpecialTagValuesStopsEarly` in each of vparquet3/4/5 asserts the callback is invoked exactly once when it stops on the first value; verified it fails on `main` (actual: 2). It also asserts the fixture spans more than one row group, since the regression is the callback firing again in a *later* row group and the test would silently stop guarding anything if flush behaviour ever produced a single row group.
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
