### PR TITLE
Add experimental trace summary endpoint

### DIFF
--- a/.chloggen/tracebyid-summary.yaml
+++ b/.chloggen/tracebyid-summary.yaml
@@ -1,0 +1,6 @@
+change_type: feature
+component: query-frontend
+note: "Add experimental `GET /api/v2/traces/<traceID>/summary` endpoint that returns a condensed summary of a trace: root span, duration, critical path, per-service breakdown, and top slowest/error spans."
+issues: []
+subtext:
+user: ie-pham

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -500,6 +500,7 @@ func (t *App) initQueryFrontend() (services.Service, error) {
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathTraces), base.Wrap(queryFrontend.TraceByIDHandler))
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathTraceDiffV2), base.Wrap(queryFrontend.TraceDiffHandler))
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathTracesV2), base.Wrap(queryFrontend.TraceByIDHandlerV2))
+	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathTraceSummaryV2), base.Wrap(queryFrontend.TraceSummaryHandler))
 
 	// http search endpoints
 	t.Server.HTTPRouter().Handle(addHTTPAPIPrefix(&t.cfg, api.PathSearch), base.Wrap(queryFrontend.SearchHandler))

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -822,10 +822,11 @@ Parameters:
 The response is a JSON object containing:
 
 - `traceId`, `rootService`, `rootSpanName`, `durationNanos`, `spanCount`, `errorSpanCount`
-- `criticalPath`: the root-to-leaf chain of spans following, at each level, whichever child ends latest. Each
-  entry carries its `attributes` and a `selfDurationNanos`. Because every span on the path nests inside the one
-  above it, the wall durations decline only slightly from hop to hop; `selfDurationNanos` is what identifies
-  which hop actually spent the time.
+- `criticalPath`: the root-to-leaf chain of spans following, at each level, whichever child's subtree reaches the
+  latest end time (not necessarily the child that itself ends latest — a detached or async descendant can keep
+  its branch on the path after the child span itself has finished). Each entry carries its `attributes` and a
+  `selfDurationNanos`. Because every span on the path nests inside the one above it, the wall durations decline
+  only slightly from hop to hop; `selfDurationNanos` is what identifies which hop actually spent the time.
 - `services`: per-service span count, `errorSpanCount`, and two durations. `durationNanos` is the sum of that
   service's span durations and is therefore inclusive of time spent in child spans (including children belonging
   to other services), so summing it across services can far exceed the trace `durationNanos`.

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -829,6 +829,9 @@ The response is a JSON object containing:
 - `slowestSpans`: the 5 slowest spans in the trace.
 - `errorSpans`: the first 5 spans with an error status.
 
+Nanosecond fields (`durationNanos`, `startTimeUnixNano`) are encoded as JSON strings, not numbers.
+They are 64-bit values that exceed the range a JSON number represents exactly in JavaScript clients.
+
 Only `GET` is allowed. Other methods return `405 Method Not Allowed`.
 
 ### Query Echo endpoint

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -823,7 +823,9 @@ The response is a JSON object containing:
 
 - `traceId`, `rootService`, `rootSpanName`, `durationNanos`, `spanCount`, `errorCount`
 - `criticalPath`: the root-to-leaf chain of spans following, at each level, whichever child ends latest.
-- `services`: per-service span count, error count, and cumulative duration.
+- `services`: per-service span count, error count, and cumulative duration. The duration is the sum of that
+  service's span durations, so it is inclusive of time spent in child spans (including child spans belonging to
+  other services) rather than self-time. Summing it across services can therefore exceed `durationNanos`.
 - `slowestSpans`: the 5 slowest spans in the trace.
 - `errorSpans`: the first 5 spans with an error status.
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -822,15 +822,28 @@ Parameters:
 The response is a JSON object containing:
 
 - `traceId`, `rootService`, `rootSpanName`, `durationNanos`, `spanCount`, `errorCount`
-- `criticalPath`: the root-to-leaf chain of spans following, at each level, whichever child ends latest.
-- `services`: per-service span count, error count, and cumulative duration. The duration is the sum of that
-  service's span durations, so it is inclusive of time spent in child spans (including child spans belonging to
-  other services) rather than self-time. Summing it across services can therefore exceed `durationNanos`.
-- `slowestSpans`: the 5 slowest spans in the trace.
+- `criticalPath`: the root-to-leaf chain of spans following, at each level, whichever child ends latest. Each
+  entry carries its `attributes` and a `selfDurationNanos`. Because every span on the path nests inside the one
+  above it, the wall durations decline only slightly from hop to hop; `selfDurationNanos` is what identifies
+  which hop actually spent the time.
+- `services`: per-service span count, error count, and two durations. `durationNanos` is the sum of that
+  service's span durations and is therefore inclusive of time spent in child spans (including children belonging
+  to other services), so summing it across services can far exceed the trace `durationNanos`.
+  `selfDurationNanos` excludes time already covered by child spans and is the field to rank services by.
+- `slowestSpans`: the 5 spans with the highest `selfDurationNanos`. Ranking by self time rather than wall time
+  keeps this list from simply restating the critical path — by wall time the slowest spans in a nested trace are
+  always the outermost ones.
 - `errorSpans`: the first 5 spans with an error status.
 
-Nanosecond fields (`durationNanos`, `startTimeUnixNano`) are encoded as JSON strings, not numbers.
-They are 64-bit values that exceed the range a JSON number represents exactly in JavaScript clients.
+Spans in `slowestSpans` and `errorSpans` carry `parentSpanId` (omitted for a root span), so a caller can
+attribute a span to whatever invoked it without fetching the full trace.
+
+Self time is computed per span as its own duration minus the time covered by its direct children, where the
+children's intervals are unioned rather than summed — so a span that fans out to concurrent children is not
+reported as having spent no time of its own. Self times are per-span and do not sum to the trace duration.
+
+Nanosecond fields (`durationNanos`, `selfDurationNanos`, `startTimeUnixNano`) are encoded as JSON strings, not
+numbers. They are 64-bit values that exceed the range a JSON number represents exactly in JavaScript clients.
 
 Only `GET` is allowed. Other methods return `405 Method Not Allowed`.
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -42,6 +42,7 @@ For externally supported gRPC API, [refer to Tempo gRPC API](#tempo-grpc-api).
 | [TraceQL Metrics](#traceql-metrics)                                                   | Query-frontend                            | HTTP | `GET /api/metrics/query_range`                            |
 | [TraceQL Metrics (instant)](#instant)                                                 | Query-frontend                            | HTTP | `GET /api/metrics/query`                                  |
 | [Trace diff](#trace-diff) (\*)                                                        | Query-frontend                            | HTTP | `POST /api/v2/traces/diff`                                |
+| [Trace summary](#trace-summary) (\*)                                                  | Query-frontend                            | HTTP | `GET /api/v2/traces/<traceID>/summary`                    |
 | [Query Echo Endpoint](#query-echo-endpoint)                                           | Query-frontend                            | HTTP | `GET /api/echo`                                           |
 | [Overrides API](#overrides-api)                                                       | Query-frontend                            | HTTP | `GET,POST,PATCH,DELETE /api/overrides`                    |
 | Memberlist                                                                            | Distributor, Querier, Live store          | HTTP | `GET /memberlist`                                         |
@@ -798,6 +799,35 @@ Parameters:
 When `start` and `end` are provided, the request validates that `start` is before `end`. When the endpoint is fully implemented, these fields will limit block search to that time range. If omitted, Tempo will search across all blocks.
 
 Only `POST` is allowed. Other methods return `405 Method Not Allowed`.
+
+### Trace summary
+
+{{< admonition type="warning" >}}
+This endpoint is experimental. The request format and behavior may change in future releases.
+{{< /admonition >}}
+
+This endpoint returns a condensed summary of a trace, useful for a quick triage view without fetching the full trace.
+
+```
+GET /api/v2/traces/<traceID>/summary?start=<start>&end=<end>
+```
+
+Parameters:
+
+- `start = (unix epoch seconds)`
+  Optional. Along with `end`, limits the time range searched for the trace.
+- `end = (unix epoch seconds)`
+  Optional. Along with `start`, limits the time range searched for the trace.
+
+The response is a JSON object containing:
+
+- `traceId`, `rootService`, `rootSpanName`, `durationNanos`, `spanCount`, `errorCount`
+- `criticalPath`: the root-to-leaf chain of spans following, at each level, whichever child ends latest.
+- `services`: per-service span count, error count, and cumulative duration.
+- `slowestSpans`: the 5 slowest spans in the trace.
+- `errorSpans`: the first 5 spans with an error status.
+
+Only `GET` is allowed. Other methods return `405 Method Not Allowed`.
 
 ### Query Echo endpoint
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -821,12 +821,12 @@ Parameters:
 
 The response is a JSON object containing:
 
-- `traceId`, `rootService`, `rootSpanName`, `durationNanos`, `spanCount`, `errorCount`
+- `traceId`, `rootService`, `rootSpanName`, `durationNanos`, `spanCount`, `errorSpanCount`
 - `criticalPath`: the root-to-leaf chain of spans following, at each level, whichever child ends latest. Each
   entry carries its `attributes` and a `selfDurationNanos`. Because every span on the path nests inside the one
   above it, the wall durations decline only slightly from hop to hop; `selfDurationNanos` is what identifies
   which hop actually spent the time.
-- `services`: per-service span count, error count, and two durations. `durationNanos` is the sum of that
+- `services`: per-service span count, `errorSpanCount`, and two durations. `durationNanos` is the sum of that
   service's span durations and is therefore inclusive of time spent in child spans (including children belonging
   to other services), so summing it across services can far exceed the trace `durationNanos`.
   `selfDurationNanos` excludes time already covered by child spans and is the field to rank services by.
@@ -841,6 +841,10 @@ attribute a span to whatever invoked it without fetching the full trace.
 Self time is computed per span as its own duration minus the time covered by its direct children, where the
 children's intervals are unioned rather than summed — so a span that fans out to concurrent children is not
 reported as having spent no time of its own. Self times are per-span and do not sum to the trace duration.
+
+Spans whose timestamps are unusable — an unset (zero) start, or an end before the start — contribute zero
+duration rather than distorting the totals, so a single badly instrumented span cannot report the trace as
+having taken decades.
 
 Nanosecond fields (`durationNanos`, `selfDurationNanos`, `startTimeUnixNano`) are encoded as JSON strings, not
 numbers. They are 64-bit values that exceed the range a JSON number represents exactly in JavaScript clients.

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -240,7 +240,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	traces := newTraceIDHandler(cfg, tracePipeline, o, combiner.NewTypedTraceByID, logger, dataAccessController)
 	tracesV2 := newTraceIDV2Handler(cfg, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
 	traceDiff := newTraceDiffHandler(cfg, apiPrefix, tracePipeline, o, combiner.NewTypedTraceByIDV2, cacheProvider, logger, dataAccessController)
-	traceSummary := newTraceSummaryHandler(cfg, apiPrefix, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
+	traceSummary := newTraceSummaryHandler(apiPrefix, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
 	search := newSearchHTTPHandler(cfg, searchPipeline, o, logger, dataAccessController)
 	searchTags := newTagsHTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagsV2 := newTagsV2HTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -47,7 +47,7 @@ type (
 )
 
 type QueryFrontend struct {
-	TraceByIDHandler, TraceByIDHandlerV2, TraceDiffHandler, SearchHandler                      http.Handler
+	TraceByIDHandler, TraceByIDHandlerV2, TraceDiffHandler, TraceSummaryHandler, SearchHandler http.Handler
 	SearchTagsHandler, SearchTagsV2Handler, SearchTagsValuesHandler, SearchTagsValuesV2Handler http.Handler
 	MetricsQueryInstantHandler, MetricsQueryRangeHandler                                       http.Handler
 	MCPHandler                                                                                 http.Handler
@@ -240,6 +240,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 	traces := newTraceIDHandler(cfg, tracePipeline, o, combiner.NewTypedTraceByID, logger, dataAccessController)
 	tracesV2 := newTraceIDV2Handler(cfg, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
 	traceDiff := newTraceDiffHandler(cfg, apiPrefix, tracePipeline, o, combiner.NewTypedTraceByIDV2, cacheProvider, logger, dataAccessController)
+	traceSummary := newTraceSummaryHandler(cfg, apiPrefix, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
 	search := newSearchHTTPHandler(cfg, searchPipeline, o, logger, dataAccessController)
 	searchTags := newTagsHTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
 	searchTagsV2 := newTagsV2HTTPHandler(cfg, searchTagsPipeline, o, logger, dataAccessController)
@@ -253,6 +254,7 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 		TraceByIDHandler:           newHandler(cfg.Config.LogQueryRequestHeaders, traces, logger),
 		TraceByIDHandlerV2:         newHandler(cfg.Config.LogQueryRequestHeaders, tracesV2, logger),
 		TraceDiffHandler:           newHandler(cfg.Config.LogQueryRequestHeaders, traceDiff, logger),
+		TraceSummaryHandler:        newHandler(cfg.Config.LogQueryRequestHeaders, traceSummary, logger),
 		SearchHandler:              newHandler(cfg.Config.LogQueryRequestHeaders, search, logger),
 		SearchTagsHandler:          newHandler(cfg.Config.LogQueryRequestHeaders, searchTags, logger),
 		SearchTagsV2Handler:        newHandler(cfg.Config.LogQueryRequestHeaders, searchTagsV2, logger),

--- a/modules/frontend/trace_summary_handler.go
+++ b/modules/frontend/trace_summary_handler.go
@@ -117,12 +117,6 @@ func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID strin
 
 	traceByIDReq := buildTraceSummaryTraceByIDRequest(ctx, apiPrefix, traceID, startTime, endTime, headers)
 
-	// check marshalling format
-	marshallingFormat := api.MarshalingFormatFromAcceptHeader(traceByIDReq.Header)
-
-	// enforce all communication internal to Tempo to be in protobuf bytes
-	traceByIDReq.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
-
 	var traceRedactor combiner.TraceRedactor
 	if dataAccessController != nil {
 		redactor, err := dataAccessController.HandleHTTPTraceByIDReq(traceByIDReq)
@@ -133,7 +127,8 @@ func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID strin
 		traceRedactor = redactor
 	}
 
-	comb := combinerFn(o.MaxBytesPerTrace(tenant), marshallingFormat, traceRedactor, combiner.TraceByIDV2Options{})
+	// all communication internal to Tempo is protobuf bytes, regardless of what the caller asked for.
+	comb := combinerFn(o.MaxBytesPerTrace(tenant), api.MarshallingFormatProtobuf, traceRedactor, combiner.TraceByIDV2Options{})
 	rt := pipeline.NewHTTPCollector(tracePipeline, cfg.ResponseConsumers, comb)
 
 	start := time.Now()
@@ -161,7 +156,7 @@ func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID strin
 		"traceID", traceID,
 		"path", traceByIDReq.URL.Path,
 		"duration_seconds", elapsed.Seconds(),
-		"err", err,
+		"partial", traceResp.GetStatus() == tempopb.PartialStatus_PARTIAL,
 	)
 	return traceResp, nil
 }

--- a/modules/frontend/trace_summary_handler.go
+++ b/modules/frontend/trace_summary_handler.go
@@ -1,0 +1,192 @@
+package frontend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level" //nolint:all //deprecated
+	"github.com/gorilla/mux"
+	"github.com/grafana/tempo/modules/frontend/combiner"
+	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/model/tracesummary"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/grafana/tempo/pkg/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var errTraceSummaryTraceNotFound = errors.New("trace not found")
+
+// newTraceSummaryHandler creates an HTTP handler for trace summary requests.
+// EXPERIMENTAL: this endpoint is not yet a stable API contract.
+func newTraceSummaryHandler(cfg Config, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			return &http.Response{
+				StatusCode: http.StatusMethodNotAllowed,
+				Status:     http.StatusText(http.StatusMethodNotAllowed),
+				Body:       io.NopCloser(strings.NewReader(http.StatusText(http.StatusMethodNotAllowed))),
+			}, nil
+		}
+
+		tenant, errResp := extractTenant(req, logger)
+		if errResp != nil {
+			return errResp, nil
+		}
+
+		traceIDBytes, err := api.ParseTraceID(req)
+		if err != nil {
+			return httpInvalidRequest(err), nil
+		}
+		traceID := util.TraceIDToHexString(traceIDBytes)
+
+		_, _, _, startTime, endTime, err := api.ParseTraceByIDRequest(req)
+		if err != nil {
+			return httpInvalidRequest(err), nil
+		}
+
+		level.Info(logger).Log(
+			"msg", "trace summary request",
+			"tenant", tenant,
+			"path", req.URL.Path,
+			"trace_id", traceID)
+
+		traceResp, err := fetchTraceForSummary(req.Context(), cfg, tenant, traceID, startTime, endTime, req.Header, apiPrefix, tracePipeline, o, combinerFn, logger, dataAccessController)
+		if err != nil {
+			return traceSummaryErrorResponse(err), nil
+		}
+
+		summary, err := tracesummary.Summarize(traceResp.Trace)
+		if err != nil {
+			return nil, fmt.Errorf("summarize trace %s: %w", traceID, err)
+		}
+
+		body, err := json.Marshal(summary)
+		if err != nil {
+			return nil, fmt.Errorf("marshal trace summary response: %w", err)
+		}
+		return jsonResponse(body), nil
+	})
+}
+
+// buildTraceSummaryTraceByIDRequest builds an internal http request to pass to the TraceByIdHandler.
+func buildTraceSummaryTraceByIDRequest(ctx context.Context, apiPrefix, traceID string, startTime, endTime time.Time, headers http.Header) *http.Request {
+	u := &url.URL{
+		Path: path.Join(apiPrefix, "/api/v2/traces", traceID),
+	}
+	q := u.Query()
+	if !startTime.IsZero() {
+		q.Set(traceByIDStartParam, strconv.FormatInt(startTime.Unix(), 10))
+	}
+	if !endTime.IsZero() {
+		q.Set(traceByIDEndParam, strconv.FormatInt(endTime.Unix(), 10))
+	}
+	u.RawQuery = q.Encode()
+
+	reqHeaders := headers.Clone()
+	if reqHeaders == nil {
+		reqHeaders = http.Header{}
+	}
+
+	req := (&http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Header: reqHeaders,
+		Body:   http.NoBody,
+	}).WithContext(ctx)
+	req.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
+
+	return mux.SetURLVars(req, map[string]string{"traceID": traceID})
+}
+
+func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID string, startTime, endTime time.Time, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) (*tempopb.TraceByIDResponse, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	traceByIDReq := buildTraceSummaryTraceByIDRequest(ctx, apiPrefix, traceID, startTime, endTime, headers)
+
+	// check marshalling format
+	marshallingFormat := api.MarshalingFormatFromAcceptHeader(traceByIDReq.Header)
+
+	// enforce all communication internal to Tempo to be in protobuf bytes
+	traceByIDReq.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
+
+	var traceRedactor combiner.TraceRedactor
+	if dataAccessController != nil {
+		redactor, err := dataAccessController.HandleHTTPTraceByIDReq(traceByIDReq)
+		if err != nil {
+			level.Error(logger).Log("msg", "trace summary: failed to get trace redactor", "err", err)
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		traceRedactor = redactor
+	}
+
+	comb := combinerFn(o.MaxBytesPerTrace(tenant), marshallingFormat, traceRedactor)
+	rt := pipeline.NewHTTPCollector(tracePipeline, cfg.ResponseConsumers, comb)
+
+	start := time.Now()
+	resp, err := rt.RoundTrip(traceByIDReq)
+	elapsed := time.Since(start)
+
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fetch trace %s: %w", traceID, err)
+	}
+
+	traceResp, err := comb.GRPCFinal()
+	if err != nil {
+		return nil, fmt.Errorf("finalize trace %s response: %w", traceID, err)
+	}
+	if traceResp == nil || !traceHasSpans(traceResp.Trace) {
+		return nil, fmt.Errorf("trace %s: %w", traceID, errTraceSummaryTraceNotFound)
+	}
+
+	logWithShape(level.Info(logger), traceByIDReq.Context(),
+		"msg", "trace id response",
+		"tenant", tenant,
+		"traceID", traceID,
+		"path", traceByIDReq.URL.Path,
+		"duration_seconds", elapsed.Seconds(),
+		"err", err,
+	)
+	return traceResp, nil
+}
+
+func traceSummaryErrorResponse(err error) *http.Response {
+	statusCode := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, errTraceSummaryTraceNotFound):
+		statusCode = http.StatusNotFound
+	case status.Code(err) == codes.NotFound:
+		statusCode = http.StatusNotFound
+	case status.Code(err) == codes.InvalidArgument:
+		statusCode = http.StatusBadRequest
+	case status.Code(err) == codes.ResourceExhausted:
+		statusCode = http.StatusTooManyRequests
+	}
+
+	body := err.Error()
+	if statusCode == http.StatusNotFound {
+		body = http.StatusText(statusCode)
+	}
+
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     http.StatusText(statusCode),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/modules/frontend/trace_summary_handler.go
+++ b/modules/frontend/trace_summary_handler.go
@@ -31,7 +31,7 @@ var errTraceSummaryTraceNotFound = errors.New("trace not found")
 
 // newTraceSummaryHandler creates an HTTP handler for trace summary requests.
 // EXPERIMENTAL: this endpoint is not yet a stable API contract.
-func newTraceSummaryHandler(cfg Config, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+func newTraceSummaryHandler(cfg Config, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor, combiner.TraceByIDV2Options) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet {
 			return &http.Response{
@@ -111,7 +111,7 @@ func buildTraceSummaryTraceByIDRequest(ctx context.Context, apiPrefix, traceID s
 	return mux.SetURLVars(req, map[string]string{"traceID": traceID})
 }
 
-func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID string, startTime, endTime time.Time, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) (*tempopb.TraceByIDResponse, error) {
+func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID string, startTime, endTime time.Time, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor, combiner.TraceByIDV2Options) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) (*tempopb.TraceByIDResponse, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -133,7 +133,7 @@ func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID strin
 		traceRedactor = redactor
 	}
 
-	comb := combinerFn(o.MaxBytesPerTrace(tenant), marshallingFormat, traceRedactor)
+	comb := combinerFn(o.MaxBytesPerTrace(tenant), marshallingFormat, traceRedactor, combiner.TraceByIDV2Options{})
 	rt := pipeline.NewHTTPCollector(tracePipeline, cfg.ResponseConsumers, comb)
 
 	start := time.Now()

--- a/modules/frontend/trace_summary_handler.go
+++ b/modules/frontend/trace_summary_handler.go
@@ -61,7 +61,8 @@ func newTraceSummaryHandler(cfg Config, apiPrefix string, tracePipeline pipeline
 			"msg", "trace summary request",
 			"tenant", tenant,
 			"path", req.URL.Path,
-			"trace_id", traceID)
+			"trace_id", traceID,
+		)
 
 		traceResp, err := fetchTraceForSummary(req.Context(), cfg, tenant, traceID, startTime, endTime, req.Header, apiPrefix, tracePipeline, o, combinerFn, logger, dataAccessController)
 		if err != nil {
@@ -150,7 +151,8 @@ func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID strin
 		return nil, fmt.Errorf("trace %s: %w", traceID, errTraceSummaryTraceNotFound)
 	}
 
-	logWithShape(level.Info(logger), traceByIDReq.Context(),
+	logWithShape(
+		level.Info(logger), traceByIDReq.Context(),
 		"msg", "trace id response",
 		"tenant", tenant,
 		"traceID", traceID,

--- a/modules/frontend/trace_summary_handler.go
+++ b/modules/frontend/trace_summary_handler.go
@@ -27,6 +27,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// muxVarTraceID is the mux URL variable, and structured-log field, naming a trace ID.
+const muxVarTraceID = "traceID"
+
 var errTraceSummaryTraceNotFound = errors.New("trace not found")
 
 // newTraceSummaryHandler creates an HTTP handler for trace summary requests.
@@ -109,7 +112,7 @@ func buildTraceSummaryTraceByIDRequest(ctx context.Context, apiPrefix, traceID s
 	}).WithContext(ctx)
 	req.Header.Set(api.HeaderAccept, api.HeaderAcceptProtobuf)
 
-	return mux.SetURLVars(req, map[string]string{"traceID": traceID})
+	return mux.SetURLVars(req, map[string]string{muxVarTraceID: traceID})
 }
 
 func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID string, startTime, endTime time.Time, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor, combiner.TraceByIDV2Options) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) (*tempopb.TraceByIDResponse, error) {

--- a/modules/frontend/trace_summary_handler.go
+++ b/modules/frontend/trace_summary_handler.go
@@ -34,7 +34,7 @@ var errTraceSummaryTraceNotFound = errors.New("trace not found")
 
 // newTraceSummaryHandler creates an HTTP handler for trace summary requests.
 // EXPERIMENTAL: this endpoint is not yet a stable API contract.
-func newTraceSummaryHandler(cfg Config, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor, combiner.TraceByIDV2Options) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
+func newTraceSummaryHandler(apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor, combiner.TraceByIDV2Options) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) http.RoundTripper {
 	return RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet {
 			return &http.Response{
@@ -67,7 +67,7 @@ func newTraceSummaryHandler(cfg Config, apiPrefix string, tracePipeline pipeline
 			"trace_id", traceID,
 		)
 
-		traceResp, err := fetchTraceForSummary(req.Context(), cfg, tenant, traceID, startTime, endTime, req.Header, apiPrefix, tracePipeline, o, combinerFn, logger, dataAccessController)
+		traceResp, err := fetchTraceForSummary(req.Context(), tenant, traceID, startTime, endTime, req.Header, apiPrefix, tracePipeline, o, combinerFn, logger, dataAccessController)
 		if err != nil {
 			return traceSummaryErrorResponse(err), nil
 		}
@@ -115,7 +115,7 @@ func buildTraceSummaryTraceByIDRequest(ctx context.Context, apiPrefix, traceID s
 	return mux.SetURLVars(req, map[string]string{muxVarTraceID: traceID})
 }
 
-func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID string, startTime, endTime time.Time, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor, combiner.TraceByIDV2Options) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) (*tempopb.TraceByIDResponse, error) {
+func fetchTraceForSummary(ctx context.Context, tenant, traceID string, startTime, endTime time.Time, headers http.Header, apiPrefix string, tracePipeline pipeline.AsyncRoundTripper[combiner.PipelineResponse], o overrides.Interface, combinerFn func(int, api.MarshallingFormat, combiner.TraceRedactor, combiner.TraceByIDV2Options) combiner.GRPCCombiner[*tempopb.TraceByIDResponse], logger log.Logger, dataAccessController DataAccessController) (*tempopb.TraceByIDResponse, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -131,20 +131,32 @@ func fetchTraceForSummary(ctx context.Context, cfg Config, tenant, traceID strin
 		traceRedactor = redactor
 	}
 
-	// all communication internal to Tempo is protobuf bytes, regardless of what the caller asked for.
-	comb := combinerFn(o.MaxBytesPerTrace(tenant), api.MarshallingFormatProtobuf, traceRedactor, combiner.TraceByIDV2Options{})
-	rt := pipeline.NewHTTPCollector(tracePipeline, cfg.ResponseConsumers, comb)
-
 	start := time.Now()
-	resp, err := rt.RoundTrip(traceByIDReq)
-	elapsed := time.Since(start)
-
-	if resp != nil && resp.Body != nil {
-		_ = resp.Body.Close()
-	}
+	resps, err := tracePipeline.RoundTrip(pipeline.NewHTTPRequest(traceByIDReq))
 	if err != nil {
 		return nil, fmt.Errorf("fetch trace %s: %w", traceID, err)
 	}
+
+	// all communication internal to Tempo is protobuf bytes, regardless of what the caller asked for.
+	// Responses are consumed directly rather than through pipeline.NewHTTPCollector: the collector
+	// calls HTTPFinal(), which finalizes (dedupe, redaction) and marshals a body this handler would
+	// only discard before finalizing a second time via GRPCFinal().
+	comb := combinerFn(o.MaxBytesPerTrace(tenant), api.MarshallingFormatProtobuf, traceRedactor, combiner.TraceByIDV2Options{})
+	for {
+		resp, done, err := resps.Next(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read trace %s response: %w", traceID, err)
+		}
+		if resp != nil {
+			if err := comb.AddResponse(resp); err != nil {
+				return nil, fmt.Errorf("combine trace %s response: %w", traceID, err)
+			}
+		}
+		if comb.ShouldQuit() || done {
+			break
+		}
+	}
+	elapsed := time.Since(start)
 
 	traceResp, err := comb.GRPCFinal()
 	if err != nil {

--- a/modules/frontend/trace_summary_handler_test.go
+++ b/modules/frontend/trace_summary_handler_test.go
@@ -182,7 +182,7 @@ func TestTraceSummaryHandler_ZipkinDualIDTrace_GoesThroughDeduperBeforeSummarize
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
 	resp := httptest.NewRecorder()
@@ -253,7 +253,7 @@ func TestFetchTraceForSummary(t *testing.T) {
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
 
-	actual, err := fetchTraceForSummary(context.Background(), Config{}, "test-tenant", traceID, time.Time{}, time.Time{}, nil, "/tempo", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil)
+	actual, err := fetchTraceForSummary(context.Background(), "test-tenant", traceID, time.Time{}, time.Time{}, nil, "/tempo", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, actual)
 	require.True(t, proto.Equal(trace, actual.Trace))
@@ -302,7 +302,7 @@ func TestTraceSummaryHandlerReturnsSummary(t *testing.T) {
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
 	resp := httptest.NewRecorder()
@@ -324,7 +324,7 @@ func TestTraceSummaryHandlerTraceNotFound(t *testing.T) {
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
 	resp := httptest.NewRecorder()
@@ -337,7 +337,7 @@ func TestTraceSummaryHandlerTraceNotFound(t *testing.T) {
 func TestTraceSummaryHandlerInvalidTraceID(t *testing.T) {
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", nil, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", nil, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodGet, "not-hex", "")
 	resp := httptest.NewRecorder()
@@ -350,7 +350,7 @@ func TestTraceSummaryHandlerInvalidTraceID(t *testing.T) {
 func TestTraceSummaryHandlerInvalidQueryParams(t *testing.T) {
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", nil, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", nil, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "?start=notanumber")
 	resp := httptest.NewRecorder()
@@ -367,7 +367,7 @@ func TestTraceSummaryHandlerDataAccessErrorReturnsBadRequest(t *testing.T) {
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
 	dataAccessController := &traceDiffDataAccessController{err: errors.New("policy rejected")}
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), dataAccessController), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), dataAccessController), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
 	resp := httptest.NewRecorder()
@@ -380,7 +380,7 @@ func TestTraceSummaryHandlerDataAccessErrorReturnsBadRequest(t *testing.T) {
 }
 
 func TestTraceSummaryHandlerWrongMethod(t *testing.T) {
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", nil, nil, nil, log.NewNopLogger(), nil), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", nil, nil, nil, log.NewNopLogger(), nil), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodPost, "abc123", "")
 	resp := httptest.NewRecorder()
@@ -399,7 +399,7 @@ func TestTraceSummaryHandlerPartialTraceStillSummarized(t *testing.T) {
 	})
 	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
 	require.NoError(t, err)
-	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+	handler := newHandler(nil, newTraceSummaryHandler("", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
 
 	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
 	resp := httptest.NewRecorder()

--- a/modules/frontend/trace_summary_handler_test.go
+++ b/modules/frontend/trace_summary_handler_test.go
@@ -29,6 +29,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// traceTestBase offsets fixture timestamps off zero: a start of 0 is an unset
+// OTLP timestamp and is treated as unmeasurable by the summarizer.
+const traceTestBase = uint64(1_700_000_000_000_000_000)
+
 func traceSummaryTestTrace() *tempopb.Trace {
 	traceID := []byte{0xab, 0xc1, 0x23}
 	rootSpanID := []byte{0, 0, 0, 0, 0, 0, 0, 1}
@@ -49,8 +53,8 @@ func traceSummaryTestTrace() *tempopb.Trace {
 								SpanId:            rootSpanID,
 								Name:              "root-op",
 								Kind:              tracev1.Span_SPAN_KIND_SERVER,
-								StartTimeUnixNano: 0,
-								EndTimeUnixNano:   100,
+								StartTimeUnixNano: traceTestBase + 0,
+								EndTimeUnixNano:   traceTestBase + 100,
 								Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
 							},
 							{
@@ -59,8 +63,8 @@ func traceSummaryTestTrace() *tempopb.Trace {
 								ParentSpanId:      rootSpanID,
 								Name:              "child-op",
 								Kind:              tracev1.Span_SPAN_KIND_CLIENT,
-								StartTimeUnixNano: 10,
-								EndTimeUnixNano:   50,
+								StartTimeUnixNano: traceTestBase + 10,
+								EndTimeUnixNano:   traceTestBase + 50,
 								Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
 							},
 						},
@@ -95,8 +99,8 @@ func zipkinDualIDTestTrace() *tempopb.Trace {
 						SpanId:            rootSpanID,
 						Name:              "root-op",
 						Kind:              tracev1.Span_SPAN_KIND_SERVER,
-						StartTimeUnixNano: 0,
-						EndTimeUnixNano:   120,
+						StartTimeUnixNano: traceTestBase + 0,
+						EndTimeUnixNano:   traceTestBase + 120,
 						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
 					},
 				}}},
@@ -114,8 +118,8 @@ func zipkinDualIDTestTrace() *tempopb.Trace {
 						ParentSpanId:      rootSpanID,
 						Name:              "call",
 						Kind:              tracev1.Span_SPAN_KIND_CLIENT,
-						StartTimeUnixNano: 10,
-						EndTimeUnixNano:   90,
+						StartTimeUnixNano: traceTestBase + 10,
+						EndTimeUnixNano:   traceTestBase + 90,
 						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
 					},
 				}}},
@@ -135,8 +139,8 @@ func zipkinDualIDTestTrace() *tempopb.Trace {
 						ParentSpanId:      rootSpanID,
 						Name:              "handle",
 						Kind:              tracev1.Span_SPAN_KIND_SERVER,
-						StartTimeUnixNano: 15,
-						EndTimeUnixNano:   95,
+						StartTimeUnixNano: traceTestBase + 15,
+						EndTimeUnixNano:   traceTestBase + 95,
 						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
 					},
 				}}},
@@ -154,8 +158,8 @@ func zipkinDualIDTestTrace() *tempopb.Trace {
 						ParentSpanId:      sharedSpanID,
 						Name:              "do-work",
 						Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
-						StartTimeUnixNano: 20,
-						EndTimeUnixNano:   80,
+						StartTimeUnixNano: traceTestBase + 20,
+						EndTimeUnixNano:   traceTestBase + 80,
 						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
 					},
 				}}},
@@ -191,7 +195,7 @@ func TestTraceSummaryHandler_ZipkinDualIDTrace_GoesThroughDeduperBeforeSummarize
 
 	require.Equal(t, http.StatusOK, resp.Code)
 
-	var summary tracesummary.Summary
+	var summary tracesummary.TraceOverview
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &summary))
 
 	require.Equal(t, 4, summary.SpanCount)
@@ -312,7 +316,7 @@ func TestTraceSummaryHandlerReturnsSummary(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.Code)
 	require.Equal(t, api.HeaderAcceptJSON, resp.Header().Get(api.HeaderContentType))
 
-	var summary tracesummary.Summary
+	var summary tracesummary.TraceOverview
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &summary))
 	require.Equal(t, "checkout", summary.RootService)
 	require.Equal(t, 2, summary.SpanCount)
@@ -408,7 +412,7 @@ func TestTraceSummaryHandlerPartialTraceStillSummarized(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.Code)
 
-	var summary tracesummary.Summary
+	var summary tracesummary.TraceOverview
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &summary))
 	require.Equal(t, 2, summary.SpanCount)
 	require.Equal(t, "checkout", summary.RootService)

--- a/modules/frontend/trace_summary_handler_test.go
+++ b/modules/frontend/trace_summary_handler_test.go
@@ -1,0 +1,415 @@
+package frontend
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gorilla/mux"
+	"github.com/grafana/dskit/user"
+	"github.com/grafana/tempo/modules/frontend/combiner"
+	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/modules/overrides"
+	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/model/tracesummary"
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func traceSummaryTestTrace() *tempopb.Trace {
+	traceID := []byte{0xab, 0xc1, 0x23}
+	rootSpanID := []byte{0, 0, 0, 0, 0, 0, 0, 1}
+	childSpanID := []byte{0, 0, 0, 0, 0, 0, 0, 2}
+	return &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						{Key: "service.name", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "checkout"}}},
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{
+					{
+						Spans: []*tracev1.Span{
+							{
+								TraceId:           traceID,
+								SpanId:            rootSpanID,
+								Name:              "root-op",
+								Kind:              tracev1.Span_SPAN_KIND_SERVER,
+								StartTimeUnixNano: 0,
+								EndTimeUnixNano:   100,
+								Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+							},
+							{
+								TraceId:           traceID,
+								SpanId:            childSpanID,
+								ParentSpanId:      rootSpanID,
+								Name:              "child-op",
+								Kind:              tracev1.Span_SPAN_KIND_CLIENT,
+								StartTimeUnixNano: 10,
+								EndTimeUnixNano:   50,
+								Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// zipkinDualIDTestTrace builds a trace with the zipkin client/server
+// duplicate-span-ID pattern: "call" (CLIENT) and "handle" (SERVER) share a
+// span ID, and "do-work" is the true child of the SERVER half. This mirrors
+// what a raw, un-deduped Zipkin import can produce before it reaches the
+// combiner's deduper.
+func zipkinDualIDTestTrace() *tempopb.Trace {
+	traceID := []byte{0xab, 0xc1, 0x23}
+	rootSpanID := []byte{0, 0, 0, 0, 0, 0, 0, 1}
+	sharedSpanID := []byte{0, 0, 0, 0, 0, 0, 0, 2}
+	grandchildSpanID := []byte{0, 0, 0, 0, 0, 0, 0, 3}
+	return &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						{Key: "service.name", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "root-svc"}}},
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{{Spans: []*tracev1.Span{
+					{
+						TraceId:           traceID,
+						SpanId:            rootSpanID,
+						Name:              "root-op",
+						Kind:              tracev1.Span_SPAN_KIND_SERVER,
+						StartTimeUnixNano: 0,
+						EndTimeUnixNano:   120,
+						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+					},
+				}}},
+			},
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						{Key: "service.name", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "caller"}}},
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{{Spans: []*tracev1.Span{
+					{
+						TraceId:           traceID,
+						SpanId:            sharedSpanID,
+						ParentSpanId:      rootSpanID,
+						Name:              "call",
+						Kind:              tracev1.Span_SPAN_KIND_CLIENT,
+						StartTimeUnixNano: 10,
+						EndTimeUnixNano:   90,
+						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+					},
+				}}},
+			},
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						{Key: "service.name", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "callee"}}},
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{{Spans: []*tracev1.Span{
+					{
+						TraceId: traceID,
+						// Shares sharedSpanID with the CLIENT-kind "call" span above,
+						// as produced by a raw zipkin import.
+						SpanId:            sharedSpanID,
+						ParentSpanId:      rootSpanID,
+						Name:              "handle",
+						Kind:              tracev1.Span_SPAN_KIND_SERVER,
+						StartTimeUnixNano: 15,
+						EndTimeUnixNano:   95,
+						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+					},
+				}}},
+			},
+			{
+				Resource: &resourcev1.Resource{
+					Attributes: []*commonv1.KeyValue{
+						{Key: "service.name", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "downstream"}}},
+					},
+				},
+				ScopeSpans: []*tracev1.ScopeSpans{{Spans: []*tracev1.Span{
+					{
+						TraceId:           traceID,
+						SpanId:            grandchildSpanID,
+						ParentSpanId:      sharedSpanID,
+						Name:              "do-work",
+						Kind:              tracev1.Span_SPAN_KIND_INTERNAL,
+						StartTimeUnixNano: 20,
+						EndTimeUnixNano:   80,
+						Status:            &tracev1.Status{Code: tracev1.Status_STATUS_CODE_OK},
+					},
+				}}},
+			},
+		},
+	}
+}
+
+// TestTraceSummaryHandler_ZipkinDualIDTrace_GoesThroughDeduperBeforeSummarize
+// drives a zipkin dual-ID fixture through the real endpoint path
+// (newTraceSummaryHandler -> fetchTraceForSummary -> combiner.NewTypedTraceByIDV2),
+// whose finalize() runs the span-ID deduper before tracesummary.Summarize
+// sees the trace. The deduper reparents the SERVER-kind "handle" span under
+// the CLIENT-kind "call" span (which kept the originally-shared span ID),
+// and reparents "do-work" (a child of the shared ID) under "handle"'s new
+// ID. The resulting critical path is therefore the full linear chain
+// root -> call -> handle -> do-work, unlike Summarize called directly on
+// the raw fixture (see TestSummarize_DuplicateSpanIDZipkinPattern in the
+// tracesummary package), where "call" and "handle" are still siblings and
+// the walk skips over "call" entirely.
+func TestTraceSummaryHandler_ZipkinDualIDTrace_GoesThroughDeduperBeforeSummarize(t *testing.T) {
+	tracePipeline := traceSummaryTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": {Trace: zipkinDualIDTestTrace()},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var summary tracesummary.Summary
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &summary))
+
+	require.Equal(t, 4, summary.SpanCount)
+	require.Equal(t, "root-svc", summary.RootService)
+	require.Equal(t, "root-op", summary.RootSpanName)
+
+	var pathNames []string
+	for _, p := range summary.CriticalPath {
+		pathNames = append(pathNames, p.Name)
+	}
+	require.Equal(t, []string{"root-op", "call", "handle", "do-work"}, pathNames)
+}
+
+func TestBuildTraceSummaryTraceByIDRequest(t *testing.T) {
+	start := time.Unix(100, 0)
+	end := time.Unix(200, 0)
+
+	req := buildTraceSummaryTraceByIDRequest(context.Background(), "", "abc123", start, end, nil)
+
+	require.Equal(t, http.MethodGet, req.Method)
+	require.Equal(t, "/api/v2/traces/abc123", req.URL.Path)
+	require.Equal(t, "100", req.URL.Query().Get("start"))
+	require.Equal(t, "200", req.URL.Query().Get("end"))
+	require.Equal(t, api.HeaderAcceptProtobuf, req.Header.Get(api.HeaderAccept))
+
+	_, err := api.ParseTraceID(req)
+	require.NoError(t, err)
+
+	_, _, _, startTime, endTime, err := api.ParseTraceByIDRequest(req)
+	require.NoError(t, err)
+	require.Equal(t, start, startTime)
+	require.Equal(t, end, endTime)
+}
+
+func TestFetchTraceForSummary(t *testing.T) {
+	traceID := "abc123"
+	trace := traceSummaryTestTrace()
+	traceByIDResp := &tempopb.TraceByIDResponse{
+		Trace: trace,
+		Metrics: &tempopb.TraceByIDMetrics{
+			InspectedBytes: 123,
+		},
+	}
+	respBytes, err := proto.Marshal(traceByIDResp)
+	require.NoError(t, err)
+
+	var gotReq *http.Request
+	tracePipeline := pipeline.AsyncRoundTripperFunc[combiner.PipelineResponse](func(req pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+		gotReq = req.HTTPRequest()
+		return pipeline.NewHTTPToAsyncResponse(&http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				api.HeaderContentType: []string{api.HeaderAcceptProtobuf},
+			},
+			Body: io.NopCloser(bytes.NewReader(respBytes)),
+		}), nil
+	})
+
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+
+	actual, err := fetchTraceForSummary(context.Background(), Config{}, "test-tenant", traceID, time.Time{}, time.Time{}, nil, "/tempo", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.True(t, proto.Equal(trace, actual.Trace))
+	require.Equal(t, uint64(123), actual.Metrics.GetInspectedBytes())
+	require.NotNil(t, gotReq)
+	require.Equal(t, "/tempo/api/v2/traces/abc123", gotReq.URL.Path)
+	require.Equal(t, api.HeaderAcceptProtobuf, gotReq.Header.Get(api.HeaderAccept))
+}
+
+func traceSummaryTestPipeline(t *testing.T, traces map[string]*tempopb.TraceByIDResponse) pipeline.AsyncRoundTripper[combiner.PipelineResponse] {
+	t.Helper()
+	return pipeline.AsyncRoundTripperFunc[combiner.PipelineResponse](func(req pipeline.Request) (pipeline.Responses[combiner.PipelineResponse], error) {
+		tracePath := req.HTTPRequest().URL.Path
+		traceID := tracePath[strings.LastIndex(tracePath, "/")+1:]
+		traceResp, ok := traces[traceID]
+		if !ok {
+			return pipeline.NewHTTPToAsyncResponse(&http.Response{
+				StatusCode: http.StatusNotFound,
+				Status:     http.StatusText(http.StatusNotFound),
+				Body:       io.NopCloser(strings.NewReader("trace not found")),
+			}), nil
+		}
+
+		respBytes, err := proto.Marshal(traceResp)
+		require.NoError(t, err)
+		return pipeline.NewHTTPToAsyncResponse(&http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				api.HeaderContentType: []string{api.HeaderAcceptProtobuf},
+			},
+			Body: io.NopCloser(bytes.NewReader(respBytes)),
+		}), nil
+	})
+}
+
+func newTraceSummaryTestRequest(t *testing.T, method, traceID string, query string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, "/api/v2/traces/"+traceID+"/summary"+query, nil)
+	req = req.WithContext(user.InjectOrgID(req.Context(), "test-tenant"))
+	return mux.SetURLVars(req, map[string]string{"traceID": traceID})
+}
+
+func TestTraceSummaryHandlerReturnsSummary(t *testing.T) {
+	tracePipeline := traceSummaryTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": {Trace: traceSummaryTestTrace()},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+	require.Equal(t, api.HeaderAcceptJSON, resp.Header().Get(api.HeaderContentType))
+
+	var summary tracesummary.Summary
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &summary))
+	require.Equal(t, "checkout", summary.RootService)
+	require.Equal(t, 2, summary.SpanCount)
+}
+
+func TestTraceSummaryHandlerTraceNotFound(t *testing.T) {
+	tracePipeline := traceSummaryTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": {Trace: &tempopb.Trace{}},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+func TestTraceSummaryHandlerInvalidTraceID(t *testing.T) {
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", nil, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodGet, "not-hex", "")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+}
+
+func TestTraceSummaryHandlerInvalidQueryParams(t *testing.T) {
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", nil, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "?start=notanumber")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+}
+
+func TestTraceSummaryHandlerDataAccessErrorReturnsBadRequest(t *testing.T) {
+	tracePipeline := traceSummaryTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": {Trace: traceSummaryTestTrace()},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	dataAccessController := &traceDiffDataAccessController{err: errors.New("policy rejected")}
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), dataAccessController), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Contains(t, resp.Body.String(), "policy rejected")
+	require.Positive(t, dataAccessController.callCount())
+}
+
+func TestTraceSummaryHandlerWrongMethod(t *testing.T) {
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", nil, nil, nil, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodPost, "abc123", "")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, resp.Code)
+}
+
+func TestTraceSummaryHandlerPartialTraceStillSummarized(t *testing.T) {
+	tracePipeline := traceSummaryTestPipeline(t, map[string]*tempopb.TraceByIDResponse{
+		"abc123": {
+			Trace:  traceSummaryTestTrace(),
+			Status: tempopb.PartialStatus_PARTIAL,
+		},
+	})
+	o, err := overrides.NewOverrides(overrides.Config{}, nil, prometheus.NewRegistry())
+	require.NoError(t, err)
+	handler := newHandler(nil, newTraceSummaryHandler(Config{}, "", tracePipeline, o, combiner.NewTypedTraceByIDV2, log.NewNopLogger(), nil), log.NewNopLogger())
+
+	req := newTraceSummaryTestRequest(t, http.MethodGet, "abc123", "")
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var summary tracesummary.Summary
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &summary))
+	require.Equal(t, 2, summary.SpanCount)
+	require.Equal(t, "checkout", summary.RootService)
+}

--- a/modules/frontend/tracediff_handler.go
+++ b/modules/frontend/tracediff_handler.go
@@ -1,7 +1,6 @@
 package frontend
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -96,7 +95,7 @@ func newTraceDiffHandler(_ Config, apiPrefix string, tracePipeline pipeline.Asyn
 		if err != nil {
 			return nil, fmt.Errorf("marshal trace diff response: %w", err)
 		}
-		return traceDiffJSONResponse(body), nil
+		return jsonResponse(body), nil
 	})
 }
 
@@ -260,18 +259,6 @@ func traceHasSpans(trace *tempopb.Trace) bool {
 		}
 	}
 	return false
-}
-
-func traceDiffJSONResponse(body []byte) *http.Response {
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Status:     http.StatusText(http.StatusOK),
-		Header: http.Header{
-			api.HeaderContentType: []string{api.HeaderAcceptJSON},
-		},
-		Body:          io.NopCloser(bytes.NewReader(body)),
-		ContentLength: int64(len(body)),
-	}
 }
 
 func traceDiffErrorResponse(err error) *http.Response {

--- a/modules/frontend/util.go
+++ b/modules/frontend/util.go
@@ -1,6 +1,7 @@
 package frontend
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/user"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
+	"github.com/grafana/tempo/pkg/api"
 	"github.com/grafana/tempo/tempodb/backend"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -31,6 +33,19 @@ func extractTenant(req *http.Request, logger log.Logger) (string, *http.Response
 }
 
 func acceptAllBlocks(_ *backend.BlockMeta) bool { return true }
+
+// jsonResponse builds a 200 OK http.Response wrapping body as a JSON payload.
+func jsonResponse(body []byte) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     http.StatusText(http.StatusOK),
+		Header: http.Header{
+			api.HeaderContentType: []string{api.HeaderAcceptJSON},
+		},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
 
 // setQueryShapeSpanAttrs stamps the query-shape attributes on the given span.
 func setQueryShapeSpanAttrs(span trace.Span, qs pipeline.QueryShape) {

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -96,6 +96,7 @@ const (
 	PathSearchTagsV2      = "/api/v2/search/tags"
 	PathTraceDiffV2       = "/api/v2/traces/diff"
 	PathTracesV2          = "/api/v2/traces/{traceID}"
+	PathTraceSummaryV2    = "/api/v2/traces/{traceID}/summary"
 
 	QueryModeKey       = "mode"
 	QueryModeIngesters = "ingesters"

--- a/pkg/model/tracediff/normalize.go
+++ b/pkg/model/tracediff/normalize.go
@@ -15,7 +15,8 @@ import (
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 )
 
-const serviceNameAttribute = "service.name"
+// ServiceNameAttribute is the OTel resource attribute naming a span's service.
+const ServiceNameAttribute = "service.name"
 
 type normalizedTrace struct {
 	meta  TraceMeta
@@ -109,7 +110,7 @@ func flattenSpans(trace *tempopb.Trace) ([]spanWithResource, TraceMeta) {
 	var meta TraceMeta
 	var spans []spanWithResource
 	for _, rs := range trace.ResourceSpans {
-		resourceService := attributeString(rs.GetResource().GetAttributes(), serviceNameAttribute)
+		resourceService := AttributeString(rs.GetResource().GetAttributes(), ServiceNameAttribute)
 		for _, ss := range rs.ScopeSpans {
 			for _, span := range ss.Spans {
 				meta.SpanCount++
@@ -162,7 +163,7 @@ func normalizeSpan(span spanWithResource, path []int, logicalKey spanLogicalKey,
 		startUnixNano:  span.span.GetStartTimeUnixNano(),
 		endUnixNano:    span.span.GetEndTimeUnixNano(),
 		durationValid:  hasValidDuration(span.span),
-		spanAttrs:      attributesMap(span.span.GetAttributes()),
+		spanAttrs:      AttributesMap(span.span.GetAttributes()),
 		snapshot: SpanSnapshot{
 			Path:          path,
 			Service:       ref.Service,
@@ -221,7 +222,7 @@ func invalidDurationExamples(invalid []spanLogicalKey, limit int) string {
 }
 
 func logicalKey(span spanWithResource) spanLogicalKey {
-	service := attributeString(span.span.GetAttributes(), serviceNameAttribute)
+	service := AttributeString(span.span.GetAttributes(), ServiceNameAttribute)
 	if service == "" {
 		service = span.resourceService
 	}
@@ -276,7 +277,9 @@ func spanIDKey(id []byte) string {
 	return string(id)
 }
 
-func attributeString(attrs []*commonv1.KeyValue, key string) string {
+// AttributeString returns the string value of key, or "" if the key is absent
+// or does not hold a string.
+func AttributeString(attrs []*commonv1.KeyValue, key string) string {
 	for _, attr := range attrs {
 		if attr.GetKey() == key {
 			return attr.GetValue().GetStringValue()
@@ -285,7 +288,8 @@ func attributeString(attrs []*commonv1.KeyValue, key string) string {
 	return ""
 }
 
-func attributesMap(attrs []*commonv1.KeyValue) map[string]any {
+// AttributesMap flattens attributes into a JSON-marshalable map.
+func AttributesMap(attrs []*commonv1.KeyValue) map[string]any {
 	out := make(map[string]any, len(attrs))
 	for _, attr := range attrs {
 		out[attr.GetKey()] = anyValue(attr.GetValue())
@@ -314,7 +318,7 @@ func anyValue(value *commonv1.AnyValue) any {
 		}
 		return out
 	case *commonv1.AnyValue_KvlistValue:
-		return attributesMap(v.KvlistValue.GetValues())
+		return AttributesMap(v.KvlistValue.GetValues())
 	case *commonv1.AnyValue_BytesValue:
 		return v.BytesValue
 	default:

--- a/pkg/model/tracesummary/summarize.go
+++ b/pkg/model/tracesummary/summarize.go
@@ -1,0 +1,458 @@
+package tracesummary
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+
+	modeltrace "github.com/grafana/tempo/pkg/model/trace"
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/grafana/tempo/pkg/util"
+)
+
+const (
+	serviceNameAttribute = "service.name"
+	childOfRefTypeKey    = "opentracing.ref_type"
+	childOfRefTypeValue  = "child_of"
+
+	maxSlowestSpans = 5
+	maxErrorSpans   = 5
+)
+
+// resolvedSpan pairs a span with its resolved service name (resource-level
+// service.name attribute — the OTel-spec source of truth — falling back to
+// a span-level attribute of the same name for non-conformant data).
+type resolvedSpan struct {
+	span    *tracev1.Span
+	service string
+}
+
+// Summarize computes a condensed Summary over an assembled trace: root
+// span, overall duration, critical path, per-service breakdown, top-5
+// slowest spans and first-5 error spans.
+//
+// A nil trace is a caller error and returns an error. A trace with no spans
+// is a valid (if unusual) input and returns a zero-value Summary with no
+// error.
+func Summarize(trace *tempopb.Trace) (*Summary, error) {
+	if trace == nil {
+		return nil, errors.New("tracesummary: trace is nil")
+	}
+
+	spans := flattenSpans(trace)
+	if len(spans) == 0 {
+		return &Summary{}, nil
+	}
+
+	byID := indexSpansByID(spans)
+	root := findRoot(spans)
+	children := buildChildrenIndex(spans, byID)
+	minStart, maxEnd := traceBounds(spans)
+
+	summary := &Summary{
+		TraceID:       util.TraceIDToHexString(root.span.GetTraceId()),
+		RootService:   root.service,
+		RootSpanName:  root.span.GetName(),
+		DurationNanos: durationBetween(minStart, maxEnd),
+		SpanCount:     len(spans),
+		ErrorCount:    countErrors(spans),
+		CriticalPath:  criticalPath(root, children),
+		Services:      serviceBreakdown(spans),
+		SlowestSpans:  slowestSpans(spans),
+		ErrorSpans:    errorSpans(spans),
+	}
+
+	return summary, nil
+}
+
+func flattenSpans(trace *tempopb.Trace) []*resolvedSpan {
+	var spans []*resolvedSpan
+	for _, rs := range trace.GetResourceSpans() {
+		resourceService := attributeString(rs.GetResource().GetAttributes(), serviceNameAttribute)
+		for _, ss := range rs.GetScopeSpans() {
+			for _, span := range ss.GetSpans() {
+				if span == nil {
+					continue
+				}
+				spans = append(spans, &resolvedSpan{
+					span:    span,
+					service: resolveService(span, resourceService),
+				})
+			}
+		}
+	}
+	return spans
+}
+
+func resolveService(span *tracev1.Span, resourceService string) string {
+	if resourceService != "" {
+		return resourceService
+	}
+	return attributeString(span.GetAttributes(), serviceNameAttribute)
+}
+
+// indexSpansByID maps a span's own ID to every span sharing that ID. Zipkin
+// traces can carry client/server span pairs with identical span IDs, so
+// lookups by ID must be disambiguated by kind (see disambiguateParent).
+func indexSpansByID(spans []*resolvedSpan) map[uint64][]*resolvedSpan {
+	idx := make(map[uint64][]*resolvedSpan, len(spans))
+	for _, s := range spans {
+		key := util.SpanIDToUint64(s.span.GetSpanId())
+		idx[key] = append(idx[key], s)
+	}
+	return idx
+}
+
+// disambiguateParent picks the parent span for child among candidates that
+// share a span ID. With two candidates (the zipkin client/server pattern), a
+// SERVER-kind child prefers a CLIENT-kind parent and vice versa.
+//
+// On the real trace-summary endpoint path this is unreachable in practice:
+// combiner.NewTraceByIDV2's finalize() runs newDeduper().dedupe() over the
+// assembled trace before Summarize ever sees it, and that deduper already
+// resolves zipkin dual-ID pairs by assigning the SERVER-kind span a new,
+// unique span ID and reparenting it (and its former children) under the
+// original shared ID, which the CLIENT-kind span keeps. So by the time
+// Summarize runs on real traffic, no two spans in the trace share an ID.
+// This function exists purely as defense-in-depth for any future or direct
+// caller of Summarize against un-deduped input, so that such input can't
+// panic or silently misattribute a parent.
+func disambiguateParent(candidates []*resolvedSpan, child *tracev1.Span) *resolvedSpan {
+	switch len(candidates) {
+	case 0:
+		return nil
+	case 1:
+		return candidates[0]
+	case 2:
+		kindWant := tracev1.Span_SPAN_KIND_SERVER
+		if child.GetKind() == tracev1.Span_SPAN_KIND_SERVER {
+			kindWant = tracev1.Span_SPAN_KIND_CLIENT
+		}
+		if candidates[0].span.GetKind() == kindWant {
+			return candidates[0]
+		}
+		if candidates[1].span.GetKind() == kindWant {
+			return candidates[1]
+		}
+		return nil
+	default:
+		// More than two spans sharing an ID is invalid data; best-effort
+		// rather than panicking or dropping the parent link entirely. Sort
+		// deterministically (earliest start, then smallest hex span ID) so
+		// the choice doesn't depend on unordered combiner merge order.
+		sorted := make([]*resolvedSpan, len(candidates))
+		copy(sorted, candidates)
+		sort.Slice(sorted, func(i, j int) bool {
+			return lessByStartThenID(sorted[i].span, sorted[j].span)
+		})
+		return sorted[0]
+	}
+}
+
+func lookupParent(byID map[uint64][]*resolvedSpan, span *tracev1.Span) *resolvedSpan {
+	if len(span.GetParentSpanId()) == 0 {
+		return nil
+	}
+	key := util.SpanIDToUint64(span.GetParentSpanId())
+	return disambiguateParent(byID[key], span)
+}
+
+func hasChildOfLink(span *tracev1.Span) bool {
+	for _, link := range span.GetLinks() {
+		if !bytes.Equal(link.GetTraceId(), span.GetTraceId()) {
+			continue
+		}
+		for _, attr := range link.GetAttributes() {
+			if attr.GetKey() == childOfRefTypeKey && attr.GetValue().GetStringValue() == childOfRefTypeValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// findRoot picks the root span: parentless and without a child_of link to
+// the same trace. Ties are broken by earliest start, then smallest hex span
+// ID. If no span qualifies, the globally earliest-starting span is used as
+// a synthetic root.
+func findRoot(spans []*resolvedSpan) *resolvedSpan {
+	var candidates []*resolvedSpan
+	for _, s := range spans {
+		if len(s.span.GetParentSpanId()) == 0 && !hasChildOfLink(s.span) {
+			candidates = append(candidates, s)
+		}
+	}
+	if len(candidates) == 0 {
+		candidates = spans
+	}
+
+	best := candidates[0]
+	for _, c := range candidates[1:] {
+		if lessByStartThenID(c.span, best.span) {
+			best = c
+		}
+	}
+	return best
+}
+
+func lessByStartThenID(a, b *tracev1.Span) bool {
+	if a.GetStartTimeUnixNano() != b.GetStartTimeUnixNano() {
+		return a.GetStartTimeUnixNano() < b.GetStartTimeUnixNano()
+	}
+	return util.SpanIDToHexString(a.GetSpanId()) < util.SpanIDToHexString(b.GetSpanId())
+}
+
+func traceBounds(spans []*resolvedSpan) (minStart, maxEnd uint64) {
+	minStart = spans[0].span.GetStartTimeUnixNano()
+	maxEnd = spans[0].span.GetEndTimeUnixNano()
+	for _, s := range spans[1:] {
+		if st := s.span.GetStartTimeUnixNano(); st < minStart {
+			minStart = st
+		}
+		if et := s.span.GetEndTimeUnixNano(); et > maxEnd {
+			maxEnd = et
+		}
+	}
+	return minStart, maxEnd
+}
+
+func durationBetween(start, end uint64) int64 {
+	if end < start {
+		return 0
+	}
+	return int64(end - start)
+}
+
+func spanDuration(span *tracev1.Span) int64 {
+	return durationBetween(span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano())
+}
+
+func isError(span *tracev1.Span) bool {
+	return span.GetStatus().GetCode() == tracev1.Status_STATUS_CODE_ERROR
+}
+
+// isLaterEnd reports whether a's end time makes it the later-ending span,
+// breaking ties by earliest start then smallest hex span ID.
+func isLaterEnd(a, b *tracev1.Span) bool {
+	if a.GetEndTimeUnixNano() != b.GetEndTimeUnixNano() {
+		return a.GetEndTimeUnixNano() > b.GetEndTimeUnixNano()
+	}
+	return lessByStartThenID(a, b)
+}
+
+// buildChildrenIndex maps each span to its direct children, resolving
+// zipkin-style duplicate span IDs the same way lookupParent does.
+func buildChildrenIndex(spans []*resolvedSpan, byID map[uint64][]*resolvedSpan) map[*resolvedSpan][]*resolvedSpan {
+	children := make(map[*resolvedSpan][]*resolvedSpan, len(spans))
+	for _, s := range spans {
+		parent := lookupParent(byID, s.span)
+		if parent == nil {
+			continue
+		}
+		children[parent] = append(children[parent], s)
+	}
+	return children
+}
+
+// criticalPath walks down from the root, at each level descending into the
+// direct child whose span ends latest (tie-break: earliest start, then
+// smallest hex span ID), until it reaches a span with no children.
+func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan) []PathSpan {
+	var chain []*resolvedSpan
+	visited := make(map[*resolvedSpan]struct{}, len(children)+1)
+
+	cur := root
+	for cur != nil {
+		if _, ok := visited[cur]; ok {
+			break
+		}
+		visited[cur] = struct{}{}
+		chain = append(chain, cur)
+
+		kids := children[cur]
+		if len(kids) == 0 {
+			break
+		}
+
+		next := kids[0]
+		for _, k := range kids[1:] {
+			if isLaterEnd(k.span, next.span) {
+				next = k
+			}
+		}
+		cur = next
+	}
+
+	out := make([]PathSpan, len(chain))
+	for i, s := range chain {
+		out[i] = PathSpan{
+			SpanID:            util.SpanIDToHexString(s.span.GetSpanId()),
+			Service:           s.service,
+			Name:              s.span.GetName(),
+			Kind:              modeltrace.KindToString(s.span.GetKind()),
+			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
+			DurationNanos:     spanDuration(s.span),
+		}
+	}
+	return out
+}
+
+func serviceBreakdown(spans []*resolvedSpan) []ServiceBreakdown {
+	type acc struct {
+		spanCount     int
+		errorCount    int
+		durationNanos int64
+	}
+
+	stats := map[string]*acc{}
+	var order []string
+	for _, s := range spans {
+		a, ok := stats[s.service]
+		if !ok {
+			a = &acc{}
+			stats[s.service] = a
+			order = append(order, s.service)
+		}
+		a.spanCount++
+		if isError(s.span) {
+			a.errorCount++
+		}
+		a.durationNanos += spanDuration(s.span)
+	}
+	sort.Strings(order)
+
+	out := make([]ServiceBreakdown, 0, len(order))
+	for _, svc := range order {
+		a := stats[svc]
+		out = append(out, ServiceBreakdown{
+			Service:       svc,
+			SpanCount:     a.spanCount,
+			ErrorCount:    a.errorCount,
+			DurationNanos: a.durationNanos,
+		})
+	}
+	return out
+}
+
+func slowestSpans(spans []*resolvedSpan) []SpanSummary {
+	sorted := make([]*resolvedSpan, len(spans))
+	copy(sorted, spans)
+	sort.Slice(sorted, func(i, j int) bool {
+		di, dj := spanDuration(sorted[i].span), spanDuration(sorted[j].span)
+		if di != dj {
+			return di > dj
+		}
+		return lessByStartThenID(sorted[i].span, sorted[j].span)
+	})
+
+	n := maxSlowestSpans
+	if len(sorted) < n {
+		n = len(sorted)
+	}
+
+	out := make([]SpanSummary, n)
+	for i := 0; i < n; i++ {
+		s := sorted[i]
+		out[i] = SpanSummary{
+			SpanID:            util.SpanIDToHexString(s.span.GetSpanId()),
+			Service:           s.service,
+			Name:              s.span.GetName(),
+			Kind:              modeltrace.KindToString(s.span.GetKind()),
+			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
+			DurationNanos:     spanDuration(s.span),
+			Attributes:        attributesMap(s.span.GetAttributes()),
+		}
+	}
+	return out
+}
+
+func errorSpans(spans []*resolvedSpan) []ErrorSpanSummary {
+	var filtered []*resolvedSpan
+	for _, s := range spans {
+		if isError(s.span) {
+			filtered = append(filtered, s)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return lessByStartThenID(filtered[i].span, filtered[j].span)
+	})
+
+	n := maxErrorSpans
+	if len(filtered) < n {
+		n = len(filtered)
+	}
+
+	out := make([]ErrorSpanSummary, n)
+	for i := 0; i < n; i++ {
+		s := filtered[i]
+		out[i] = ErrorSpanSummary{
+			SpanID:            util.SpanIDToHexString(s.span.GetSpanId()),
+			Service:           s.service,
+			Name:              s.span.GetName(),
+			Kind:              modeltrace.KindToString(s.span.GetKind()),
+			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
+			DurationNanos:     spanDuration(s.span),
+			StatusMessage:     s.span.GetStatus().GetMessage(),
+			Attributes:        attributesMap(s.span.GetAttributes()),
+		}
+	}
+	return out
+}
+
+func countErrors(spans []*resolvedSpan) int {
+	count := 0
+	for _, s := range spans {
+		if isError(s.span) {
+			count++
+		}
+	}
+	return count
+}
+
+func attributeString(attrs []*commonv1.KeyValue, key string) string {
+	for _, attr := range attrs {
+		if attr.GetKey() == key {
+			return attr.GetValue().GetStringValue()
+		}
+	}
+	return ""
+}
+
+func attributesMap(attrs []*commonv1.KeyValue) map[string]any {
+	out := make(map[string]any, len(attrs))
+	for _, attr := range attrs {
+		out[attr.GetKey()] = anyValue(attr.GetValue())
+	}
+	return out
+}
+
+func anyValue(value *commonv1.AnyValue) any {
+	if value == nil {
+		return nil
+	}
+	switch v := value.GetValue().(type) {
+	case *commonv1.AnyValue_StringValue:
+		return v.StringValue
+	case *commonv1.AnyValue_BoolValue:
+		return v.BoolValue
+	case *commonv1.AnyValue_IntValue:
+		return v.IntValue
+	case *commonv1.AnyValue_DoubleValue:
+		return v.DoubleValue
+	case *commonv1.AnyValue_ArrayValue:
+		values := v.ArrayValue.GetValues()
+		out := make([]any, 0, len(values))
+		for _, item := range values {
+			out = append(out, anyValue(item))
+		}
+		return out
+	case *commonv1.AnyValue_KvlistValue:
+		return attributesMap(v.KvlistValue.GetValues())
+	case *commonv1.AnyValue_BytesValue:
+		return v.BytesValue
+	default:
+		return nil
+	}
+}

--- a/pkg/model/tracesummary/summarize.go
+++ b/pkg/model/tracesummary/summarize.go
@@ -49,6 +49,7 @@ func Summarize(trace *tempopb.Trace) (*Summary, error) {
 	byID := indexSpansByID(spans)
 	root := findRoot(spans)
 	children := buildChildrenIndex(spans, byID)
+	self := selfDurations(spans, children)
 	minStart, maxEnd := traceBounds(spans)
 
 	summary := &Summary{
@@ -58,9 +59,9 @@ func Summarize(trace *tempopb.Trace) (*Summary, error) {
 		DurationNanos: durationBetween(minStart, maxEnd),
 		SpanCount:     len(spans),
 		ErrorCount:    countErrors(spans),
-		CriticalPath:  criticalPath(root, children),
-		Services:      serviceBreakdown(spans),
-		SlowestSpans:  slowestSpans(spans),
+		CriticalPath:  criticalPath(root, children, self),
+		Services:      serviceBreakdown(spans, self),
+		SlowestSpans:  slowestSpans(spans, self),
 		ErrorSpans:    errorSpans(spans),
 	}
 
@@ -229,6 +230,77 @@ func spanDuration(span *tracev1.Span) int64 {
 	return durationBetween(span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano())
 }
 
+func parentSpanIDHex(span *tracev1.Span) string {
+	if len(span.GetParentSpanId()) == 0 {
+		return ""
+	}
+	return util.SpanIDToHexString(span.GetParentSpanId())
+}
+
+// selfDurations computes each span's exclusive duration: its own wall time
+// minus the time already accounted for by its direct children.
+//
+// Child intervals are unioned rather than summed, and clipped to the parent's
+// own window. Summing would over-subtract whenever children run concurrently —
+// a span fanning out to ten parallel calls would report zero self time — and
+// children can start before or outlive their parent in real traces.
+func selfDurations(spans []*resolvedSpan, children map[*resolvedSpan][]*resolvedSpan) map[*tracev1.Span]int64 {
+	self := make(map[*tracev1.Span]int64, len(spans))
+	for _, s := range spans {
+		self[s.span] = exclusiveDuration(s, children[s])
+	}
+	return self
+}
+
+func exclusiveDuration(parent *resolvedSpan, kids []*resolvedSpan) int64 {
+	total := spanDuration(parent.span)
+	if total == 0 || len(kids) == 0 {
+		return total
+	}
+
+	windowStart := parent.span.GetStartTimeUnixNano()
+	windowEnd := parent.span.GetEndTimeUnixNano()
+
+	intervals := make([][2]uint64, 0, len(kids))
+	for _, k := range kids {
+		start := k.span.GetStartTimeUnixNano()
+		end := k.span.GetEndTimeUnixNano()
+		if start < windowStart {
+			start = windowStart
+		}
+		if end > windowEnd {
+			end = windowEnd
+		}
+		if end > start {
+			intervals = append(intervals, [2]uint64{start, end})
+		}
+	}
+	if len(intervals) == 0 {
+		return total
+	}
+	sort.Slice(intervals, func(i, j int) bool { return intervals[i][0] < intervals[j][0] })
+
+	var covered uint64
+	curStart, curEnd := intervals[0][0], intervals[0][1]
+	for _, iv := range intervals[1:] {
+		if iv[0] > curEnd {
+			covered += curEnd - curStart
+			curStart, curEnd = iv[0], iv[1]
+			continue
+		}
+		if iv[1] > curEnd {
+			curEnd = iv[1]
+		}
+	}
+	covered += curEnd - curStart
+
+	// covered is clipped to the parent's window, so it can't exceed total.
+	if int64(covered) >= total {
+		return 0
+	}
+	return total - int64(covered)
+}
+
 func isError(span *tracev1.Span) bool {
 	return span.GetStatus().GetCode() == tracev1.Status_STATUS_CODE_ERROR
 }
@@ -259,7 +331,7 @@ func buildChildrenIndex(spans []*resolvedSpan, byID map[uint64][]*resolvedSpan) 
 // criticalPath walks down from the root, at each level descending into the
 // direct child whose span ends latest (tie-break: earliest start, then
 // smallest hex span ID), until it reaches a span with no children.
-func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan) []PathSpan {
+func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan, self map[*tracev1.Span]int64) []PathSpan {
 	var chain []*resolvedSpan
 	visited := make(map[*resolvedSpan]struct{}, len(children)+1)
 
@@ -294,16 +366,19 @@ func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan
 			Kind:              modeltrace.KindToString(s.span.GetKind()),
 			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
 			DurationNanos:     spanDuration(s.span),
+			SelfDurationNanos: self[s.span],
+			Attributes:        attributesMap(s.span.GetAttributes()),
 		}
 	}
 	return out
 }
 
-func serviceBreakdown(spans []*resolvedSpan) []ServiceBreakdown {
+func serviceBreakdown(spans []*resolvedSpan, self map[*tracev1.Span]int64) []ServiceBreakdown {
 	type acc struct {
 		spanCount     int
 		errorCount    int
 		durationNanos int64
+		selfNanos     int64
 	}
 
 	stats := map[string]*acc{}
@@ -320,6 +395,7 @@ func serviceBreakdown(spans []*resolvedSpan) []ServiceBreakdown {
 			a.errorCount++
 		}
 		a.durationNanos += spanDuration(s.span)
+		a.selfNanos += self[s.span]
 	}
 	sort.Strings(order)
 
@@ -327,10 +403,11 @@ func serviceBreakdown(spans []*resolvedSpan) []ServiceBreakdown {
 	for _, svc := range order {
 		a := stats[svc]
 		out = append(out, ServiceBreakdown{
-			Service:       svc,
-			SpanCount:     a.spanCount,
-			ErrorCount:    a.errorCount,
-			DurationNanos: a.durationNanos,
+			Service:           svc,
+			SpanCount:         a.spanCount,
+			ErrorCount:        a.errorCount,
+			DurationNanos:     a.durationNanos,
+			SelfDurationNanos: a.selfNanos,
 		})
 	}
 	return out
@@ -360,31 +437,41 @@ func insertRanked(top []*resolvedSpan, k int, s *resolvedSpan, less func(a, b *t
 	return top
 }
 
-// longerDuration reports whether a is the longer-running span, breaking ties
+// longerSelfDuration reports whether a spent more time in itself, breaking ties
 // by earliest start then smallest hex span ID.
-func longerDuration(a, b *tracev1.Span) bool {
-	da, db := spanDuration(a), spanDuration(b)
-	if da != db {
-		return da > db
+//
+// Ranking by self time rather than wall time is what makes this list worth
+// returning. Wall time in a nested trace is dominated by ancestry — the slowest
+// spans are trivially the outermost ones, which the critical path already
+// names. Self time surfaces the spans that actually burned the time.
+func longerSelfDuration(self map[*tracev1.Span]int64) func(a, b *tracev1.Span) bool {
+	return func(a, b *tracev1.Span) bool {
+		sa, sb := self[a], self[b]
+		if sa != sb {
+			return sa > sb
+		}
+		return lessByStartThenID(a, b)
 	}
-	return lessByStartThenID(a, b)
 }
 
-func slowestSpans(spans []*resolvedSpan) []SpanSummary {
+func slowestSpans(spans []*resolvedSpan, self map[*tracev1.Span]int64) []SpanSummary {
+	less := longerSelfDuration(self)
 	top := make([]*resolvedSpan, 0, maxSlowestSpans)
 	for _, s := range spans {
-		top = insertRanked(top, maxSlowestSpans, s, longerDuration)
+		top = insertRanked(top, maxSlowestSpans, s, less)
 	}
 
 	out := make([]SpanSummary, len(top))
 	for i, s := range top {
 		out[i] = SpanSummary{
 			SpanID:            util.SpanIDToHexString(s.span.GetSpanId()),
+			ParentSpanID:      parentSpanIDHex(s.span),
 			Service:           s.service,
 			Name:              s.span.GetName(),
 			Kind:              modeltrace.KindToString(s.span.GetKind()),
 			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
 			DurationNanos:     spanDuration(s.span),
+			SelfDurationNanos: self[s.span],
 			Attributes:        attributesMap(s.span.GetAttributes()),
 		}
 	}
@@ -404,6 +491,7 @@ func errorSpans(spans []*resolvedSpan) []ErrorSpanSummary {
 	for i, s := range top {
 		out[i] = ErrorSpanSummary{
 			SpanID:            util.SpanIDToHexString(s.span.GetSpanId()),
+			ParentSpanID:      parentSpanIDHex(s.span),
 			Service:           s.service,
 			Name:              s.span.GetName(),
 			Kind:              modeltrace.KindToString(s.span.GetKind()),

--- a/pkg/model/tracesummary/summarize.go
+++ b/pkg/model/tracesummary/summarize.go
@@ -6,16 +6,15 @@ import (
 	"sort"
 
 	modeltrace "github.com/grafana/tempo/pkg/model/trace"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/grafana/tempo/pkg/tempopb"
-	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/grafana/tempo/pkg/util"
 )
 
 const (
-	serviceNameAttribute = "service.name"
-	childOfRefTypeKey    = "opentracing.ref_type"
-	childOfRefTypeValue  = "child_of"
+	childOfRefTypeKey   = "opentracing.ref_type"
+	childOfRefTypeValue = "child_of"
 
 	maxSlowestSpans = 5
 	maxErrorSpans   = 5
@@ -29,40 +28,41 @@ type resolvedSpan struct {
 	service string
 }
 
-// Summarize computes a condensed Summary over an assembled trace: root
+// Summarize computes a condensed TraceOverview over an assembled trace: root
 // span, overall duration, critical path, per-service breakdown, top-5
 // slowest spans and first-5 error spans.
 //
 // A nil trace is a caller error and returns an error. A trace with no spans
-// is a valid (if unusual) input and returns a zero-value Summary with no
-// error.
-func Summarize(trace *tempopb.Trace) (*Summary, error) {
+// is a valid (if unusual) input and returns a zero-value TraceOverview with
+// no error.
+func Summarize(trace *tempopb.Trace) (*TraceOverview, error) {
 	if trace == nil {
 		return nil, errors.New("tracesummary: trace is nil")
 	}
 
 	spans := flattenSpans(trace)
 	if len(spans) == 0 {
-		return &Summary{}, nil
+		return &TraceOverview{}, nil
 	}
 
 	byID := indexSpansByID(spans)
 	root := findRoot(spans)
 	children := buildChildrenIndex(spans, byID)
 	self := selfDurations(spans, children)
+	reach := subtreeEnds(spans, children)
 	minStart, maxEnd := traceBounds(spans)
 
-	summary := &Summary{
-		TraceID:       util.TraceIDToHexString(root.span.GetTraceId()),
-		RootService:   root.service,
-		RootSpanName:  root.span.GetName(),
-		DurationNanos: durationBetween(minStart, maxEnd),
-		SpanCount:     len(spans),
-		ErrorCount:    countErrors(spans),
-		CriticalPath:  criticalPath(root, children, self),
-		Services:      serviceBreakdown(spans, self),
-		SlowestSpans:  slowestSpans(spans, self),
-		ErrorSpans:    errorSpans(spans),
+	summary := &TraceOverview{
+		TraceID:        util.TraceIDToHexString(root.span.GetTraceId()),
+		RootService:    root.service,
+		RootSpanName:   root.span.GetName(),
+		DurationNanos:  durationBetween(minStart, maxEnd),
+		SpanCount:      len(spans),
+		ErrorSpanCount: countErrors(spans),
+		CriticalPath:   criticalPath(root, children, self, reach),
+		Services:       serviceBreakdown(spans, self),
+		SlowestSpans:   slowestSpans(spans, self),
+		ErrorSpans:     errorSpans(spans),
 	}
 
 	return summary, nil
@@ -71,7 +71,7 @@ func Summarize(trace *tempopb.Trace) (*Summary, error) {
 func flattenSpans(trace *tempopb.Trace) []*resolvedSpan {
 	var spans []*resolvedSpan
 	for _, rs := range trace.GetResourceSpans() {
-		resourceService := attributeString(rs.GetResource().GetAttributes(), serviceNameAttribute)
+		resourceService := tracediff.AttributeString(rs.GetResource().GetAttributes(), tracediff.ServiceNameAttribute)
 		for _, ss := range rs.GetScopeSpans() {
 			for _, span := range ss.GetSpans() {
 				if span == nil {
@@ -91,7 +91,7 @@ func resolveService(span *tracev1.Span, resourceService string) string {
 	if resourceService != "" {
 		return resourceService
 	}
-	return attributeString(span.GetAttributes(), serviceNameAttribute)
+	return tracediff.AttributeString(span.GetAttributes(), tracediff.ServiceNameAttribute)
 }
 
 // indexSpansByID maps a span's own ID to every span sharing that ID. Zipkin
@@ -205,15 +205,31 @@ func lessByStartThenID(a, b *tracev1.Span) bool {
 	return util.SpanIDToHexString(a.GetSpanId()) < util.SpanIDToHexString(b.GetSpanId())
 }
 
+// hasUsableTimestamps reports whether a span's timestamps can be measured. A
+// start of 0 is unset — OTLP start times are non-zero — and treating it as the
+// epoch would report a duration of decades against a real end time, letting one
+// badly instrumented span poison the whole trace's numbers.
+func hasUsableTimestamps(span *tracev1.Span) bool {
+	start := span.GetStartTimeUnixNano()
+	return start > 0 && span.GetEndTimeUnixNano() >= start
+}
+
+// traceBounds returns the trace's wall-clock envelope across spans with usable
+// timestamps. Spans without them contribute nothing rather than dragging the
+// envelope back to the epoch.
 func traceBounds(spans []*resolvedSpan) (minStart, maxEnd uint64) {
-	minStart = spans[0].span.GetStartTimeUnixNano()
-	maxEnd = spans[0].span.GetEndTimeUnixNano()
-	for _, s := range spans[1:] {
-		if st := s.span.GetStartTimeUnixNano(); st < minStart {
-			minStart = st
+	var found bool
+	for _, s := range spans {
+		if !hasUsableTimestamps(s.span) {
+			continue
 		}
-		if et := s.span.GetEndTimeUnixNano(); et > maxEnd {
-			maxEnd = et
+		start := s.span.GetStartTimeUnixNano()
+		if !found || start < minStart {
+			minStart = start
+			found = true
+		}
+		if end := s.span.GetEndTimeUnixNano(); end > maxEnd {
+			maxEnd = end
 		}
 	}
 	return minStart, maxEnd
@@ -227,6 +243,9 @@ func durationBetween(start, end uint64) int64 {
 }
 
 func spanDuration(span *tracev1.Span) int64 {
+	if !hasUsableTimestamps(span) {
+		return 0
+	}
 	return durationBetween(span.GetStartTimeUnixNano(), span.GetEndTimeUnixNano())
 }
 
@@ -263,6 +282,9 @@ func exclusiveDuration(parent *resolvedSpan, kids []*resolvedSpan) int64 {
 
 	intervals := make([][2]uint64, 0, len(kids))
 	for _, k := range kids {
+		if !hasUsableTimestamps(k.span) {
+			continue
+		}
 		start := k.span.GetStartTimeUnixNano()
 		end := k.span.GetEndTimeUnixNano()
 		if start < windowStart {
@@ -314,6 +336,15 @@ func isLaterEnd(a, b *tracev1.Span) bool {
 	return lessByStartThenID(a, b)
 }
 
+// reachesLater reports whether a's subtree extends later than b's, falling back
+// to the spans' own end times when both branches reach the same instant.
+func reachesLater(a, b *resolvedSpan, reach map[*resolvedSpan]uint64) bool {
+	if reach[a] != reach[b] {
+		return reach[a] > reach[b]
+	}
+	return isLaterEnd(a.span, b.span)
+}
+
 // buildChildrenIndex maps each span to its direct children, resolving
 // zipkin-style duplicate span IDs the same way lookupParent does.
 func buildChildrenIndex(spans []*resolvedSpan, byID map[uint64][]*resolvedSpan) map[*resolvedSpan][]*resolvedSpan {
@@ -328,10 +359,68 @@ func buildChildrenIndex(spans []*resolvedSpan, byID map[uint64][]*resolvedSpan) 
 	return children
 }
 
+// subtreeEnds maps each span to the latest end time anywhere in its subtree,
+// including its own. Computed with an iterative post-order walk so a deep
+// trace can't overflow the stack; a back edge (cycle) is simply not folded in,
+// which leaves the traversal finite.
+func subtreeEnds(spans []*resolvedSpan, children map[*resolvedSpan][]*resolvedSpan) map[*resolvedSpan]uint64 {
+	const (
+		unvisited = iota
+		inProgress
+		done
+	)
+
+	state := make(map[*resolvedSpan]int, len(spans))
+	end := make(map[*resolvedSpan]uint64, len(spans))
+
+	for _, start := range spans {
+		if state[start] == done {
+			continue
+		}
+		stack := []*resolvedSpan{start}
+		for len(stack) > 0 {
+			cur := stack[len(stack)-1]
+			switch state[cur] {
+			case done:
+				stack = stack[:len(stack)-1]
+			case inProgress:
+				// Children have been resolved by now; fold them in.
+				var latest uint64
+				if hasUsableTimestamps(cur.span) {
+					latest = cur.span.GetEndTimeUnixNano()
+				}
+				for _, k := range children[cur] {
+					if state[k] == done && end[k] > latest {
+						latest = end[k]
+					}
+				}
+				end[cur] = latest
+				state[cur] = done
+				stack = stack[:len(stack)-1]
+			default:
+				state[cur] = inProgress
+				for _, k := range children[cur] {
+					if state[k] == unvisited {
+						stack = append(stack, k)
+					}
+				}
+			}
+		}
+	}
+	return end
+}
+
 // criticalPath walks down from the root, at each level descending into the
-// direct child whose span ends latest (tie-break: earliest start, then
-// smallest hex span ID), until it reaches a span with no children.
-func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan, self map[*tracev1.Span]int64) []PathSpan {
+// child whose subtree reaches latest, until it reaches a span with no children.
+//
+// The choice is made on the subtree's latest end rather than the direct child's
+// own end time. Picking the child that itself ends latest is greedy and can
+// walk away from the branch that actually determines the trace duration: a
+// child may finish early while a descendant of it — detached or async work
+// outliving its parent — runs on well past every sibling. Ties fall back to the
+// spans' own end times, then earliest start and smallest hex span ID, so the
+// result stays deterministic regardless of combiner merge order.
+func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan, self map[*tracev1.Span]int64, reach map[*resolvedSpan]uint64) []PathSpan {
 	var chain []*resolvedSpan
 	visited := make(map[*resolvedSpan]struct{}, len(children)+1)
 
@@ -350,7 +439,7 @@ func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan
 
 		next := kids[0]
 		for _, k := range kids[1:] {
-			if isLaterEnd(k.span, next.span) {
+			if reachesLater(k, next, reach) {
 				next = k
 			}
 		}
@@ -367,7 +456,7 @@ func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan
 			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
 			DurationNanos:     spanDuration(s.span),
 			SelfDurationNanos: self[s.span],
-			Attributes:        attributesMap(s.span.GetAttributes()),
+			Attributes:        tracediff.AttributesMap(s.span.GetAttributes()),
 		}
 	}
 	return out
@@ -375,10 +464,10 @@ func criticalPath(root *resolvedSpan, children map[*resolvedSpan][]*resolvedSpan
 
 func serviceBreakdown(spans []*resolvedSpan, self map[*tracev1.Span]int64) []ServiceBreakdown {
 	type acc struct {
-		spanCount     int
-		errorCount    int
-		durationNanos int64
-		selfNanos     int64
+		spanCount      int
+		errorSpanCount int
+		durationNanos  int64
+		selfNanos      int64
 	}
 
 	stats := map[string]*acc{}
@@ -392,7 +481,7 @@ func serviceBreakdown(spans []*resolvedSpan, self map[*tracev1.Span]int64) []Ser
 		}
 		a.spanCount++
 		if isError(s.span) {
-			a.errorCount++
+			a.errorSpanCount++
 		}
 		a.durationNanos += spanDuration(s.span)
 		a.selfNanos += self[s.span]
@@ -405,7 +494,7 @@ func serviceBreakdown(spans []*resolvedSpan, self map[*tracev1.Span]int64) []Ser
 		out = append(out, ServiceBreakdown{
 			Service:           svc,
 			SpanCount:         a.spanCount,
-			ErrorCount:        a.errorCount,
+			ErrorSpanCount:    a.errorSpanCount,
 			DurationNanos:     a.durationNanos,
 			SelfDurationNanos: a.selfNanos,
 		})
@@ -472,7 +561,7 @@ func slowestSpans(spans []*resolvedSpan, self map[*tracev1.Span]int64) []SpanSum
 			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
 			DurationNanos:     spanDuration(s.span),
 			SelfDurationNanos: self[s.span],
-			Attributes:        attributesMap(s.span.GetAttributes()),
+			Attributes:        tracediff.AttributesMap(s.span.GetAttributes()),
 		}
 	}
 	return out
@@ -498,7 +587,7 @@ func errorSpans(spans []*resolvedSpan) []ErrorSpanSummary {
 			StartTimeUnixNano: s.span.GetStartTimeUnixNano(),
 			DurationNanos:     spanDuration(s.span),
 			StatusMessage:     s.span.GetStatus().GetMessage(),
-			Attributes:        attributesMap(s.span.GetAttributes()),
+			Attributes:        tracediff.AttributesMap(s.span.GetAttributes()),
 		}
 	}
 	return out
@@ -512,50 +601,4 @@ func countErrors(spans []*resolvedSpan) int {
 		}
 	}
 	return count
-}
-
-func attributeString(attrs []*commonv1.KeyValue, key string) string {
-	for _, attr := range attrs {
-		if attr.GetKey() == key {
-			return attr.GetValue().GetStringValue()
-		}
-	}
-	return ""
-}
-
-func attributesMap(attrs []*commonv1.KeyValue) map[string]any {
-	out := make(map[string]any, len(attrs))
-	for _, attr := range attrs {
-		out[attr.GetKey()] = anyValue(attr.GetValue())
-	}
-	return out
-}
-
-func anyValue(value *commonv1.AnyValue) any {
-	if value == nil {
-		return nil
-	}
-	switch v := value.GetValue().(type) {
-	case *commonv1.AnyValue_StringValue:
-		return v.StringValue
-	case *commonv1.AnyValue_BoolValue:
-		return v.BoolValue
-	case *commonv1.AnyValue_IntValue:
-		return v.IntValue
-	case *commonv1.AnyValue_DoubleValue:
-		return v.DoubleValue
-	case *commonv1.AnyValue_ArrayValue:
-		values := v.ArrayValue.GetValues()
-		out := make([]any, 0, len(values))
-		for _, item := range values {
-			out = append(out, anyValue(item))
-		}
-		return out
-	case *commonv1.AnyValue_KvlistValue:
-		return attributesMap(v.KvlistValue.GetValues())
-	case *commonv1.AnyValue_BytesValue:
-		return v.BytesValue
-	default:
-		return nil
-	}
 }

--- a/pkg/model/tracesummary/summarize.go
+++ b/pkg/model/tracesummary/summarize.go
@@ -336,25 +336,48 @@ func serviceBreakdown(spans []*resolvedSpan) []ServiceBreakdown {
 	return out
 }
 
-func slowestSpans(spans []*resolvedSpan) []SpanSummary {
-	sorted := make([]*resolvedSpan, len(spans))
-	copy(sorted, spans)
-	sort.Slice(sorted, func(i, j int) bool {
-		di, dj := spanDuration(sorted[i].span), spanDuration(sorted[j].span)
-		if di != dj {
-			return di > dj
+// insertRanked inserts s into top, which is kept sorted by less and capped at
+// k entries, dropping the lowest-ranked entry once full. Selecting a bounded
+// number of spans this way avoids copying and sorting every span in the trace.
+func insertRanked(top []*resolvedSpan, k int, s *resolvedSpan, less func(a, b *tracev1.Span) bool) []*resolvedSpan {
+	if k <= 0 {
+		return top
+	}
+	if len(top) == k {
+		if !less(s.span, top[k-1].span) {
+			return top
 		}
-		return lessByStartThenID(sorted[i].span, sorted[j].span)
-	})
-
-	n := maxSlowestSpans
-	if len(sorted) < n {
-		n = len(sorted)
+	} else {
+		top = append(top, nil)
 	}
 
-	out := make([]SpanSummary, n)
-	for i := 0; i < n; i++ {
-		s := sorted[i]
+	i := len(top) - 1
+	for i > 0 && less(s.span, top[i-1].span) {
+		top[i] = top[i-1]
+		i--
+	}
+	top[i] = s
+	return top
+}
+
+// longerDuration reports whether a is the longer-running span, breaking ties
+// by earliest start then smallest hex span ID.
+func longerDuration(a, b *tracev1.Span) bool {
+	da, db := spanDuration(a), spanDuration(b)
+	if da != db {
+		return da > db
+	}
+	return lessByStartThenID(a, b)
+}
+
+func slowestSpans(spans []*resolvedSpan) []SpanSummary {
+	top := make([]*resolvedSpan, 0, maxSlowestSpans)
+	for _, s := range spans {
+		top = insertRanked(top, maxSlowestSpans, s, longerDuration)
+	}
+
+	out := make([]SpanSummary, len(top))
+	for i, s := range top {
 		out[i] = SpanSummary{
 			SpanID:            util.SpanIDToHexString(s.span.GetSpanId()),
 			Service:           s.service,
@@ -369,24 +392,16 @@ func slowestSpans(spans []*resolvedSpan) []SpanSummary {
 }
 
 func errorSpans(spans []*resolvedSpan) []ErrorSpanSummary {
-	var filtered []*resolvedSpan
+	top := make([]*resolvedSpan, 0, maxErrorSpans)
 	for _, s := range spans {
-		if isError(s.span) {
-			filtered = append(filtered, s)
+		if !isError(s.span) {
+			continue
 		}
-	}
-	sort.Slice(filtered, func(i, j int) bool {
-		return lessByStartThenID(filtered[i].span, filtered[j].span)
-	})
-
-	n := maxErrorSpans
-	if len(filtered) < n {
-		n = len(filtered)
+		top = insertRanked(top, maxErrorSpans, s, lessByStartThenID)
 	}
 
-	out := make([]ErrorSpanSummary, n)
-	for i := 0; i < n; i++ {
-		s := filtered[i]
+	out := make([]ErrorSpanSummary, len(top))
+	for i, s := range top {
 		out[i] = ErrorSpanSummary{
 			SpanID:            util.SpanIDToHexString(s.span.GetSpanId()),
 			Service:           s.service,

--- a/pkg/model/tracesummary/summarize.go
+++ b/pkg/model/tracesummary/summarize.go
@@ -3,6 +3,7 @@ package tracesummary
 import (
 	"bytes"
 	"errors"
+	"math"
 	"sort"
 
 	modeltrace "github.com/grafana/tempo/pkg/model/trace"
@@ -208,10 +209,13 @@ func lessByStartThenID(a, b *tracev1.Span) bool {
 // hasUsableTimestamps reports whether a span's timestamps can be measured. A
 // start of 0 is unset — OTLP start times are non-zero — and treating it as the
 // epoch would report a duration of decades against a real end time, letting one
-// badly instrumented span poison the whole trace's numbers.
+// badly instrumented span poison the whole trace's numbers. A gap that doesn't
+// fit in int64 is likewise rejected, matching tracediff's hasValidDuration, so
+// the later uint64-to-int64 cast in durationBetween can't wrap negative.
 func hasUsableTimestamps(span *tracev1.Span) bool {
 	start := span.GetStartTimeUnixNano()
-	return start > 0 && span.GetEndTimeUnixNano() >= start
+	end := span.GetEndTimeUnixNano()
+	return start > 0 && end >= start && end-start <= math.MaxInt64
 }
 
 // traceBounds returns the trace's wall-clock envelope across spans with usable

--- a/pkg/model/tracesummary/summarize_test.go
+++ b/pkg/model/tracesummary/summarize_test.go
@@ -48,17 +48,20 @@ func resourceSpans(service string, spans ...*tracev1.Span) *tracev1.ResourceSpan
 func TestSummarize_SimpleMultiLevelTrace(t *testing.T) {
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("checkout",
+			resourceSpans(
+				"checkout",
 				// Root's own span ends before some of its descendants (e.g. an
 				// async downstream call outliving the parent's response) so the
 				// critical path is a genuine multi-hop walk, not just the root.
 				testSpan("root", "", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 60, tracev1.Status_STATUS_CODE_OK, ""),
 			),
-			resourceSpans("inventory",
+			resourceSpans(
+				"inventory",
 				testSpan("inventory", "root", "reserve inventory", tracev1.Span_SPAN_KIND_CLIENT, 20, 90, tracev1.Status_STATUS_CODE_OK, ""),
 				testSpan("reserve", "inventory", "reserve", tracev1.Span_SPAN_KIND_SERVER, 25, 100, tracev1.Status_STATUS_CODE_OK, ""),
 			),
-			resourceSpans("payment",
+			resourceSpans(
+				"payment",
 				testSpan("payment", "root", "charge", tracev1.Span_SPAN_KIND_CLIENT, 30, 45, tracev1.Status_STATUS_CODE_OK, ""),
 			),
 		},
@@ -96,7 +99,8 @@ func TestSummarize_NormalNestedTraceFollowsLastFinishingBranch(t *testing.T) {
 	// each level.
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("svc",
+			resourceSpans(
+				"svc",
 				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
 				// branch-a finishes later than branch-b, so the walk descends
 				// into branch-a at the root level.
@@ -124,7 +128,8 @@ func TestSummarize_NormalNestedTraceFollowsLastFinishingBranch(t *testing.T) {
 func TestSummarize_SingleSpanTrace(t *testing.T) {
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("solo",
+			resourceSpans(
+				"solo",
 				testSpan("only", "", "do-thing", tracev1.Span_SPAN_KIND_INTERNAL, 5, 15, tracev1.Status_STATUS_CODE_OK, ""),
 			),
 		},
@@ -146,7 +151,8 @@ func TestSummarize_SingleSpanTrace(t *testing.T) {
 func TestSummarize_NoErrors(t *testing.T) {
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("svc",
+			resourceSpans(
+				"svc",
 				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 10, tracev1.Status_STATUS_CODE_OK, ""),
 				testSpan("child", "root", "child-op", tracev1.Span_SPAN_KIND_CLIENT, 1, 9, tracev1.Status_STATUS_CODE_UNSET, ""),
 			),
@@ -241,7 +247,8 @@ func expectedSpanIDs(spans []*resolvedSpan, k int) []string {
 func TestSummarize_FewerThanFive(t *testing.T) {
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("svc",
+			resourceSpans(
+				"svc",
 				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 30, tracev1.Status_STATUS_CODE_OK, ""),
 				testSpan("child", "root", "child-op", tracev1.Span_SPAN_KIND_CLIENT, 1, 20, tracev1.Status_STATUS_CODE_ERROR, "oops"),
 			),
@@ -264,10 +271,12 @@ func TestSummarize_DisconnectedTraceFallsBackToEarliestSpan(t *testing.T) {
 	// qualifies as a normal root.
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("orphan-a",
+			resourceSpans(
+				"orphan-a",
 				testSpan("a", "missing-1", "op-a", tracev1.Span_SPAN_KIND_INTERNAL, 50, 60, tracev1.Status_STATUS_CODE_OK, ""),
 			),
-			resourceSpans("orphan-b",
+			resourceSpans(
+				"orphan-b",
 				testSpan("b", "missing-2", "op-b", tracev1.Span_SPAN_KIND_INTERNAL, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
 			),
 		},
@@ -297,18 +306,22 @@ func TestSummarize_DuplicateSpanIDZipkinPattern(t *testing.T) {
 	// client-kind half.
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("root-svc",
+			resourceSpans(
+				"root-svc",
 				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 120, tracev1.Status_STATUS_CODE_OK, ""),
 			),
-			resourceSpans("caller",
+			resourceSpans(
+				"caller",
 				testSpan("shared", "root", "call", tracev1.Span_SPAN_KIND_CLIENT, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
 			),
-			resourceSpans("callee",
+			resourceSpans(
+				"callee",
 				// Ends later than the client-kind half so the top-down walk
 				// descends into it, not "call".
 				testSpan("shared", "root", "handle", tracev1.Span_SPAN_KIND_SERVER, 15, 95, tracev1.Status_STATUS_CODE_OK, ""),
 			),
-			resourceSpans("downstream",
+			resourceSpans(
+				"downstream",
 				testSpan("grandchild", "shared", "do-work", tracev1.Span_SPAN_KIND_INTERNAL, 20, 80, tracev1.Status_STATUS_CODE_OK, ""),
 			),
 		},
@@ -367,7 +380,8 @@ func TestCriticalPath_CycleGuardTerminates(t *testing.T) {
 	// result (both cycle members visited once each).
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("svc",
+			resourceSpans(
+				"svc",
 				testSpan("a", "b", "op-a", tracev1.Span_SPAN_KIND_INTERNAL, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
 				testSpan("b", "a", "op-b", tracev1.Span_SPAN_KIND_INTERNAL, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
 			),
@@ -395,7 +409,8 @@ func TestCriticalPath_SelfReferentialSpanTerminates(t *testing.T) {
 	// terminate immediately rather than looping on itself forever.
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
-			resourceSpans("svc",
+			resourceSpans(
+				"svc",
 				testSpan("loopy", "loopy", "op-loopy", tracev1.Span_SPAN_KIND_INTERNAL, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
 			),
 		},

--- a/pkg/model/tracesummary/summarize_test.go
+++ b/pkg/model/tracesummary/summarize_test.go
@@ -15,6 +15,12 @@ import (
 
 var testTraceID = []byte("trace-id-0000001")
 
+// testBase offsets fixture timestamps off zero. A start of 0 is an unset
+// timestamp in OTLP and is deliberately treated as unmeasurable (see
+// hasUsableTimestamps), so fixtures need realistic wall-clock values. Offsets
+// passed to testSpan stay relative, so durations read the same as written.
+const testBase = uint64(1_700_000_000_000_000_000)
+
 func stringAttribute(key, value string) *commonv1.KeyValue {
 	return &commonv1.KeyValue{
 		Key:   key,
@@ -29,8 +35,8 @@ func testSpan(spanID, parentID, name string, kind tracev1.Span_SpanKind, start, 
 		ParentSpanId:      []byte(parentID),
 		Name:              name,
 		Kind:              kind,
-		StartTimeUnixNano: start,
-		EndTimeUnixNano:   end,
+		StartTimeUnixNano: testBase + start,
+		EndTimeUnixNano:   testBase + end,
 		Status:            &tracev1.Status{Code: status, Message: statusMsg},
 	}
 }
@@ -75,7 +81,7 @@ func TestSummarize_SimpleMultiLevelTrace(t *testing.T) {
 	require.Equal(t, "POST /checkout", got.RootSpanName)
 	require.Equal(t, int64(100), got.DurationNanos)
 	require.Equal(t, 4, got.SpanCount)
-	require.Equal(t, 0, got.ErrorCount)
+	require.Equal(t, 0, got.ErrorSpanCount)
 
 	var pathNames []string
 	for _, p := range got.CriticalPath {
@@ -91,9 +97,9 @@ func TestSummarize_SimpleMultiLevelTrace(t *testing.T) {
 	// Self time excludes what child spans already account for. The root runs
 	// 0-60 with children spanning 20-90 (clipped to 60) and 30-45, so 40ns of
 	// it is covered and 20ns is its own.
-	require.Equal(t, ServiceBreakdown{Service: "checkout", SpanCount: 1, ErrorCount: 0, DurationNanos: 60, SelfDurationNanos: 20}, byService["checkout"])
-	require.Equal(t, ServiceBreakdown{Service: "inventory", SpanCount: 2, ErrorCount: 0, DurationNanos: 145, SelfDurationNanos: 80}, byService["inventory"])
-	require.Equal(t, ServiceBreakdown{Service: "payment", SpanCount: 1, ErrorCount: 0, DurationNanos: 15, SelfDurationNanos: 15}, byService["payment"])
+	require.Equal(t, ServiceBreakdown{Service: "checkout", SpanCount: 1, ErrorSpanCount: 0, DurationNanos: 60, SelfDurationNanos: 20}, byService["checkout"])
+	require.Equal(t, ServiceBreakdown{Service: "inventory", SpanCount: 2, ErrorSpanCount: 0, DurationNanos: 145, SelfDurationNanos: 80}, byService["inventory"])
+	require.Equal(t, ServiceBreakdown{Service: "payment", SpanCount: 1, ErrorSpanCount: 0, DurationNanos: 15, SelfDurationNanos: 15}, byService["payment"])
 }
 
 func TestSummarize_NormalNestedTraceFollowsLastFinishingBranch(t *testing.T) {
@@ -165,7 +171,7 @@ func TestSummarize_NoErrors(t *testing.T) {
 
 	got, err := Summarize(trace)
 	require.NoError(t, err)
-	require.Equal(t, 0, got.ErrorCount)
+	require.Equal(t, 0, got.ErrorSpanCount)
 	require.Empty(t, got.ErrorSpans)
 }
 
@@ -185,7 +191,7 @@ func TestSummarize_TruncatesToFive(t *testing.T) {
 
 	require.Len(t, got.SlowestSpans, 5)
 	require.Len(t, got.ErrorSpans, 5)
-	require.Equal(t, 8, got.ErrorCount)
+	require.Equal(t, 8, got.ErrorSpanCount)
 
 	for i := 1; i < len(got.SlowestSpans); i++ {
 		require.GreaterOrEqual(t, got.SlowestSpans[i-1].DurationNanos, got.SlowestSpans[i].DurationNanos)
@@ -254,13 +260,15 @@ func expectedSpanIDs(spans []*resolvedSpan, k int) []string {
 // numbers they would not: an epoch-nanosecond timestamp is past 2^53, where a
 // JavaScript client silently rounds.
 func TestSummary_NanosMarshalAsJSONStrings(t *testing.T) {
-	const startNano = uint64(1763000000123456789)
+	// testSpan adds testBase, so the wire value is testBase + this offset.
+	const offsetNano = uint64(123456789)
+	const startNano = testBase + offsetNano
 
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
 			resourceSpans(
 				"svc",
-				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, startNano, startNano+1500, tracev1.Status_STATUS_CODE_ERROR, "boom"),
+				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, offsetNano, offsetNano+1500, tracev1.Status_STATUS_CODE_ERROR, "boom"),
 			),
 		},
 	}
@@ -270,10 +278,10 @@ func TestSummary_NanosMarshalAsJSONStrings(t *testing.T) {
 
 	body, err := json.Marshal(got)
 	require.NoError(t, err)
-	require.Contains(t, string(body), `"startTimeUnixNano":"1763000000123456789"`)
+	require.Contains(t, string(body), `"startTimeUnixNano":"1700000000123456789"`)
 	require.Contains(t, string(body), `"durationNanos":"1500"`)
 
-	var round Summary
+	var round TraceOverview
 	require.NoError(t, json.Unmarshal(body, &round))
 	require.Equal(t, int64(1500), round.DurationNanos)
 	require.Equal(t, startNano, round.CriticalPath[0].StartTimeUnixNano)
@@ -381,6 +389,31 @@ func TestSummary_CarriesAttributesAndParentage(t *testing.T) {
 	require.Empty(t, got.SlowestSpans[1].ParentSpanID)
 }
 
+// A span with an unset start time must contribute nothing rather than dragging
+// the envelope back to the epoch — otherwise one badly instrumented span
+// reports the trace as having taken decades.
+func TestSummarize_UnsetStartTimeDoesNotPoisonDurations(t *testing.T) {
+	root := testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 500, tracev1.Status_STATUS_CODE_OK, "")
+	bad := testSpan("bad", "root", "buggy", tracev1.Span_SPAN_KIND_CLIENT, 100, 400, tracev1.Status_STATUS_CODE_OK, "")
+	bad.StartTimeUnixNano = 0 // unset, as buggy instrumentation emits it
+
+	trace := &tempopb.Trace{ResourceSpans: []*tracev1.ResourceSpans{resourceSpans("svc", root, bad)}}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, got.SpanCount)
+	require.Equal(t, int64(500), got.DurationNanos)
+
+	// It is counted as a span but measured as zero, everywhere.
+	require.Equal(t, int64(500), got.Services[0].DurationNanos)
+	require.Equal(t, 2, got.Services[0].SpanCount)
+	for _, s := range got.SlowestSpans {
+		require.LessOrEqual(t, s.DurationNanos, int64(500))
+		require.LessOrEqual(t, s.SelfDurationNanos, int64(500))
+	}
+}
+
 func TestSummarize_FewerThanFive(t *testing.T) {
 	trace := &tempopb.Trace{
 		ResourceSpans: []*tracev1.ResourceSpans{
@@ -464,7 +497,7 @@ func TestSummarize_DuplicateSpanIDZipkinPattern(t *testing.T) {
 		},
 	}
 
-	var got *Summary
+	var got *TraceOverview
 	var err error
 	require.NotPanics(t, func() {
 		got, err = Summarize(trace)
@@ -509,6 +542,40 @@ func TestSummarize_RootCandidateExcludedByChildOfLink(t *testing.T) {
 	require.Equal(t, "real-op", got.RootSpanName)
 }
 
+// Descending into whichever direct child ends latest is greedy: a branch can
+// finish early while a descendant of it runs on past every sibling. The walk
+// must choose on how far a branch reaches, not on where its first hop stops.
+func TestCriticalPath_FollowsBranchThatReachesLatest(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans(
+				"svc",
+				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
+				// Ends first of the two branches, but spawns work that outlives
+				// everything else in the trace.
+				testSpan("early", "root", "returns-early", tracev1.Span_SPAN_KIND_CLIENT, 10, 40, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("detached", "early", "async-worker", tracev1.Span_SPAN_KIND_INTERNAL, 20, 200, tracev1.Status_STATUS_CODE_OK, ""),
+				// Ends later than "early" and would win a greedy comparison.
+				testSpan("late", "root", "ends-later", tracev1.Span_SPAN_KIND_CLIENT, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	var names []string
+	for _, p := range got.CriticalPath {
+		names = append(names, p.Name)
+	}
+	// Greedy on direct-child end time would stop at ["root-op", "ends-later"].
+	require.Equal(t, []string{"root-op", "returns-early", "async-worker"}, names)
+
+	// The path ends on the latest-ending span in the trace, which is what the
+	// trace duration is measured to.
+	require.Equal(t, int64(200), got.DurationNanos)
+}
+
 func TestCriticalPath_CycleGuardTerminates(t *testing.T) {
 	// Malformed data: A's parent is B and B's parent is A, a mutual (2-node)
 	// cycle with no true root. findRoot falls back to the earliest-starting
@@ -525,7 +592,7 @@ func TestCriticalPath_CycleGuardTerminates(t *testing.T) {
 		},
 	}
 
-	var got *Summary
+	var got *TraceOverview
 	var err error
 	require.NotPanics(t, func() {
 		got, err = Summarize(trace)
@@ -553,7 +620,7 @@ func TestCriticalPath_SelfReferentialSpanTerminates(t *testing.T) {
 		},
 	}
 
-	var got *Summary
+	var got *TraceOverview
 	var err error
 	require.NotPanics(t, func() {
 		got, err = Summarize(trace)

--- a/pkg/model/tracesummary/summarize_test.go
+++ b/pkg/model/tracesummary/summarize_test.go
@@ -1,0 +1,377 @@
+package tracesummary
+
+import (
+	"testing"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
+	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
+	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testTraceID = []byte("trace-id-0000001")
+
+func stringAttribute(key, value string) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: value}},
+	}
+}
+
+func testSpan(spanID, parentID, name string, kind tracev1.Span_SpanKind, start, end uint64, status tracev1.Status_StatusCode, statusMsg string, attrs ...*commonv1.KeyValue) *tracev1.Span {
+	return &tracev1.Span{
+		TraceId:           testTraceID,
+		SpanId:            []byte(spanID),
+		ParentSpanId:      []byte(parentID),
+		Name:              name,
+		Kind:              kind,
+		StartTimeUnixNano: start,
+		EndTimeUnixNano:   end,
+		Status:            &tracev1.Status{Code: status, Message: statusMsg},
+		Attributes:        attrs,
+	}
+}
+
+func resourceSpans(service string, spans ...*tracev1.Span) *tracev1.ResourceSpans {
+	return &tracev1.ResourceSpans{
+		Resource: &resourcev1.Resource{
+			Attributes: []*commonv1.KeyValue{stringAttribute("service.name", service)},
+		},
+		ScopeSpans: []*tracev1.ScopeSpans{
+			{Spans: spans},
+		},
+	}
+}
+
+func TestSummarize_SimpleMultiLevelTrace(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("checkout",
+				// Root's own span ends before some of its descendants (e.g. an
+				// async downstream call outliving the parent's response) so the
+				// critical path is a genuine multi-hop walk, not just the root.
+				testSpan("root", "", "POST /checkout", tracev1.Span_SPAN_KIND_SERVER, 0, 60, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+			resourceSpans("inventory",
+				testSpan("inventory", "root", "reserve inventory", tracev1.Span_SPAN_KIND_CLIENT, 20, 90, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("reserve", "inventory", "reserve", tracev1.Span_SPAN_KIND_SERVER, 25, 100, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+			resourceSpans("payment",
+				testSpan("payment", "root", "charge", tracev1.Span_SPAN_KIND_CLIENT, 30, 45, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	assert.Equal(t, "checkout", got.RootService)
+	assert.Equal(t, "POST /checkout", got.RootSpanName)
+	assert.Equal(t, int64(100), got.DurationNanos)
+	assert.Equal(t, 4, got.SpanCount)
+	assert.Equal(t, 0, got.ErrorCount)
+
+	var pathNames []string
+	for _, p := range got.CriticalPath {
+		pathNames = append(pathNames, p.Name)
+	}
+	assert.Equal(t, []string{"POST /checkout", "reserve inventory", "reserve"}, pathNames)
+
+	require.Len(t, got.Services, 3)
+	byService := map[string]ServiceBreakdown{}
+	for _, s := range got.Services {
+		byService[s.Service] = s
+	}
+	assert.Equal(t, ServiceBreakdown{Service: "checkout", SpanCount: 1, ErrorCount: 0, DurationNanos: 60}, byService["checkout"])
+	assert.Equal(t, ServiceBreakdown{Service: "inventory", SpanCount: 2, ErrorCount: 0, DurationNanos: 145}, byService["inventory"])
+	assert.Equal(t, ServiceBreakdown{Service: "payment", SpanCount: 1, ErrorCount: 0, DurationNanos: 15}, byService["payment"])
+}
+
+func TestSummarize_NormalNestedTraceFollowsLastFinishingBranch(t *testing.T) {
+	// Fully-synchronous instrumentation: every span's end time is <= its
+	// parent's end time (the common case). The critical path must still be
+	// a multi-hop walk, following whichever direct child finishes latest at
+	// each level.
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("svc",
+				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
+				// branch-a finishes later than branch-b, so the walk descends
+				// into branch-a at the root level.
+				testSpan("branch-a", "root", "branch-a", tracev1.Span_SPAN_KIND_CLIENT, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("branch-b", "root", "branch-b", tracev1.Span_SPAN_KIND_CLIENT, 20, 70, tracev1.Status_STATUS_CODE_OK, ""),
+				// leaf-a1 finishes later than leaf-a2, so the walk descends
+				// into leaf-a1 at the branch-a level.
+				testSpan("leaf-a1", "branch-a", "leaf-a1", tracev1.Span_SPAN_KIND_INTERNAL, 15, 85, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("leaf-a2", "branch-a", "leaf-a2", tracev1.Span_SPAN_KIND_INTERNAL, 30, 60, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	var pathNames []string
+	for _, p := range got.CriticalPath {
+		pathNames = append(pathNames, p.Name)
+	}
+	require.Greater(t, len(pathNames), 1)
+	assert.Equal(t, []string{"root-op", "branch-a", "leaf-a1"}, pathNames)
+}
+
+func TestSummarize_SingleSpanTrace(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("solo",
+				testSpan("only", "", "do-thing", tracev1.Span_SPAN_KIND_INTERNAL, 5, 15, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	assert.Equal(t, "solo", got.RootService)
+	assert.Equal(t, "do-thing", got.RootSpanName)
+	assert.Equal(t, int64(10), got.DurationNanos)
+	assert.Equal(t, 1, got.SpanCount)
+	require.Len(t, got.CriticalPath, 1)
+	assert.Equal(t, "do-thing", got.CriticalPath[0].Name)
+	require.Len(t, got.SlowestSpans, 1)
+	assert.Empty(t, got.ErrorSpans)
+}
+
+func TestSummarize_NoErrors(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("svc",
+				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 10, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("child", "root", "child-op", tracev1.Span_SPAN_KIND_CLIENT, 1, 9, tracev1.Status_STATUS_CODE_UNSET, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.ErrorCount)
+	assert.Empty(t, got.ErrorSpans)
+}
+
+func TestSummarize_TruncatesToFive(t *testing.T) {
+	var spans []*tracev1.Span
+	spans = append(spans, testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 1000, tracev1.Status_STATUS_CODE_OK, ""))
+	for i := 0; i < 8; i++ {
+		id := string([]byte{byte('a' + i)})
+		start := uint64(i * 10)
+		end := start + uint64(100+i)
+		spans = append(spans, testSpan("slow-"+id, "root", "op-"+id, tracev1.Span_SPAN_KIND_CLIENT, start, end, tracev1.Status_STATUS_CODE_ERROR, "boom"))
+	}
+	trace := &tempopb.Trace{ResourceSpans: []*tracev1.ResourceSpans{resourceSpans("svc", spans...)}}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	assert.Len(t, got.SlowestSpans, 5)
+	assert.Len(t, got.ErrorSpans, 5)
+	assert.Equal(t, 8, got.ErrorCount)
+
+	for i := 1; i < len(got.SlowestSpans); i++ {
+		assert.GreaterOrEqual(t, got.SlowestSpans[i-1].DurationNanos, got.SlowestSpans[i].DurationNanos)
+	}
+	for i := 1; i < len(got.ErrorSpans); i++ {
+		assert.LessOrEqual(t, got.ErrorSpans[i-1].StartTimeUnixNano, got.ErrorSpans[i].StartTimeUnixNano)
+	}
+}
+
+func TestSummarize_FewerThanFive(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("svc",
+				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 30, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("child", "root", "child-op", tracev1.Span_SPAN_KIND_CLIENT, 1, 20, tracev1.Status_STATUS_CODE_ERROR, "oops"),
+			),
+		},
+	}
+
+	require.NotPanics(t, func() {
+		got, err := Summarize(trace)
+		require.NoError(t, err)
+		assert.Len(t, got.SlowestSpans, 2)
+		assert.Len(t, got.ErrorSpans, 1)
+	})
+}
+
+func TestSummarize_DisconnectedTraceFallsBackToEarliestSpan(t *testing.T) {
+	// Neither span has an empty parent id pointing nowhere in the trace
+	// AND both look like orphans (parent ids that don't resolve to any
+	// span present); this exercises the zero-root-candidate fallback only
+	// when both spans additionally have non-empty parent ids so neither
+	// qualifies as a normal root.
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("orphan-a",
+				testSpan("a", "missing-1", "op-a", tracev1.Span_SPAN_KIND_INTERNAL, 50, 60, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+			resourceSpans("orphan-b",
+				testSpan("b", "missing-2", "op-b", tracev1.Span_SPAN_KIND_INTERNAL, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	// Fallback picks the globally earliest-starting span as synthetic root.
+	assert.Equal(t, "orphan-b", got.RootService)
+	assert.Equal(t, "op-b", got.RootSpanName)
+	assert.Equal(t, int64(80), got.DurationNanos)
+}
+
+func TestSummarize_DuplicateSpanIDZipkinPattern(t *testing.T) {
+	// This exercises disambiguateParent's own defense-in-depth logic on raw,
+	// un-deduped input. It does NOT reflect real /summary endpoint behavior:
+	// on that path, combiner.NewTraceByIDV2's deduper resolves zipkin
+	// dual-ID pairs before Summarize ever runs (see TestTraceSummaryHandler_
+	// ZipkinDualIDTrace_GoesThroughDeduperBeforeSummarize in the frontend
+	// package for the real, deduped path).
+	//
+	// Client and server spans share a span ID (zipkin pattern), across two
+	// different ResourceSpans batches, both parented under a real root. A
+	// fourth span is the true child of the server-kind half of the pair and
+	// must resolve its parent without panicking or misattributing to the
+	// client-kind half.
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("root-svc",
+				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 120, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+			resourceSpans("caller",
+				testSpan("shared", "root", "call", tracev1.Span_SPAN_KIND_CLIENT, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+			resourceSpans("callee",
+				// Ends later than the client-kind half so the top-down walk
+				// descends into it, not "call".
+				testSpan("shared", "root", "handle", tracev1.Span_SPAN_KIND_SERVER, 15, 95, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+			resourceSpans("downstream",
+				testSpan("grandchild", "shared", "do-work", tracev1.Span_SPAN_KIND_INTERNAL, 20, 80, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	var got *Summary
+	var err error
+	require.NotPanics(t, func() {
+		got, err = Summarize(trace)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 4, got.SpanCount)
+
+	var pathNames []string
+	for _, p := range got.CriticalPath {
+		pathNames = append(pathNames, p.Name)
+	}
+	// At the root, "handle" ends later than "call" so the walk descends into
+	// it. grandchild's parent (kindWant=SERVER, since grandchild is INTERNAL)
+	// then correctly resolves to the SERVER-kind "handle", not "call".
+	assert.Equal(t, []string{"root-op", "handle", "do-work"}, pathNames)
+}
+
+func TestSummarize_RootCandidateExcludedByChildOfLink(t *testing.T) {
+	linked := testSpan("linked-root", "", "linked-op", tracev1.Span_SPAN_KIND_SERVER, 0, 50, tracev1.Status_STATUS_CODE_OK, "")
+	linked.Links = []*tracev1.Span_Link{
+		{
+			TraceId: testTraceID,
+			SpanId:  []byte("elsewhere"),
+			Attributes: []*commonv1.KeyValue{
+				stringAttribute("opentracing.ref_type", "child_of"),
+			},
+		},
+	}
+	realRoot := testSpan("real-root", "", "real-op", tracev1.Span_SPAN_KIND_SERVER, 10, 20, tracev1.Status_STATUS_CODE_OK, "")
+
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("linked-svc", linked),
+			resourceSpans("real-svc", realRoot),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	assert.Equal(t, "real-svc", got.RootService)
+	assert.Equal(t, "real-op", got.RootSpanName)
+}
+
+func TestCriticalPath_CycleGuardTerminates(t *testing.T) {
+	// Malformed data: A's parent is B and B's parent is A, a mutual (2-node)
+	// cycle with no true root. findRoot falls back to the earliest-starting
+	// span. The critical path walk must still terminate via the visited-map
+	// guard rather than looping forever, and must produce a sane, bounded
+	// result (both cycle members visited once each).
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("svc",
+				testSpan("a", "b", "op-a", tracev1.Span_SPAN_KIND_INTERNAL, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("b", "a", "op-b", tracev1.Span_SPAN_KIND_INTERNAL, 10, 90, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	var got *Summary
+	var err error
+	require.NotPanics(t, func() {
+		got, err = Summarize(trace)
+	})
+	require.NoError(t, err)
+
+	var pathNames []string
+	for _, p := range got.CriticalPath {
+		pathNames = append(pathNames, p.Name)
+	}
+	assert.Equal(t, []string{"op-a", "op-b"}, pathNames)
+}
+
+func TestCriticalPath_SelfReferentialSpanTerminates(t *testing.T) {
+	// A single span whose ParentSpanId equals its own SpanId. No span in the
+	// trace has an empty parent, so findRoot falls back to the (only) span,
+	// which is then also its own child in the children index. The walk must
+	// terminate immediately rather than looping on itself forever.
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans("svc",
+				testSpan("loopy", "loopy", "op-loopy", tracev1.Span_SPAN_KIND_INTERNAL, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	var got *Summary
+	var err error
+	require.NotPanics(t, func() {
+		got, err = Summarize(trace)
+	})
+	require.NoError(t, err)
+
+	var pathNames []string
+	for _, p := range got.CriticalPath {
+		pathNames = append(pathNames, p.Name)
+	}
+	assert.Equal(t, []string{"op-loopy"}, pathNames)
+}
+
+func TestSummarize_NilTraceReturnsError(t *testing.T) {
+	got, err := Summarize(nil)
+	require.Error(t, err)
+	assert.Nil(t, got)
+}
+
+func TestSummarize_EmptyTraceReturnsZeroSummary(t *testing.T) {
+	got, err := Summarize(&tempopb.Trace{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 0, got.SpanCount)
+	assert.Empty(t, got.CriticalPath)
+}

--- a/pkg/model/tracesummary/summarize_test.go
+++ b/pkg/model/tracesummary/summarize_test.go
@@ -1,13 +1,14 @@
 package tracesummary
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/grafana/tempo/pkg/tempopb"
 	commonv1 "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	resourcev1 "github.com/grafana/tempo/pkg/tempopb/resource/v1"
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
-	"github.com/stretchr/testify/assert"
+	"github.com/grafana/tempo/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +21,7 @@ func stringAttribute(key, value string) *commonv1.KeyValue {
 	}
 }
 
-func testSpan(spanID, parentID, name string, kind tracev1.Span_SpanKind, start, end uint64, status tracev1.Status_StatusCode, statusMsg string, attrs ...*commonv1.KeyValue) *tracev1.Span {
+func testSpan(spanID, parentID, name string, kind tracev1.Span_SpanKind, start, end uint64, status tracev1.Status_StatusCode, statusMsg string) *tracev1.Span {
 	return &tracev1.Span{
 		TraceId:           testTraceID,
 		SpanId:            []byte(spanID),
@@ -30,7 +31,6 @@ func testSpan(spanID, parentID, name string, kind tracev1.Span_SpanKind, start, 
 		StartTimeUnixNano: start,
 		EndTimeUnixNano:   end,
 		Status:            &tracev1.Status{Code: status, Message: statusMsg},
-		Attributes:        attrs,
 	}
 }
 
@@ -67,26 +67,26 @@ func TestSummarize_SimpleMultiLevelTrace(t *testing.T) {
 	got, err := Summarize(trace)
 	require.NoError(t, err)
 
-	assert.Equal(t, "checkout", got.RootService)
-	assert.Equal(t, "POST /checkout", got.RootSpanName)
-	assert.Equal(t, int64(100), got.DurationNanos)
-	assert.Equal(t, 4, got.SpanCount)
-	assert.Equal(t, 0, got.ErrorCount)
+	require.Equal(t, "checkout", got.RootService)
+	require.Equal(t, "POST /checkout", got.RootSpanName)
+	require.Equal(t, int64(100), got.DurationNanos)
+	require.Equal(t, 4, got.SpanCount)
+	require.Equal(t, 0, got.ErrorCount)
 
 	var pathNames []string
 	for _, p := range got.CriticalPath {
 		pathNames = append(pathNames, p.Name)
 	}
-	assert.Equal(t, []string{"POST /checkout", "reserve inventory", "reserve"}, pathNames)
+	require.Equal(t, []string{"POST /checkout", "reserve inventory", "reserve"}, pathNames)
 
 	require.Len(t, got.Services, 3)
 	byService := map[string]ServiceBreakdown{}
 	for _, s := range got.Services {
 		byService[s.Service] = s
 	}
-	assert.Equal(t, ServiceBreakdown{Service: "checkout", SpanCount: 1, ErrorCount: 0, DurationNanos: 60}, byService["checkout"])
-	assert.Equal(t, ServiceBreakdown{Service: "inventory", SpanCount: 2, ErrorCount: 0, DurationNanos: 145}, byService["inventory"])
-	assert.Equal(t, ServiceBreakdown{Service: "payment", SpanCount: 1, ErrorCount: 0, DurationNanos: 15}, byService["payment"])
+	require.Equal(t, ServiceBreakdown{Service: "checkout", SpanCount: 1, ErrorCount: 0, DurationNanos: 60}, byService["checkout"])
+	require.Equal(t, ServiceBreakdown{Service: "inventory", SpanCount: 2, ErrorCount: 0, DurationNanos: 145}, byService["inventory"])
+	require.Equal(t, ServiceBreakdown{Service: "payment", SpanCount: 1, ErrorCount: 0, DurationNanos: 15}, byService["payment"])
 }
 
 func TestSummarize_NormalNestedTraceFollowsLastFinishingBranch(t *testing.T) {
@@ -118,7 +118,7 @@ func TestSummarize_NormalNestedTraceFollowsLastFinishingBranch(t *testing.T) {
 		pathNames = append(pathNames, p.Name)
 	}
 	require.Greater(t, len(pathNames), 1)
-	assert.Equal(t, []string{"root-op", "branch-a", "leaf-a1"}, pathNames)
+	require.Equal(t, []string{"root-op", "branch-a", "leaf-a1"}, pathNames)
 }
 
 func TestSummarize_SingleSpanTrace(t *testing.T) {
@@ -133,14 +133,14 @@ func TestSummarize_SingleSpanTrace(t *testing.T) {
 	got, err := Summarize(trace)
 	require.NoError(t, err)
 
-	assert.Equal(t, "solo", got.RootService)
-	assert.Equal(t, "do-thing", got.RootSpanName)
-	assert.Equal(t, int64(10), got.DurationNanos)
-	assert.Equal(t, 1, got.SpanCount)
+	require.Equal(t, "solo", got.RootService)
+	require.Equal(t, "do-thing", got.RootSpanName)
+	require.Equal(t, int64(10), got.DurationNanos)
+	require.Equal(t, 1, got.SpanCount)
 	require.Len(t, got.CriticalPath, 1)
-	assert.Equal(t, "do-thing", got.CriticalPath[0].Name)
+	require.Equal(t, "do-thing", got.CriticalPath[0].Name)
 	require.Len(t, got.SlowestSpans, 1)
-	assert.Empty(t, got.ErrorSpans)
+	require.Empty(t, got.ErrorSpans)
 }
 
 func TestSummarize_NoErrors(t *testing.T) {
@@ -155,8 +155,8 @@ func TestSummarize_NoErrors(t *testing.T) {
 
 	got, err := Summarize(trace)
 	require.NoError(t, err)
-	assert.Equal(t, 0, got.ErrorCount)
-	assert.Empty(t, got.ErrorSpans)
+	require.Equal(t, 0, got.ErrorCount)
+	require.Empty(t, got.ErrorSpans)
 }
 
 func TestSummarize_TruncatesToFive(t *testing.T) {
@@ -173,16 +173,69 @@ func TestSummarize_TruncatesToFive(t *testing.T) {
 	got, err := Summarize(trace)
 	require.NoError(t, err)
 
-	assert.Len(t, got.SlowestSpans, 5)
-	assert.Len(t, got.ErrorSpans, 5)
-	assert.Equal(t, 8, got.ErrorCount)
+	require.Len(t, got.SlowestSpans, 5)
+	require.Len(t, got.ErrorSpans, 5)
+	require.Equal(t, 8, got.ErrorCount)
 
 	for i := 1; i < len(got.SlowestSpans); i++ {
-		assert.GreaterOrEqual(t, got.SlowestSpans[i-1].DurationNanos, got.SlowestSpans[i].DurationNanos)
+		require.GreaterOrEqual(t, got.SlowestSpans[i-1].DurationNanos, got.SlowestSpans[i].DurationNanos)
 	}
 	for i := 1; i < len(got.ErrorSpans); i++ {
-		assert.LessOrEqual(t, got.ErrorSpans[i-1].StartTimeUnixNano, got.ErrorSpans[i].StartTimeUnixNano)
+		require.LessOrEqual(t, got.ErrorSpans[i-1].StartTimeUnixNano, got.ErrorSpans[i].StartTimeUnixNano)
 	}
+}
+
+// The bounded top-K selection must pick exactly what a full sort over every
+// span would have picked, including on the tie-break paths.
+func TestSummarize_TopKSelectionMatchesFullSort(t *testing.T) {
+	durations := []uint64{50, 10, 50, 30, 10, 90, 30, 90, 50, 70, 10, 90}
+
+	spans := []*tracev1.Span{
+		testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 1000, tracev1.Status_STATUS_CODE_OK, ""),
+	}
+	for i, d := range durations {
+		id := string([]byte{byte('a' + i)})
+		start := uint64((i % 3) * 10)
+		spans = append(spans, testSpan(id, "root", "op-"+id, tracev1.Span_SPAN_KIND_CLIENT, start, start+d, tracev1.Status_STATUS_CODE_ERROR, "boom"))
+	}
+	trace := &tempopb.Trace{ResourceSpans: []*tracev1.ResourceSpans{resourceSpans("svc", spans...)}}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	all := flattenSpans(trace)
+
+	bySlowest := make([]*resolvedSpan, len(all))
+	copy(bySlowest, all)
+	sort.Slice(bySlowest, func(i, j int) bool { return longerDuration(bySlowest[i].span, bySlowest[j].span) })
+
+	errored := make([]*resolvedSpan, 0, len(all))
+	for _, s := range all {
+		if isError(s.span) {
+			errored = append(errored, s)
+		}
+	}
+	sort.Slice(errored, func(i, j int) bool { return lessByStartThenID(errored[i].span, errored[j].span) })
+
+	gotSlowest := make([]string, len(got.SlowestSpans))
+	for i, s := range got.SlowestSpans {
+		gotSlowest[i] = s.SpanID
+	}
+	gotErrors := make([]string, len(got.ErrorSpans))
+	for i, s := range got.ErrorSpans {
+		gotErrors[i] = s.SpanID
+	}
+
+	require.Equal(t, expectedSpanIDs(bySlowest, maxSlowestSpans), gotSlowest)
+	require.Equal(t, expectedSpanIDs(errored, maxErrorSpans), gotErrors)
+}
+
+func expectedSpanIDs(spans []*resolvedSpan, k int) []string {
+	out := make([]string, 0, k)
+	for _, s := range spans[:k] {
+		out = append(out, util.SpanIDToHexString(s.span.GetSpanId()))
+	}
+	return out
 }
 
 func TestSummarize_FewerThanFive(t *testing.T) {
@@ -198,8 +251,8 @@ func TestSummarize_FewerThanFive(t *testing.T) {
 	require.NotPanics(t, func() {
 		got, err := Summarize(trace)
 		require.NoError(t, err)
-		assert.Len(t, got.SlowestSpans, 2)
-		assert.Len(t, got.ErrorSpans, 1)
+		require.Len(t, got.SlowestSpans, 2)
+		require.Len(t, got.ErrorSpans, 1)
 	})
 }
 
@@ -224,9 +277,9 @@ func TestSummarize_DisconnectedTraceFallsBackToEarliestSpan(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fallback picks the globally earliest-starting span as synthetic root.
-	assert.Equal(t, "orphan-b", got.RootService)
-	assert.Equal(t, "op-b", got.RootSpanName)
-	assert.Equal(t, int64(80), got.DurationNanos)
+	require.Equal(t, "orphan-b", got.RootService)
+	require.Equal(t, "op-b", got.RootSpanName)
+	require.Equal(t, int64(80), got.DurationNanos)
 }
 
 func TestSummarize_DuplicateSpanIDZipkinPattern(t *testing.T) {
@@ -267,7 +320,7 @@ func TestSummarize_DuplicateSpanIDZipkinPattern(t *testing.T) {
 		got, err = Summarize(trace)
 	})
 	require.NoError(t, err)
-	assert.Equal(t, 4, got.SpanCount)
+	require.Equal(t, 4, got.SpanCount)
 
 	var pathNames []string
 	for _, p := range got.CriticalPath {
@@ -276,7 +329,7 @@ func TestSummarize_DuplicateSpanIDZipkinPattern(t *testing.T) {
 	// At the root, "handle" ends later than "call" so the walk descends into
 	// it. grandchild's parent (kindWant=SERVER, since grandchild is INTERNAL)
 	// then correctly resolves to the SERVER-kind "handle", not "call".
-	assert.Equal(t, []string{"root-op", "handle", "do-work"}, pathNames)
+	require.Equal(t, []string{"root-op", "handle", "do-work"}, pathNames)
 }
 
 func TestSummarize_RootCandidateExcludedByChildOfLink(t *testing.T) {
@@ -302,8 +355,8 @@ func TestSummarize_RootCandidateExcludedByChildOfLink(t *testing.T) {
 	got, err := Summarize(trace)
 	require.NoError(t, err)
 
-	assert.Equal(t, "real-svc", got.RootService)
-	assert.Equal(t, "real-op", got.RootSpanName)
+	require.Equal(t, "real-svc", got.RootService)
+	require.Equal(t, "real-op", got.RootSpanName)
 }
 
 func TestCriticalPath_CycleGuardTerminates(t *testing.T) {
@@ -332,7 +385,7 @@ func TestCriticalPath_CycleGuardTerminates(t *testing.T) {
 	for _, p := range got.CriticalPath {
 		pathNames = append(pathNames, p.Name)
 	}
-	assert.Equal(t, []string{"op-a", "op-b"}, pathNames)
+	require.Equal(t, []string{"op-a", "op-b"}, pathNames)
 }
 
 func TestCriticalPath_SelfReferentialSpanTerminates(t *testing.T) {
@@ -359,19 +412,19 @@ func TestCriticalPath_SelfReferentialSpanTerminates(t *testing.T) {
 	for _, p := range got.CriticalPath {
 		pathNames = append(pathNames, p.Name)
 	}
-	assert.Equal(t, []string{"op-loopy"}, pathNames)
+	require.Equal(t, []string{"op-loopy"}, pathNames)
 }
 
 func TestSummarize_NilTraceReturnsError(t *testing.T) {
 	got, err := Summarize(nil)
 	require.Error(t, err)
-	assert.Nil(t, got)
+	require.Nil(t, got)
 }
 
 func TestSummarize_EmptyTraceReturnsZeroSummary(t *testing.T) {
 	got, err := Summarize(&tempopb.Trace{})
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, 0, got.SpanCount)
-	assert.Empty(t, got.CriticalPath)
+	require.Equal(t, 0, got.SpanCount)
+	require.Empty(t, got.CriticalPath)
 }

--- a/pkg/model/tracesummary/summarize_test.go
+++ b/pkg/model/tracesummary/summarize_test.go
@@ -88,9 +88,12 @@ func TestSummarize_SimpleMultiLevelTrace(t *testing.T) {
 	for _, s := range got.Services {
 		byService[s.Service] = s
 	}
-	require.Equal(t, ServiceBreakdown{Service: "checkout", SpanCount: 1, ErrorCount: 0, DurationNanos: 60}, byService["checkout"])
-	require.Equal(t, ServiceBreakdown{Service: "inventory", SpanCount: 2, ErrorCount: 0, DurationNanos: 145}, byService["inventory"])
-	require.Equal(t, ServiceBreakdown{Service: "payment", SpanCount: 1, ErrorCount: 0, DurationNanos: 15}, byService["payment"])
+	// Self time excludes what child spans already account for. The root runs
+	// 0-60 with children spanning 20-90 (clipped to 60) and 30-45, so 40ns of
+	// it is covered and 20ns is its own.
+	require.Equal(t, ServiceBreakdown{Service: "checkout", SpanCount: 1, ErrorCount: 0, DurationNanos: 60, SelfDurationNanos: 20}, byService["checkout"])
+	require.Equal(t, ServiceBreakdown{Service: "inventory", SpanCount: 2, ErrorCount: 0, DurationNanos: 145, SelfDurationNanos: 80}, byService["inventory"])
+	require.Equal(t, ServiceBreakdown{Service: "payment", SpanCount: 1, ErrorCount: 0, DurationNanos: 15, SelfDurationNanos: 15}, byService["payment"])
 }
 
 func TestSummarize_NormalNestedTraceFollowsLastFinishingBranch(t *testing.T) {
@@ -211,10 +214,12 @@ func TestSummarize_TopKSelectionMatchesFullSort(t *testing.T) {
 	require.NoError(t, err)
 
 	all := flattenSpans(trace)
+	self := selfDurations(all, buildChildrenIndex(all, indexSpansByID(all)))
+	less := longerSelfDuration(self)
 
 	bySlowest := make([]*resolvedSpan, len(all))
 	copy(bySlowest, all)
-	sort.Slice(bySlowest, func(i, j int) bool { return longerDuration(bySlowest[i].span, bySlowest[j].span) })
+	sort.Slice(bySlowest, func(i, j int) bool { return less(bySlowest[i].span, bySlowest[j].span) })
 
 	errored := make([]*resolvedSpan, 0, len(all))
 	for _, s := range all {
@@ -274,6 +279,106 @@ func TestSummary_NanosMarshalAsJSONStrings(t *testing.T) {
 	require.Equal(t, startNano, round.CriticalPath[0].StartTimeUnixNano)
 	require.Equal(t, startNano, round.SlowestSpans[0].StartTimeUnixNano)
 	require.Equal(t, startNano, round.ErrorSpans[0].StartTimeUnixNano)
+}
+
+// Children that overlap must be unioned, not summed. Summing would report the
+// parent as having spent no time of its own.
+func TestSelfDuration_ParallelChildrenAreUnioned(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans(
+				"svc",
+				testSpan("root", "", "fan-out", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
+				// Three concurrent children covering 10-60 between them.
+				testSpan("a", "root", "call-a", tracev1.Span_SPAN_KIND_CLIENT, 10, 60, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("b", "root", "call-b", tracev1.Span_SPAN_KIND_CLIENT, 15, 55, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("c", "root", "call-c", tracev1.Span_SPAN_KIND_CLIENT, 20, 50, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	// Summed children would be 120ns against a 100ns parent. Unioned they cover
+	// 10-60, so the root keeps 50ns of self time.
+	require.Equal(t, int64(50), got.CriticalPath[0].SelfDurationNanos)
+	require.Equal(t, int64(100), got.CriticalPath[0].DurationNanos)
+
+	svc := got.Services[0]
+	require.Equal(t, "svc", svc.Service)
+	require.Equal(t, int64(220), svc.DurationNanos)     // inclusive, double-counts
+	require.Equal(t, int64(170), svc.SelfDurationNanos) // 50 + 50 + 40 + 30
+}
+
+// A disjoint gap between children stays the parent's own time.
+func TestSelfDuration_GapBetweenChildrenCountsAsSelf(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans(
+				"svc",
+				testSpan("root", "", "serial", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("a", "root", "call-a", tracev1.Span_SPAN_KIND_CLIENT, 10, 30, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("b", "root", "call-b", tracev1.Span_SPAN_KIND_CLIENT, 60, 80, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+	// 100ns total, 40ns covered by children, 60ns left to the parent.
+	require.Equal(t, int64(60), got.CriticalPath[0].SelfDurationNanos)
+}
+
+// Slowest spans rank by self time, so a long ancestor that merely waits on a
+// child must lose to the child that actually burned the time.
+func TestSlowestSpans_RankBySelfTimeNotWallTime(t *testing.T) {
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans(
+				"svc",
+				testSpan("root", "", "waits", tracev1.Span_SPAN_KIND_SERVER, 0, 1000, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("mid", "root", "also-waits", tracev1.Span_SPAN_KIND_CLIENT, 5, 995, tracev1.Status_STATUS_CODE_OK, ""),
+				testSpan("leaf", "mid", "does-the-work", tracev1.Span_SPAN_KIND_CLIENT, 10, 990, tracev1.Status_STATUS_CODE_OK, ""),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	// By wall time the order would be root (1000) > mid (990) > leaf (980).
+	require.Equal(t, "does-the-work", got.SlowestSpans[0].Name)
+	require.Equal(t, int64(980), got.SlowestSpans[0].SelfDurationNanos)
+	require.Equal(t, int64(980), got.SlowestSpans[0].DurationNanos)
+}
+
+// Attributes and parentage are what make a finding actionable, so they must
+// reach the caller without a second fetch of the full trace.
+func TestSummary_CarriesAttributesAndParentage(t *testing.T) {
+	root := testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, 0, 100, tracev1.Status_STATUS_CODE_OK, "")
+	child := testSpan("child", "root", "SELECT stock", tracev1.Span_SPAN_KIND_CLIENT, 10, 95, tracev1.Status_STATUS_CODE_ERROR, "deadlock")
+	child.Attributes = []*commonv1.KeyValue{stringAttribute("db.lock.holder", "batch-reconciler")}
+
+	trace := &tempopb.Trace{ResourceSpans: []*tracev1.ResourceSpans{resourceSpans("svc", root, child)}}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	// The critical path carries the attribute that names the culprit.
+	require.Len(t, got.CriticalPath, 2)
+	require.Equal(t, "batch-reconciler", got.CriticalPath[1].Attributes["db.lock.holder"])
+	require.Empty(t, got.CriticalPath[0].Attributes)
+
+	// Error and slowest spans name their caller.
+	require.Len(t, got.ErrorSpans, 1)
+	require.Equal(t, util.SpanIDToHexString([]byte("root")), got.ErrorSpans[0].ParentSpanID)
+	require.Equal(t, "batch-reconciler", got.ErrorSpans[0].Attributes["db.lock.holder"])
+
+	require.Equal(t, "SELECT stock", got.SlowestSpans[0].Name)
+	require.Equal(t, util.SpanIDToHexString([]byte("root")), got.SlowestSpans[0].ParentSpanID)
+	// The root has no parent, so the field is omitted rather than zero-filled.
+	require.Empty(t, got.SlowestSpans[1].ParentSpanID)
 }
 
 func TestSummarize_FewerThanFive(t *testing.T) {

--- a/pkg/model/tracesummary/summarize_test.go
+++ b/pkg/model/tracesummary/summarize_test.go
@@ -1,6 +1,7 @@
 package tracesummary
 
 import (
+	"encoding/json"
 	"sort"
 	"testing"
 
@@ -242,6 +243,37 @@ func expectedSpanIDs(spans []*resolvedSpan, k int) []string {
 		out = append(out, util.SpanIDToHexString(s.span.GetSpanId()))
 	}
 	return out
+}
+
+// Nanosecond fields must survive a JSON round trip exactly. Encoded as JSON
+// numbers they would not: an epoch-nanosecond timestamp is past 2^53, where a
+// JavaScript client silently rounds.
+func TestSummary_NanosMarshalAsJSONStrings(t *testing.T) {
+	const startNano = uint64(1763000000123456789)
+
+	trace := &tempopb.Trace{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			resourceSpans(
+				"svc",
+				testSpan("root", "", "root-op", tracev1.Span_SPAN_KIND_SERVER, startNano, startNano+1500, tracev1.Status_STATUS_CODE_ERROR, "boom"),
+			),
+		},
+	}
+
+	got, err := Summarize(trace)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(got)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"startTimeUnixNano":"1763000000123456789"`)
+	require.Contains(t, string(body), `"durationNanos":"1500"`)
+
+	var round Summary
+	require.NoError(t, json.Unmarshal(body, &round))
+	require.Equal(t, int64(1500), round.DurationNanos)
+	require.Equal(t, startNano, round.CriticalPath[0].StartTimeUnixNano)
+	require.Equal(t, startNano, round.SlowestSpans[0].StartTimeUnixNano)
+	require.Equal(t, startNano, round.ErrorSpans[0].StartTimeUnixNano)
 }
 
 func TestSummarize_FewerThanFive(t *testing.T) {

--- a/pkg/model/tracesummary/types.go
+++ b/pkg/model/tracesummary/types.go
@@ -1,0 +1,59 @@
+package tracesummary
+
+// Summary is a condensed, human-readable view of a trace: its root, overall
+// duration, critical path, per-service breakdown, and the spans most likely
+// to matter for triage (slowest spans, error spans).
+type Summary struct {
+	TraceID       string             `json:"traceId"`
+	RootService   string             `json:"rootService"`
+	RootSpanName  string             `json:"rootSpanName"`
+	DurationNanos int64              `json:"durationNanos"`
+	SpanCount     int                `json:"spanCount"`
+	ErrorCount    int                `json:"errorCount"`
+	CriticalPath  []PathSpan         `json:"criticalPath"`
+	Services      []ServiceBreakdown `json:"services"`
+	SlowestSpans  []SpanSummary      `json:"slowestSpans"`
+	ErrorSpans    []ErrorSpanSummary `json:"errorSpans"`
+}
+
+// PathSpan is a span on the trace's critical path, in root-to-leaf order.
+type PathSpan struct {
+	SpanID            string `json:"spanId"`
+	Service           string `json:"service"`
+	Name              string `json:"name"`
+	Kind              string `json:"kind"`
+	StartTimeUnixNano uint64 `json:"startTimeUnixNano"`
+	DurationNanos     int64  `json:"durationNanos"`
+}
+
+// ServiceBreakdown aggregates span/error counts and cumulative duration for
+// a single resolved service name.
+type ServiceBreakdown struct {
+	Service       string `json:"service"`
+	SpanCount     int    `json:"spanCount"`
+	ErrorCount    int    `json:"errorCount"`
+	DurationNanos int64  `json:"durationNanos"`
+}
+
+// SpanSummary describes a single span, e.g. one of the trace's slowest spans.
+type SpanSummary struct {
+	SpanID            string         `json:"spanId"`
+	Service           string         `json:"service"`
+	Name              string         `json:"name"`
+	Kind              string         `json:"kind"`
+	StartTimeUnixNano uint64         `json:"startTimeUnixNano"`
+	DurationNanos     int64          `json:"durationNanos"`
+	Attributes        map[string]any `json:"attributes,omitempty"`
+}
+
+// ErrorSpanSummary describes a single span with an error status.
+type ErrorSpanSummary struct {
+	SpanID            string         `json:"spanId"`
+	Service           string         `json:"service"`
+	Name              string         `json:"name"`
+	Kind              string         `json:"kind"`
+	StartTimeUnixNano uint64         `json:"startTimeUnixNano"`
+	DurationNanos     int64          `json:"durationNanos"`
+	StatusMessage     string         `json:"statusMessage"`
+	Attributes        map[string]any `json:"attributes,omitempty"`
+}

--- a/pkg/model/tracesummary/types.go
+++ b/pkg/model/tracesummary/types.go
@@ -1,5 +1,11 @@
 package tracesummary
 
+// Nanosecond timestamps and durations are encoded as JSON strings. They are
+// 64-bit values — an epoch-nanosecond timestamp is already ~1.7e18 — and so
+// exceed the 2^53 integer range a JSON number survives in JavaScript clients.
+// This matches the protobuf JSON convention Tempo's trace endpoints already
+// follow for 64-bit fields.
+
 // Summary is a condensed, human-readable view of a trace: its root, overall
 // duration, critical path, per-service breakdown, and the spans most likely
 // to matter for triage (slowest spans, error spans).
@@ -7,7 +13,7 @@ type Summary struct {
 	TraceID       string             `json:"traceId"`
 	RootService   string             `json:"rootService"`
 	RootSpanName  string             `json:"rootSpanName"`
-	DurationNanos int64              `json:"durationNanos"`
+	DurationNanos int64              `json:"durationNanos,string"`
 	SpanCount     int                `json:"spanCount"`
 	ErrorCount    int                `json:"errorCount"`
 	CriticalPath  []PathSpan         `json:"criticalPath"`
@@ -22,8 +28,8 @@ type PathSpan struct {
 	Service           string `json:"service"`
 	Name              string `json:"name"`
 	Kind              string `json:"kind"`
-	StartTimeUnixNano uint64 `json:"startTimeUnixNano"`
-	DurationNanos     int64  `json:"durationNanos"`
+	StartTimeUnixNano uint64 `json:"startTimeUnixNano,string"`
+	DurationNanos     int64  `json:"durationNanos,string"`
 }
 
 // ServiceBreakdown aggregates span/error counts and cumulative duration for
@@ -32,7 +38,7 @@ type ServiceBreakdown struct {
 	Service       string `json:"service"`
 	SpanCount     int    `json:"spanCount"`
 	ErrorCount    int    `json:"errorCount"`
-	DurationNanos int64  `json:"durationNanos"`
+	DurationNanos int64  `json:"durationNanos,string"`
 }
 
 // SpanSummary describes a single span, e.g. one of the trace's slowest spans.
@@ -41,8 +47,8 @@ type SpanSummary struct {
 	Service           string         `json:"service"`
 	Name              string         `json:"name"`
 	Kind              string         `json:"kind"`
-	StartTimeUnixNano uint64         `json:"startTimeUnixNano"`
-	DurationNanos     int64          `json:"durationNanos"`
+	StartTimeUnixNano uint64         `json:"startTimeUnixNano,string"`
+	DurationNanos     int64          `json:"durationNanos,string"`
 	Attributes        map[string]any `json:"attributes,omitempty"`
 }
 
@@ -52,8 +58,8 @@ type ErrorSpanSummary struct {
 	Service           string         `json:"service"`
 	Name              string         `json:"name"`
 	Kind              string         `json:"kind"`
-	StartTimeUnixNano uint64         `json:"startTimeUnixNano"`
-	DurationNanos     int64          `json:"durationNanos"`
+	StartTimeUnixNano uint64         `json:"startTimeUnixNano,string"`
+	DurationNanos     int64          `json:"durationNanos,string"`
 	StatusMessage     string         `json:"statusMessage"`
 	Attributes        map[string]any `json:"attributes,omitempty"`
 }

--- a/pkg/model/tracesummary/types.go
+++ b/pkg/model/tracesummary/types.go
@@ -23,38 +23,52 @@ type Summary struct {
 }
 
 // PathSpan is a span on the trace's critical path, in root-to-leaf order.
+//
+// SelfDurationNanos is what this hop actually contributed: on a critical path
+// every span nests inside the one above it, so the wall durations decline only
+// slightly from hop to hop and don't say which level spent the time.
 type PathSpan struct {
-	SpanID            string `json:"spanId"`
-	Service           string `json:"service"`
-	Name              string `json:"name"`
-	Kind              string `json:"kind"`
-	StartTimeUnixNano uint64 `json:"startTimeUnixNano,string"`
-	DurationNanos     int64  `json:"durationNanos,string"`
-}
-
-// ServiceBreakdown aggregates span/error counts and cumulative duration for
-// a single resolved service name.
-type ServiceBreakdown struct {
-	Service       string `json:"service"`
-	SpanCount     int    `json:"spanCount"`
-	ErrorCount    int    `json:"errorCount"`
-	DurationNanos int64  `json:"durationNanos,string"`
-}
-
-// SpanSummary describes a single span, e.g. one of the trace's slowest spans.
-type SpanSummary struct {
 	SpanID            string         `json:"spanId"`
 	Service           string         `json:"service"`
 	Name              string         `json:"name"`
 	Kind              string         `json:"kind"`
 	StartTimeUnixNano uint64         `json:"startTimeUnixNano,string"`
 	DurationNanos     int64          `json:"durationNanos,string"`
+	SelfDurationNanos int64          `json:"selfDurationNanos,string"`
+	Attributes        map[string]any `json:"attributes,omitempty"`
+}
+
+// ServiceBreakdown aggregates span/error counts and duration for a single
+// resolved service name.
+//
+// DurationNanos is inclusive of child span time and so double-counts nested
+// work; summed across services it can far exceed the trace duration. Rank
+// services by SelfDurationNanos, which excludes time covered by child spans.
+type ServiceBreakdown struct {
+	Service           string `json:"service"`
+	SpanCount         int    `json:"spanCount"`
+	ErrorCount        int    `json:"errorCount"`
+	DurationNanos     int64  `json:"durationNanos,string"`
+	SelfDurationNanos int64  `json:"selfDurationNanos,string"`
+}
+
+// SpanSummary describes a single span, e.g. one of the trace's slowest spans.
+type SpanSummary struct {
+	SpanID            string         `json:"spanId"`
+	ParentSpanID      string         `json:"parentSpanId,omitempty"`
+	Service           string         `json:"service"`
+	Name              string         `json:"name"`
+	Kind              string         `json:"kind"`
+	StartTimeUnixNano uint64         `json:"startTimeUnixNano,string"`
+	DurationNanos     int64          `json:"durationNanos,string"`
+	SelfDurationNanos int64          `json:"selfDurationNanos,string"`
 	Attributes        map[string]any `json:"attributes,omitempty"`
 }
 
 // ErrorSpanSummary describes a single span with an error status.
 type ErrorSpanSummary struct {
 	SpanID            string         `json:"spanId"`
+	ParentSpanID      string         `json:"parentSpanId,omitempty"`
 	Service           string         `json:"service"`
 	Name              string         `json:"name"`
 	Kind              string         `json:"kind"`

--- a/pkg/model/tracesummary/types.go
+++ b/pkg/model/tracesummary/types.go
@@ -6,20 +6,24 @@ package tracesummary
 // This matches the protobuf JSON convention Tempo's trace endpoints already
 // follow for 64-bit fields.
 
-// Summary is a condensed, human-readable view of a trace: its root, overall
-// duration, critical path, per-service breakdown, and the spans most likely
-// to matter for triage (slowest spans, error spans).
-type Summary struct {
-	TraceID       string             `json:"traceId"`
-	RootService   string             `json:"rootService"`
-	RootSpanName  string             `json:"rootSpanName"`
-	DurationNanos int64              `json:"durationNanos,string"`
-	SpanCount     int                `json:"spanCount"`
-	ErrorCount    int                `json:"errorCount"`
-	CriticalPath  []PathSpan         `json:"criticalPath"`
-	Services      []ServiceBreakdown `json:"services"`
-	SlowestSpans  []SpanSummary      `json:"slowestSpans"`
-	ErrorSpans    []ErrorSpanSummary `json:"errorSpans"`
+// TraceOverview is a condensed, human-readable view of a trace: its root,
+// overall duration, critical path, per-service breakdown, and the spans most
+// likely to matter for triage (slowest spans, error spans).
+//
+// Named to stay distinct from tracediff's TraceSummary, which is a compact
+// per-side scalar rollup used only as an input to a trace comparison — not a
+// general-purpose single-trace summary.
+type TraceOverview struct {
+	TraceID        string             `json:"traceId"`
+	RootService    string             `json:"rootService"`
+	RootSpanName   string             `json:"rootSpanName"`
+	DurationNanos  int64              `json:"durationNanos,string"`
+	SpanCount      int                `json:"spanCount"`
+	ErrorSpanCount int                `json:"errorSpanCount"`
+	CriticalPath   []PathSpan         `json:"criticalPath"`
+	Services       []ServiceBreakdown `json:"services"`
+	SlowestSpans   []SpanSummary      `json:"slowestSpans"`
+	ErrorSpans     []ErrorSpanSummary `json:"errorSpans"`
 }
 
 // PathSpan is a span on the trace's critical path, in root-to-leaf order.
@@ -47,7 +51,7 @@ type PathSpan struct {
 type ServiceBreakdown struct {
 	Service           string `json:"service"`
 	SpanCount         int    `json:"spanCount"`
-	ErrorCount        int    `json:"errorCount"`
+	ErrorSpanCount    int    `json:"errorSpanCount"`
 	DurationNanos     int64  `json:"durationNanos,string"`
 	SelfDurationNanos int64  `json:"selfDurationNanos,string"`
 }


### PR DESCRIPTION
**What this PR does**:

Adds an experimental `GET /api/v2/traces/{traceID}/summary` endpoint to the query frontend. Given a trace ID, it fetches the full trace internally (via the existing `tracePipeline` + `combiner.NewTypedTraceByIDV2`, same pattern as `tracediff_handler.go`) and returns a condensed JSON summary instead of the raw trace: root service/span name, total duration, span/error counts, critical path (root→leaf chain determining total duration), per-service breakdown (span count, error count, time spent), top-5 slowest spans, and first-5 error spans.

New code:
- `pkg/model/tracesummary/` — pure-Go summarizer over `*tempopb.Trace` (root detection, critical path, per-service stats), independent of any storage-format code
- `modules/frontend/trace_summary_handler.go` — HTTP handler, mirrors `tracediff_handler.go`
- Route + wiring in `pkg/api/http.go`, `modules/frontend/frontend.go`, `cmd/tempo/app/modules.go`

Notable trade-offs:
- Per-service "time spent" is inclusive of child span time, not self-time
- Partial traces are summarized rather than rejected
- Root detection: parentless span with no `child_of` link; falls back to earliest-starting span if none qualify

**Example response**:

```json
{
  "traceId": "3fa4a1b2c3d4e5f60718293a4b5c6d7e",
  "rootService": "checkout",
  "rootSpanName": "POST /cart/checkout",
  "durationNanos": 482000000,
  "spanCount": 47,
  "errorCount": 2,
  "criticalPath": [
    {
      "spanId": "a1b2c3d4e5f60718",
      "service": "checkout",
      "name": "POST /cart/checkout",
      "kind": "server",
      "startTimeUnixNano": 1700000000000000000,
      "durationNanos": 482000000
    },
    {
      "spanId": "b2c3d4e5f6071829",
      "service": "payments",
      "name": "POST /charge",
      "kind": "client",
      "startTimeUnixNano": 1700000000050000000,
      "durationNanos": 400000000
    },
    {
      "spanId": "c3d4e5f607182930",
      "service": "payments",
      "name": "SELECT accounts",
      "kind": "client",
      "startTimeUnixNano": 1700000000120000000,
      "durationNanos": 310000000
    }
  ],
  "services": [
    {
      "service": "checkout",
      "spanCount": 12,
      "errorCount": 0,
      "durationNanos": 482000000
    },
    {
      "service": "payments",
      "spanCount": 20,
      "errorCount": 1,
      "durationNanos": 400000000
    },
    {
      "service": "inventory",
      "spanCount": 15,
      "errorCount": 1,
      "durationNanos": 90000000
    }
  ],
  "slowestSpans": [
    {
      "spanId": "b2c3d4e5f6071829",
      "service": "payments",
      "name": "POST /charge",
      "kind": "client",
      "startTimeUnixNano": 1700000000050000000,
      "durationNanos": 400000000,
      "attributes": {
        "http.method": "POST",
        "http.status_code": 200
      }
    }
  ],
  "errorSpans": [
    {
      "spanId": "d4e5f6071829303a",
      "service": "inventory",
      "name": "SELECT stock",
      "kind": "client",
      "startTimeUnixNano": 1700000000200000000,
      "durationNanos": 15000000,
      "statusMessage": "connection reset by peer",
      "attributes": {
        "db.system": "postgresql"
      }
    }
  ]
}
```

No UI is planned for this. This is just a visual representation of how this trace summary can be helpful.
<img width="1245" height="649" alt="Screenshot 2026-08-14 at 3 28 36 PM" src="https://github.com/user-attachments/assets/26e4599c-f876-4e24-b1e6-40acf3df6e86" />


**AI assistance disclosure**: Claude was used substantially in developing this implementation (design, code, and tests). I have reviewed and understand every line of this change.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
