### PR TITLE
[backend-scheduler] redaction: dry-run does not block compaction, quiesce, or rescan

### DIFF
--- a/.chloggen/redaction-dryrun-lifecycle.yaml
+++ b/.chloggen/redaction-dryrun-lifecycle.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: a dry-run redaction (read-only preview) no longer disables the tenant's compaction/retention, enters quiescence, or arms a rescan — those only apply to an apply-mode redaction, which actually rewrites blocks.
+issues: []
+subtext:
+user: zalegrala

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -479,7 +479,10 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 		return nil, status.Error(codes.FailedPrecondition, "compaction is disabled for this tenant")
 	}
 
-	if s.work.TenantPending(tenant) {
+	// One batch per tenant, any mode. GetBatch is the mode-agnostic existence check; a dry-run
+	// does not make TenantPending true, so guarding on TenantPending here would wrongly admit a
+	// second submission over a running dry-run.
+	if s.work.GetBatch(tenant) != nil {
 		return nil, status.Error(codes.AlreadyExists, "a redaction is already in progress for this tenant")
 	}
 
@@ -502,8 +505,8 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 	// can process them — their contents will be merged into a new output block not
 	// yet covered by any pending redaction job. We record the job IDs so the
 	// maintenance loop can look up output blocks once compaction finishes.
-	// Since TenantPending returned false above, there are no active redaction jobs
-	// for this tenant, so busy blocks are exclusively from other providers.
+	// Since GetBatch returned nil above (no batch of any mode), there are no active redaction
+	// jobs for this tenant, so busy blocks are exclusively from other providers.
 	busyBlocks := s.work.BusyBlocksForTenant(tenant)
 
 	skippedJobSet := make(map[string]struct{})
@@ -549,7 +552,11 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 		Mode:              req.Mode,
 		CreatedAtUnixNano: time.Now().UnixNano(),
 	}
-	if len(skippedJobSet) > 0 {
+	// Only apply-mode batches arm a rescan. A dry-run rewrites nothing, so there is no output
+	// block to re-cover once a skipped compaction finishes; a rescan would only re-count and
+	// inflate the dry-run metric. Blocks busy at submission simply go uncounted (a minor,
+	// documented preview undercount).
+	if len(skippedJobSet) > 0 && req.Mode != tempopb.RedactionMode_REDACTION_MODE_DRY_RUN {
 		skippedJobIDs := make([]string, 0, len(skippedJobSet))
 		for id := range skippedJobSet {
 			skippedJobIDs = append(skippedJobIDs, id)
@@ -642,8 +649,16 @@ func (s *BackendScheduler) redactionBatchActive(tenantID string, rescanPending b
 // promoted to the active map) still count via redactionBatchActive, so the batch is not treated
 // as done while any are outstanding.
 func (s *BackendScheduler) cleanupBatchIfDone(ctx context.Context, tenantID string) {
-	quiesceUntil, rescanPending, ok := s.work.BatchQuiescenceState(tenantID)
+	quiesceUntil, rescanPending, dryRun, ok := s.work.BatchQuiescenceState(tenantID)
 	if !ok || s.redactionBatchActive(tenantID, rescanPending) {
+		return
+	}
+	if dryRun {
+		// A dry-run writes nothing and never disabled compaction, so there is no cleanup-window
+		// race to hold open: remove the batch at once and free the tenant's slot.
+		s.work.RemoveBatch(tenantID)
+		s.flushBatches(ctx)
+		level.Info(log.Logger).Log("msg", "dry-run redaction batch complete, removed", "tenant", tenantID)
 		return
 	}
 	if quiesceUntil == 0 {
@@ -666,7 +681,7 @@ func (s *BackendScheduler) enterQuiescence(tenantID string) {
 // change (returns false), so the manifest is not rewritten on every tick. The caller flushes once
 // per tick if anything changed.
 func (s *BackendScheduler) advanceQuiescence(tenantID string) (changed bool) {
-	quiesceUntil, rescanPending, ok := s.work.BatchQuiescenceState(tenantID)
+	quiesceUntil, rescanPending, dryRun, ok := s.work.BatchQuiescenceState(tenantID)
 	if !ok {
 		return false
 	}
@@ -676,6 +691,14 @@ func (s *BackendScheduler) advanceQuiescence(tenantID string) (changed bool) {
 			return true
 		}
 		return false
+	}
+	if dryRun {
+		// Dry-run batches do not quiesce (nothing was written); remove on the tick that finds
+		// them done. Normally cleanupBatchIfDone already handled this on job completion; this
+		// covers a batch that went done without a completion callback (e.g. all jobs dropped).
+		s.work.RemoveBatch(tenantID)
+		level.Info(log.Logger).Log("msg", "dry-run redaction batch complete, removed", "tenant", tenantID)
+		return true
 	}
 	if quiesceUntil == 0 {
 		s.enterQuiescence(tenantID)

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -556,7 +556,7 @@ func (s *BackendScheduler) SubmitRedaction(ctx context.Context, req *tempopb.Sub
 	// block to re-cover once a skipped compaction finishes; a rescan would only re-count and
 	// inflate the dry-run metric. Blocks busy at submission simply go uncounted (a minor,
 	// documented preview undercount).
-	if len(skippedJobSet) > 0 && req.Mode != tempopb.RedactionMode_REDACTION_MODE_DRY_RUN {
+	if len(skippedJobSet) > 0 && !req.Mode.IsDryRun() {
 		skippedJobIDs := make([]string, 0, len(skippedJobSet))
 		for id := range skippedJobSet {
 			skippedJobIDs = append(skippedJobIDs, id)

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -96,7 +96,7 @@ func recordRedactionResult(tenant string, mode tempopb.RedactionMode, found int3
 
 // redactionModeLabel is a short, stable metric label for a redaction mode.
 func redactionModeLabel(mode tempopb.RedactionMode) string {
-	if mode == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN {
+	if mode.IsDryRun() {
 		return "dry_run"
 	}
 	return "apply"

--- a/modules/backendscheduler/redaction_dryrun_test.go
+++ b/modules/backendscheduler/redaction_dryrun_test.go
@@ -1,0 +1,52 @@
+package backendscheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// TestDryRunBatchDoesNotBlockCompaction verifies a dry-run batch is not an exclusive tenant
+// operation: it must not gate compaction/retention (TenantPending false), though it still
+// occupies the tenant's single batch slot (HasBatch true).
+func TestDryRunBatchDoesNotBlockCompaction(t *testing.T) {
+	_, s := newQuiescenceScheduler(t)
+	tenant := "t-dry"
+	require.NoError(t, s.work.AddBatch(&tempopb.RedactionBatch{
+		BatchId: "b", TenantId: tenant, CreatedAtUnixNano: time.Now().UnixNano(),
+		Mode: tempopb.RedactionMode_REDACTION_MODE_DRY_RUN,
+	}))
+	require.False(t, s.work.TenantPending(tenant), "a dry-run batch must not block compaction/retention")
+	require.NotNil(t, s.work.GetBatch(tenant), "the dry-run batch still occupies the tenant's batch slot")
+}
+
+// TestApplyBatchBlocksCompaction guards the apply path: an apply batch remains an exclusive
+// operation that gates compaction (TenantPending true).
+func TestApplyBatchBlocksCompaction(t *testing.T) {
+	_, s := newQuiescenceScheduler(t)
+	tenant := "t-apply"
+	require.NoError(t, s.work.AddBatch(&tempopb.RedactionBatch{
+		BatchId: "b", TenantId: tenant, CreatedAtUnixNano: time.Now().UnixNano(),
+		Mode: tempopb.RedactionMode_REDACTION_MODE_APPLY,
+	}))
+	require.True(t, s.work.TenantPending(tenant), "an apply batch must block compaction")
+	require.NotNil(t, s.work.GetBatch(tenant))
+}
+
+// TestDryRunBatchRemovedImmediatelyOnCompletion verifies a completed dry-run batch is removed
+// at once rather than entering quiescence: a dry-run writes nothing, so there is no
+// cleanup-window race to hold compaction for, and the tenant's slot frees immediately.
+func TestDryRunBatchRemovedImmediatelyOnCompletion(t *testing.T) {
+	ctx, s := newQuiescenceScheduler(t)
+	tenant := "t-dry-done"
+	require.NoError(t, s.work.AddBatch(&tempopb.RedactionBatch{
+		BatchId: "b", TenantId: tenant, CreatedAtUnixNano: time.Now().UnixNano(),
+		Mode: tempopb.RedactionMode_REDACTION_MODE_DRY_RUN,
+	}))
+	// No jobs and no rescan pending → the batch is done.
+	s.cleanupBatchIfDone(ctx, tenant)
+	require.Nil(t, s.work.GetBatch(tenant), "a completed dry-run batch is removed immediately, not quiesced")
+}

--- a/modules/backendscheduler/redaction_dryrun_test.go
+++ b/modules/backendscheduler/redaction_dryrun_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/status"
+	"github.com/grafana/dskit/user"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 
 	"github.com/grafana/tempo/pkg/tempopb"
 )
@@ -49,4 +52,24 @@ func TestDryRunBatchRemovedImmediatelyOnCompletion(t *testing.T) {
 	// No jobs and no rescan pending → the batch is done.
 	s.cleanupBatchIfDone(ctx, tenant)
 	require.Nil(t, s.work.GetBatch(tenant), "a completed dry-run batch is removed immediately, not quiesced")
+}
+
+// TestSecondSubmissionRejectedWhileDryRunActive guards the one-batch-per-tenant invariant across
+// the TenantPending change: because a dry-run no longer makes TenantPending true, the submission
+// guard must key off batch existence (GetBatch), not TenantPending — otherwise a second redaction
+// could be admitted over a running dry-run. Regression test for the guard swap in SubmitRedaction.
+func TestSecondSubmissionRejectedWhileDryRunActive(t *testing.T) {
+	ctx, s := newQuiescenceScheduler(t)
+	tenant := "t-dup"
+	require.NoError(t, s.work.AddBatch(&tempopb.RedactionBatch{
+		BatchId: "b", TenantId: tenant, CreatedAtUnixNano: time.Now().UnixNano(),
+		Mode: tempopb.RedactionMode_REDACTION_MODE_DRY_RUN,
+	}))
+	require.False(t, s.work.TenantPending(tenant), "precondition: a dry-run does not make the tenant pending")
+
+	_, err := s.SubmitRedaction(user.InjectOrgID(ctx, tenant), &tempopb.SubmitRedactionRequest{
+		TraceIds: [][]byte{{0x01}},
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.AlreadyExists, status.Code(err), "a second submission over an active dry-run must be rejected")
 }

--- a/modules/backendscheduler/work/batch.go
+++ b/modules/backendscheduler/work/batch.go
@@ -49,11 +49,14 @@ func (b *batchStore) remove(tenantID string) {
 	delete(b.byTenant, tenantID)
 }
 
-func (b *batchStore) hasActive(tenantID string) bool {
+// hasBlockingBatch reports whether the tenant has a batch that must block compaction/retention,
+// i.e. an apply-mode redaction. A dry-run writes nothing and is not an exclusive operation, so it
+// does not block. Fails safe: an unset/unrecognized mode (zero value APPLY) blocks.
+func (b *batchStore) hasBlockingBatch(tenantID string) bool {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	_, ok := b.byTenant[tenantID]
-	return ok
+	batch, ok := b.byTenant[tenantID]
+	return ok && batch.Mode != tempopb.RedactionMode_REDACTION_MODE_DRY_RUN
 }
 
 // flush writes all active batches to batches.pb in localPath using proto encoding.
@@ -112,14 +115,14 @@ func (b *batchStore) setQuiesceUntil(tenantID string, untilUnixNano int64) {
 
 // quiescenceState reads a tenant's quiescence-relevant fields under the lock, returning a
 // snapshot so callers never touch the live batch pointer's mutable fields unsynchronized.
-func (b *batchStore) quiescenceState(tenantID string) (quiesceUntilUnixNano int64, rescanPending, ok bool) {
+func (b *batchStore) quiescenceState(tenantID string) (quiesceUntilUnixNano int64, rescanPending, dryRun, ok bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	batch, exists := b.byTenant[tenantID]
 	if !exists {
-		return 0, false, false
+		return 0, false, false, false
 	}
-	return batch.QuiesceUntilUnixNano, batch.RescanAfterUnixNano > 0, true
+	return batch.QuiesceUntilUnixNano, batch.RescanAfterUnixNano > 0, batch.Mode == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN, true
 }
 
 // load reads batches.pb from localPath. Missing file is not an error (clean start).
@@ -185,8 +188,8 @@ func (w *Work) SetBatchQuiesceUntil(tenantID string, untilUnixNano int64) {
 	w.batches.setQuiesceUntil(tenantID, untilUnixNano)
 }
 
-// BatchQuiescenceState returns a locked snapshot of a tenant's quiesce-until deadline and
-// whether a rescan is pending; ok is false when no batch exists.
-func (w *Work) BatchQuiescenceState(tenantID string) (quiesceUntilUnixNano int64, rescanPending, ok bool) {
+// BatchQuiescenceState returns a locked snapshot of a tenant's quiesce-until deadline, whether a
+// rescan is pending, and whether the batch is a dry-run; ok is false when no batch exists.
+func (w *Work) BatchQuiescenceState(tenantID string) (quiesceUntilUnixNano int64, rescanPending, dryRun, ok bool) {
 	return w.batches.quiescenceState(tenantID)
 }

--- a/modules/backendscheduler/work/batch.go
+++ b/modules/backendscheduler/work/batch.go
@@ -56,7 +56,7 @@ func (b *batchStore) hasBlockingBatch(tenantID string) bool {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	batch, ok := b.byTenant[tenantID]
-	return ok && batch.Mode != tempopb.RedactionMode_REDACTION_MODE_DRY_RUN
+	return ok && !batch.Mode.IsDryRun()
 }
 
 // flush writes all active batches to batches.pb in localPath using proto encoding.
@@ -122,7 +122,7 @@ func (b *batchStore) quiescenceState(tenantID string) (quiesceUntilUnixNano int6
 	if !exists {
 		return 0, false, false, false
 	}
-	return batch.QuiesceUntilUnixNano, batch.RescanAfterUnixNano > 0, batch.Mode == tempopb.RedactionMode_REDACTION_MODE_DRY_RUN, true
+	return batch.QuiesceUntilUnixNano, batch.RescanAfterUnixNano > 0, batch.Mode.IsDryRun(), true
 }
 
 // load reads batches.pb from localPath. Missing file is not an error (clean start).

--- a/modules/backendscheduler/work/interface.go
+++ b/modules/backendscheduler/work/interface.go
@@ -45,19 +45,21 @@ type Interface interface {
 	BusyBlocksForTenant(tenantID string) map[string]string
 
 	// TenantPending returns true when an exclusive tenant operation exists whose
-	// full scope is not yet reflected in the job queue — e.g. a batch was just
-	// created or the system is in a rescan delay window. Distinct from
-	// CompactionDisabled; this reflects transient internal state.
+	// full scope is not yet reflected in the job queue — i.e. an apply-mode redaction batch
+	// (just created or in its rescan-wait window). Gates compaction and retention. A dry-run
+	// batch is not exclusive and does not make a tenant pending; use GetBatch != nil for a
+	// mode-agnostic existence check. Distinct from CompactionDisabled.
 	TenantPending(tenantID string) bool
 
 	// Batch management -- shared trace ID list for redaction jobs to avoid per-job copies.
+	// GetBatch doubles as the mode-agnostic existence check (one batch per tenant at submission).
 	AddBatch(batch *tempopb.RedactionBatch) error
 	GetBatch(tenantID string) *tempopb.RedactionBatch
 	RemoveBatch(tenantID string)
 	ListBatches() []*tempopb.RedactionBatch
 	SetBatchRescan(tenantID string, skippedJobIDs []string, rescanAfterUnixNano int64)
 	SetBatchQuiesceUntil(tenantID string, untilUnixNano int64)
-	BatchQuiescenceState(tenantID string) (quiesceUntilUnixNano int64, rescanPending, ok bool)
+	BatchQuiescenceState(tenantID string) (quiesceUntilUnixNano int64, rescanPending, dryRun, ok bool)
 	FlushBatchesToLocal(ctx context.Context, localPath string) error
 	LoadBatchesFromLocal(ctx context.Context, localPath string) error
 

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -914,9 +914,12 @@ func (w *Work) BusyBlocksForTenant(tenantID string) map[string]string {
 }
 
 // TenantPending returns true when an exclusive tenant operation exists whose
-// full scope is not yet reflected in the job queue. Delegates to the batch store.
+// full scope is not yet reflected in the job queue — i.e. an apply-mode redaction batch that
+// gates compaction and retention. A dry-run batch writes nothing and is not exclusive, so it does
+// not make a tenant pending (use GetBatch != nil for a mode-agnostic existence check). Delegates
+// to the batch store.
 func (w *Work) TenantPending(tenantID string) bool {
-	return w.batches.hasActive(tenantID)
+	return w.batches.hasBlockingBatch(tenantID)
 }
 
 // runningBlockKeys returns pendingBlockKey strings for every block referenced by j.

--- a/pkg/tempopb/redaction.go
+++ b/pkg/tempopb/redaction.go
@@ -1,0 +1,8 @@
+package tempopb
+
+// IsDryRun reports whether the redaction mode is a dry-run: evaluate and count matches without
+// rewriting any blocks. Centralizes the mode comparison used across the backend-scheduler
+// redaction lifecycle (compaction gating, quiescence, rescan, metrics).
+func (m RedactionMode) IsDryRun() bool {
+	return m == RedactionMode_REDACTION_MODE_DRY_RUN
+}

--- a/pkg/tempopb/redaction_test.go
+++ b/pkg/tempopb/redaction_test.go
@@ -1,0 +1,12 @@
+package tempopb
+
+import "testing"
+
+func TestRedactionModeIsDryRun(t *testing.T) {
+	if !RedactionMode_REDACTION_MODE_DRY_RUN.IsDryRun() {
+		t.Error("DRY_RUN mode must report IsDryRun() == true")
+	}
+	if RedactionMode_REDACTION_MODE_APPLY.IsDryRun() {
+		t.Error("APPLY mode must report IsDryRun() == false")
+	}
+}


### PR DESCRIPTION
**What this PR does**:

A dry-run redaction is read-only — it scans each block and reports match counts but rewrites nothing. Today it rides the same lifecycle as an apply-mode redaction, so it wrongly **disables the tenant's compaction and retention**, holds a post-completion **quiescence** window, and **arms a rescan**. This makes all three apply-only.

Root cause: `Work.TenantPending` — the compaction/retention gate — was `batchStore.hasActive` (*"a batch exists"*), conflating two meanings: **exclusivity** (blocks compaction) and **existence** (one batch per tenant). A dry-run needs the latter but not the former.

- `TenantPending` now delegates to `hasBlockingBatch` = batch exists **and** `Mode != DRY_RUN` (fail-safe: unset/apply blocks). This flips the compaction gate, retention gate, and the `Next()` retention-drop to apply-only — matching `TenantPending`'s documented "*exclusive* tenant operation" contract.
- The submit "already in progress" guard uses `GetBatch(tenant) != nil` (mode-agnostic existence — one batch per tenant, any mode). No new interface method.
- Dry-run arms **no rescan** (nothing to re-cover once a skipped compaction finishes; a rescan would only re-count and inflate the dry-run metric).
- A completed dry-run batch is **removed immediately** in `cleanupBatchIfDone`/`advanceQuiescence` instead of entering quiescence.

Net: a dry-run runs without blocking the tenant's compaction, quiescing, or rescanning; the apply-mode path is unchanged.

**Trade-off** (documented at the skip site): a block mid-compaction at submission is skipped and, for a dry-run, not re-counted — so the preview can undercount slightly.

**Interface surface**: the only `work.Interface` change is one extra return value (`dryRun`) on the existing `BatchQuiescenceState`; no methods added or removed.

Follows the merged query selector (#7663), quiescence (#7695), and metric (#7699).

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
