### PR TITLE
Fix querier panic on tag value autocomplete with only metadata-only intrinsic conditions

### DIFF
--- a/.chloggen/tagvalues-empty-join-panic.yaml
+++ b/.chloggen/tagvalues-empty-join-panic.yaml
@@ -1,0 +1,25 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Fix querier panic on tag value autocomplete when every condition is a metadata-only intrinsic, e.g. `span:id` filtered by `{trace:id="..."}`
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  Metadata-only intrinsics such as `trace:id`, `trace:start`, `span:id` and `span:startTime` are
+  deliberately not fetched from columns. When a tag value autocomplete request consisted solely of
+  those, the trace-level join was built with zero sub-iterators and panicked on the first `Next()`,
+  restarting the querier. Affects vparquet3, vparquet4 and vparquet5.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: zalegrala

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -96,6 +96,9 @@ func (b *backendBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsR
 		if err != nil {
 			return fmt.Errorf("creating fetch iter: %w", err)
 		}
+		if iter == nil {
+			continue // nothing to read for this condition group
+		}
 
 		done, iterErr := func() (bool, error) {
 			defer iter.Close()
@@ -231,6 +234,9 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagV
 		iter, err := autocompleteIter(ctx, tr, pf, opts, b.meta.DedicatedColumns)
 		if err != nil {
 			return fmt.Errorf("creating fetch iter: %w", err)
+		}
+		if iter == nil {
+			continue // nothing to read for this condition group
 		}
 
 		done, iterErr := func() (bool, error) {
@@ -867,6 +873,14 @@ func createDistinctTraceIterator(
 	// or the time range filtering first?
 	if resourceIter != nil {
 		traceIters = append(traceIters, resourceIter)
+	}
+
+	// Every condition may have been metadata-only (trace:id, trace:start) and the
+	// lower scopes may have collapsed to nothing, leaving no iterators at all. A
+	// join over zero iterators has nothing to read, so report that rather than
+	// building a degenerate one.
+	if len(traceIters) == 0 {
+		return nil, nil
 	}
 
 	// Final trace iterator

--- a/tempodb/encoding/vparquet3/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete_test.go
@@ -830,6 +830,44 @@ func TestFetchTagNamesWithOrConditions(t *testing.T) {
 	}
 }
 
+// A WAL block runs the same autocomplete iterator as a backend block, so it hits
+// the same empty-join and nil-iterator cases when every condition is a
+// metadata-only intrinsic.
+func TestWalBlockFetchTagValuesMetadataOnlyIntrinsics(t *testing.T) {
+	queries := []string{
+		`{trace:id="000000000000000000000000000000ff"}`,
+		`{span:id="0000000000000001"}`,
+	}
+
+	testWalBlock(t, func(w *walBlock, _ []common.ID, _ []*tempopb.Trace) {
+		for _, query := range queries {
+			t.Run(query, func(t *testing.T) {
+				req, err := traceql.ExtractFetchSpansRequest(query)
+				require.NoError(t, err)
+
+				tag, err := traceql.ParseIdentifier("span:id")
+				require.NoError(t, err)
+
+				var (
+					mc               = collector.NewMetricsCollector()
+					distinctValues   = collector.NewDistinctValue(1_000_000, 0, 0, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+					autocompletedReq = traceql.FetchTagValuesRequest{
+						TagName: tag,
+						ConditionGroups: [][]traceql.Condition{append(
+							req.Conditions,
+							traceql.Condition{Attribute: tag, Op: traceql.OpNone},
+						)},
+					}
+				)
+
+				err = w.FetchTagValues(t.Context(), autocompletedReq, traceql.MakeCollectTagValueFunc(distinctValues.Collect), mc.Add, common.DefaultSearchOptions())
+				require.NoError(t, err)
+				require.Empty(t, distinctValues.Values())
+			})
+		}
+	})
+}
+
 func TestFetchTagValuesWithOrConditions(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/tempodb/encoding/vparquet3/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete_test.go
@@ -341,6 +341,21 @@ func TestFetchTagValues(t *testing.T) {
 		expectedValues []tempopb.TagValue
 	}{
 		{
+			// Both span:id and trace:id are metadata-only intrinsics: neither
+			// contributes a column iterator, so the trace-level join ends up with
+			// zero sub-iterators. It must return no values instead of panicking.
+			name:           "metadata-only intrinsic tag with metadata-only intrinsic condition",
+			tag:            "span:id",
+			query:          `{trace:id="000000000000000000000000000000ff"}`,
+			expectedValues: []tempopb.TagValue{},
+		},
+		{
+			name:           "metadata-only intrinsic tag with span-scoped metadata-only condition",
+			tag:            "span:id",
+			query:          `{span:id="0000000000000001"}`,
+			expectedValues: []tempopb.TagValue{},
+		},
+		{
 			name:  "intrinsic with no query - match",
 			tag:   "name",
 			query: "{}",

--- a/tempodb/encoding/vparquet3/wal_block.go
+++ b/tempodb/encoding/vparquet3/wal_block.go
@@ -758,6 +758,9 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValue
 				if err != nil {
 					return false, fmt.Errorf("creating fetch iter: %w", err)
 				}
+				if iter == nil {
+					continue // nothing to read for this condition group
+				}
 
 				for {
 					// Exhaust the iterator
@@ -847,6 +850,9 @@ func (b *walBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsReque
 				iter, err := autocompleteIter(ctx, tr, file.parquetFile, opts, b.meta.DedicatedColumns)
 				if err != nil {
 					return false, fmt.Errorf("creating fetch iter: %w", err)
+				}
+				if iter == nil {
+					continue // nothing to read for this condition group
 				}
 
 				for {

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -117,6 +117,9 @@ func (b *backendBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsR
 		if err != nil {
 			return fmt.Errorf("creating fetch iter: %w", err)
 		}
+		if iter == nil {
+			continue // nothing to read for this condition group
+		}
 
 		done, iterErr := func() (bool, error) {
 			defer iter.Close()
@@ -261,6 +264,9 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagV
 		iter, err := autocompleteIter(ctx, tr, pf, opts, b.meta.DedicatedColumns)
 		if err != nil {
 			return fmt.Errorf("creating fetch iter: %w", err)
+		}
+		if iter == nil {
+			continue // nothing to read for this condition group
 		}
 
 		done, iterErr := func() (bool, error) {
@@ -1123,6 +1129,14 @@ func createDistinctTraceIterator(
 	// or the time range filtering first?
 	if resourceIter != nil {
 		traceIters = append(traceIters, resourceIter)
+	}
+
+	// Every condition may have been metadata-only (trace:id, trace:start) and the
+	// lower scopes may have collapsed to nothing, leaving no iterators at all. A
+	// join over zero iterators has nothing to read, so report that rather than
+	// building a degenerate one.
+	if len(traceIters) == 0 {
+		return nil, nil
 	}
 
 	// Final trace iterator

--- a/tempodb/encoding/vparquet4/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete_test.go
@@ -1089,6 +1089,44 @@ func TestFetchTagNamesWithOrConditions(t *testing.T) {
 	}
 }
 
+// A WAL block runs the same autocomplete iterator as a backend block, so it hits
+// the same empty-join and nil-iterator cases when every condition is a
+// metadata-only intrinsic.
+func TestWalBlockFetchTagValuesMetadataOnlyIntrinsics(t *testing.T) {
+	queries := []string{
+		`{trace:id="000000000000000000000000000000ff"}`,
+		`{span:id="0000000000000001"}`,
+	}
+
+	testWalBlock(t, func(w *walBlock, _ []common.ID, _ []*tempopb.Trace) {
+		for _, query := range queries {
+			t.Run(query, func(t *testing.T) {
+				req, err := traceql.ExtractFetchSpansRequest(query)
+				require.NoError(t, err)
+
+				tag, err := traceql.ParseIdentifier("span:id")
+				require.NoError(t, err)
+
+				var (
+					mc               = collector.NewMetricsCollector()
+					distinctValues   = collector.NewDistinctValue(1_000_000, 0, 0, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+					autocompletedReq = traceql.FetchTagValuesRequest{
+						TagName: tag,
+						ConditionGroups: [][]traceql.Condition{append(
+							req.Conditions,
+							traceql.Condition{Attribute: tag, Op: traceql.OpNone},
+						)},
+					}
+				)
+
+				err = w.FetchTagValues(t.Context(), autocompletedReq, traceql.MakeCollectTagValueFunc(distinctValues.Collect), mc.Add, common.DefaultSearchOptions())
+				require.NoError(t, err)
+				require.Empty(t, distinctValues.Values())
+			})
+		}
+	})
+}
+
 func TestFetchTagValuesWithOrConditions(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/tempodb/encoding/vparquet4/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete_test.go
@@ -487,6 +487,21 @@ func TestFetchTagValues(t *testing.T) {
 		expectedValues []tempopb.TagValue
 	}{
 		{
+			// Both span:id and trace:id are metadata-only intrinsics: neither
+			// contributes a column iterator, so the trace-level join ends up with
+			// zero sub-iterators. It must return no values instead of panicking.
+			name:           "metadata-only intrinsic tag with metadata-only intrinsic condition",
+			tag:            "span:id",
+			query:          `{trace:id="000000000000000000000000000000ff"}`,
+			expectedValues: []tempopb.TagValue{},
+		},
+		{
+			name:           "metadata-only intrinsic tag with span-scoped metadata-only condition",
+			tag:            "span:id",
+			query:          `{span:id="0000000000000001"}`,
+			expectedValues: []tempopb.TagValue{},
+		},
+		{
 			name:  "intrinsic with no query - match",
 			tag:   "name",
 			query: "{}",

--- a/tempodb/encoding/vparquet4/wal_block.go
+++ b/tempodb/encoding/vparquet4/wal_block.go
@@ -814,6 +814,9 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValue
 				if err != nil {
 					return false, fmt.Errorf("creating fetch iter: %w", err)
 				}
+				if iter == nil {
+					continue // nothing to read for this condition group
+				}
 
 				for {
 					// Exhaust the iterator
@@ -911,6 +914,9 @@ func (b *walBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsReque
 				iter, err := autocompleteIter(ctx, tr, file.parquetFile, opts, b.meta.DedicatedColumns)
 				if err != nil {
 					return false, fmt.Errorf("creating fetch iter: %w", err)
+				}
+				if iter == nil {
+					continue // nothing to read for this condition group
 				}
 
 				for {

--- a/tempodb/encoding/vparquet5/block_autocomplete.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete.go
@@ -117,6 +117,9 @@ func (b *backendBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsR
 		if err != nil {
 			return fmt.Errorf("creating fetch iter: %w", err)
 		}
+		if iter == nil {
+			continue // nothing to read for this condition group
+		}
 
 		done, iterErr := func() (bool, error) {
 			defer iter.Close()
@@ -273,6 +276,9 @@ func (b *backendBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagV
 		iter, err := autocompleteIter(ctx, tr, pf, opts, b.meta.DedicatedColumns)
 		if err != nil {
 			return fmt.Errorf("creating fetch iter: %w", err)
+		}
+		if iter == nil {
+			continue // nothing to read for this condition group
 		}
 
 		done, iterErr := func() (bool, error) {
@@ -1168,6 +1174,14 @@ func createDistinctTraceIterator(
 	// or the time range filtering first?
 	if resourceIter != nil {
 		traceIters = append(traceIters, resourceIter)
+	}
+
+	// Every condition may have been metadata-only (trace:id, trace:start) and the
+	// lower scopes may have collapsed to nothing, leaving no iterators at all. A
+	// join over zero iterators has nothing to read, so report that rather than
+	// building a degenerate one.
+	if len(traceIters) == 0 {
+		return nil, nil
 	}
 
 	// Final trace iterator

--- a/tempodb/encoding/vparquet5/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete_test.go
@@ -1094,6 +1094,44 @@ func TestFetchTagNamesWithOrConditions(t *testing.T) {
 	}
 }
 
+// A WAL block runs the same autocomplete iterator as a backend block, so it hits
+// the same empty-join and nil-iterator cases when every condition is a
+// metadata-only intrinsic.
+func TestWalBlockFetchTagValuesMetadataOnlyIntrinsics(t *testing.T) {
+	queries := []string{
+		`{trace:id="000000000000000000000000000000ff"}`,
+		`{span:id="0000000000000001"}`,
+	}
+
+	testWalBlock(t, func(w *walBlock, _ []common.ID, _ []*tempopb.Trace) {
+		for _, query := range queries {
+			t.Run(query, func(t *testing.T) {
+				req, err := traceql.ExtractFetchSpansRequest(query)
+				require.NoError(t, err)
+
+				tag, err := traceql.ParseIdentifier("span:id")
+				require.NoError(t, err)
+
+				var (
+					mc               = collector.NewMetricsCollector()
+					distinctValues   = collector.NewDistinctValue(1_000_000, 0, 0, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
+					autocompletedReq = traceql.FetchTagValuesRequest{
+						TagName: tag,
+						ConditionGroups: [][]traceql.Condition{append(
+							req.Conditions,
+							traceql.Condition{Attribute: tag, Op: traceql.OpNone},
+						)},
+					}
+				)
+
+				err = w.FetchTagValues(t.Context(), autocompletedReq, traceql.MakeCollectTagValueFunc(distinctValues.Collect), mc.Add, common.DefaultSearchOptions())
+				require.NoError(t, err)
+				require.Empty(t, distinctValues.Values())
+			})
+		}
+	})
+}
+
 func TestFetchTagValuesWithOrConditions(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/tempodb/encoding/vparquet5/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete_test.go
@@ -465,6 +465,21 @@ func TestFetchTagValues(t *testing.T) {
 		dc             backend.DedicatedColumns
 	}{
 		{
+			// Both span:id and trace:id are metadata-only intrinsics: neither
+			// contributes a column iterator, so the trace-level join ends up with
+			// zero sub-iterators. It must return no values instead of panicking.
+			name:           "metadata-only intrinsic tag with metadata-only intrinsic condition",
+			tag:            "span:id",
+			query:          `{trace:id="000000000000000000000000000000ff"}`,
+			expectedValues: []tempopb.TagValue{},
+		},
+		{
+			name:           "metadata-only intrinsic tag with span-scoped metadata-only condition",
+			tag:            "span:id",
+			query:          `{span:id="0000000000000001"}`,
+			expectedValues: []tempopb.TagValue{},
+		},
+		{
 			name:  "intrinsic with no query - match",
 			tag:   "name",
 			query: "{}",

--- a/tempodb/encoding/vparquet5/wal_block.go
+++ b/tempodb/encoding/vparquet5/wal_block.go
@@ -870,6 +870,9 @@ func (b *walBlock) FetchTagValues(ctx context.Context, req traceql.FetchTagValue
 				if err != nil {
 					return false, fmt.Errorf("creating fetch iter: %w", err)
 				}
+				if iter == nil {
+					continue // nothing to read for this condition group
+				}
 
 				for {
 					// Exhaust the iterator
@@ -967,6 +970,9 @@ func (b *walBlock) FetchTagNames(ctx context.Context, req traceql.FetchTagsReque
 				iter, err := autocompleteIter(ctx, tr, file.parquetFile, opts, b.meta.DedicatedColumns)
 				if err != nil {
 					return false, fmt.Errorf("creating fetch iter: %w", err)
+				}
+				if iter == nil {
+					continue // nothing to read for this condition group
 				}
 
 				for {


### PR DESCRIPTION
**What this PR does**:

Fixes a querier panic when every condition in a tag value autocomplete request is a metadata-only intrinsic. `SearchTagValuesV2` for `span:id` with query `{trace:id="..."}` crashes the process:

```
panic: runtime error: index out of range [0] with length 0
  pkg/parquetquery.(*JoinIterator).Next            iters.go:1052
  vparquet5.(*backendBlock).FetchTagValues.func2   block_autocomplete.go:281
  querier.(*Querier).SearchTagValuesV2Handler      http.go:317
```

`span:id`, `span:startTime`, `trace:id` and `trace:start` are skipped with a bare `continue` and contribute no iterator. When *every* condition is one of those, the span stage yields `nil` and `createDistinctTraceIterator` builds a `JoinIterator` over an empty slice, which indexes `j.peeks[0]` unconditionally.

`NewLeftJoinIterator` already rejects this shape; `NewJoinIterator` doesn't, and giving it an error return would touch ~45 call sites. So this fixes the two places that produce the degenerate input:

- `createDistinctTraceIterator` returns `nil, nil` when it has nothing to join, matching `createDistinctAttributeIterator`.
- The four `autocompleteIter` call sites skip a `nil` iterator. Required, not defensive — without it the same request panics on WAL blocks at `wal_block.go:876`.

Applied to vparquet3/4/5; identical code, all three reproduce. Behaviour change is limited to the crashing case: these requests now return no values, as these intrinsics already do elsewhere in this path.

Separately, these conditions are *dropped* rather than applied, so `{trace:id="..."}` returns tag values from other traces. Tracked in #7706; out of scope here.

**Which issue(s) this PR fixes**:

None filed; found from a production panic.

**Checklist**
- [x] Tests updated — cases in `TestFetchTagValues` plus a new `TestWalBlockFetchTagValuesMetadataOnlyIntrinsics` (WAL autocomplete had no coverage); all panic without the fix
- [ ] Documentation added — n/a
- [x] Changelog entry added under `.chloggen/`
