### PR TITLE
TraceByID V2: add match_depth and ancestor_depth query params

### DIFF
--- a/.chloggen/tracebyid-match-ancestor-depth.yaml
+++ b/.chloggen/tracebyid-match-ancestor-depth.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: query-frontend
+note: "TraceByID V2: Add `match_depth` and `ancestor_depth` query params to the `q` filter to bound how many hops of descendants/ancestors of matched spans are kept (`-1` unbounded, `0` none, `n` exactly n hops)"
+issues: []
+subtext:
+user: ie-pham

--- a/cmd/tempo-cli/cmd-query-trace-id.go
+++ b/cmd/tempo-cli/cmd-query-trace-id.go
@@ -21,6 +21,8 @@ type queryTraceIDCmd struct {
 	// Trace By ID V2 filtering and selection params
 	Q             string `name:"q" help:"TraceQL spanset filter, only matching spans are returned (V2 only)"`
 	KeepHierarchy bool   `name:"keep-hierarchy" default:"false" help:"include ancestor path to the root for each matched span, requires --q (V2 only)"`
+	MatchDepth    int    `name:"match-depth" default:"0" help:"levels of descendants to keep below each matched span: -1 = all, 0 = matched spans only, n = n levels (V2 only, requires --q)"`
+	AncestorDepth int    `name:"ancestor-depth" default:"-1" help:"levels of ancestors to keep above each matched span when --keep-hierarchy is set: -1 = all (default), 0 = none, n = n levels (V2 only)"`
 }
 
 func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
@@ -50,7 +52,12 @@ func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
 	var traceResp *tempopb.TraceByIDResponse
 	var err error
 	if cmd.Q != "" {
-		params := map[string]string{"q": cmd.Q, "keep_hierarchy": strconv.FormatBool(cmd.KeepHierarchy)}
+		params := map[string]string{
+			"q":              cmd.Q,
+			"keep_hierarchy": strconv.FormatBool(cmd.KeepHierarchy),
+			"match_depth":    strconv.Itoa(cmd.MatchDepth),
+			"ancestor_depth": strconv.Itoa(cmd.AncestorDepth),
+		}
 		traceResp, err = client.QueryTraceV2WithQueryParams(cmd.TraceID, params)
 	} else {
 		traceResp, err = client.QueryTraceV2(cmd.TraceID)

--- a/cmd/tempo-cli/cmd-query-trace-id.go
+++ b/cmd/tempo-cli/cmd-query-trace-id.go
@@ -20,9 +20,9 @@ type queryTraceIDCmd struct {
 
 	// Trace By ID V2 filtering and selection params
 	Q             string `name:"q" help:"TraceQL spanset filter, only matching spans are returned (V2 only)"`
-	KeepHierarchy bool   `name:"keep-hierarchy" default:"false" help:"include ancestor path to the root for each matched span, requires --q (V2 only)"`
-	MatchDepth    int    `name:"match-depth" default:"0" help:"levels of descendants to keep below each matched span: -1 = all, 0 = matched spans only, n = n levels (V2 only, requires --q)"`
-	AncestorDepth int    `name:"ancestor-depth" default:"-1" help:"levels of ancestors to keep above each matched span when --keep-hierarchy is set: -1 = all (default), 0 = none, n = n levels (V2 only)"`
+	KeepHierarchy bool   `name:"keep-hierarchy" default:"false" help:"include ancestor path to the root for each matched span (V2 only, ignored without --q)"`
+	MatchDepth    int    `name:"match-depth" default:"0" help:"levels of descendants to keep below each matched span: -1 = all, 0 = matched spans only, n = n levels (V2 only, ignored without --q)"`
+	AncestorDepth int    `name:"ancestor-depth" default:"-1" help:"levels of ancestors to keep above each matched span: -1 = all (default), 0 = none, n = n levels (V2 only, ignored without --q or --keep-hierarchy)"`
 }
 
 func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
@@ -30,15 +30,15 @@ func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
 	applyHeaders(client, cmd.Headers)
 	// util.QueryTrace will only add orgID header if len(orgID) > 0
 
-	// the v1 endpoint does not support spanset filtering
+	// the v1 endpoint cannot filter at all, so honoring --v1 would silently return the whole trace
+	// instead of the requested subset. That is a wrong answer, not an inert flag, so it must fail.
 	if cmd.Q != "" && cmd.V1 {
 		return fmt.Errorf("--q filtering is only supported on the v2 API, remove --v1 to call v2 endpoint")
 	}
 
-	// keep_hierarchy only shapes the filtered result, so it is meaningless without --q.
-	if cmd.KeepHierarchy && cmd.Q == "" {
-		return fmt.Errorf("--keep-hierarchy only applies with --q")
-	}
+	// --keep-hierarchy, --match-depth and --ancestor-depth only shape a filtered result, so without
+	// --q they are ignored rather than rejected: the full trace is already a superset of anything
+	// they could select, and someone iterating on a trace should not have to clear stale flags.
 
 	// use v1 API if specified, we default to v2
 	if cmd.V1 {

--- a/cmd/tempo-cli/cmd-query-trace-id_test.go
+++ b/cmd/tempo-cli/cmd-query-trace-id_test.go
@@ -33,3 +33,20 @@ func TestQueryTraceIDCmdRejectsKeepHierarchyWithoutQ(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "--keep-hierarchy only applies with --q")
 }
+
+func TestQueryTraceIDCmdAllowsMatchDepthAndAncestorDepthWithQ(t *testing.T) {
+	// --match-depth and --ancestor-depth are validated server-side, so with --q set they
+	// must pass client-side validation and reach the HTTP call instead of failing fast.
+	cmd := &queryTraceIDCmd{
+		APIEndpoint:   "http://localhost:0",
+		TraceID:       "1234",
+		Q:             `{ .foo = "bar" }`,
+		MatchDepth:    2,
+		AncestorDepth: 1,
+	}
+
+	err := cmd.Run(nil)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "only supported on the v2 API")
+	require.NotContains(t, err.Error(), "--keep-hierarchy only applies with --q")
+}

--- a/cmd/tempo-cli/cmd-query-trace-id_test.go
+++ b/cmd/tempo-cli/cmd-query-trace-id_test.go
@@ -21,32 +21,35 @@ func TestQueryTraceIDCmdRejectsQWithV1(t *testing.T) {
 	require.Contains(t, err.Error(), "only supported on the v2 API")
 }
 
-func TestQueryTraceIDCmdRejectsKeepHierarchyWithoutQ(t *testing.T) {
-	// --keep-hierarchy only shapes a filtered result, so it must fail fast without --q.
-	cmd := &queryTraceIDCmd{
-		APIEndpoint:   "http://localhost:0",
-		TraceID:       "1234",
-		KeepHierarchy: true,
+// TestQueryTraceIDCmdShapingFlagsNeverFailFast covers the shaping flags that only refine a filtered
+// result. None of them may fail client-side validation, whether or not the combination is meaningful:
+// a flag with nothing to act on is ignored, so someone iterating on a trace never has to clear stale
+// flags between runs. Each case must get past validation and die on the unreachable endpoint instead.
+func TestQueryTraceIDCmdShapingFlagsNeverFailFast(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  queryTraceIDCmd
+	}{
+		{name: "keep_hierarchy without q", cmd: queryTraceIDCmd{KeepHierarchy: true}},
+		{name: "ancestor_depth without q", cmd: queryTraceIDCmd{AncestorDepth: 1}},
+		{name: "match_depth without q", cmd: queryTraceIDCmd{MatchDepth: 2}},
+		{name: "all shaping flags without q", cmd: queryTraceIDCmd{KeepHierarchy: true, MatchDepth: 2, AncestorDepth: 1}},
+		// ancestor_depth has nothing to bound while keep_hierarchy is false, but that is inert, not invalid.
+		{name: "ancestor_depth with q but keep_hierarchy false", cmd: queryTraceIDCmd{Q: `{ .foo = "bar" }`, AncestorDepth: 1}},
+		{name: "all shaping flags with q", cmd: queryTraceIDCmd{Q: `{ .foo = "bar" }`, KeepHierarchy: true, MatchDepth: 2, AncestorDepth: 1}},
 	}
 
-	err := cmd.Run(nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "--keep-hierarchy only applies with --q")
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.cmd
+			cmd.APIEndpoint = "http://localhost:0"
+			cmd.TraceID = "1234"
 
-func TestQueryTraceIDCmdAllowsMatchDepthAndAncestorDepthWithQ(t *testing.T) {
-	// --match-depth and --ancestor-depth are validated server-side, so with --q set they
-	// must pass client-side validation and reach the HTTP call instead of failing fast.
-	cmd := &queryTraceIDCmd{
-		APIEndpoint:   "http://localhost:0",
-		TraceID:       "1234",
-		Q:             `{ .foo = "bar" }`,
-		MatchDepth:    2,
-		AncestorDepth: 1,
+			// port 0 is unreachable, so reaching the request at all surfaces as a connection error.
+			err := cmd.Run(nil)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "only supported on the v2 API")
+			require.NotContains(t, err.Error(), "only applies with")
+		})
 	}
-
-	err := cmd.Run(nil)
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "only supported on the v2 API")
-	require.NotContains(t, err.Error(), "--keep-hierarchy only applies with --q")
 }

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -204,6 +204,10 @@ Span pruning is experimental. The `span_pruning*` parameters, their behavior, an
   Optional. A single TraceQL spanset filter (for example `{ span.http.status_code = 500 }`) that returns only the matching spans. When it drops spans, the response status is `PARTIAL` to signal a subset. Only a single `{ ... }` filter is supported: pipelines, structural operators, metrics queries, trace-level intrinsics, and trace-scoped attributes return a `400`, and an absent or empty `q` returns the full trace.
 - `keep_hierarchy = (bool)`
   Optional. When `true`, the response also includes the ancestor path from the root spans to each matched span, so the result is still a complete hierarchy that can be rendered as a waterfall. Defaults to `false` (only the spans matching `q`). Ignored when `q` isn't set.
+- `match_depth = (int)`
+  Optional. Controls how many levels of descendants of each span matched by `q` are kept, independent of `keep_hierarchy`. Use `-1` to keep all descendants (the full subtree), `0` to keep only the matched spans with no descendants, or `n` (`n >= 1`) to keep descendants from level 1 (direct children) through level `n`, cumulative. When the parameter is omitted, the behavior is the same as `0`, preserving the existing matched-only behavior for backward compatibility; pass `-1` explicitly to get all descendants. Ignored when `q` isn't set.
+- `ancestor_depth = (int)`
+  Optional. Controls how many levels of ancestors are kept, only when `keep_hierarchy` is `true`. Use `-1` to keep all ancestors up to the root, `0` to keep no ancestors, or `n` (`n >= 1`) to keep ancestors from level 1 (immediate parent) through level `n`, cumulative. Defaults to `-1`, which matches the existing behavior when `keep_hierarchy=true`. Ignored when `q` isn't set or `keep_hierarchy` is `false` or unset.
 
 The following query API is also provided on the querier service for _debugging_ purposes.
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -205,9 +205,11 @@ Span pruning is experimental. The `span_pruning*` parameters, their behavior, an
 - `keep_hierarchy = (bool)`
   Optional. When `true`, the response also includes the ancestor path from the root spans to each matched span, so the result is still a complete hierarchy that can be rendered as a waterfall. Defaults to `false` (only the spans matching `q`). Ignored when `q` isn't set.
 - `match_depth = (int)`
-  Optional. Controls how many levels of descendants of each span matched by `q` are kept, independent of `keep_hierarchy`. Use `-1` to keep all descendants (the full subtree), `0` to keep only the matched spans with no descendants, or `n` (`n >= 1`) to keep descendants from level 1 (direct children) through level `n`, cumulative. When the parameter is omitted, the behavior is the same as `0`, preserving the existing matched-only behavior for backward compatibility; pass `-1` explicitly to get all descendants. Ignored when `q` isn't set.
+  Optional. How many levels of descendants to keep below each span matched by `q`, independent of `keep_hierarchy`. Use `-1` for the full subtree, `0` for the matched spans alone, or `n` (`n >= 1`) to keep levels 1 (direct children) through `n`. Values below `-1` are invalid and return a `400`. Ignored when `q` isn't set.
+  Default = `0`
 - `ancestor_depth = (int)`
-  Optional. Controls how many levels of ancestors are kept, only when `keep_hierarchy` is `true`. Use `-1` to keep all ancestors up to the root, `0` to keep no ancestors, or `n` (`n >= 1`) to keep ancestors from level 1 (immediate parent) through level `n`, cumulative. Defaults to `-1`, which matches the existing behavior when `keep_hierarchy=true`. Ignored entirely when `q` isn't set or `keep_hierarchy` is `false` or unset: the value isn't read or validated in those cases, so even an out-of-range one doesn't fail the request.
+  Optional. How many levels of ancestors to keep above each matched span. Use `-1` for the whole path to the root, `0` for none, or `n` (`n >= 1`) to keep levels 1 (immediate parent) through `n`. Values below `-1` are invalid and return a `400`. Only read when `keep_hierarchy` is `true`; otherwise it's ignored without being validated.
+  Default = `-1`
 
 The following query API is also provided on the querier service for _debugging_ purposes.
 

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -207,7 +207,7 @@ Span pruning is experimental. The `span_pruning*` parameters, their behavior, an
 - `match_depth = (int)`
   Optional. Controls how many levels of descendants of each span matched by `q` are kept, independent of `keep_hierarchy`. Use `-1` to keep all descendants (the full subtree), `0` to keep only the matched spans with no descendants, or `n` (`n >= 1`) to keep descendants from level 1 (direct children) through level `n`, cumulative. When the parameter is omitted, the behavior is the same as `0`, preserving the existing matched-only behavior for backward compatibility; pass `-1` explicitly to get all descendants. Ignored when `q` isn't set.
 - `ancestor_depth = (int)`
-  Optional. Controls how many levels of ancestors are kept, only when `keep_hierarchy` is `true`. Use `-1` to keep all ancestors up to the root, `0` to keep no ancestors, or `n` (`n >= 1`) to keep ancestors from level 1 (immediate parent) through level `n`, cumulative. Defaults to `-1`, which matches the existing behavior when `keep_hierarchy=true`. Ignored when `q` isn't set or `keep_hierarchy` is `false` or unset.
+  Optional. Controls how many levels of ancestors are kept, only when `keep_hierarchy` is `true`. Use `-1` to keep all ancestors up to the root, `0` to keep no ancestors, or `n` (`n >= 1`) to keep ancestors from level 1 (immediate parent) through level `n`, cumulative. Defaults to `-1`, which matches the existing behavior when `keep_hierarchy=true`. Ignored entirely when `q` isn't set or `keep_hierarchy` is `false` or unset: the value isn't read or validated in those cases, so even an out-of-range one doesn't fail the request.
 
 The following query API is also provided on the querier service for _debugging_ purposes.
 

--- a/integration/api/api_test.go
+++ b/integration/api/api_test.go
@@ -1127,8 +1127,9 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 	}, func(h *util.TempoHarness) {
 		h.WaitTracesWritable(t)
 
-		// trace shape: A(root) -> B -> C(status_code=500), and A -> D(status_code=200).
-		// only C matches the filter; B and A are its ancestors; D is an unrelated branch.
+		// trace shape: A(root) -> B -> C(status_code=500) -> E -> F, and A -> D(status_code=200).
+		// only C matches the filter; B and A are its ancestors; E and F are its descendants;
+		// D is an unrelated branch.
 		traceID := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
 		require.NoError(t, h.WriteTempoProtoTraces(buildFilterTestTrace(traceID), ""))
 		h.WaitTracesQueryable(t, 1)
@@ -1136,13 +1137,15 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 		hexID := tempoUtil.TraceIDToHexString(traceID)
 
 		assertFiltering := func(t *testing.T, apiClient *httpclient.Client) {
-			// no params: full trace, all four spans, and a complete (not partial) status.
+			// no params: full trace, all six spans, and a complete (not partial) status.
 			full, err := apiClient.QueryTraceV2WithQueryParams(hexID, nil)
 			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{1, 2, 3, 4}, spanLastBytes(full.Trace))
+			require.ElementsMatch(t, []byte{1, 2, 3, 4, 5, 6}, spanLastBytes(full.Trace))
 			require.Equal(t, tempopb.PartialStatus_COMPLETE, full.Status, "an unfiltered trace is complete")
 
-			// q only: keep_hierarchy defaults to false, so only the matched span (C).
+			// q only, no match_depth param at all: keep_hierarchy defaults to false and match_depth
+			// defaults to 0, so only the matched span (C). This is the backward-compat baseline:
+			// behavior must be identical to what the endpoint returned before match_depth existed.
 			matchedOnly, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }"})
 			require.NoError(t, err)
 			require.ElementsMatch(t, []byte{3}, spanLastBytes(matchedOnly.Trace))
@@ -1150,11 +1153,38 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 			require.Equal(t, tempopb.PartialStatus_PARTIAL, matchedOnly.Status)
 			require.Contains(t, matchedOnly.Message, "only a subset of spans matching the filter")
 
-			// keep_hierarchy=true: the match plus its ancestor path (A,B,C), still a subset of the full trace.
+			// keep_hierarchy=true: the match plus its unbounded ancestor path (A,B,C), still a
+			// subset of the full trace. ancestor_depth defaults to -1 (unbounded) when absent.
 			withHierarchy, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "keep_hierarchy": "true"})
 			require.NoError(t, err)
 			require.ElementsMatch(t, []byte{1, 2, 3}, spanLastBytes(withHierarchy.Trace))
 			require.Equal(t, tempopb.PartialStatus_PARTIAL, withHierarchy.Status, "a filtered subset is partial even with ancestors")
+
+			// match_depth=1: the match plus its direct children only (E), not the grandchild F.
+			matchDepthOne, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "match_depth": "1"})
+			require.NoError(t, err)
+			require.ElementsMatch(t, []byte{3, 5}, spanLastBytes(matchDepthOne.Trace))
+			require.Equal(t, tempopb.PartialStatus_PARTIAL, matchDepthOne.Status)
+
+			// match_depth=-1: the match plus its full descendant subtree (E, F).
+			matchDepthUnbounded, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "match_depth": "-1"})
+			require.NoError(t, err)
+			require.ElementsMatch(t, []byte{3, 5, 6}, spanLastBytes(matchDepthUnbounded.Trace))
+			require.Equal(t, tempopb.PartialStatus_PARTIAL, matchDepthUnbounded.Status)
+
+			// keep_hierarchy=true + ancestor_depth=0: matched span only, no ancestors kept
+			// despite keep_hierarchy being set.
+			ancestorDepthZero, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "keep_hierarchy": "true", "ancestor_depth": "0"})
+			require.NoError(t, err)
+			require.ElementsMatch(t, []byte{3}, spanLastBytes(ancestorDepthZero.Trace))
+			require.Equal(t, tempopb.PartialStatus_PARTIAL, ancestorDepthZero.Status)
+
+			// keep_hierarchy=true + ancestor_depth=1: the match plus its immediate parent (B)
+			// only, not the full ancestor chain to the root (A).
+			ancestorDepthOne, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "keep_hierarchy": "true", "ancestor_depth": "1"})
+			require.NoError(t, err)
+			require.ElementsMatch(t, []byte{2, 3}, spanLastBytes(ancestorDepthOne.Trace))
+			require.Equal(t, tempopb.PartialStatus_PARTIAL, ancestorDepthOne.Status)
 		}
 
 		apiClient := h.APIClientHTTP("")
@@ -1163,6 +1193,7 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 		assertFiltering(t, apiClient)
 		assertBadFilterRejected(t, apiClient, hexID)
 		assertOversizedFilterRejected(t, apiClient, hexID)
+		assertBadDepthParamsRejected(t, apiClient, hexID)
 
 		// backend path.
 		h.WaitTracesWrittenToBackend(t, 1)
@@ -1171,6 +1202,7 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 		assertFiltering(t, apiClient)
 		assertBadFilterRejected(t, apiClient, hexID)
 		assertOversizedFilterRejected(t, apiClient, hexID)
+		assertBadDepthParamsRejected(t, apiClient, hexID)
 	})
 }
 
@@ -1198,6 +1230,21 @@ func assertOversizedFilterRejected(t *testing.T, apiClient *httpclient.Client, h
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+// assertBadDepthParamsRejected confirms out-of-range match_depth/ancestor_depth values (< -1) are
+// rejected with 400, not 500.
+func assertBadDepthParamsRejected(t *testing.T, apiClient *httpclient.Client, hexID string) {
+	t.Helper()
+
+	for _, param := range []string{"match_depth", "ancestor_depth"} {
+		req, err := http.NewRequest(http.MethodGet, apiClient.BaseURL+"/api/v2/traces/"+hexID+"?q="+url.QueryEscape("{ .http.status_code = 500 }")+"&"+param+"=-2", nil)
+		require.NoError(t, err)
+		resp, err := apiClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "expected 400 for %s=-2", param)
+		require.NoError(t, resp.Body.Close())
+	}
+}
+
 // spanLastBytes returns the last byte of each span id in the trace, used as a compact span identity.
 func spanLastBytes(tr *tempopb.Trace) []byte {
 	var ids []byte
@@ -1211,7 +1258,9 @@ func spanLastBytes(tr *tempopb.Trace) []byte {
 	return ids
 }
 
-// buildFilterTestTrace builds the A->B->C(500), A->D(200) trace used by TestTraceByIDV2Filtering.
+// buildFilterTestTrace builds the A->B->C(500)->E->F, A->D(200) trace used by
+// TestTraceByIDV2Filtering. E and F give C a two-level descendant subtree so match_depth has
+// something meaningful to bound.
 func buildFilterTestTrace(traceID []byte) *tempopb.Trace {
 	start := uint64(time.Now().Add(-3 * time.Second).UnixNano())
 	spanID := func(n byte) []byte { return []byte{0, 0, 0, 0, 0, 0, 0, n} }
@@ -1248,6 +1297,8 @@ func buildFilterTestTrace(traceID []byte) *tempopb.Trace {
 					span(2, 1, 0),   // B child of A
 					span(3, 2, 500), // C child of B, matches
 					span(4, 1, 200), // D child of A, unrelated
+					span(5, 3, 0),   // E child of C
+					span(6, 5, 0),   // F child of E
 				},
 			}},
 		}},

--- a/integration/api/api_test.go
+++ b/integration/api/api_test.go
@@ -1173,6 +1173,10 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 			{name: "ancestor_depth_2_without_keep_hierarchy", query: matchC, params: map[string]string{"ancestor_depth": "2"}, expect: []byte{3}},
 			{name: "ancestor_depth_unbounded_keep_hierarchy_false", query: matchC, params: map[string]string{"keep_hierarchy": "false", "ancestor_depth": "-1"}, expect: []byte{3}},
 			{name: "ancestor_depth_inert_but_match_depth_applies", query: matchC, params: map[string]string{"keep_hierarchy": "false", "ancestor_depth": "-1", "match_depth": "1"}, expect: []byte{3, 5}},
+			// an unusable ancestor_depth is not read at all without keep_hierarchy, so it neither fails
+			// the request nor changes the result. See assertBadDepthParamsRejected for the 400 it earns
+			// once keep_hierarchy=true makes it meaningful.
+			{name: "ancestor_depth_out_of_range_ignored_without_keep_hierarchy", query: matchC, params: map[string]string{"ancestor_depth": "-2"}, expect: []byte{3}},
 
 			// keep_hierarchy with ancestor_depth, no descendants.
 			{name: "keep_hierarchy_default_ancestor_depth", query: matchC, params: map[string]string{"keep_hierarchy": "true"}, expect: []byte{1, 2, 3}},
@@ -1281,17 +1285,42 @@ func assertOversizedFilterRejected(t *testing.T, apiClient *httpclient.Client, h
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
-// assertBadDepthParamsRejected confirms out-of-range match_depth/ancestor_depth values (< -1) are
-// rejected with 400, not 500.
+// assertBadDepthParamsRejected confirms an out-of-range depth is rejected with 400, not 500, but only
+// where the depth is actually read. match_depth always applies once q is set, while ancestor_depth is
+// read only under keep_hierarchy=true — so the same -2 that fails there is accepted and ignored
+// without it, and must not fail a request it could not have changed.
 func assertBadDepthParamsRejected(t *testing.T, apiClient *httpclient.Client, hexID string) {
 	t.Helper()
 
-	for _, param := range []string{"match_depth", "ancestor_depth"} {
-		req, err := http.NewRequest(http.MethodGet, apiClient.BaseURL+"/api/v2/traces/"+hexID+"?q="+url.QueryEscape("{ .http.status_code = 500 }")+"&"+param+"=-2", nil)
+	rejected := []string{
+		"match_depth=-2",
+		"match_depth=abc",
+		"keep_hierarchy=true&ancestor_depth=-2",
+		"keep_hierarchy=true&ancestor_depth=abc",
+	}
+	ignored := []string{
+		"ancestor_depth=-2",
+		"ancestor_depth=abc",
+		"keep_hierarchy=false&ancestor_depth=-2",
+	}
+
+	filterQuery := url.QueryEscape("{ .http.status_code = 500 }")
+
+	for _, param := range rejected {
+		req, err := http.NewRequest(http.MethodGet, apiClient.BaseURL+"/api/v2/traces/"+hexID+"?q="+filterQuery+"&"+param, nil)
 		require.NoError(t, err)
 		resp, err := apiClient.Do(req)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "expected 400 for %s=-2", param)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "expected 400 for %s", param)
+		require.NoError(t, resp.Body.Close())
+	}
+
+	for _, param := range ignored {
+		req, err := http.NewRequest(http.MethodGet, apiClient.BaseURL+"/api/v2/traces/"+hexID+"?q="+filterQuery+"&"+param, nil)
+		require.NoError(t, err)
+		resp, err := apiClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode, "expected 200 for unread %s", param)
 		require.NoError(t, resp.Body.Close())
 	}
 }

--- a/integration/api/api_test.go
+++ b/integration/api/api_test.go
@@ -1119,8 +1119,9 @@ func TestTagValuesWithSpecialCharacters(t *testing.T) {
 	})
 }
 
-// TestTraceByIDV2Filtering exercises the `q` spanset filter and keep_hierarchy options on the V2
-// trace-by-id endpoint end to end, on both the recent-data and backend querying paths.
+// TestTraceByIDV2Filtering exercises the `q` spanset filter and its keep_hierarchy, match_depth
+// and ancestor_depth options on the V2 trace-by-id endpoint end to end, on both the recent-data
+// and backend querying paths.
 func TestTraceByIDV2Filtering(t *testing.T) {
 	util.RunIntegrationTests(t, util.TestHarnessConfig{
 		Components: util.ComponentsRecentDataQuerying | util.ComponentsBackendQuerying,
@@ -1136,61 +1137,111 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 
 		hexID := tempoUtil.TraceIDToHexString(traceID)
 
-		assertFiltering := func(t *testing.T, apiClient *httpclient.Client) {
-			// no params: full trace, all six spans, and a complete (not partial) status.
-			full, err := apiClient.QueryTraceV2WithQueryParams(hexID, nil)
-			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{1, 2, 3, 4, 5, 6}, spanLastBytes(full.Trace))
-			require.Equal(t, tempopb.PartialStatus_COMPLETE, full.Status, "an unfiltered trace is complete")
+		// spans are identified by the last byte of their id:
+		//   1=A(root)  2=B  3=C(http.status_code=500)  4=D(http.status_code=200)  5=E  6=F
+		// relative to C: ancestors are B at 1 hop then A at 2 hops; descendants are E at 1 hop
+		// then F at 2 hops. Relative to D: A is its only ancestor, and it has no descendants.
+		const (
+			matchC  = "{ .http.status_code = 500 }" // matches C only
+			matchCD = "{ .http.status_code > 0 }"   // matches C and D
+		)
 
-			// q only, no match_depth param at all: keep_hierarchy defaults to false and match_depth
-			// defaults to 0, so only the matched span (C). This is the backward-compat baseline:
-			// behavior must be identical to what the endpoint returned before match_depth existed.
-			matchedOnly, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }"})
-			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{3}, spanLastBytes(matchedOnly.Trace))
-			// a filter that dropped spans marks the response partial so a client knows it is a subset.
-			require.Equal(t, tempopb.PartialStatus_PARTIAL, matchedOnly.Status)
-			require.Contains(t, matchedOnly.Message, "only a subset of spans matching the filter")
+		// filterCases covers the interaction of keep_hierarchy, match_depth and ancestor_depth.
+		// The two depth params default differently when absent — match_depth to 0 (no descendants),
+		// ancestor_depth to -1 (unbounded) — so absent and explicit values are both asserted.
+		filterCases := []struct {
+			name   string
+			query  string
+			params map[string]string
+			expect []byte
+			// a filter only reports COMPLETE when it dropped nothing, so this is the exception.
+			wantComplete bool
+		}{
+			// backward-compat baseline: no depth params at all must behave exactly as the endpoint
+			// did before match_depth and ancestor_depth existed — the matched span and nothing else.
+			{name: "defaults_match_only", query: matchC, expect: []byte{3}},
 
-			// keep_hierarchy=true: the match plus its unbounded ancestor path (A,B,C), still a
-			// subset of the full trace. ancestor_depth defaults to -1 (unbounded) when absent.
-			withHierarchy, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "keep_hierarchy": "true"})
-			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{1, 2, 3}, spanLastBytes(withHierarchy.Trace))
-			require.Equal(t, tempopb.PartialStatus_PARTIAL, withHierarchy.Status, "a filtered subset is partial even with ancestors")
+			// match_depth alone, without keep_hierarchy.
+			{name: "match_depth_0", query: matchC, params: map[string]string{"match_depth": "0"}, expect: []byte{3}},
+			{name: "match_depth_1", query: matchC, params: map[string]string{"match_depth": "1"}, expect: []byte{3, 5}},
+			{name: "match_depth_2", query: matchC, params: map[string]string{"match_depth": "2"}, expect: []byte{3, 5, 6}},
+			{name: "match_depth_beyond_subtree", query: matchC, params: map[string]string{"match_depth": "9"}, expect: []byte{3, 5, 6}},
+			{name: "match_depth_unbounded", query: matchC, params: map[string]string{"match_depth": "-1"}, expect: []byte{3, 5, 6}},
 
-			// match_depth=1: the match plus its direct children only (E), not the grandchild F.
-			matchDepthOne, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "match_depth": "1"})
-			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{3, 5}, spanLastBytes(matchDepthOne.Trace))
-			require.Equal(t, tempopb.PartialStatus_PARTIAL, matchDepthOne.Status)
+			// ancestor_depth is inert unless keep_hierarchy is true, at any value.
+			{name: "ancestor_depth_unbounded_without_keep_hierarchy", query: matchC, params: map[string]string{"ancestor_depth": "-1"}, expect: []byte{3}},
+			{name: "ancestor_depth_2_without_keep_hierarchy", query: matchC, params: map[string]string{"ancestor_depth": "2"}, expect: []byte{3}},
+			{name: "ancestor_depth_unbounded_keep_hierarchy_false", query: matchC, params: map[string]string{"keep_hierarchy": "false", "ancestor_depth": "-1"}, expect: []byte{3}},
+			{name: "ancestor_depth_inert_but_match_depth_applies", query: matchC, params: map[string]string{"keep_hierarchy": "false", "ancestor_depth": "-1", "match_depth": "1"}, expect: []byte{3, 5}},
 
-			// match_depth=-1: the match plus its full descendant subtree (E, F).
-			matchDepthUnbounded, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "match_depth": "-1"})
-			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{3, 5, 6}, spanLastBytes(matchDepthUnbounded.Trace))
-			require.Equal(t, tempopb.PartialStatus_PARTIAL, matchDepthUnbounded.Status)
+			// keep_hierarchy with ancestor_depth, no descendants.
+			{name: "keep_hierarchy_default_ancestor_depth", query: matchC, params: map[string]string{"keep_hierarchy": "true"}, expect: []byte{1, 2, 3}},
+			{name: "keep_hierarchy_ancestor_depth_unbounded", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "-1"}, expect: []byte{1, 2, 3}},
+			{name: "keep_hierarchy_ancestor_depth_0", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "0"}, expect: []byte{3}},
+			{name: "keep_hierarchy_ancestor_depth_1", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "1"}, expect: []byte{2, 3}},
+			{name: "keep_hierarchy_ancestor_depth_2", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "2"}, expect: []byte{1, 2, 3}},
+			{name: "keep_hierarchy_ancestor_depth_past_root", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "9"}, expect: []byte{1, 2, 3}},
 
-			// keep_hierarchy=true + ancestor_depth=0: matched span only, no ancestors kept
-			// despite keep_hierarchy being set.
-			ancestorDepthZero, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "keep_hierarchy": "true", "ancestor_depth": "0"})
-			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{3}, spanLastBytes(ancestorDepthZero.Trace))
-			require.Equal(t, tempopb.PartialStatus_PARTIAL, ancestorDepthZero.Status)
+			// all three together: ancestors and descendants are bounded independently.
+			{name: "hierarchy_ancestor_0_match_0", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "0", "match_depth": "0"}, expect: []byte{3}},
+			{name: "hierarchy_ancestor_0_match_1", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "0", "match_depth": "1"}, expect: []byte{3, 5}},
+			{name: "hierarchy_ancestor_0_match_unbounded", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "0", "match_depth": "-1"}, expect: []byte{3, 5, 6}},
+			{name: "hierarchy_ancestor_1_match_1", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "1", "match_depth": "1"}, expect: []byte{2, 3, 5}},
+			{name: "hierarchy_ancestor_1_match_2", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "1", "match_depth": "2"}, expect: []byte{2, 3, 5, 6}},
+			{name: "hierarchy_ancestor_1_match_unbounded", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "1", "match_depth": "-1"}, expect: []byte{2, 3, 5, 6}},
+			{name: "hierarchy_ancestor_2_match_1", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "2", "match_depth": "1"}, expect: []byte{1, 2, 3, 5}},
+			{name: "hierarchy_ancestor_2_match_2", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "2", "match_depth": "2"}, expect: []byte{1, 2, 3, 5, 6}},
+			{name: "hierarchy_ancestor_past_root_match_past_leaf", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "9", "match_depth": "9"}, expect: []byte{1, 2, 3, 5, 6}},
+			// unbounded in both directions still excludes D: it is on a sibling branch, neither an
+			// ancestor nor a descendant of C.
+			{name: "hierarchy_both_unbounded_excludes_sibling_branch", query: matchC, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "-1", "match_depth": "-1"}, expect: []byte{1, 2, 3, 5, 6}},
 
-			// keep_hierarchy=true + ancestor_depth=1: the match plus its immediate parent (B)
-			// only, not the full ancestor chain to the root (A).
-			ancestorDepthOne, err := apiClient.QueryTraceV2WithQueryParams(hexID, map[string]string{"q": "{ .http.status_code = 500 }", "keep_hierarchy": "true", "ancestor_depth": "1"})
-			require.NoError(t, err)
-			require.ElementsMatch(t, []byte{2, 3}, spanLastBytes(ancestorDepthOne.Trace))
-			require.Equal(t, tempopb.PartialStatus_PARTIAL, ancestorDepthOne.Status)
+			// two matched spans: depths are counted per match, so the kept set is the union.
+			{name: "two_matches_defaults", query: matchCD, expect: []byte{3, 4}},
+			// A is 2 hops above C but only 1 above D, so ancestor_depth=1 still pulls it in.
+			{name: "two_matches_ancestor_1", query: matchCD, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "1"}, expect: []byte{1, 2, 3, 4}},
+			// D is a leaf, so only C contributes a descendant.
+			{name: "two_matches_ancestor_0_match_1", query: matchCD, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "0", "match_depth": "1"}, expect: []byte{3, 4, 5}},
+			// the union covers every span, so nothing was dropped and the response is not partial.
+			{name: "two_matches_both_unbounded_keeps_whole_trace", query: matchCD, params: map[string]string{"keep_hierarchy": "true", "ancestor_depth": "-1", "match_depth": "-1"}, expect: []byte{1, 2, 3, 4, 5, 6}, wantComplete: true},
+		}
+
+		assertFiltering := func(t *testing.T, pathName string, apiClient *httpclient.Client) {
+			t.Run(pathName, func(t *testing.T) {
+				// no params: full trace, all six spans, and a complete (not partial) status.
+				full, err := apiClient.QueryTraceV2WithQueryParams(hexID, nil)
+				require.NoError(t, err)
+				require.ElementsMatch(t, []byte{1, 2, 3, 4, 5, 6}, spanLastBytes(full.Trace))
+				require.Equal(t, tempopb.PartialStatus_COMPLETE, full.Status, "an unfiltered trace is complete")
+
+				for _, tc := range filterCases {
+					t.Run(tc.name, func(t *testing.T) {
+						params := map[string]string{"q": tc.query}
+						for k, v := range tc.params {
+							params[k] = v
+						}
+
+						resp, err := apiClient.QueryTraceV2WithQueryParams(hexID, params)
+						require.NoError(t, err)
+						require.ElementsMatch(t, tc.expect, spanLastBytes(resp.Trace))
+
+						if tc.wantComplete {
+							require.Equal(t, tempopb.PartialStatus_COMPLETE, resp.Status)
+							require.Empty(t, resp.Message)
+							return
+						}
+						// a filter that dropped spans marks the response partial so a client knows it is a subset.
+						require.Equal(t, tempopb.PartialStatus_PARTIAL, resp.Status)
+						require.Contains(t, resp.Message, "only a subset of spans matching the filter")
+					})
+				}
+			})
 		}
 
 		apiClient := h.APIClientHTTP("")
 
 		// recent-data path.
-		assertFiltering(t, apiClient)
+		assertFiltering(t, "recent_data", apiClient)
 		assertBadFilterRejected(t, apiClient, hexID)
 		assertOversizedFilterRejected(t, apiClient, hexID)
 		assertBadDepthParamsRejected(t, apiClient, hexID)
@@ -1199,7 +1250,7 @@ func TestTraceByIDV2Filtering(t *testing.T) {
 		h.WaitTracesWrittenToBackend(t, 1)
 		h.ForceBackendQuerying(t)
 		apiClient = h.APIClientHTTP("")
-		assertFiltering(t, apiClient)
+		assertFiltering(t, "backend", apiClient)
 		assertBadFilterRejected(t, apiClient, hexID)
 		assertOversizedFilterRejected(t, apiClient, hexID)
 		assertBadDepthParamsRejected(t, apiClient, hexID)

--- a/modules/frontend/tracefilter/filter.go
+++ b/modules/frontend/tracefilter/filter.go
@@ -149,7 +149,15 @@ func depthBoundedWalk(adjacency map[string][]string, seeds map[*tracev1.Span]str
 
 	queue := make([]idAndDepth, 0, len(seeds))
 	for s := range seeds {
-		queue = append(queue, idAndDepth{id: string(s.SpanId), depth: 0})
+		id := string(s.SpanId)
+		// "" is the key every parentless span is indexed under, so a matched span that arrived with no
+		// span id at all must not be walked from: childrenByID[""] is every root in the trace, and
+		// parentsByID[""] is every parent of an id-less span. Seeding from it would adopt unrelated
+		// branches as the malformed span's own family. It still gets returned, just with no relatives.
+		if id == "" {
+			continue
+		}
+		queue = append(queue, idAndDepth{id: id, depth: 0})
 	}
 
 	for len(queue) > 0 {
@@ -230,7 +238,9 @@ func (idx *spanIndex) addParent(spanID, parentID string) {
 }
 
 // addChild records a child id under its parent id. A parent can legitimately have many distinct
-// children, so unlike addParent this does not dedup.
+// children, so unlike addParent this does not dedup. Every parentless span lands under the "" key,
+// which is deliberate and never walked: depthBoundedWalk skips "" as a neighbor and refuses to seed
+// from an id-less span, so that bucket is only ever a place roots go to be ignored.
 func (idx *spanIndex) addChild(parentID, childID string) {
 	idx.childrenByID[parentID] = append(idx.childrenByID[parentID], childID)
 }

--- a/modules/frontend/tracefilter/filter.go
+++ b/modules/frontend/tracefilter/filter.go
@@ -23,10 +23,13 @@ type Options struct {
 	// KeepHierarchy includes each matched span's ancestor path. Ignored when Query is empty.
 	KeepHierarchy bool
 	// MatchDepth bounds how many hops of descendants of each matched span are kept, cumulatively.
-	// -1 means unlimited, 0 means no descendants are kept. Ignored when Query is empty.
+	// -1 means unlimited and 0 means no descendants are kept; -1 is the only negative value accepted,
+	// and Compile rejects anything below it. Ignored when Query is empty.
 	MatchDepth int
 	// AncestorDepth bounds how many hops of ancestors of each matched span are kept, cumulatively.
-	// -1 means unlimited, 0 means no ancestors are kept. Ignored when Query is empty or KeepHierarchy is false.
+	// -1 means unlimited and 0 means no ancestors are kept. Ignored when Query is empty or
+	// KeepHierarchy is false, and only checked when it is read: -1 is then the only negative value
+	// accepted, and Compile rejects anything below it.
 	AncestorDepth int
 }
 
@@ -53,9 +56,24 @@ func NewFilter(opts Options, logger log.Logger) (*Filter, error) {
 }
 
 // Compile compiles the options into a Filter. Returns (nil, nil) for an empty Query (passthrough).
+// -1 is the only negative depth with a meaning, so anything below it is rejected rather than quietly
+// treated as unlimited: a caller that passes -5 is confused about the contract, not asking for the
+// whole subtree. A depth is only checked where it is actually read, so AncestorDepth is validated
+// only under KeepHierarchy — the same rule api.ParseTraceByIDFilterParams applies to the request
+// params. Errors are the caller's to map to a 400.
 func (o Options) Compile() (*Filter, error) {
 	if o.Query == "" {
 		return nil, nil
+	}
+
+	if o.KeepHierarchy {
+		if o.AncestorDepth < -1 {
+			return nil, fmt.Errorf("invalid ancestor depth %d: must be >= -1", o.AncestorDepth)
+		}
+	}
+
+	if o.MatchDepth < -1 {
+		return nil, fmt.Errorf("invalid match depth %d: must be >= -1", o.MatchDepth)
 	}
 
 	sf, err := traceql.CompileSpansetFilter(o.Query)
@@ -115,8 +133,11 @@ type idAndDepth struct {
 }
 
 // depthBoundedWalk does a breadth-first walk of adjacency starting from the ids of seeds, returning
-// every id reachable within maxDepth hops (cumulative). maxDepth < 0 means unlimited (whole reachable
-// graph); maxDepth == 0 returns an empty result. adjacency maps an id to its neighbor ids: pass
+// every id reachable within maxDepth hops (cumulative). maxDepth -1 means unlimited (whole reachable
+// graph) and is the only negative Compile lets through; maxDepth == 0 returns an empty result. The
+// guard below is written as maxDepth < 0 so a stray negative degrades to unlimited instead of
+// silently truncating, but callers are validated, not trusted to be lucky. adjacency maps an id to
+// its neighbor ids: pass
 // parentsByID for an ancestor walk (skipping the "" root sentinel) or childrenByID for a descendant walk.
 // True BFS (front-of-queue pop) is required: a node must be assigned its shortest-path depth, since a
 // depth cutoff applied to a DFS could reach a node via a longer path first and wrongly exclude it.

--- a/modules/frontend/tracefilter/filter.go
+++ b/modules/frontend/tracefilter/filter.go
@@ -1,5 +1,6 @@
 // Plumbing for the trace-by-id q filter: parse options, compile, build the span index, walk ancestors
-// for keep_hierarchy, and rebuild the trace. Span matching itself lives in protospan.go.
+// and descendants of matched spans with depthBoundedWalk, and rebuild the trace. Span matching itself
+// lives in protospan.go.
 
 package tracefilter
 
@@ -21,12 +22,20 @@ type Options struct {
 	Query string
 	// KeepHierarchy includes each matched span's ancestor path. Ignored when Query is empty.
 	KeepHierarchy bool
+	// MatchDepth bounds how many hops of descendants of each matched span are kept, cumulatively.
+	// -1 means unlimited, 0 means no descendants are kept. Ignored when Query is empty.
+	MatchDepth int
+	// AncestorDepth bounds how many hops of ancestors of each matched span are kept, cumulatively.
+	// -1 means unlimited, 0 means no ancestors are kept. Ignored when Query is empty or KeepHierarchy is false.
+	AncestorDepth int
 }
 
 // Filter is a compiled, ready-to-apply trace filter.
 type Filter struct {
 	spansetFilter *traceql.SpansetFilter
 	keepHierarchy bool
+	matchDepth    int
+	ancestorDepth int
 	// expandElements is used to expand event/link elements.
 	expandElements bool
 	// logger warns when a span's event/link fan-out is truncated. Defaults to a nop logger.
@@ -57,6 +66,8 @@ func (o Options) Compile() (*Filter, error) {
 	return &Filter{
 		spansetFilter:  sf,
 		keepHierarchy:  o.KeepHierarchy,
+		matchDepth:     o.MatchDepth,
+		ancestorDepth:  o.AncestorDepth,
 		expandElements: sf.ReferencesEventOrLink(),
 		logger:         log.NewNopLogger(),
 	}, nil
@@ -68,7 +79,7 @@ func (f *Filter) Process(trace *tempopb.Trace) (*tempopb.Trace, error) {
 		return trace, nil
 	}
 
-	idx := newSpanIndex(trace, f.expandElements, f.keepHierarchy)
+	idx := newSpanIndex(trace, f.expandElements, f.keepHierarchy, f.matchDepth != 0)
 	if idx.truncatedSpans > 0 {
 		level.Warn(f.logger).Log("msg", "trace by id q filter: span event/link fan-out hit the cap, some spans may under-match", "cap", maxBindingsPerSpan, "truncated_spans", idx.truncatedSpans)
 	}
@@ -86,57 +97,87 @@ func (f *Filter) Process(trace *tempopb.Trace) (*tempopb.Trace, error) {
 		}
 	}
 
-	var keptAncestorIDs map[string]struct{}
+	var keptAncestorIDs, keptDescendantIDs map[string]struct{}
 	if f.keepHierarchy {
-		keptAncestorIDs = ancestorIDs(idx, keptSpans)
+		keptAncestorIDs = depthBoundedWalk(idx.parentsByID, keptSpans, f.ancestorDepth)
+	}
+	if f.matchDepth != 0 {
+		keptDescendantIDs = depthBoundedWalk(idx.childrenByID, keptSpans, f.matchDepth)
 	}
 
-	return rebuildTrace(trace, keptSpans, keptAncestorIDs), nil
+	return rebuildTrace(trace, keptSpans, keptAncestorIDs, keptDescendantIDs), nil
 }
 
-func ancestorIDs(idx *spanIndex, matched map[*tracev1.Span]struct{}) map[string]struct{} {
-	ancestors := make(map[string]struct{})
+// idAndDepth pairs a span id with the number of hops it took to reach it from a seed, for BFS.
+type idAndDepth struct {
+	id    string
+	depth int
+}
 
-	queue := make([]string, 0, len(matched))
-	for s := range matched {
-		queue = append(queue, string(s.SpanId))
+// depthBoundedWalk does a breadth-first walk of adjacency starting from the ids of seeds, returning
+// every id reachable within maxDepth hops (cumulative). maxDepth < 0 means unlimited (whole reachable
+// graph); maxDepth == 0 returns an empty result. adjacency maps an id to its neighbor ids: pass
+// parentsByID for an ancestor walk (skipping the "" root sentinel) or childrenByID for a descendant walk.
+// True BFS (front-of-queue pop) is required: a node must be assigned its shortest-path depth, since a
+// depth cutoff applied to a DFS could reach a node via a longer path first and wrongly exclude it.
+func depthBoundedWalk(adjacency map[string][]string, seeds map[*tracev1.Span]struct{}, maxDepth int) map[string]struct{} {
+	result := make(map[string]struct{})
+	if maxDepth == 0 {
+		return result
+	}
+
+	queue := make([]idAndDepth, 0, len(seeds))
+	for s := range seeds {
+		queue = append(queue, idAndDepth{id: string(s.SpanId), depth: 0})
 	}
 
 	for len(queue) > 0 {
-		current := queue[len(queue)-1]
-		queue = queue[:len(queue)-1]
-		for _, parentID := range idx.parentsByID[current] {
-			if parentID == "" {
+		current := queue[0]
+		queue = queue[1:]
+		for _, neighborID := range adjacency[current.id] {
+			if neighborID == "" {
 				continue // reached a root.
 			}
-			if _, seen := ancestors[parentID]; seen {
+			if _, seen := result[neighborID]; seen {
 				continue // already recorded, also breaks cycles.
 			}
-			// a dangling parentID is harmless: rebuildTrace only emits spans that exist.
-			ancestors[parentID] = struct{}{}
-			queue = append(queue, parentID)
+			nextDepth := current.depth + 1
+			if maxDepth >= 0 && nextDepth > maxDepth {
+				continue
+			}
+			// a dangling neighborID is harmless: rebuildTrace only emits spans that exist.
+			result[neighborID] = struct{}{}
+			queue = append(queue, idAndDepth{id: neighborID, depth: nextDepth})
 		}
 	}
 
-	return ancestors
+	return result
 }
 
-// spanIndex is a flattened view of a trace for matching and ancestor walks.
+// spanIndex is a flattened view of a trace for matching and ancestor/descendant walks.
 type spanIndex struct {
 	spans []traceql.Span
-	// hierarchy is keyed by span id, so identical ids across batches merge parents and can over-include
-	// ancestors (rare, bad instrumentation). Matching is pointer-keyed, so matches stay exact.
+	// hierarchy is keyed by span id, so identical ids across batches merge parents/children and can
+	// over-include ancestors/descendants (rare, bad instrumentation). Matching is pointer-keyed, so
+	// matches stay exact.
 	parentsByID map[string][]string
+	// childrenByID maps a parent span id to all of its child span ids. Unlike parentsByID, entries are
+	// not deduped: a parent can legitimately have many distinct children.
+	childrenByID map[string][]string
 	// truncatedSpans counts spans whose event x link fan-out hit maxBindingsPerSpan and was cut short.
 	truncatedSpans int
 }
 
-func newSpanIndex(trace *tempopb.Trace, expandElements, keepHierarchy bool) *spanIndex {
+func newSpanIndex(trace *tempopb.Trace, expandElements, keepHierarchy, buildChildren bool) *spanIndex {
 	// pre-size to the span count, a lower bound since events/links expand a span into more (append grows it).
 	idx := &spanIndex{spans: make([]traceql.Span, 0, countSpans(trace))}
-	// parentsByID is only read by ancestorIDs (keep_hierarchy), so only allocate it then.
+	// parentsByID is only read by the ancestor walk (keep_hierarchy), so only allocate it then.
 	if keepHierarchy {
 		idx.parentsByID = make(map[string][]string)
+	}
+	// childrenByID is only read by the descendant walk (match_depth != 0), so only allocate it then.
+	if buildChildren {
+		idx.childrenByID = make(map[string][]string)
 	}
 	for _, rs := range trace.ResourceSpans {
 		for _, ss := range rs.ScopeSpans {
@@ -148,6 +189,9 @@ func newSpanIndex(trace *tempopb.Trace, expandElements, keepHierarchy bool) *spa
 				}
 				if keepHierarchy {
 					idx.addParent(string(span.SpanId), string(span.ParentSpanId))
+				}
+				if buildChildren {
+					idx.addChild(string(span.ParentSpanId), string(span.SpanId))
 				}
 			}
 		}
@@ -164,10 +208,17 @@ func (idx *spanIndex) addParent(spanID, parentID string) {
 	idx.parentsByID[spanID] = append(idx.parentsByID[spanID], parentID)
 }
 
+// addChild records a child id under its parent id. A parent can legitimately have many distinct
+// children, so unlike addParent this does not dedup.
+func (idx *spanIndex) addChild(parentID, childID string) {
+	idx.childrenByID[parentID] = append(idx.childrenByID[parentID], childID)
+}
+
 // rebuildTrace returns a new trace of only the kept spans, preserving grouping and dropping empties.
-// A span is kept if it matched or its id is an ancestor to keep(keep_hierarchy=true). It reuses the
-// input's *Span/*Resource/*Scope pointers (only the slices are new), so the result must be treated as read only, and the input trace may be cached.
-func rebuildTrace(trace *tempopb.Trace, keptSpans map[*tracev1.Span]struct{}, keptAncestorIDs map[string]struct{}) *tempopb.Trace {
+// A span is kept if it matched, its id is an ancestor to keep (keep_hierarchy=true), or its id is a
+// descendant to keep (match_depth != 0). It reuses the input's *Span/*Resource/*Scope pointers (only
+// the slices are new), so the result must be treated as read only, and the input trace may be cached.
+func rebuildTrace(trace *tempopb.Trace, keptSpans map[*tracev1.Span]struct{}, keptAncestorIDs, keptDescendantIDs map[string]struct{}) *tempopb.Trace {
 	out := &tempopb.Trace{}
 
 	for _, rs := range trace.ResourceSpans {
@@ -180,6 +231,10 @@ func rebuildTrace(trace *tempopb.Trace, keptSpans map[*tracev1.Span]struct{}, ke
 					continue
 				}
 				if _, ok := keptAncestorIDs[string(span.SpanId)]; ok {
+					kept = append(kept, span)
+					continue
+				}
+				if _, ok := keptDescendantIDs[string(span.SpanId)]; ok {
 					kept = append(kept, span)
 				}
 			}

--- a/modules/frontend/tracefilter/filter_test.go
+++ b/modules/frontend/tracefilter/filter_test.go
@@ -136,6 +136,23 @@ func TestApplyQueryOnlyReturnsMatchedSpans(t *testing.T) {
 	require.ElementsMatch(t, []byte{3}, keptIDs(out), "only the matching span is returned without keep_hierarchy")
 }
 
+func TestApplyMatchDepthZeroMatchesOnly(t *testing.T) {
+	// trace: A(root) -> B -> C, only C has http.status_code=500. An explicit match_depth=0 must
+	// behave identically to today's default (matched spans only, no descendants).
+	trace := buildTrace([]testSpan{
+		{id: 1, attrs: map[string]any{"http.status_code": 200}},
+		{id: 2, parent: 1, attrs: map[string]any{"http.status_code": 200}},
+		{id: 3, parent: 2, attrs: map[string]any{"http.status_code": 500}},
+	}, nil)
+
+	f, err := Options{Query: `{ .http.status_code = 500 }`, MatchDepth: 0}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{3}, keptIDs(out), "match_depth=0 keeps only the matching span")
+}
+
 func TestApplyKeepHierarchyAddsAncestors(t *testing.T) {
 	// trace: A(root) -> B -> C, only C matches. keep_hierarchy should also return A and B.
 	trace := buildTrace([]testSpan{
@@ -144,7 +161,7 @@ func TestApplyKeepHierarchyAddsAncestors(t *testing.T) {
 		{id: 3, parent: 2, attrs: map[string]any{"http.status_code": 500}},
 	}, nil)
 
-	f, err := Options{Query: `{ .http.status_code = 500 }`, KeepHierarchy: true}.Compile()
+	f, err := Options{Query: `{ .http.status_code = 500 }`, KeepHierarchy: true, AncestorDepth: -1}.Compile()
 	require.NoError(t, err)
 
 	out, err := f.Process(trace)
@@ -162,12 +179,44 @@ func TestApplyKeepHierarchyMultipleBranches(t *testing.T) {
 		{id: 5, parent: 3},
 	}, nil)
 
-	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true}.Compile()
+	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: -1}.Compile()
 	require.NoError(t, err)
 
 	out, err := f.Process(trace)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []byte{1, 2, 4}, keptIDs(out))
+}
+
+func TestApplyAncestorDepthZero(t *testing.T) {
+	// A(root) -> B -> C(match). ancestor_depth=0 keeps no ancestors, even with keep_hierarchy=true.
+	trace := buildTrace([]testSpan{
+		{id: 1},
+		{id: 2, parent: 1},
+		{id: 3, parent: 2, attrs: map[string]any{"match": true}},
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: 0}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{3}, keptIDs(out), "ancestor_depth=0 keeps only the matched span, no ancestors")
+}
+
+func TestApplyAncestorDepthLimitsToImmediateParent(t *testing.T) {
+	// A(root) -> B -> C(match). ancestor_depth=1 keeps only the immediate parent B, not the root A.
+	trace := buildTrace([]testSpan{
+		{id: 1},
+		{id: 2, parent: 1},
+		{id: 3, parent: 2, attrs: map[string]any{"match": true}},
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: 1}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{2, 3}, keptIDs(out), "ancestor_depth=1 keeps only the immediate parent")
 }
 
 func TestApplyKeepHierarchyFollowsAllParentsOfDuplicateID(t *testing.T) {
@@ -180,7 +229,7 @@ func TestApplyKeepHierarchyFollowsAllParentsOfDuplicateID(t *testing.T) {
 		{id: 3, parent: 2, attrs: map[string]any{"match": true}},
 	}, nil)
 
-	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true}.Compile()
+	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: -1}.Compile()
 	require.NoError(t, err)
 
 	out, err := f.Process(trace)
@@ -203,6 +252,88 @@ func TestApplyDuplicateIDKeepsOnlyMatchingSpan(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte{3}, keptIDs(out), "only the matching span survives, not both duplicates")
 	require.Equal(t, []string{"keep"}, stringAttrValues(out, "which"))
+}
+
+func TestApplyMatchDepthKeepsDirectChildren(t *testing.T) {
+	// A(match) -> B -> C, a 3-level chain. match_depth=1 keeps only the direct child B, not C.
+	trace := buildTrace([]testSpan{
+		{id: 1, attrs: map[string]any{"match": true}},
+		{id: 2, parent: 1},
+		{id: 3, parent: 2},
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, MatchDepth: 1}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{1, 2}, keptIDs(out), "match_depth=1 keeps only direct children")
+}
+
+func TestApplyMatchDepthCumulativeLevels(t *testing.T) {
+	// A(match) -> B -> C -> D, a 4-level chain.
+	trace := buildTrace([]testSpan{
+		{id: 1, attrs: map[string]any{"match": true}},
+		{id: 2, parent: 1},
+		{id: 3, parent: 2},
+		{id: 4, parent: 3},
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, MatchDepth: 2}.Compile()
+	require.NoError(t, err)
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{1, 2, 3}, keptIDs(out), "match_depth=2 keeps two cumulative levels of descendants, D excluded")
+
+	unlimited, err := Options{Query: `{ .match = true }`, MatchDepth: -1}.Compile()
+	require.NoError(t, err)
+	out, err = unlimited.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{1, 2, 3, 4}, keptIDs(out), "match_depth=-1 keeps the full subtree")
+}
+
+func TestApplyMatchDepthMultipleBranches(t *testing.T) {
+	// A(match) -> {B -> D (shallow), C -> E -> F (deep)}. match_depth=2 keeps the shallow branch in
+	// full (B, D) and truncates the deep branch before F (C, E kept, F dropped).
+	trace := buildTrace([]testSpan{
+		{id: 1, attrs: map[string]any{"match": true}},
+		{id: 2, parent: 1},
+		{id: 3, parent: 1},
+		{id: 4, parent: 2},
+		{id: 5, parent: 3},
+		{id: 6, parent: 5},
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, MatchDepth: 2}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{1, 2, 3, 4, 5}, keptIDs(out), "shallow branch kept in full, deep branch truncated at the cutoff")
+}
+
+func TestApplyDepthAssignmentUsesShortestPath(t *testing.T) {
+	// A(match) has two branches to span id 5: a short one (A -> B -> X, depth 2) and a longer one
+	// through a duplicate span sharing id 5 (A -> C -> D -> X', depth 3). X has a real child Y at
+	// true depth 3. With match_depth=3, Y is within budget only if X is assigned its shortest-path
+	// depth (2); a DFS-based walk that visits the longer branch first would record X at depth 3
+	// instead, push Y past the cutoff at depth 4, and wrongly drop it.
+	trace := buildTrace([]testSpan{
+		{id: 1, attrs: map[string]any{"match": true}}, // A
+		{id: 2, parent: 1},                            // B, short branch
+		{id: 5, parent: 2},                            // X, true shortest depth 2
+		{id: 6, parent: 5},                            // Y, X's child, true depth 3
+		{id: 3, parent: 1},                            // C, long branch
+		{id: 4, parent: 3},                            // D
+		{id: 5, parent: 4},                            // X' (duplicate id 5), reached at depth 3 via the long branch
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, MatchDepth: 3}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{1, 2, 3, 4, 5, 5, 6}, keptIDs(out), "id 5 must be assigned its shortest-path depth so its child Y stays within budget")
 }
 
 func TestApplyNoMatchReturnsEmptyTrace(t *testing.T) {
@@ -268,7 +399,7 @@ func TestApplyKeepHierarchyToleratesMissingParent(t *testing.T) {
 		{id: 2, parent: 9, attrs: map[string]any{"match": true}},
 	}, nil)
 
-	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true}.Compile()
+	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: -1}.Compile()
 	require.NoError(t, err)
 
 	out, err := f.Process(trace)
@@ -283,7 +414,42 @@ func TestApplyKeepHierarchyTerminatesOnCycle(t *testing.T) {
 		{id: 2, parent: 1},
 	}, nil)
 
-	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true}.Compile()
+	f, err := Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: -1}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{1, 2}, keptIDs(out))
+}
+
+func TestApplyMatchDepthToleratesMissingParent(t *testing.T) {
+	// span id 5 is declared twice: one instance genuinely parented under matched span 2, the other
+	// parented under a dangling id 99 that appears nowhere else in the trace. Since keptDescendantIDs
+	// is id-keyed (not pointer-keyed), reaching id 5 through either instance keeps both - this must
+	// not panic and must still return every span, including the one behind the dangling reference.
+	trace := buildTrace([]testSpan{
+		{id: 2, attrs: map[string]any{"match": true}},
+		{id: 5, parent: 2},
+		{id: 5, parent: 99},
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, MatchDepth: 1}.Compile()
+	require.NoError(t, err)
+
+	out, err := f.Process(trace)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []byte{2, 5, 5}, keptIDs(out))
+}
+
+func TestApplyMatchDepthTerminatesOnCycle(t *testing.T) {
+	// 1 -> 2 -> 1 is a child cycle (same shape as the ancestor cycle, inverted). The walk must
+	// terminate (not hang) and keep both.
+	trace := buildTrace([]testSpan{
+		{id: 1, parent: 2, attrs: map[string]any{"match": true}},
+		{id: 2, parent: 1},
+	}, nil)
+
+	f, err := Options{Query: `{ .match = true }`, MatchDepth: -1}.Compile()
 	require.NoError(t, err)
 
 	out, err := f.Process(trace)
@@ -372,9 +538,9 @@ func TestKeepHierarchyIgnoredWhenQueryAbsent(t *testing.T) {
 		{id: 3, parent: 2},
 	}, nil)
 
-	f, err := Options{KeepHierarchy: true}.Compile()
+	f, err := Options{KeepHierarchy: true, MatchDepth: 2, AncestorDepth: 1}.Compile()
 	require.NoError(t, err)
-	require.Nil(t, f, "no query means no filter regardless of keep_hierarchy")
+	require.Nil(t, f, "no query means no filter regardless of keep_hierarchy, match_depth, or ancestor_depth")
 
 	out, err := f.Process(trace)
 	require.NoError(t, err)
@@ -420,9 +586,11 @@ func buildBenchTrace(n int) *tempopb.Trace {
 func BenchmarkProcess(b *testing.B) {
 	trace := buildBenchTrace(2000)
 
-	keep, err := Options{Query: `{ .http.status_code = 500 }`, KeepHierarchy: true}.Compile()
+	keep, err := Options{Query: `{ .http.status_code = 500 }`, KeepHierarchy: true, AncestorDepth: -1}.Compile()
 	require.NoError(b, err)
 	flat, err := Options{Query: `{ .http.status_code = 500 }`, KeepHierarchy: false}.Compile()
+	require.NoError(b, err)
+	matchDepth, err := Options{Query: `{ .http.status_code = 500 }`, MatchDepth: 2}.Compile()
 	require.NoError(b, err)
 
 	b.Run("keep_hierarchy=true", func(b *testing.B) {
@@ -437,6 +605,14 @@ func BenchmarkProcess(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			if _, err := flat.Process(trace); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("match_depth=2", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if _, err := matchDepth.Process(trace); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/modules/frontend/tracefilter/filter_test.go
+++ b/modules/frontend/tracefilter/filter_test.go
@@ -112,6 +112,45 @@ func TestCompileInvalidQueryErrors(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCompileDepthRange pins -1 as the only negative depth with a meaning. Anything below it is a
+// caller that misread the contract, so it is rejected rather than rounded up to unlimited.
+func TestCompileDepthRange(t *testing.T) {
+	const query = `{ .a = 1 }`
+
+	tests := []struct {
+		name    string
+		opts    Options
+		wantErr string
+	}{
+		{name: "match_depth -1 is unlimited", opts: Options{Query: query, MatchDepth: -1}},
+		{name: "match_depth 0 keeps no descendants", opts: Options{Query: query, MatchDepth: 0}},
+		{name: "match_depth positive", opts: Options{Query: query, MatchDepth: 3}},
+		{name: "ancestor_depth -1 is unlimited", opts: Options{Query: query, KeepHierarchy: true, AncestorDepth: -1}},
+		{name: "ancestor_depth 0 keeps no ancestors", opts: Options{Query: query, KeepHierarchy: true, AncestorDepth: 0}},
+		{name: "ancestor_depth positive", opts: Options{Query: query, KeepHierarchy: true, AncestorDepth: 3}},
+		{name: "match_depth below -1", opts: Options{Query: query, MatchDepth: -2}, wantErr: "invalid match depth -2"},
+		{name: "match_depth far below -1", opts: Options{Query: query, MatchDepth: -99}, wantErr: "invalid match depth -99"},
+		{name: "ancestor_depth below -1", opts: Options{Query: query, KeepHierarchy: true, AncestorDepth: -2}, wantErr: "invalid ancestor depth -2"},
+		// ancestor depth is only checked if keep_hierarchy is true, so this is a valid combination.
+		{name: "ancestor_depth below -1 without keep_hierarchy", opts: Options{Query: query, AncestorDepth: -2}},
+		// an empty query is a passthrough, so the depths are never consulted and never rejected.
+		{name: "out of range depths ignored without a query", opts: Options{MatchDepth: -2, AncestorDepth: -2}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := tt.opts.Compile()
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				require.Nil(t, f, "a rejected filter must not be returned")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestApplyNilFilterReturnsInput(t *testing.T) {
 	trace := buildTrace([]testSpan{{id: 1}}, nil)
 	var f *Filter

--- a/modules/frontend/tracefilter/filter_test.go
+++ b/modules/frontend/tracefilter/filter_test.go
@@ -480,6 +480,61 @@ func TestApplyMatchDepthToleratesMissingParent(t *testing.T) {
 	require.ElementsMatch(t, []byte{2, 5, 5}, keptIDs(out))
 }
 
+// TestApplyIDLessMatchedSpanWalksToNothing covers a matched span that arrived with no span id at all.
+// Every parentless span is indexed under the "" parent key, so seeding the descendant walk from an
+// id-less span would look up that bucket and adopt every root in the trace (and their subtrees) as
+// its children. The same applies to the ancestor walk via parentsByID. A malformed span must walk to
+// nothing rather than drag in unrelated branches.
+func TestApplyIDLessMatchedSpanWalksToNothing(t *testing.T) {
+	span := func(name string, id, parent []byte, match bool) *tracev1.Span {
+		s := &tracev1.Span{SpanId: id, ParentSpanId: parent, Name: name}
+		if match {
+			s.Attributes = keyValues(map[string]any{"match": true})
+		}
+		return s
+	}
+	// two separate roots, each with a child, plus a matched span carrying no span id.
+	trace := &tempopb.Trace{ResourceSpans: []*tracev1.ResourceSpans{{
+		ScopeSpans: []*tracev1.ScopeSpans{{Spans: []*tracev1.Span{
+			span("root-a", []byte{1}, nil, false),
+			span("child-a", []byte{2}, []byte{1}, false),
+			span("root-b", []byte{3}, nil, false),
+			span("child-b", []byte{4}, []byte{3}, false),
+			span("orphan", nil, nil, true),
+		}}},
+	}}}
+
+	allSpanNamesInTrace := func(tr *tempopb.Trace) []string {
+		var out []string
+		for _, rs := range tr.ResourceSpans {
+			for _, ss := range rs.ScopeSpans {
+				for _, s := range ss.Spans {
+					out = append(out, s.Name)
+				}
+			}
+		}
+		return out
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts Options
+	}{
+		{name: "descendant walk", opts: Options{Query: `{ .match = true }`, MatchDepth: -1}},
+		{name: "ancestor walk", opts: Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: -1}},
+		{name: "both walks", opts: Options{Query: `{ .match = true }`, KeepHierarchy: true, AncestorDepth: -1, MatchDepth: -1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := tc.opts.Compile()
+			require.NoError(t, err)
+
+			outTrace, err := f.Process(trace)
+			require.NoError(t, err)
+			require.Equal(t, []string{"orphan"}, allSpanNamesInTrace(outTrace), "an id-less span has no ancestors or descendants to reach")
+		})
+	}
+}
+
 func TestApplyMatchDepthTerminatesOnCycle(t *testing.T) {
 	// 1 -> 2 -> 1 is a child cycle (same shape as the ancestor cycle, inverted). The walk must
 	// terminate (not hang) and keep both.

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -116,11 +116,11 @@ func newTraceIDV2Handler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pi
 		}
 
 		// parse and compile filter params up front so a malformed filter can fail-fast as HTTP 4xx.
-		query, keepHierarchy, err := api.ParseTraceByIDFilterParams(req)
+		params, err := api.ParseTraceByIDFilterParams(req)
 		if err != nil {
 			return httpInvalidRequest(err), nil
 		}
-		filter, err := tracefilter.NewFilter(tracefilter.Options{Query: query, KeepHierarchy: keepHierarchy}, logger)
+		filter, err := tracefilter.NewFilter(tracefilter.Options{Query: params.Query, KeepHierarchy: params.KeepHierarchy, MatchDepth: params.MatchDepth, AncestorDepth: params.AncestorDepth}, logger)
 		if err != nil {
 			return httpInvalidRequest(err), nil
 		}

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -65,6 +65,8 @@ const (
 
 	// trace by id v2 filtering (q reuses urlParamQuery)
 	urlParamKeepHierarchy = "keep_hierarchy"
+	urlParamMatchDepth    = "match_depth"
+	urlParamAncestorDepth = "ancestor_depth"
 
 	// search tags
 	urlParamScope = "scope"
@@ -934,28 +936,69 @@ func ParseTraceByIDRequest(r *http.Request) (string, string, string, time.Time, 
 	return blockStart, blockEnd, queryMode, startTime, endTime, nil
 }
 
+// TraceByIDFilterParams holds the parsed q spanset filter params for the trace by id v2 API.
+type TraceByIDFilterParams struct {
+	Query         string
+	KeepHierarchy bool
+	MatchDepth    int
+	AncestorDepth int
+}
+
 // ParseTraceByIDFilterParams parses the q spanset filter params for the trace by id v2 API.
-// It returns (query, keepHierarchy, error). keep_hierarchy is only parsed when q is set: it is
-// documented as ignored without a query, so a malformed value must not fail an unfiltered request.
-func ParseTraceByIDFilterParams(r *http.Request) (string, bool, error) {
+// keep_hierarchy, match_depth, and ancestor_depth are only parsed and validated when q is set:
+// they are documented as ignored without a query, so malformed values must not fail an
+// unfiltered request. When q is empty, the zero-value TraceByIDFilterParams is returned.
+//
+// match_depth and ancestor_depth have different defaults when absent from the request, both
+// chosen to preserve pre-existing behavior: an absent match_depth defaults to 0 (matched spans
+// only, no descendants), while an absent ancestor_depth defaults to -1 (unbounded ancestor walk).
+// When present, both accept -1 (unbounded) or any non-negative depth.
+func ParseTraceByIDFilterParams(r *http.Request) (TraceByIDFilterParams, error) {
 	vals := r.URL.Query()
 
 	// trim so a blank or whitespace-only q means no filter (full trace), matching the docs.
 	query := strings.TrimSpace(vals.Get(urlParamQuery))
 	if query == "" {
-		return "", false, nil
+		return TraceByIDFilterParams{}, nil
 	}
 
-	keepHierarchy := false
+	params := TraceByIDFilterParams{
+		Query:         query,
+		MatchDepth:    0,
+		AncestorDepth: -1,
+	}
+
 	if raw := vals.Get(urlParamKeepHierarchy); raw != "" {
 		keep, err := strconv.ParseBool(raw)
 		if err != nil {
-			return "", false, fmt.Errorf("invalid value for %s: %w", urlParamKeepHierarchy, err)
+			return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: %w", urlParamKeepHierarchy, err)
 		}
-		keepHierarchy = keep
+		params.KeepHierarchy = keep
 	}
 
-	return query, keepHierarchy, nil
+	if raw := vals.Get(urlParamMatchDepth); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: %w", urlParamMatchDepth, err)
+		}
+		if n < -1 {
+			return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: must be >= -1", urlParamMatchDepth)
+		}
+		params.MatchDepth = n
+	}
+
+	if raw := vals.Get(urlParamAncestorDepth); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: %w", urlParamAncestorDepth, err)
+		}
+		if n < -1 {
+			return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: must be >= -1", urlParamAncestorDepth)
+		}
+		params.AncestorDepth = n
+	}
+
+	return params, nil
 }
 
 func ReadBodyToBuffer(resp *http.Response) (*bytes.Buffer, error) {

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -949,10 +949,14 @@ type TraceByIDFilterParams struct {
 // they are documented as ignored without a query, so malformed values must not fail an
 // unfiltered request. When q is empty, the zero-value TraceByIDFilterParams is returned.
 //
+// ancestor_depth is narrower still: it is only read when keep_hierarchy is true, since that is the
+// only case where it changes the response. Otherwise it is left at its default and never validated,
+// so an out-of-range ancestor_depth cannot fail a request it would not have affected.
+//
 // match_depth and ancestor_depth have different defaults when absent from the request, both
 // chosen to preserve pre-existing behavior: an absent match_depth defaults to 0 (matched spans
 // only, no descendants), while an absent ancestor_depth defaults to -1 (unbounded ancestor walk).
-// When present, both accept -1 (unbounded) or any non-negative depth.
+// When read, both accept -1 (unbounded) or any non-negative depth.
 func ParseTraceByIDFilterParams(r *http.Request) (TraceByIDFilterParams, error) {
 	vals := r.URL.Query()
 
@@ -987,15 +991,21 @@ func ParseTraceByIDFilterParams(r *http.Request) (TraceByIDFilterParams, error) 
 		params.MatchDepth = n
 	}
 
-	if raw := vals.Get(urlParamAncestorDepth); raw != "" {
-		n, err := strconv.Atoi(raw)
-		if err != nil {
-			return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: %w", urlParamAncestorDepth, err)
+	// ancestor_depth only bounds the keep_hierarchy ancestor walk, so without keep_hierarchy it is not
+	// read at all: a param with nothing to act on should not be able to fail a request that would
+	// otherwise succeed. Someone iterating on a trace can flip keep_hierarchy off without also having
+	// to strip the depth that goes with it.
+	if params.KeepHierarchy {
+		if raw := vals.Get(urlParamAncestorDepth); raw != "" {
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: %w", urlParamAncestorDepth, err)
+			}
+			if n < -1 {
+				return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: must be >= -1", urlParamAncestorDepth)
+			}
+			params.AncestorDepth = n
 		}
-		if n < -1 {
-			return TraceByIDFilterParams{}, fmt.Errorf("invalid value for %s: must be >= -1", urlParamAncestorDepth)
-		}
-		params.AncestorDepth = n
 	}
 
 	return params, nil

--- a/pkg/api/http_test.go
+++ b/pkg/api/http_test.go
@@ -778,24 +778,44 @@ func TestParseTraceByIDFilterParams(t *testing.T) {
 		},
 		{
 			name:              "ancestor_depth explicit zero",
-			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=0",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=true&ancestor_depth=0",
 			wantQuery:         "{ .a = 1 }",
+			wantKeepHierarchy: true,
 			wantMatchDepth:    0,
 			wantAncestorDepth: 0,
 		},
 		{
 			name:              "ancestor_depth explicit -1 means unbounded",
-			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=-1",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=true&ancestor_depth=-1",
 			wantQuery:         "{ .a = 1 }",
+			wantKeepHierarchy: true,
 			wantMatchDepth:    0,
 			wantAncestorDepth: -1,
 		},
 		{
 			name:              "ancestor_depth explicit positive value",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=true&ancestor_depth=3",
+			wantQuery:         "{ .a = 1 }",
+			wantKeepHierarchy: true,
+			wantMatchDepth:    0,
+			wantAncestorDepth: 3,
+		},
+		// without keep_hierarchy, ancestor_depth has nothing to bound, so it is never read: the value
+		// is left at its default no matter what was sent, and even an unusable one cannot fail the
+		// request. This lets someone flip keep_hierarchy off without stripping the depth beside it.
+		{
+			name:              "ancestor_depth not read when keep_hierarchy absent",
 			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=3",
 			wantQuery:         "{ .a = 1 }",
 			wantMatchDepth:    0,
-			wantAncestorDepth: 3,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "ancestor_depth not read when keep_hierarchy false",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=false&ancestor_depth=0",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
 		},
 		{
 			name:     "match_depth below -1 with query is an error",
@@ -808,9 +828,36 @@ func TestParseTraceByIDFilterParams(t *testing.T) {
 			wantErr:  true,
 		},
 		{
-			name:     "ancestor_depth below -1 with query is an error",
-			urlQuery: "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=-2",
+			name:     "ancestor_depth below -1 with keep_hierarchy is an error",
+			urlQuery: "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=true&ancestor_depth=-2",
 			wantErr:  true,
+		},
+		{
+			name:     "non-numeric ancestor_depth with keep_hierarchy is an error",
+			urlQuery: "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=true&ancestor_depth=abc",
+			wantErr:  true,
+		},
+		// the same unusable values are accepted without keep_hierarchy, because they are never read.
+		{
+			name:              "ancestor_depth below -1 ignored without keep_hierarchy",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=-2",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "ancestor_depth below -1 ignored with keep_hierarchy false",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=false&ancestor_depth=-2",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "non-numeric ancestor_depth ignored without keep_hierarchy",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=abc",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
 		},
 		{
 			name:              "invalid match_depth ignored without query",

--- a/pkg/api/http_test.go
+++ b/pkg/api/http_test.go
@@ -708,44 +708,139 @@ func TestParseTraceByIDFilterParams(t *testing.T) {
 		urlQuery          string
 		wantQuery         string
 		wantKeepHierarchy bool
+		wantMatchDepth    int
+		wantAncestorDepth int
 		wantErr           bool
 	}{
-		{name: "no params means no filter", urlQuery: ""},
-		{name: "query only defaults keep_hierarchy false", urlQuery: "q=" + url.QueryEscape("{ .a = 1 }"), wantQuery: "{ .a = 1 }"},
+		// no q means no filter at all, so the zero-value TraceByIDFilterParams is returned:
+		// match_depth and ancestor_depth are both 0 here, not their filtered-path defaults.
+		{name: "no params means no filter", urlQuery: "", wantMatchDepth: 0, wantAncestorDepth: 0},
+		{name: "query only defaults keep_hierarchy false", urlQuery: "q=" + url.QueryEscape("{ .a = 1 }"), wantQuery: "{ .a = 1 }", wantMatchDepth: 0, wantAncestorDepth: -1},
 		// a whitespace-only q is trimmed to empty, so it is treated as no filter and keep_hierarchy is ignored.
-		{name: "whitespace-only q is treated as empty", urlQuery: "q=" + url.QueryEscape("   ") + "&keep_hierarchy=true"},
+		{name: "whitespace-only q is treated as empty", urlQuery: "q=" + url.QueryEscape("   ") + "&keep_hierarchy=true", wantMatchDepth: 0, wantAncestorDepth: 0},
 		// surrounding whitespace on a real query is trimmed, not passed to the parser.
-		{name: "surrounding whitespace on q is trimmed", urlQuery: "q=" + url.QueryEscape("  { .a = 1 }  "), wantQuery: "{ .a = 1 }"},
+		{name: "surrounding whitespace on q is trimmed", urlQuery: "q=" + url.QueryEscape("  { .a = 1 }  "), wantQuery: "{ .a = 1 }", wantMatchDepth: 0, wantAncestorDepth: -1},
 		{
 			name:              "query and explicit keep_hierarchy true",
 			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=true",
 			wantQuery:         "{ .a = 1 }",
 			wantKeepHierarchy: true,
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
 		},
 		{
-			name:      "explicit keep_hierarchy false overrides default",
-			urlQuery:  "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=false",
-			wantQuery: "{ .a = 1 }",
+			name:              "explicit keep_hierarchy false overrides default",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=false",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
 		},
 		{
 			name:     "invalid keep_hierarchy with query",
 			urlQuery: "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=yes-please",
 			wantErr:  true,
 		},
-		{name: "invalid keep_hierarchy ignored without query", urlQuery: "keep_hierarchy=yes-please"},
+		{name: "invalid keep_hierarchy ignored without query", urlQuery: "keep_hierarchy=yes-please", wantMatchDepth: 0, wantAncestorDepth: 0},
+		{
+			name:              "match_depth absent with query defaults to 0",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }"),
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "match_depth explicit zero",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&match_depth=0",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "match_depth explicit -1 means unbounded",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&match_depth=-1",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    -1,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "match_depth explicit positive value",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&match_depth=2",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    2,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "ancestor_depth absent with query defaults to -1",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }"),
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "ancestor_depth explicit zero",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=0",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: 0,
+		},
+		{
+			name:              "ancestor_depth explicit -1 means unbounded",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=-1",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: -1,
+		},
+		{
+			name:              "ancestor_depth explicit positive value",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=3",
+			wantQuery:         "{ .a = 1 }",
+			wantMatchDepth:    0,
+			wantAncestorDepth: 3,
+		},
+		{
+			name:     "match_depth below -1 with query is an error",
+			urlQuery: "q=" + url.QueryEscape("{ .a = 1 }") + "&match_depth=-2",
+			wantErr:  true,
+		},
+		{
+			name:     "non-numeric match_depth with query is an error",
+			urlQuery: "q=" + url.QueryEscape("{ .a = 1 }") + "&match_depth=abc",
+			wantErr:  true,
+		},
+		{
+			name:     "ancestor_depth below -1 with query is an error",
+			urlQuery: "q=" + url.QueryEscape("{ .a = 1 }") + "&ancestor_depth=-2",
+			wantErr:  true,
+		},
+		{
+			name:              "invalid match_depth ignored without query",
+			urlQuery:          "match_depth=-2",
+			wantMatchDepth:    0,
+			wantAncestorDepth: 0,
+		},
+		{
+			name:              "query, keep_hierarchy, and ancestor_depth combined",
+			urlQuery:          "q=" + url.QueryEscape("{ .a = 1 }") + "&keep_hierarchy=true&ancestor_depth=2",
+			wantQuery:         "{ .a = 1 }",
+			wantKeepHierarchy: true,
+			wantMatchDepth:    0,
+			wantAncestorDepth: 2,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := httptest.NewRequest("GET", "/api/v2/traces/1234?"+tt.urlQuery, nil)
-			query, keepHierarchy, err := ParseTraceByIDFilterParams(r)
+			params, err := ParseTraceByIDFilterParams(r)
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, tt.wantQuery, query)
-			require.Equal(t, tt.wantKeepHierarchy, keepHierarchy)
+			require.Equal(t, tt.wantQuery, params.Query)
+			require.Equal(t, tt.wantKeepHierarchy, params.KeepHierarchy)
+			require.Equal(t, tt.wantMatchDepth, params.MatchDepth)
+			require.Equal(t, tt.wantAncestorDepth, params.AncestorDepth)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does**:

Adds `match_depth` and `ancestor_depth` query params to the TraceByID V2 `q`-filter (extends #7483). Both use a `-1`=all / `0`=none / `n`=n cumulative levels convention.

- `match_depth` bounds how many levels of descendants are kept below each matched span, independent of `keep_hierarchy`. Absent defaults to `0`, preserving today's existing matched-spans-only behavior for backward compatibility.
- `ancestor_depth` bounds how many levels of ancestors are kept, only when `keep_hierarchy=true`. Absent defaults to `-1` (today's existing unbounded-ancestor behavior), so no compatibility concern there.
- The prior ancestor-only walk was actually a DFS despite looking BFS-shaped; both directions now share one true-BFS `depthBoundedWalk` helper for correct cumulative-depth semantics under a cutoff.
- Adds matching `--match-depth`/`--ancestor-depth` flags to `tempo-cli query-trace-id`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)