### PR TITLE
metrics-generator: label expired edges by span kind

### DIFF
--- a/.chloggen/service-graph-expired-edge-span-kind.yaml
+++ b/.chloggen/service-graph-expired-edge-span-kind.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: metrics-generator
+note: Improve service graph troubleshooting by labeling expired edges with the unmatched span kind.
+issues: []
+subtext:
+user: javiermolinar

--- a/docs/sources/tempo/troubleshooting/metrics-generator.md
+++ b/docs/sources/tempo/troubleshooting/metrics-generator.md
@@ -276,6 +276,19 @@ Rate of edges that have expired without a match:
 sum(rate(tempo_metrics_generator_processor_service_graphs_expired_edges{}[1m]))
 ```
 
+The `unmatched_span_kind` label identifies the kind of span that did not find its matching span.
+Use it to determine which side of an edge is missing:
+
+```promql
+sum by (unmatched_span_kind) (
+  rate(tempo_metrics_generator_processor_service_graphs_expired_edges{}[1m])
+)
+```
+
+For example, `unmatched_span_kind="SPAN_KIND_SERVER"` means that server spans are arriving without matching client spans.
+This can indicate discarded client spans or incorrect instrumentation,
+such as a server span directly parenting another server span.
+
 Rate of all edges:
 
 ```

--- a/modules/generator/processor/servicegraphs/servicegraphs.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs.go
@@ -49,8 +49,8 @@ var (
 	metricExpiredEdges = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
 		Name:      "metrics_generator_processor_service_graphs_expired_edges",
-		Help:      "Number of edges that expired before finding its matching span",
-	}, []string{"tenant"})
+		Help:      "Number of edges that expired before finding a matching span, labeled by the unmatched span kind",
+	}, []string{"tenant", "unmatched_span_kind"})
 )
 
 const (
@@ -100,7 +100,7 @@ type Processor struct {
 	metricDroppedEdges                  prometheus.Counter
 	metricDroppedSpanSideCacheOverflows prometheus.Counter
 	metricTotalEdges                    prometheus.Counter
-	metricExpiredEdges                  prometheus.Counter
+	metricExpiredEdges                  *prometheus.CounterVec
 	invalidUTF8Counter                  prometheus.Counter
 	logger                              log.Logger
 }
@@ -161,7 +161,7 @@ func New(cfg Config, tenant string, reg registry.Registry, logger log.Logger, fi
 		metricDroppedEdges:                  metricDroppedEdges.WithLabelValues(tenant),
 		metricDroppedSpanSideCacheOverflows: metricDroppedSpanSideCacheOverflows.WithLabelValues(tenant),
 		metricTotalEdges:                    metricTotalEdges.WithLabelValues(tenant),
-		metricExpiredEdges:                  metricExpiredEdges.WithLabelValues(tenant),
+		metricExpiredEdges:                  metricExpiredEdges.MustCurryWith(prometheus.Labels{"tenant": tenant}),
 		invalidUTF8Counter:                  invalidUTF8Counter,
 		logger:                              log.With(logger, "component", "service-graphs"),
 	}
@@ -255,6 +255,7 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 				case v1_trace.Span_SPAN_KIND_CLIENT:
 					isNew, err = p.store.UpsertEdgeFromBytes(span.TraceId, span.SpanId, store.Client, func(e *store.Edge) {
 						e.SetTraceID(span.TraceId)
+						e.SpanKind = span.Kind
 						e.ConnectionType = connectionType
 						e.ClientService = svcName
 						e.ClientLatencySec = spanDurationSec(span)
@@ -272,6 +273,7 @@ func (p *Processor) consume(resourceSpans []*v1_trace.ResourceSpans) (err error)
 					fallthrough
 				case v1_trace.Span_SPAN_KIND_SERVER:
 					isNew, err = p.store.UpsertEdgeFromBytes(span.TraceId, span.ParentSpanId, store.Server, func(e *store.Edge) {
+						e.SpanKind = span.Kind
 						// Non-root server spans cannot produce metrics without a client
 						// update, which supplies the same trace ID.
 						if len(span.ParentSpanId) == 0 {
@@ -517,7 +519,7 @@ func (p *Processor) onExpire(e *store.Edge) {
 
 	// there was no match and no information in the one found span to create a service graph edge. mark expired
 	if !wasCounted {
-		p.metricExpiredEdges.Inc()
+		p.metricExpiredEdges.WithLabelValues(e.SpanKind.String()).Inc()
 	}
 }
 

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -22,6 +22,7 @@ import (
 	tempo_util "github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/pkg/util/test"
 	"github.com/prometheus/client_golang/prometheus"
+	prometheus_testutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
 	prom_histogram "github.com/prometheus/prometheus/model/histogram"
@@ -641,8 +642,7 @@ func TestServiceGraphs_expiredEdges(t *testing.T) {
 
 	p.(*Processor).store.Expire()
 
-	expiredEdges, err := test.GetCounterVecValue(metricExpiredEdges, tenant)
-	require.NoError(t, err)
+	expiredEdges := prometheus_testutil.ToFloat64(metricExpiredEdges.WithLabelValues(tenant, tracev1.Span_SPAN_KIND_SERVER.String()))
 	assert.Equal(t, 1.0, expiredEdges)
 
 	totalEdges, err := test.GetCounterVecValue(metricTotalEdges, tenant)
@@ -652,6 +652,47 @@ func TestServiceGraphs_expiredEdges(t *testing.T) {
 	droppedSpans, err := test.GetCounterVecValue(metricDroppedSpans, tenant)
 	require.NoError(t, err)
 	assert.Equal(t, 0.0, droppedSpans)
+}
+
+func TestServiceGraphs_expiredEdgesByUnmatchedSpanKind(t *testing.T) {
+	testRegistry := registry.NewTestRegistry()
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.Wait = time.Nanosecond
+
+	const tenant = "expired-edge-span-kind-test"
+
+	p, err := New(cfg, tenant, testRegistry, log.NewNopLogger(), prometheus.NewCounter(prometheus.CounterOpts{}), prometheus.NewCounter(prometheus.CounterOpts{}))
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	testCases := []struct {
+		name         string
+		kind         tracev1.Span_SpanKind
+		parentSpanID []byte
+	}{
+		{name: "client", kind: tracev1.Span_SPAN_KIND_CLIENT},
+		{name: "server", kind: tracev1.Span_SPAN_KIND_SERVER, parentSpanID: []byte{0x10}},
+		{name: "producer", kind: tracev1.Span_SPAN_KIND_PRODUCER},
+		{name: "consumer", kind: tracev1.Span_SPAN_KIND_CONSUMER, parentSpanID: []byte{0x11}},
+	}
+
+	batches := make([]*tracev1.ResourceSpans, 0, len(testCases))
+	for i, tc := range testCases {
+		id := byte(i + 1)
+		batches = append(batches, makeServiceGraphBatch(tc.name, tc.kind, []byte{id}, []byte{id}, tc.parentSpanID))
+	}
+
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: batches})
+	p.(*Processor).store.Expire()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expiredEdges := prometheus_testutil.ToFloat64(metricExpiredEdges.WithLabelValues(tenant, tc.kind.String()))
+			assert.Equal(t, 1.0, expiredEdges)
+		})
+	}
 }
 
 func TestServiceGraphs_droppedEdgesMetric(t *testing.T) {
@@ -1699,9 +1740,15 @@ func TestServiceGraphs_serverPeerSurvivesClientDatabaseUpdate(t *testing.T) {
 	})
 	assert.Equal(t, 1.0, testRegistry.Query("traces_service_graph_request_total", virtualNodeLabels))
 
-	expiredEdges, err := test.GetCounterVecValue(metricExpiredEdges, tenant)
-	require.NoError(t, err)
-	assert.Zero(t, expiredEdges)
+	for _, kind := range []tracev1.Span_SpanKind{
+		tracev1.Span_SPAN_KIND_CLIENT,
+		tracev1.Span_SPAN_KIND_SERVER,
+		tracev1.Span_SPAN_KIND_PRODUCER,
+		tracev1.Span_SPAN_KIND_CONSUMER,
+	} {
+		expiredEdges := prometheus_testutil.ToFloat64(metricExpiredEdges.WithLabelValues(tenant, kind.String()))
+		assert.Zero(t, expiredEdges)
+	}
 }
 
 // TestServiceGraphs_emptyServiceNameServerSpanInfersVirtualNodeFromPeer covers

--- a/modules/generator/processor/servicegraphs/store/edge.go
+++ b/modules/generator/processor/servicegraphs/store/edge.go
@@ -1,6 +1,10 @@
 package store
 
-import "time"
+import (
+	"time"
+
+	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
+)
 
 type ConnectionType string
 
@@ -31,6 +35,9 @@ type Edge struct {
 	ServerService, ClientService                   string
 	ServerLatencySec, ClientLatencySec             float64
 	ServerStartTimeUnixNano, ClientEndTimeUnixNano uint64
+
+	// SpanKind is the kind of the most recently added span.
+	SpanKind v1_trace.Span_SpanKind
 
 	// If either the client or the server spans have status code error,
 	// the Edge will be considered as failed.

--- a/modules/generator/processor/servicegraphs/store/store_test.go
+++ b/modules/generator/processor/servicegraphs/store/store_test.go
@@ -10,6 +10,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	v1_trace "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
@@ -533,6 +534,7 @@ func TestResetEdge(t *testing.T) {
 		key:                     testEdgeKey("test-key"),
 		traceID:                 []byte("trace-123"),
 		ConnectionType:          Database,
+		SpanKind:                v1_trace.Span_SPAN_KIND_CLIENT,
 		ServerService:           "server-svc",
 		ClientService:           "client-svc",
 		ServerLatencySec:        1.5,
@@ -553,6 +555,7 @@ func TestResetEdge(t *testing.T) {
 	assert.Equal(t, edgeKey{}, e.key, "key should be reset")
 	assert.Empty(t, e.traceID, "traceID should be reset (buffer retained, length zero)")
 	assert.Equal(t, Unknown, e.ConnectionType, "ConnectionType should be reset to Unknown")
+	assert.Equal(t, v1_trace.Span_SPAN_KIND_UNSPECIFIED, e.SpanKind, "SpanKind should be reset to unspecified")
 	assert.Equal(t, "", e.ServerService, "ServerService should be reset")
 	assert.Equal(t, "", e.ClientService, "ClientService should be reset")
 	assert.Equal(t, 0.0, e.ServerLatencySec, "ServerLatencySec should be reset")


### PR DESCRIPTION
**What this PR does**:

Adds `unmatched_span_kind` to the expired service graph edge metric. The goal is to detect bad instrumentation. For instance if there is a high number of discarded edges with span kind SERVER that could mean we are instrumenting SERVER -> SERVER and that will never produce a node or a virtual one

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
