### PR TITLE
Block format doc incorrectly says Each row represents a span

### DIFF
--- a/docs/sources/tempo/reference-tempo-architecture/block-format.md
+++ b/docs/sources/tempo/reference-tempo-architecture/block-format.md
@@ -43,9 +43,12 @@ The block-builder uses this property to ensure atomicity during flushes.
 
 ## Schema
 
-Tempo uses a span-oriented heavily nested Parquet schema.
-Each row represents a span, with columns for intrinsic fields (trace ID, span ID, parent span ID, span name, span kind, span status, duration, start time, root service name, root span name),
+Tempo uses a heavily nested Parquet schema.
+Each row represents a trace, and rows are sorted by trace ID within the file.
+Spans are stored inside the row as nested, repeated groups that mirror the OpenTelemetry hierarchy: resource spans, scope spans, and spans.
+The schema has columns for intrinsic fields (trace ID, span ID, parent span ID, span name, span kind, span status, duration, start time, root service name, root span name),
 resource attributes (for example, `service.name`, `deployment.environment`), and span attributes (for example, `http.method`, `http.status_code`).
+Each span contributes one value to every span-level column, so a single trace row holds many values per column.
 
 ### Intrinsic fields vs generic attributes
 


### PR DESCRIPTION
**What this PR does:**

The block format doc incorrectly says "Each row represents a span". Each row represents a trace, sorted by trace ID, with spans stored as nested repeated groups (resource spans > scope spans > spans) — matching the `Trace` struct written by `parquet.NewGenericWriter[*Trace]` in `tempodb/encoding` (vparquet3/4/5). The same page already implies row-per-trace: `meta.json` counts objects as traces and the index maps trace IDs to row groups.

Wording introduced in #6754.

Docs-only change — no changelog entry (`Skip Changelog`).

**Which issue(s) this PR fixes:**
n/a

Disclosure: drafted with Claude Code assistance; verified against the schema and writer code and reviewed by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)