### PR TITLE
[backend-scheduler] redaction: per-tenant traces-found metric + Backend Work panels

### DIFF
--- a/.chloggen/redaction-traces-found-metric.yaml
+++ b/.chloggen/redaction-traces-found-metric.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: backend-scheduler
+note: add the `tempo_backend_scheduler_redaction_traces_found_total{tenant, mode}` metric — traces matched by redaction jobs per tenant, with mode=apply counting traces actually removed and mode=dry_run counting a dry-run's previewed blast radius.
+issues: []
+subtext:
+user: zalegrala

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -389,6 +389,7 @@ func (s *BackendScheduler) UpdateJob(ctx context.Context, req *tempopb.UpdateJob
 			}
 		case tempopb.JobType_JOB_TYPE_REDACTION:
 			if req.Redaction != nil {
+				recordRedactionResult(j.Tenant(), j.JobDetail.GetRedaction().GetMode(), req.Redaction.TracesFound)
 				level.Info(log.Logger).Log("msg", "redaction job result",
 					"job_id", req.JobId,
 					"tenant", j.Tenant(),

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/grafana/tempo/pkg/tempopb"
 )
 
 var (
@@ -76,4 +78,26 @@ var (
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	}, []string{"job_type"})
+	metricRedactionTracesFound = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "backend_scheduler_redaction_traces_found_total",
+		Help:      "Total traces matched by redaction jobs, by tenant and mode. mode=apply counts traces actually removed; mode=dry_run counts previewed blast radius (nothing removed).",
+	}, []string{"tenant", "mode"})
 )
+
+// recordRedactionResult records a completed redaction job's match count on the per-tenant,
+// per-mode counter. A zero/empty result (block scanned clean) is a no-op.
+func recordRedactionResult(tenant string, mode tempopb.RedactionMode, found int32) {
+	if found <= 0 {
+		return
+	}
+	metricRedactionTracesFound.WithLabelValues(tenant, redactionModeLabel(mode)).Add(float64(found))
+}
+
+// redactionModeLabel is a short, stable metric label for a redaction mode.
+func redactionModeLabel(mode tempopb.RedactionMode) string {
+	if mode == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN {
+		return "dry_run"
+	}
+	return "apply"
+}

--- a/modules/backendscheduler/redaction_metrics_test.go
+++ b/modules/backendscheduler/redaction_metrics_test.go
@@ -1,0 +1,25 @@
+package backendscheduler
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// TestRecordRedactionResult verifies the per-tenant traces-found counter is incremented by the
+// reported count and labelled by mode, so apply (real redactions) and dry-run (previewed blast
+// radius) are distinguishable, and that a zero/empty result is a no-op.
+func TestRecordRedactionResult(t *testing.T) {
+	recordRedactionResult("t-apply", tempopb.RedactionMode_REDACTION_MODE_APPLY, 5)
+	require.Equal(t, 5.0, testutil.ToFloat64(metricRedactionTracesFound.WithLabelValues("t-apply", "apply")))
+
+	recordRedactionResult("t-dry", tempopb.RedactionMode_REDACTION_MODE_DRY_RUN, 7)
+	require.Equal(t, 7.0, testutil.ToFloat64(metricRedactionTracesFound.WithLabelValues("t-dry", "dry_run")))
+
+	// Zero found: no-op (block scanned clean).
+	recordRedactionResult("t-zero", tempopb.RedactionMode_REDACTION_MODE_APPLY, 0)
+	require.Equal(t, 0.0, testutil.ToFloat64(metricRedactionTracesFound.WithLabelValues("t-zero", "apply")))
+}

--- a/modules/backendscheduler/redaction_metrics_test.go
+++ b/modules/backendscheduler/redaction_metrics_test.go
@@ -13,13 +13,19 @@ import (
 // reported count and labelled by mode, so apply (real redactions) and dry-run (previewed blast
 // radius) are distinguishable, and that a zero/empty result is a no-op.
 func TestRecordRedactionResult(t *testing.T) {
+	metricRedactionTracesFound.Reset()
+
 	recordRedactionResult("t-apply", tempopb.RedactionMode_REDACTION_MODE_APPLY, 5)
 	require.Equal(t, 5.0, testutil.ToFloat64(metricRedactionTracesFound.WithLabelValues("t-apply", "apply")))
 
 	recordRedactionResult("t-dry", tempopb.RedactionMode_REDACTION_MODE_DRY_RUN, 7)
 	require.Equal(t, 7.0, testutil.ToFloat64(metricRedactionTracesFound.WithLabelValues("t-dry", "dry_run")))
 
-	// Zero found: no-op (block scanned clean).
+	// Two labelled series exist so far (t-apply, t-dry).
+	require.Equal(t, 2, testutil.CollectAndCount(metricRedactionTracesFound))
+
+	// Zero found is a no-op (block scanned clean): it must NOT create a series, or a clean
+	// high-volume tenant would spray zero-valued per-tenant series (cardinality footgun).
 	recordRedactionResult("t-zero", tempopb.RedactionMode_REDACTION_MODE_APPLY, 0)
-	require.Equal(t, 0.0, testutil.ToFloat64(metricRedactionTracesFound.WithLabelValues("t-zero", "apply")))
+	require.Equal(t, 2, testutil.CollectAndCount(metricRedactionTracesFound), "zero result must not create a new series")
 }

--- a/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
@@ -2445,12 +2445,218 @@
    "type": "timeseries"
   },
   {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${metrics}"
+   },
+   "description": "Traces actually removed by applied redaction jobs (mode=apply), by tenant. The durable record of what was deleted.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "barWidthFactor": 0.6,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [
+
+     ],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green"
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     }
+    },
+    "overrides": [
+
+    ]
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 12,
+    "x": 0,
+    "y": 40
+   },
+   "id": 42,
+   "options": {
+    "legend": {
+     "calcs": [
+
+     ],
+     "displayMode": "list",
+     "placement": "right",
+     "showLegend": true
+    },
+    "tooltip": {
+     "hideZeros": false,
+     "mode": "single",
+     "sort": "none"
+    }
+   },
+   "pluginVersion": "12.0.1",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "sum(increase(tempo_backend_scheduler_redaction_traces_found_total{cluster=~\"$cluster\", namespace=~\"$namespace\", mode=\"apply\"}[1h])) by (tenant)",
+     "legendFormat": "{{tenant}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Traces Redacted / h",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${metrics}"
+   },
+   "description": "Traces a dry-run redaction matched but did NOT remove (mode=dry_run), by tenant. Preview of a query selector’s blast radius before applying.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "barWidthFactor": 0.6,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [
+
+     ],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green"
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     }
+    },
+    "overrides": [
+
+    ]
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 12,
+    "x": 12,
+    "y": 40
+   },
+   "id": 43,
+   "options": {
+    "legend": {
+     "calcs": [
+
+     ],
+     "displayMode": "list",
+     "placement": "right",
+     "showLegend": true
+    },
+    "tooltip": {
+     "hideZeros": false,
+     "mode": "single",
+     "sort": "none"
+    }
+   },
+   "pluginVersion": "12.0.1",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "sum(increase(tempo_backend_scheduler_redaction_traces_found_total{cluster=~\"$cluster\", namespace=~\"$namespace\", mode=\"dry_run\"}[1h])) by (tenant)",
+     "legendFormat": "{{tenant}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Dry-run Blast Radius / h",
+   "type": "timeseries"
+  },
+  {
    "collapsed": false,
    "gridPos": {
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 40
+    "y": 46
    },
    "id": 8,
    "panels": [
@@ -2526,7 +2732,7 @@
     "h": 6,
     "w": 5,
     "x": 0,
-    "y": 41
+    "y": 47
    },
    "id": 9,
    "options": {
@@ -2630,7 +2836,7 @@
     "h": 6,
     "w": 4,
     "x": 5,
-    "y": 41
+    "y": 47
    },
    "id": 11,
    "options": {
@@ -2733,7 +2939,7 @@
     "h": 6,
     "w": 5,
     "x": 9,
-    "y": 41
+    "y": 47
    },
    "id": 10,
    "options": {
@@ -2836,7 +3042,7 @@
     "h": 6,
     "w": 4,
     "x": 14,
-    "y": 41
+    "y": 47
    },
    "id": 13,
    "options": {
@@ -2940,7 +3146,7 @@
     "h": 6,
     "w": 4,
     "x": 18,
-    "y": 41
+    "y": 47
    },
    "id": 12,
    "options": {
@@ -3043,7 +3249,7 @@
     "h": 6,
     "w": 2,
     "x": 22,
-    "y": 41
+    "y": 47
    },
    "id": 29,
    "options": {
@@ -3084,7 +3290,7 @@
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 47
+    "y": 53
    },
    "id": 25,
    "panels": [
@@ -3205,7 +3411,7 @@
     "h": 8,
     "w": 6,
     "x": 12,
-    "y": 48
+    "y": 54
    },
    "id": 7,
    "options": {
@@ -3377,7 +3583,7 @@
     "h": 8,
     "w": 6,
     "x": 18,
-    "y": 48
+    "y": 54
    },
    "id": 6,
    "options": {
@@ -3456,7 +3662,7 @@
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 56
+    "y": 62
    },
    "id": 1,
    "panels": [
@@ -3532,7 +3738,7 @@
     "h": 8,
     "w": 6,
     "x": 0,
-    "y": 57
+    "y": 63
    },
    "id": 2,
    "options": {
@@ -3715,7 +3921,7 @@
     "h": 8,
     "w": 6,
     "x": 6,
-    "y": 57
+    "y": 63
    },
    "id": 3,
    "options": {
@@ -3876,7 +4082,7 @@
     "h": 8,
     "w": 6,
     "x": 12,
-    "y": 57
+    "y": 63
    },
    "id": 4,
    "options": {
@@ -4048,7 +4254,7 @@
     "h": 8,
     "w": 6,
     "x": 18,
-    "y": 57
+    "y": 63
    },
    "id": 5,
    "options": {

--- a/operations/tempo-mixin/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin/dashboards/tempo-backendwork.json
@@ -2309,12 +2309,206 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(tempo_backend_scheduler_redaction_traces_found_total{cluster=~\"$cluster\", namespace=~\"$namespace\", mode=\"apply\"}[1h])) by (tenant)",
+          "legendFormat": "{{tenant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Traces Redacted / h",
+      "type": "timeseries",
+      "description": "Traces actually removed by applied redaction jobs (mode=apply), by tenant. The durable record of what was deleted."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 43,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(tempo_backend_scheduler_redaction_traces_found_total{cluster=~\"$cluster\", namespace=~\"$namespace\", mode=\"dry_run\"}[1h])) by (tenant)",
+          "legendFormat": "{{tenant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dry-run Blast Radius / h",
+      "type": "timeseries",
+      "description": "Traces a dry-run redaction matched but did NOT remove (mode=dry_run), by tenant. Preview of a query selector’s blast radius before applying."
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 46
       },
       "id": 8,
       "panels": [],
@@ -2384,7 +2578,7 @@
         "h": 6,
         "w": 5,
         "x": 0,
-        "y": 41
+        "y": 47
       },
       "id": 9,
       "options": {
@@ -2482,7 +2676,7 @@
         "h": 6,
         "w": 4,
         "x": 5,
-        "y": 41
+        "y": 47
       },
       "id": 11,
       "options": {
@@ -2579,7 +2773,7 @@
         "h": 6,
         "w": 5,
         "x": 9,
-        "y": 41
+        "y": 47
       },
       "id": 10,
       "options": {
@@ -2676,7 +2870,7 @@
         "h": 6,
         "w": 4,
         "x": 14,
-        "y": 41
+        "y": 47
       },
       "id": 13,
       "options": {
@@ -2774,7 +2968,7 @@
         "h": 6,
         "w": 4,
         "x": 18,
-        "y": 41
+        "y": 47
       },
       "id": 12,
       "options": {
@@ -2871,7 +3065,7 @@
         "h": 6,
         "w": 2,
         "x": 22,
-        "y": 41
+        "y": 47
       },
       "id": 29,
       "options": {
@@ -2910,7 +3104,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 53
       },
       "id": 25,
       "panels": [],
@@ -3025,7 +3219,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 48
+        "y": 54
       },
       "id": 7,
       "options": {
@@ -3191,7 +3385,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 48
+        "y": 54
       },
       "id": 6,
       "options": {
@@ -3268,7 +3462,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 62
       },
       "id": 1,
       "panels": [],
@@ -3338,7 +3532,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 57
+        "y": 63
       },
       "id": 2,
       "options": {
@@ -3515,7 +3709,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 57
+        "y": 63
       },
       "id": 3,
       "options": {
@@ -3670,7 +3864,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 57
+        "y": 63
       },
       "id": 4,
       "options": {
@@ -3836,7 +4030,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 57
+        "y": 63
       },
       "id": 5,
       "options": {


### PR DESCRIPTION
**What this PR does**:

Adds observability for backend-scheduler redaction: a per-tenant metric plus dashboard panels showing how many traces each redaction job matched.

- New counter `tempo_backend_scheduler_redaction_traces_found_total{tenant, mode}`, incremented in `UpdateJob` as redaction jobs complete. `mode=apply` counts traces actually removed; `mode=dry_run` counts a dry-run's previewed blast radius (nothing removed). A block that scans clean is a no-op.
- Adds two panels to the **Redaction** row of the Backend Work dashboard (tempo-mixin): "Traces Redacted / h" (mode=apply — the durable record of what was deleted) and "Dry-run Blast Radius / h" (mode=dry_run — preview a query selector's scope before applying), each broken down by tenant.

The status API is live-only, so this counter is the durable, per-tenant record of what redaction actually removed over time.

Context: follows the merged TraceQL query selector (#7663) and quiescence (#7695); part of a small series completing redaction lifecycle handling.

**Which issue(s) this PR fixes**:


**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
