### PR TITLE
[backend-scheduler] fix redaction in-flight job-accounting leak + dequeue TOCTOU

### DIFF
--- a/.chloggen/redaction-inflight-accounting.yaml
+++ b/.chloggen/redaction-inflight-accounting.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: backend-scheduler
+note: fix a redaction in-flight job-accounting leak in the backend-scheduler — a redaction job dequeued from the pending queue but dropped at assignment (its batch already gone) leaked the per-tenant in-flight counter, which could make the tenant's batch look perpetually active and wedge future redaction submissions. The dequeue now counts the job in-flight atomically (closing a TOCTOU where a dequeued-but-not-yet-counted job could be misread as done), and the drop path releases the count.
+issues: []
+subtext:
+user: zalegrala

--- a/.chloggen/redaction-inflight-accounting.yaml
+++ b/.chloggen/redaction-inflight-accounting.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 component: backend-scheduler
-note: fix a redaction in-flight job-accounting leak in the backend-scheduler — a redaction job dequeued from the pending queue but dropped at assignment (its batch already gone) leaked the per-tenant in-flight counter, which could make the tenant's batch look perpetually active and wedge future redaction submissions. The dequeue now counts the job in-flight atomically (closing a TOCTOU where a dequeued-but-not-yet-counted job could be misread as done), and the drop path releases the count.
+note: fix a backend-scheduler bug where a redaction job dropped at assignment leaked an internal in-flight counter, which could leave a tenant's redaction looking perpetually in progress and block that tenant's future redaction submissions.
 issues: []
 subtext:
 user: zalegrala

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -165,6 +165,11 @@ func (s *BackendScheduler) starting(ctx context.Context) error {
 					metricProviderJobsMerged.WithLabelValues(strconv.Itoa(i)).Inc()
 				case <-ctx.Done():
 					level.Info(log.Logger).Log("msg", "stopping provider", "provider", i)
+					// This job was received but not forwarded; if it's a redaction job it was
+					// counted in-flight at dequeue and will never reach Next(), so release it.
+					if job.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
+						s.work.ReleaseRedactionInFlight(job.Tenant())
+					}
 					return
 				}
 			}

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -153,8 +153,14 @@ func (s *BackendScheduler) starting(ctx context.Context) error {
 			var job *work.Job
 
 			for {
+				var ok bool
 				select {
-				case job = <-jobs:
+				case job, ok = <-jobs:
+					if !ok {
+						// Provider closed its channel (it has stopped); nothing more to forward.
+						level.Info(log.Logger).Log("msg", "provider channel closed", "provider", i)
+						return
+					}
 				case <-ctx.Done():
 					level.Info(log.Logger).Log("msg", "stopping provider", "provider", i)
 					return
@@ -167,7 +173,7 @@ func (s *BackendScheduler) starting(ctx context.Context) error {
 					level.Info(log.Logger).Log("msg", "stopping provider", "provider", i)
 					// This job was received but not forwarded; if it's a redaction job it was
 					// counted in-flight at dequeue and will never reach Next(), so release it.
-					if job.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
+					if job != nil && job.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
 						s.work.ReleaseRedactionInFlight(job.Tenant())
 					}
 					return

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -168,7 +168,12 @@ func (s *BackendScheduler) starting(ctx context.Context) error {
 					// not leak on shutdown.
 					for {
 						select {
-						case j := <-jobs:
+						case j, ok := <-jobs:
+							// A closed channel is always ready, so use the two-value receive and
+							// return on close; otherwise this loop would spin forever.
+							if !ok {
+								return
+							}
 							if j != nil && j.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
 								s.work.ReleaseRedactionInFlight(j.Tenant())
 							}

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -311,6 +311,9 @@ func (s *BackendScheduler) Next(ctx context.Context, req *tempopb.NextJobRequest
 						level.Debug(log.Logger).Log("msg", "dropping redaction job: batch no longer exists",
 							"job_id", j.ID, "tenant", j.Tenant())
 						metricJobsDropped.WithLabelValues(j.Tenant(), j.GetType().String()).Inc()
+						// This job was counted in-flight when NextPendingJob dequeued it; since it is
+						// dropped rather than promoted via AddJob, release that count or it leaks.
+						s.work.ReleaseRedactionInFlight(j.Tenant())
 						drop = true
 					} else if j.JobDetail.Redaction != nil {
 						// Inject the batch's selector (trace IDs or query) and mode so the

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -163,7 +163,19 @@ func (s *BackendScheduler) starting(ctx context.Context) error {
 					}
 				case <-ctx.Done():
 					level.Info(log.Logger).Log("msg", "stopping provider", "provider", i)
-					return
+					// The provider channel is buffered: drain any job it already handed off but we
+					// never forwarded, releasing the in-flight count of redaction jobs so it does
+					// not leak on shutdown.
+					for {
+						select {
+						case j := <-jobs:
+							if j != nil && j.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
+								s.work.ReleaseRedactionInFlight(j.Tenant())
+							}
+						default:
+							return
+						}
+					}
 				}
 
 				select {

--- a/modules/backendscheduler/provider/redaction.go
+++ b/modules/backendscheduler/provider/redaction.go
@@ -70,6 +70,10 @@ func (p *RedactionProvider) Start(ctx context.Context) <-chan *work.Job {
 					select {
 					case jobs <- job:
 					case <-ctx.Done():
+						// Shutdown lost the handoff: this job was counted in-flight by
+						// NextPendingJob and will never reach Next() to be promoted or dropped,
+						// so release its count here or it leaks.
+						p.sched.ReleaseRedactionInFlight(job.Tenant())
 						return
 					}
 					continue

--- a/modules/backendscheduler/provider/types.go
+++ b/modules/backendscheduler/provider/types.go
@@ -18,6 +18,11 @@ type Scheduler interface {
 	ListJobs() []*work.Job
 	NextPendingJob(jobType tempopb.JobType) *work.Job
 
+	// ReleaseRedactionInFlight releases the in-flight count for a redaction job that was dequeued
+	// via NextPendingJob but is being dropped rather than dispatched (e.g. on shutdown), so the
+	// counter does not leak.
+	ReleaseRedactionInFlight(tenantID string)
+
 	// RegisterJob makes a job visible to other components before it is
 	// promoted to the active map via AddJob.
 	RegisterJob(job *work.Job)

--- a/modules/backendscheduler/work/inflight_test.go
+++ b/modules/backendscheduler/work/inflight_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -147,5 +148,14 @@ func TestAddJobAndAddPendingJobsConcurrent(t *testing.T) {
 			w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION)
 		}
 	}()
-	wg.Wait()
+
+	// Completion is the assertion: a lock-order inversion would deadlock these two goroutines. Turn
+	// that into a clean failure instead of a CI hang.
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("AddJob/AddPendingJobs did not complete: likely a shard.mtx/pendingMtx lock-order inversion deadlock")
+	}
 }

--- a/modules/backendscheduler/work/inflight_test.go
+++ b/modules/backendscheduler/work/inflight_test.go
@@ -27,10 +27,16 @@ func TestReleaseRedactionInFlight(t *testing.T) {
 	require.False(t, w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION), "released job no longer counts; no leak")
 }
 
-// TestNextPendingJobCountsInFlightAtomically verifies a dequeued redaction job is counted in-flight
-// immediately (dequeue and increment are one critical section), so a concurrent HasJobsForTenant
-// can't observe the job as gone-but-not-yet-counted.
-func TestNextPendingJobCountsInFlightAtomically(t *testing.T) {
+// TestNextPendingJobCountsInFlightOnDequeue verifies a dequeued redaction job is counted in-flight
+// as soon as it leaves the pending queue, so HasJobsForTenant keeps reporting the tenant busy before
+// the job is promoted via AddJob.
+//
+// Note: this asserts the count is set on dequeue; it does NOT prove the increment shares the dequeue's
+// critical section (the TOCTOU the fix closes). That atomicity is a structural property — increment
+// and dequeue are under one pendingMtx hold in NextPendingJob — and is not observable through the
+// public API, since HasJobsForTenant serializes on the same mutex and so can never see the interior
+// of a single critical section either way. It is verified by inspection, not by this test.
+func TestNextPendingJobCountsInFlightOnDequeue(t *testing.T) {
 	w := New(Config{}).(*Work)
 	tenant := "t"
 	require.NoError(t, w.AddPendingJobs([]*Job{createRedactionJob("j1", tenant, "blk1")}))
@@ -39,9 +45,39 @@ func TestNextPendingJobCountsInFlightAtomically(t *testing.T) {
 	require.True(t, w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION), "job counted the instant it leaves the pending queue")
 }
 
+// TestAddJobDuplicateReleasesInFlight covers the leak path where a redaction job is dequeued (and
+// thus counted in-flight) but AddJob then finds an identical job ID already active and returns
+// ErrJobAlreadyExists before the promote-path decrement. Reachable in normal operation because
+// AddPendingJobs dedups only against shard.Pending, so an active ID can be re-enqueued and
+// re-dequeued. Without releasing on the duplicate path the count leaks permanently and
+// HasJobsForTenant stays true forever, wedging the tenant's future redactions.
+func TestAddJobDuplicateReleasesInFlight(t *testing.T) {
+	w := New(Config{}).(*Work)
+	tenant := "t"
+
+	// An identical job ID is already active.
+	require.NoError(t, w.AddJob(createRedactionJob("dup", tenant, "blkA")))
+
+	// Re-enqueue the same ID and dequeue it: NextPendingJob counts it in-flight.
+	require.NoError(t, w.AddPendingJobs([]*Job{createRedactionJob("dup", tenant, "blkB")}))
+	dup := w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION)
+	require.NotNil(t, dup)
+
+	// AddJob rejects the duplicate; it must still release the in-flight count it did not promote.
+	require.ErrorIs(t, w.AddJob(dup), ErrJobAlreadyExists)
+
+	w.pendingMtx.Lock()
+	inFlight := w.redactionInFlight[tenant]
+	w.pendingMtx.Unlock()
+	require.Zero(t, inFlight, "duplicate AddJob must release the unpromoted in-flight count, else the tenant wedges")
+}
+
 // TestRedactionInFlightAccountingNoLeakUnderRace drains a queue by dequeuing then dropping each job
-// (the leak-prone path) while another goroutine hammers HasJobsForTenant. Under -race it guards the
-// counter/queue access; functionally it asserts the in-flight count returns to zero — no leak.
+// (the leak-prone path) while another goroutine hammers HasJobsForTenant. The functional assertion
+// is that every dequeued-then-dropped job releases its count, so the in-flight total returns to
+// zero. Running under -race additionally validates that the concurrent NextPendingJob /
+// ReleaseRedactionInFlight / HasJobsForTenant callers keep the shared counter and queue maps
+// correctly synchronized under pendingMtx.
 func TestRedactionInFlightAccountingNoLeakUnderRace(t *testing.T) {
 	w := New(Config{}).(*Work)
 	tenant := "t"

--- a/modules/backendscheduler/work/inflight_test.go
+++ b/modules/backendscheduler/work/inflight_test.go
@@ -118,3 +118,34 @@ func TestRedactionInFlightAccountingNoLeakUnderRace(t *testing.T) {
 
 	require.False(t, w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION), "every dequeued job was released; in-flight count must be back to zero")
 }
+
+// TestAddJobAndAddPendingJobsConcurrent exercises AddJob and AddPendingJobs racing on the same shards
+// and tenant. AddPendingJobs locks pendingMtx then shard.mtx; AddJob must not hold shard.mtx while
+// taking pendingMtx or the two invert and can deadlock. This does not deterministically prove
+// deadlock-freedom (a reintroduced inversion would surface as a timeout, not a clean failure), but it
+// keeps the two lock orders under concurrent load and, with -race, guards the reordered access. It
+// also covers the AddJob-duplicate release path under contention.
+func TestAddJobAndAddPendingJobsConcurrent(t *testing.T) {
+	w := New(Config{}).(*Work)
+	tenant := "t"
+	const iters = 300
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			id := fmt.Sprintf("j%d", i%16) // small ID space => AddJob sees duplicates and hits the release path
+			_ = w.AddJob(createRedactionJob(id, tenant, fmt.Sprintf("blk%d", i)))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			id := fmt.Sprintf("j%d", i%16)
+			_ = w.AddPendingJobs([]*Job{createRedactionJob(id, tenant, fmt.Sprintf("pblk%d", i))})
+			w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION)
+		}
+	}()
+	wg.Wait()
+}

--- a/modules/backendscheduler/work/inflight_test.go
+++ b/modules/backendscheduler/work/inflight_test.go
@@ -1,0 +1,84 @@
+package work
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// TestReleaseRedactionInFlight verifies a redaction job dequeued via NextPendingJob (now counted
+// in-flight) can be released without ever reaching AddJob — the case of a job dropped at
+// assignment. Without the release, the counter leaks and HasJobsForTenant stays true forever.
+func TestReleaseRedactionInFlight(t *testing.T) {
+	w := New(Config{}).(*Work)
+	tenant := "t"
+	require.NoError(t, w.AddPendingJobs([]*Job{createRedactionJob("j1", tenant, "blk1")}))
+
+	j := w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION)
+	require.NotNil(t, j)
+	require.True(t, w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION), "dequeued job is counted in-flight")
+
+	// The job is dropped at assignment (never promoted via AddJob): release its in-flight count.
+	w.ReleaseRedactionInFlight(tenant)
+	require.False(t, w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION), "released job no longer counts; no leak")
+}
+
+// TestNextPendingJobCountsInFlightAtomically verifies a dequeued redaction job is counted in-flight
+// immediately (dequeue and increment are one critical section), so a concurrent HasJobsForTenant
+// can't observe the job as gone-but-not-yet-counted.
+func TestNextPendingJobCountsInFlightAtomically(t *testing.T) {
+	w := New(Config{}).(*Work)
+	tenant := "t"
+	require.NoError(t, w.AddPendingJobs([]*Job{createRedactionJob("j1", tenant, "blk1")}))
+
+	require.NotNil(t, w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION))
+	require.True(t, w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION), "job counted the instant it leaves the pending queue")
+}
+
+// TestRedactionInFlightAccountingNoLeakUnderRace drains a queue by dequeuing then dropping each job
+// (the leak-prone path) while another goroutine hammers HasJobsForTenant. Under -race it guards the
+// counter/queue access; functionally it asserts the in-flight count returns to zero — no leak.
+func TestRedactionInFlightAccountingNoLeakUnderRace(t *testing.T) {
+	w := New(Config{}).(*Work)
+	tenant := "t"
+	const n = 500
+	jobs := make([]*Job, n)
+	for i := range jobs {
+		jobs[i] = createRedactionJob(fmt.Sprintf("j%d", i), tenant, fmt.Sprintf("blk%d", i))
+	}
+	require.NoError(t, w.AddPendingJobs(jobs))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION)
+			}
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			j := w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION)
+			if j == nil {
+				break
+			}
+			w.ReleaseRedactionInFlight(j.Tenant()) // dropped, not promoted
+		}
+		close(stop)
+	}()
+	wg.Wait()
+
+	require.False(t, w.HasJobsForTenant(tenant, tempopb.JobType_JOB_TYPE_REDACTION), "every dequeued job was released; in-flight count must be back to zero")
+}

--- a/modules/backendscheduler/work/interface.go
+++ b/modules/backendscheduler/work/interface.go
@@ -25,6 +25,9 @@ type Interface interface {
 	AddPendingJobs(jobs []*Job) error
 	ListAllPendingJobs() []*Job
 	NextPendingJob(jobType tempopb.JobType) *Job
+	// ReleaseRedactionInFlight releases the in-flight count for a dequeued redaction job that is
+	// dropped rather than promoted to active (else the counter leaks and wedges the tenant).
+	ReleaseRedactionInFlight(tenantID string)
 
 	// RegisterJob registers a job before it enters the channel pipeline, making it
 	// visible to other components. Cleared automatically by AddJob when promoted to active.

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -139,6 +139,15 @@ func (w *Work) AddJob(j *Job) error {
 	defer shard.mtx.Unlock()
 
 	if _, ok := shard.Jobs[j.ID]; ok {
+		// This job is already active, so it will not be promoted here. If it was dequeued via
+		// NextPendingJob it was counted in-flight; release that count now — the promote-path
+		// decrement below is skipped by this early return, and without the release the counter
+		// leaks and HasJobsForTenant wedges the tenant permanently.
+		if j.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
+			w.pendingMtx.Lock()
+			w.decRedactionInFlightLocked(j.Tenant())
+			w.pendingMtx.Unlock()
+		}
 		return ErrJobAlreadyExists
 	}
 
@@ -869,30 +878,23 @@ func (w *Work) decRedactionInFlightLocked(tenantID string) {
 // ReleaseRedactionInFlight decrements the tenant's in-flight redaction counter for a job that was
 // dequeued via NextPendingJob (and thus counted) but will NOT be promoted to active — e.g. dropped
 // at assignment because its batch is gone or cancelled. AddJob performs the same decrement on the
-// normal promote path; this covers the drop path so the counter can't leak and permanently wedge
-// the tenant's future redactions.
+// normal promote path; this releases the count on a drop path so it is not leaked there.
 func (w *Work) ReleaseRedactionInFlight(tenantID string) {
 	w.pendingMtx.Lock()
 	defer w.pendingMtx.Unlock()
 	w.decRedactionInFlightLocked(tenantID)
 }
 
-// hasRedactionInFlight returns true if there are redaction jobs for the tenant
-// that have been popped from the pending queue but not yet promoted to active.
-// Caller must hold pendingMtx.
-func (w *Work) hasRedactionInFlight(tenantID string) bool {
-	return w.redactionInFlight[tenantID] > 0
-}
-
-// HasJobsForTenant returns true if there are any jobs of the given type in any
-// state (pending queue, registered, or active map) for the tenant.
+// HasJobsForTenant returns true if there are any jobs of the given type for the tenant in any of
+// its tracked states: pending queue, in-flight (redaction jobs dequeued but not yet promoted),
+// registered, or active map.
 func (w *Work) HasJobsForTenant(tenantID string, jobType tempopb.JobType) bool {
 	w.pendingMtx.Lock()
 	hasPending := len(w.pendingByTenant[tenantID][jobType]) > 0
 	hasRunning := w.runningByTenant[tenantID][jobType] > 0
 	hasInFlight := false
 	if jobType == tempopb.JobType_JOB_TYPE_REDACTION {
-		hasInFlight = w.hasRedactionInFlight(tenantID)
+		hasInFlight = w.redactionInFlight[tenantID] > 0
 	}
 	if !hasInFlight && !hasRunning {
 		for _, j := range w.registeredJobs {

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -153,9 +153,7 @@ func (w *Work) AddJob(j *Job) error {
 	// If this redaction job was previously in-flight (popped from pending but not
 	// yet active), decrement the counter now that it has been promoted to active.
 	if j.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
-		if w.redactionInFlight[j.Tenant()] > 0 {
-			w.redactionInFlight[j.Tenant()]--
-		}
+		w.decRedactionInFlightLocked(j.Tenant())
 	}
 	// Index the worker -> job assignment so GetJobForWorker is O(1).
 	if wid := j.GetWorkerID(); wid != "" {
@@ -828,6 +826,13 @@ func (w *Work) NextPendingJob(jobType tempopb.JobType) *Job {
 				break
 			}
 		}
+		// Count a redaction job as in-flight in the SAME critical section as the dequeue, so it is
+		// never dequeued-but-uncounted — a window in which HasJobsForTenant could misread the batch
+		// as done and remove it. If the shard lookup below shows the entry was stale, we undo this
+		// increment before retrying.
+		if tenantID != "" && jobType == tempopb.JobType_JOB_TYPE_REDACTION {
+			w.redactionInFlight[tenantID]++
+		}
 		w.pendingMtx.Unlock()
 
 		if tenantID == "" {
@@ -843,17 +848,33 @@ func (w *Work) NextPendingJob(jobType tempopb.JobType) *Job {
 
 		if j != nil {
 			w.removePendingBlockIndex(j)
-			// Track that this redaction job is now in-flight: it has been removed
-			// from the pending queue but not yet promoted to the active map.
-			if j.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
-				w.pendingMtx.Lock()
-				w.redactionInFlight[j.Tenant()]++
-				w.pendingMtx.Unlock()
-			}
 			return j
 		}
-		// j is nil: stale index entry, skip and retry.
+		// Stale index entry (present in pendingByTenant but missing from the shard): undo the
+		// optimistic in-flight increment taken above, then retry.
+		if jobType == tempopb.JobType_JOB_TYPE_REDACTION {
+			w.ReleaseRedactionInFlight(tenantID)
+		}
 	}
+}
+
+// decRedactionInFlightLocked decrements a tenant's in-flight redaction counter, guarding against
+// underflow. Caller must hold pendingMtx.
+func (w *Work) decRedactionInFlightLocked(tenantID string) {
+	if w.redactionInFlight[tenantID] > 0 {
+		w.redactionInFlight[tenantID]--
+	}
+}
+
+// ReleaseRedactionInFlight decrements the tenant's in-flight redaction counter for a job that was
+// dequeued via NextPendingJob (and thus counted) but will NOT be promoted to active — e.g. dropped
+// at assignment because its batch is gone or cancelled. AddJob performs the same decrement on the
+// normal promote path; this covers the drop path so the counter can't leak and permanently wedge
+// the tenant's future redactions.
+func (w *Work) ReleaseRedactionInFlight(tenantID string) {
+	w.pendingMtx.Lock()
+	defer w.pendingMtx.Unlock()
+	w.decRedactionInFlightLocked(tenantID)
 }
 
 // hasRedactionInFlight returns true if there are redaction jobs for the tenant

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -135,26 +135,27 @@ func (w *Work) AddJob(j *Job) error {
 	}
 
 	shard := w.getShard(j.ID)
-	shard.mtx.Lock()
-	defer shard.mtx.Unlock()
 
+	// Lock ordering: never hold shard.mtx while acquiring pendingMtx. AddPendingJobs takes them in
+	// the opposite order (pendingMtx then shard.mtx), so nesting the two here would be a lock-order
+	// inversion and could deadlock. We release shard.mtx before touching the pending-side maps.
+	shard.mtx.Lock()
 	if _, ok := shard.Jobs[j.ID]; ok {
+		shard.mtx.Unlock()
 		// This job is already active, so it will not be promoted here. If it was dequeued via
-		// NextPendingJob it was counted in-flight; release that count now — the promote-path
-		// decrement below is skipped by this early return, and without the release the counter
-		// leaks and HasJobsForTenant wedges the tenant permanently.
+		// NextPendingJob it was counted in-flight; release that count now — the promote path below
+		// is skipped by this early return, and without the release the counter leaks and
+		// HasJobsForTenant wedges the tenant permanently.
 		if j.GetType() == tempopb.JobType_JOB_TYPE_REDACTION {
-			w.pendingMtx.Lock()
-			w.decRedactionInFlightLocked(j.Tenant())
-			w.pendingMtx.Unlock()
+			w.ReleaseRedactionInFlight(j.Tenant())
 		}
 		return ErrJobAlreadyExists
 	}
 
 	j.CreatedTime = time.Now()
 	j.Status = tempopb.JobStatus_JOB_STATUS_UNSPECIFIED
-
 	shard.Jobs[j.ID] = j
+	shard.mtx.Unlock()
 
 	w.pendingMtx.Lock()
 	// Clear registered job now that it is promoted to active.


### PR DESCRIPTION
**What this PR does**:

Fixes a **pre-existing** in-flight job-accounting bug in the backend-scheduler's redaction queue — independent of any redaction feature, but surfaced by an adversarial review of the cancel work (cancel makes batch removal aggressive/synchronous enough to actually hit it).

**The bug:** `redactionInFlight` counts redaction jobs dequeued from the pending queue but not yet promoted to the active map, and is only decremented in `AddJob` (the promote path). A job **dropped** at assignment (`Next()`, when its batch is already gone) is never promoted → the counter leaks. A leaked count makes `HasJobsForTenant` return true forever → the tenant's batch looks perpetually active → **future redaction submissions for that tenant wedge.**

Plus a **TOCTOU:** `NextPendingJob` dequeued from `pendingByTenant` and released the lock *before* incrementing `redactionInFlight`, so a concurrent `HasJobsForTenant` could observe the job as gone-but-not-yet-counted and misjudge the batch as done.

**The fix:**
- Increment `redactionInFlight` in the **same critical section** as the dequeue (atomic) — a dequeued job is never uncounted; the existing stale-shard path undoes the increment before retrying.
- Add `Work.ReleaseRedactionInFlight(tenant)` and call it on the `Next()` drop path so a dropped redaction job releases its in-flight count (shared decrement helper with `AddJob`).

Tests: release accounting, atomic-count-on-dequeue, and a `-race` drain-and-drop test asserting the counter returns to zero.

Found via an adversarial review of the redaction-cancel PR (#7701); landing this **first** so cancel and the window PR (#7702) rebase onto a correct foundation.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
