### PR TITLE
feat(servicegraphs): Add support for `db.system.name`

### DIFF
--- a/.chloggen/servicegraphs-db-system-name.yaml
+++ b/.chloggen/servicegraphs-db-system-name.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+component: metrics-generator
+note: Recognize the `db.system.name` attribute in service graphs, for database node detection and virtual node naming.
+issues: []
+subtext: |
+  OpenTelemetry semantic conventions v1.30.0 renamed `db.system` to `db.system.name`. Spans from
+  instrumentation that emits only the new attribute were no longer identified as database requests
+  and could not name a virtual node.
+
+  `db.system.name` is appended to the defaults for both `peer_attributes` and
+  `database_name_attributes`, after `db.system`. Because the lists are searched in order and the
+  older attribute is still listed first, spans that carry `db.system` keep producing the node names
+  they do today. Both defaults can still be overridden per tenant.
+user: iamrajiv

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -736,7 +736,7 @@ metrics_generator:
             # Attributes are searched in the order they are provided
             # See: https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.25.0
             # Example: ["peer.service", "db.name", "db.system", "host.name"]
-            [peer_attributes: <list of string> | default = ["peer.service", "db.name", "db.system"] ]
+            [peer_attributes: <list of string> | default = ["peer.service", "db.name", "db.system", "db.system.name"] ]
 
             # Attribute Key to multiply span metrics
             # Note that the attribute name is searched for in both
@@ -752,8 +752,11 @@ metrics_generator:
             # Enables additional labels for services and virtual nodes.
             [enable_virtual_node_label: <bool> | default = false]
 
-            # List of attribute names used to identify the database name from span attributes. If it isn't set, the order is peer.service -> server.address -> network.peer.address -> db.name
-            [database_name_attributes: <list of string> | default = ["db.namespace","db.name","db.system"]]
+            # List of attribute names used to identify the database name from span attributes.
+            # Attributes are searched in the order they are provided and the first match is used.
+            # The database node itself is named after peer.service -> server.address ->
+            # network.peer.address -> the matching attribute from this list.
+            [database_name_attributes: <list of string> | default = ["db.namespace","db.name","db.system","db.system.name"]]
 
             # List of policies that will be applied to spans for inclusion or exclusion.
             [filter_policies: <list of filter policies config> | default = []]

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -734,7 +734,7 @@ metrics_generator:
 
             # Attributes that will be used to create a peer edge
             # Attributes are searched in the order they are provided
-            # See: https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.25.0
+            # See: https://opentelemetry.io/docs/specs/semconv/registry/attributes/
             # Example: ["peer.service", "db.name", "db.system", "host.name"]
             [peer_attributes: <list of string> | default = ["peer.service", "db.name", "db.system", "db.system.name"] ]
 

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -429,6 +429,7 @@ metrics_generator:
                 - peer.service
                 - db.name
                 - db.system
+                - db.system.name
             span_multiplier_key: ""
             enable_tracestate_span_multiplier: false
             enable_virtual_node_label: false
@@ -436,6 +437,7 @@ metrics_generator:
                 - db.namespace
                 - db.name
                 - db.system
+                - db.system.name
             filter_policies: []
         span_metrics:
             histogram_buckets:

--- a/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
@@ -164,7 +164,8 @@ When enabled, the tracestate threshold takes priority over `span_multiplier_key`
 The `database_name_attributes` option controls which span attributes the processor uses to identify a span as a database request.
 The defaults are `db.namespace`, `db.name`, `db.system`, and `db.system.name`.
 The processor searches the list in order and uses the first attribute the span carries.
-Renamed OpenTelemetry attributes are listed after the attribute they replaced, so `db.namespace` (which replaced `db.name` in semantic conventions v1.26.0) and `db.system.name` (which replaced `db.system` in v1.30.0) don't change the node name for instrumentation that still emits the older attributes.
+`db.namespace` and `db.name` identify the database itself, such as `mydb`, so they take precedence over `db.system` and `db.system.name`, which identify only the database product, such as `postgresql`.
+Within that second pair, `db.system.name` (which replaced `db.system` in semantic conventions v1.30.0) is listed last, so instrumentation that still emits `db.system` produces the same node name as before.
 You can override this list to match your instrumentation if it uses non-standard attribute names.
 
 ### Filter policies

--- a/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/service_graphs/_index.md
@@ -38,7 +38,7 @@ It supports the following requests:
 
 - A direct request between two services where the outgoing and the incoming span must have [`span.kind`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind), `client`, and `server`, respectively.
 - A request across a messaging system where the outgoing and the incoming span must have `span.kind`, `producer`, and `consumer` respectively.
-- A database request; in this case the processor looks for spans containing attributes `span.kind`=`client` as well as one of `db.namespace`, `db.name` or `db.system`. You can customize which attributes identify a database span using the `database_name_attributes` [configuration option](/docs/tempo/<TEMPO_VERSION>/configuration/#metrics-generator). See below for how the name of the node is determined for a database request.
+- A database request; in this case the processor looks for spans containing attributes `span.kind`=`client` as well as one of `db.namespace`, `db.name`, `db.system`, or `db.system.name`. You can customize which attributes identify a database span using the `database_name_attributes` [configuration option](/docs/tempo/<TEMPO_VERSION>/configuration/#metrics-generator). See below for how the name of the node is determined for a database request.
 
 The processor keeps every span that can form a request pair in an in-memory store until the corresponding pair span arrives or the maximum waiting time passes.
 When either condition occurs, the processor records the request and removes it from the local store.
@@ -61,12 +61,12 @@ The processor detects virtual nodes in two ways:
   - In the Tempo metrics-generator, the processor checks the configured `peer_attributes` on the server span first. If it finds a matching attribute, it uses that value as the client node name. Otherwise, the client node name defaults to `user`.
   - In Grafana Alloy and the OpenTelemetry Collector `servicegraph` connector, the connector doesn't evaluate peer attributes for this case. The client node name always defaults to `user` and you can't override it. An [upstream feature request](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/45397) exists to add this capability.
 - **Uninstrumented server (missing server span):** A `client` span doesn't have its matching `server` span, but has a peer attribute present. In this case, the client called an external service that doesn't send spans. The processor uses the peer attribute value as the virtual server node name.
-  - The default peer attributes are `peer.service`, `db.name`, and `db.system`.
+  - The default peer attributes are `peer.service`, `db.name`, `db.system`, and `db.system.name`.
   - The processor searches the attributes in order and uses the first match as the virtual node name.
 
-The processor identifies a database node when the span has at least one `db.namespace`, `db.name`, or `db.system` attribute.
+The processor identifies a database node when the span has at least one `db.namespace`, `db.name`, `db.system`, or `db.system.name` attribute.
 
-The processor determines the database node name using the following span attributes in order of precedence: `peer.service`, `server.address`, `network.peer.address:network.peer.port`, `db.namespace`, `db.name`.
+The processor determines the database node name using the following span attributes in order of precedence: `peer.service`, `server.address`, `network.peer.address:network.peer.port`, and finally the first attribute from `database_name_attributes` that the span carries.
 
 ### Enabling specific metrics (subprocessors)
 
@@ -162,7 +162,9 @@ When enabled, the tracestate threshold takes priority over `span_multiplier_key`
 ### Database name attributes
 
 The `database_name_attributes` option controls which span attributes the processor uses to identify a span as a database request.
-The defaults are `db.namespace`, `db.name`, and `db.system`.
+The defaults are `db.namespace`, `db.name`, `db.system`, and `db.system.name`.
+The processor searches the list in order and uses the first attribute the span carries.
+Renamed OpenTelemetry attributes are listed after the attribute they replaced, so `db.namespace` (which replaced `db.name` in semantic conventions v1.26.0) and `db.system.name` (which replaced `db.system` in v1.30.0) don't change the node name for instrumentation that still emits the older attributes.
 You can override this list to match your instrumentation if it uses non-standard attribute names.
 
 ### Filter policies

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -425,6 +425,7 @@ metrics_generator:
                 - peer.service
                 - db.name
                 - db.system
+                - db.system.name
             span_multiplier_key: ""
             enable_tracestate_span_multiplier: false
             enable_virtual_node_label: false
@@ -432,6 +433,7 @@ metrics_generator:
                 - db.namespace
                 - db.name
                 - db.system
+                - db.system.name
             filter_policies: []
         span_metrics:
             histogram_buckets:

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -82,9 +82,12 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 
 	cfg.EnableMessagingSystemLatencyHistogram = false
 
-	// db.name was renamed to db.namespace in semconv v1.26.0 and db.system to
-	// db.system.name in v1.30.0. Each renamed key is listed after the one it
-	// replaced so that existing pipelines keep resolving the same database name.
+	// Searched in order, first match wins. db.namespace and db.name identify the
+	// database itself (for example "mydb"), so they are preferred over db.system
+	// and db.system.name, which only identify the DBMS product (for example
+	// "postgresql"). Within that second pair, db.system was renamed to
+	// db.system.name in semconv v1.30.0 and is kept first, so spans that still
+	// emit the older key resolve to the name they do today.
 	cfg.DatabaseNameAttributes = []string{
 		string(semconvnew.DBNamespaceKey),
 		string(semconv.DBNameKey),

--- a/modules/generator/processor/servicegraphs/config.go
+++ b/modules/generator/processor/servicegraphs/config.go
@@ -82,10 +82,14 @@ func (cfg *Config) RegisterFlagsAndApplyDefaults(string, *flag.FlagSet) {
 
 	cfg.EnableMessagingSystemLatencyHistogram = false
 
+	// db.name was renamed to db.namespace in semconv v1.26.0 and db.system to
+	// db.system.name in v1.30.0. Each renamed key is listed after the one it
+	// replaced so that existing pipelines keep resolving the same database name.
 	cfg.DatabaseNameAttributes = []string{
 		string(semconvnew.DBNamespaceKey),
 		string(semconv.DBNameKey),
 		string(semconv.DBSystemKey),
+		string(semconvnew.DBSystemNameKey),
 	}
 
 	// Request and Latency are on for backwards compatibility with the bare "service-graphs"

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconvnew "go.opentelemetry.io/otel/semconv/v1.34.0"
 
 	gen "github.com/grafana/tempo/modules/generator/processor"
 	"github.com/grafana/tempo/modules/generator/processor/servicegraphs/store"
@@ -64,8 +65,10 @@ const (
 
 const virtualNodeLabel = "virtual_node"
 
+// db.system was renamed to db.system.name in semconv v1.30.0. Both are consulted,
+// the older key first, so existing pipelines keep naming virtual nodes as they do today.
 var defaultPeerAttributes = []attribute.Key{
-	semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey,
+	semconv.PeerServiceKey, semconv.DBNameKey, semconv.DBSystemKey, semconvnew.DBSystemNameKey,
 }
 
 type tooManySpansError struct {

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -46,6 +46,20 @@ func TestSemconvKeys(t *testing.T) {
 	require.Equal(t, string(semconv.NetworkPeerPortKey), "network.peer.port")
 	require.Equal(t, string(semconv.ServerAddressKey), "server.address")
 	require.Equal(t, string(semconvnew.DBNamespaceKey), "db.namespace")
+	require.Equal(t, string(semconvnew.DBSystemNameKey), "db.system.name")
+}
+
+// TestServiceGraphs_defaultDatabaseAttributeOrder locks in the order in which
+// database attributes are consulted. Renamed keys (db.namespace for db.name,
+// db.system.name for db.system) are always listed after the key they replace,
+// so adding support for a new semconv name never changes the node name an
+// existing pipeline produces.
+func TestServiceGraphs_defaultDatabaseAttributeOrder(t *testing.T) {
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+
+	require.Equal(t, []string{"peer.service", "db.name", "db.system", "db.system.name"}, cfg.PeerAttributes)
+	require.Equal(t, []string{"db.namespace", "db.name", "db.system", "db.system.name"}, cfg.DatabaseNameAttributes)
 }
 
 func TestServiceGraphs(t *testing.T) {
@@ -1045,6 +1059,33 @@ func TestServiceGraphs_databaseVirtualNodes(t *testing.T) {
 			total:  1.0,
 			errors: 0.0,
 		},
+		{
+			// db.system was renamed to db.system.name in semconv v1.30.0. A span
+			// carrying only the new name still has to be recognised as a database.
+			name:        "dbSystemNameAttribute",
+			fixturePath: "testdata/trace-with-db-system-name.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "postgresql",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
+		{
+			// v1.30.0 also changed the recognised constants, so db.system and
+			// db.system.name can disagree on the same span. The older key keeps
+			// winning to preserve the node name existing pipelines already emit.
+			name:        "bothDbSystemAndSystemName",
+			fixturePath: "testdata/trace-with-db-system-and-system-name.json",
+			databaseLabels: labels.FromMap(map[string]string{
+				"client":          "mythical-server",
+				"server":          "mssql",
+				"connection_type": "database",
+			}),
+			total:  1.0,
+			errors: 0.0,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1702,6 +1743,53 @@ func TestServiceGraphs_serverPeerSurvivesClientDatabaseUpdate(t *testing.T) {
 	expiredEdges, err := test.GetCounterVecValue(metricExpiredEdges, tenant)
 	require.NoError(t, err)
 	assert.Zero(t, expiredEdges)
+}
+
+// TestServiceGraphs_dbSystemNamePeerAttribute covers the virtual node path: a
+// client span with no server counterpart is named after the first matching peer
+// attribute. db.system.name has to work here exactly like the db.system key it
+// replaced in semconv v1.30.0.
+func TestServiceGraphs_dbSystemNamePeerAttribute(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		attrKey string
+	}{
+		{name: "db.system", attrKey: string(semconv.DBSystemKey)},
+		{name: "db.system.name", attrKey: string(semconvnew.DBSystemNameKey)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testRegistry := registry.NewTestRegistry()
+
+			cfg := Config{}
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.Wait = time.Nanosecond
+			// Isolate the peer attribute path. Left at its default, the same
+			// attribute would identify a database edge and name the server
+			// before the edge ever expires.
+			cfg.DatabaseNameAttributes = nil
+
+			p, err := New(cfg, "test", testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+			require.NoError(t, err)
+			defer p.Shutdown(context.Background())
+
+			dbAttr := &v1.KeyValue{
+				Key:   tc.attrKey,
+				Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "postgresql"}},
+			}
+
+			p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*tracev1.ResourceSpans{
+				makeServiceGraphBatch("svc-a", tracev1.Span_SPAN_KIND_CLIENT, []byte{0x3a}, []byte{0x3b}, nil, dbAttr),
+			}})
+			p.(*Processor).store.Expire()
+
+			virtualNodeLabels := labels.FromMap(map[string]string{
+				"client":          "svc-a",
+				"server":          "postgresql",
+				"connection_type": "virtual_node",
+			})
+			assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", virtualNodeLabels))
+		})
+	}
 }
 
 // TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer covers

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -50,10 +50,12 @@ func TestSemconvKeys(t *testing.T) {
 }
 
 // TestServiceGraphs_defaultDatabaseAttributeOrder locks in the order in which
-// database attributes are consulted. Renamed keys (db.namespace for db.name,
-// db.system.name for db.system) are always listed after the key they replace,
-// so adding support for a new semconv name never changes the node name an
-// existing pipeline produces.
+// database attributes are consulted, since the first match wins and reordering
+// them changes the node names an existing pipeline emits. Attributes naming the
+// database (db.namespace, db.name) come before those naming the DBMS product
+// (db.system, db.system.name), and db.system.name is placed after the db.system
+// it replaced in semconv v1.30.0 so that spans carrying the older key are
+// unaffected.
 func TestServiceGraphs_defaultDatabaseAttributeOrder(t *testing.T) {
 	cfg := Config{}
 	cfg.RegisterFlagsAndApplyDefaults("", nil)

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-db-system-and-system-name.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-db-system-and-system-name.json
@@ -1,0 +1,1662 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.system",
+                  "value": {
+                    "stringValue": "mssql"
+                  }
+                },
+                {
+                  "key": "db.system.name",
+                  "value": {
+                    "stringValue": "microsoft.sql_server"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/modules/generator/processor/servicegraphs/testdata/trace-with-db-system-name.json
+++ b/modules/generator/processor/servicegraphs/testdata/trace-with-db-system-name.json
@@ -1,0 +1,1656 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "1gZXnld4dYc=",
+              "name": "requester",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854877522688",
+              "endTimeUnixNano": "1658320854923357184",
+              "attributes": [
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "ares"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "U/Mym4Y9qV0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854877839616",
+              "endTimeUnixNano": "1658320854878545408",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "mZKWiJfzyEY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "GET /:endpoint",
+              "kind": "SPAN_KIND_SERVER",
+              "startTimeUnixNano": "1658320854878927360",
+              "endTimeUnixNano": "1658320854908913408",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://mythical-server:4000/manticore"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "mythical-server:4000"
+                  }
+                },
+                {
+                  "key": "net.host.name",
+                  "value": {
+                    "stringValue": "mythical-server"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/manticore"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "god",
+                  "value": {
+                    "stringValue": "zeus"
+                  }
+                },
+                {
+                  "key": "beast",
+                  "value": {
+                    "stringValue": "manticore"
+                  }
+                },
+                {
+                  "key": "span.kind",
+                  "value": {
+                    "intValue": "2"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "4000"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "::ffff:172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "46950"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "OK"
+                  }
+                },
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "A38EGjeny0Y=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - query",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879122688",
+              "endTimeUnixNano": "1658320854879143680",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "query"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "7eLzskA9GzQ=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - expressInit",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879322624",
+              "endTimeUnixNano": "1658320854879355136",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "expressInit"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "I+ErHCWWzIw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "middleware - jsonParser",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879422208",
+              "endTimeUnixNano": "1658320854879444480",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "jsonParser"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "middleware"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-express",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "w4/Ni3Fq4S4=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "request handler - /:endpoint",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854879524608",
+              "endTimeUnixNano": "1658320854879526400",
+              "attributes": [
+                {
+                  "key": "http.route",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.name",
+                  "value": {
+                    "stringValue": "/:endpoint"
+                  }
+                },
+                {
+                  "key": "express.type",
+                  "value": {
+                    "stringValue": "request_handler"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-pg",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "JT4hL+I0IWw=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "pg.query:SELECT",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854879610624",
+              "endTimeUnixNano": "1658320854903392000",
+              "attributes": [
+                {
+                  "key": "db.system.name",
+                  "value": {
+                    "stringValue": "postgresql"
+                  }
+                },
+                {
+                  "key": "db.connection_string",
+                  "value": {
+                    "stringValue": "jdbc:postgresql://mythical-database:5432/postgres"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-database"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5432"
+                  }
+                },
+                {
+                  "key": "db.user",
+                  "value": {
+                    "stringValue": "postgres"
+                  }
+                },
+                {
+                  "key": "db.statement",
+                  "value": {
+                    "stringValue": "SELECT name from manticore"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-http",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "Iq8HyyCGMcA=",
+              "parentSpanId": "mZKWiJfzyEY=",
+              "name": "HTTP POST",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909347584",
+              "endTimeUnixNano": "1658320854913202688",
+              "attributes": [
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "http://loki:3100/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "POST"
+                  }
+                },
+                {
+                  "key": "http.target",
+                  "value": {
+                    "stringValue": "/loki/api/v1/push"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "3100"
+                  }
+                },
+                {
+                  "key": "http.host",
+                  "value": {
+                    "stringValue": "loki:3100"
+                  }
+                },
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "204"
+                  }
+                },
+                {
+                  "key": "http.status_text",
+                  "value": {
+                    "stringValue": "NO CONTENT"
+                  }
+                },
+                {
+                  "key": "http.flavor",
+                  "value": {
+                    "stringValue": "1.1"
+                  }
+                },
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                }
+              ],
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "5xenytYWGCM=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854909465856",
+              "endTimeUnixNano": "1658320854911322112",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.7"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "51090"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-server"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-dns",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "G1lOVPULKHA=",
+              "parentSpanId": "Iq8HyyCGMcA=",
+              "name": "dns.lookup",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854909490688",
+              "endTimeUnixNano": "1658320854910292992",
+              "attributes": [
+                {
+                  "key": "peer.ipv4",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "oMg46pqD9yY=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "publish_to_queue",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854915519232",
+              "endTimeUnixNano": "1658320854916681216",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "CbyBh8ln9LQ=",
+              "parentSpanId": "oMg46pqD9yY=",
+              "name": "<default> -> messages send",
+              "kind": "SPAN_KIND_PRODUCER",
+              "startTimeUnixNano": "1658320854915559936",
+              "endTimeUnixNano": "1658320854915628800",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "HZ43ugub274=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854916730624",
+              "endTimeUnixNano": "1658320854930536704",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-requester"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ByBJTXxe2aI=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "log_to_loki",
+              "kind": "SPAN_KIND_CLIENT",
+              "startTimeUnixNano": "1658320854923263232",
+              "endTimeUnixNano": "1658320854929491200",
+              "status": {
+                "code": "STATUS_CODE_OK"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "ivrh44gllP0=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854923789312",
+              "endTimeUnixNano": "1658320854925569280",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41594"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-requester"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.4"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-net",
+            "version": "0.27.1"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "o/mJQtsdDeE=",
+              "parentSpanId": "1gZXnld4dYc=",
+              "name": "tcp.connect",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854924354560",
+              "endTimeUnixNano": "1658320854925760768",
+              "attributes": [
+                {
+                  "key": "net.transport",
+                  "value": {
+                    "stringValue": "ip_tcp"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "loki"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "stringValue": "3100"
+                  }
+                },
+                {
+                  "key": "net.peer.ip",
+                  "value": {
+                    "stringValue": "172.22.0.6"
+                  }
+                },
+                {
+                  "key": "net.host.ip",
+                  "value": {
+                    "stringValue": "172.22.0.11"
+                  }
+                },
+                {
+                  "key": "net.host.port",
+                  "value": {
+                    "intValue": "41596"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@opentelemetry/instrumentation-amqplib",
+            "version": "0.28.0"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "qMP7VjNGIK8=",
+              "parentSpanId": "CbyBh8ln9LQ=",
+              "name": "messages process",
+              "kind": "SPAN_KIND_CONSUMER",
+              "startTimeUnixNano": "1658320854925510400",
+              "endTimeUnixNano": "1658320854926209792",
+              "attributes": [
+                {
+                  "key": "messaging.protocol_version",
+                  "value": {
+                    "stringValue": "0.9.1"
+                  }
+                },
+                {
+                  "key": "messaging.url",
+                  "value": {
+                    "stringValue": "amqp://mythical-queue"
+                  }
+                },
+                {
+                  "key": "messaging.protocol",
+                  "value": {
+                    "stringValue": "AMQP"
+                  }
+                },
+                {
+                  "key": "net.peer.name",
+                  "value": {
+                    "stringValue": "mythical-queue"
+                  }
+                },
+                {
+                  "key": "net.peer.port",
+                  "value": {
+                    "intValue": "5672"
+                  }
+                },
+                {
+                  "key": "messaging.system",
+                  "value": {
+                    "stringValue": "rabbitmq"
+                  }
+                },
+                {
+                  "key": "messaging.destination",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "messaging.destination_kind",
+                  "value": {
+                    "stringValue": "topic"
+                  }
+                },
+                {
+                  "key": "messaging.rabbitmq.routing_key",
+                  "value": {
+                    "stringValue": "messages"
+                  }
+                },
+                {
+                  "key": "messaging.operation",
+                  "value": {
+                    "stringValue": "process"
+                  }
+                }
+              ],
+              "status": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "mythical-recorder"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "1.4.0"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "1.2.3.5"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "mythical-recorder"
+          },
+          "spans": [
+            {
+              "traceId": "QpC1h3qZMN55u0KDZTmOzA==",
+              "spanId": "j9WiKB5PGKw=",
+              "parentSpanId": "qMP7VjNGIK8=",
+              "name": "process_message",
+              "kind": "SPAN_KIND_INTERNAL",
+              "startTimeUnixNano": "1658320854925532928",
+              "endTimeUnixNano": "1658320854963292160",
+              "status": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**What this PR does**:

OpenTelemetry semantic conventions [v1.30.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.30.0) renamed `db.system` to `db.system.name` and changed the recognized value constants. Spans from instrumentation that emits only the new attribute are not identified as database requests by the service graph processor, and cannot be used to name a virtual node.

**Behavior**, verified end to end through the processor with default config:

| span attributes                                           | before                    | after                           |
| --------------------------------------------------------- | ------------------------- | ------------------------------- |
| only `db.system.name=postgresql`                          | no database edge produced | `server="postgresql"`,          |
| `connection_type="database"`                              |
| `db.system=mssql` + `db.system.name=microsoft.sql_server` | `server="mssql"`          |
| `server="mssql"` (unchanged)                              |
| only `db.system=postgresql`                               | `server="postgres"`       | `server="postgres"` (unchanged) |

**Notes for reviewers** — this supersedes #4656, #4774, #4916 and #5445, and the blockers
raised on those are now resolve

Tests added:

- `TestServiceGraphs_dbSystemNamePeerAttribute` — table-driven over `db.system` and
  `db.system.name`; the old key pnd the new key fails, so it pinsthe exact regression.
- `TestServiceGraphs_databaseViures: `db.system.name`alone, and`db.system`+`db.system.name` disagreeing (asserts the older key still wins).
- `TestServiceGraphs_defaultDaterts both default lists exactly.
- `TestSemconvKeys` — extended with `db.system.name`.

Docs for `peer_attributes` and `database_name_attributes` are updated in the configuration
reference and the service graph/ `config-reference.md` wereregenerated with `make generate-manifest`.

**Which issue(s) this PR fixes**:
Fixes #4640

**Checklist**

- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`
