### PR TITLE
docs: update single binary docker compose example

### DIFF
--- a/.chloggen/docs_update-getting-started.yaml
+++ b/.chloggen/docs_update-getting-started.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: docs
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Correct single-binary quickstart documentation regarding Redpanda and Kafka requirements.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: veenoise

--- a/docs/sources/tempo/docker-example.md
+++ b/docs/sources/tempo/docker-example.md
@@ -66,10 +66,6 @@ A setup script is running in the background to install the necessary dependencie
 This quick start guide uses the `single-binary` docker-compose example. Check out our [collection of examples](https://github.com/grafana/tempo/blob/main/example/docker-compose) to explore various
 operating modes and configurations.
 
-Tempo requires a Kafka-compatible system for its write path, even when running as a single binary.
-This example uses [Redpanda](https://redpanda.com/), a Kafka-compatible streaming platform, to handle trace ingestion.
-Redpanda provides the durable queue that Tempo uses to decouple its write and read paths.
-
 1. Clone the Tempo repository:
 
    ```bash
@@ -98,15 +94,13 @@ Redpanda provides the durable queue that Tempo uses to decouple its write and re
 
    ```console
    docker compose ps
-   NAME                            COMMAND                  SERVICE             STATUS              PORTS
-   single-binary-alloy-1           "/bin/alloy run /etc…"   alloy               running             0.0.0.0:4319->4317/tcp, 0.0.0.0:12345->12345/tcp
-   single-binary-grafana-1         "/run.sh"                grafana             running             0.0.0.0:3000->3000/tcp
-   single-binary-k6-tracing-1      "/k6-tracing run /ex…"   k6-tracing          running
-   single-binary-prometheus-1      "/bin/prometheus --c…"   prometheus          running             0.0.0.0:9090->9090/tcp
-   single-binary-redpanda-1        "/entrypoint.sh redp…"   redpanda            running             0.0.0.0:9092->9092/tcp
-   single-binary-redpanda-console-1 "/bin/sh -c 'echo \"$…" redpanda-console    running             0.0.0.0:8080->8080/tcp
-   single-binary-tempo-1           "/tempo -target=all …"   tempo               running             0.0.0.0:3200->3200/tcp, 0.0.0.0:4317-4318->4317-4318/tcp
-   single-binary-vulture-1         "/tempo-vulture -pro…"   vulture             running
+   NAME                         IMAGE                                                                                               COMMAND                  SERVICE      CREATED         STATUS         PORTS
+   single-binary-alloy-1        docker.io/grafana/alloy@sha256:4f6ddc56ffdcf8a6316748fc5162972e20cb301523cac1bb4a31957df733ae9b     "run /etc/alloy/conf…"   alloy        7 seconds ago   Up 6 seconds   0.0.0.0:12345->12345/tcp, 0.0.0.0:4319->4317/tcp
+   single-binary-grafana-1      docker.io/grafana/grafana@sha256:121a7a9ece6dc10b969f1f96eed64b4f07dfac0d0b8abc070f7cb83bbde86f63   ""                       grafana      7 seconds ago   Up 6 seconds   0.0.0.0:3000->3000/tcp
+   single-binary-k6-tracing-1   ghcr.io/grafana/xk6-client-tracing:v0.0.9                                                           "run /example-script…"   k6-tracing   7 hours ago     Up 6 seconds
+   single-binary-prometheus-1   docker.io/prom/prometheus:latest                                                                    "--config.file=/etc/…"   prometheus   7 seconds ago   Up 6 seconds   0.0.0.0:9090->9090/tcp
+   single-binary-tempo-1        docker.io/grafana/tempo:3.0.0                                                                       "-target=all -config…"   tempo        7 seconds ago   Up 6 seconds   0.0.0.0:3200->3200/tcp, 0.0.0.0:4317-4318->4317-4318/tcp
+   single-binary-vulture-1      docker.io/grafana/tempo-vulture:3.0.0                                                               "-prometheus-listen-…"   vulture      7 hours ago     Up 6 seconds
    ```
 
 <!-- INTERACTIVE page step1.md END -->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
This PR updates the [docs for getting started in tempo docker compose 
](https://grafana.com/docs/tempo/latest/docker-example/). I tried running the single binary as instructed by the guide and I noticed this does not need RedPanda or Kafka anymore.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)