### PR TITLE
fix: single binary dashboard

### DIFF
--- a/.chloggen/fix_single-binary-dashboard.yaml
+++ b/.chloggen/fix_single-binary-dashboard.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: operations
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: "Fix metric name to `traces_service_graph_request_total` in Service Topology Grafana dashboard"
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: veenoise

--- a/example/docker-compose/single-binary/dashboards/service-graph.json
+++ b/example/docker-compose/single-binary/dashboards/service-graph.json
@@ -22,7 +22,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "label_replace(label_replace(label_replace(max by (client) (traces_service_graph_connection_info), \"id\", \"$1\", \"client\", \"(.*)\"), \"title\", \"$1\", \"client\", \"(.*)\"), \"color\", \"#1F3A6E\", \"\", \"\")",
+          "expr": "label_replace(label_replace(label_replace(max by (client) (traces_service_graph_request_total), \"id\", \"$1\", \"client\", \"(.*)\"), \"title\", \"$1\", \"client\", \"(.*)\"), \"color\", \"#1F3A6E\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -30,7 +30,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "label_replace(label_replace(label_replace(max by (server) (traces_service_graph_connection_info), \"id\", \"$1\", \"server\", \"(.*)\"), \"title\", \"$1\", \"server\", \"(.*)\"), \"color\", \"#1F3A6E\", \"\", \"\")",
+          "expr": "label_replace(label_replace(label_replace(max by (server) (traces_service_graph_request_total), \"id\", \"$1\", \"server\", \"(.*)\"), \"title\", \"$1\", \"server\", \"(.*)\"), \"color\", \"#1F3A6E\", \"\", \"\")",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -38,7 +38,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
-          "expr": "label_replace(label_replace(label_join(traces_service_graph_connection_info, \"id\", \"->\", \"client\", \"server\"), \"source\", \"$1\", \"client\", \"(.*)\"), \"target\", \"$1\", \"server\", \"(.*)\")",
+          "expr": "label_replace(label_replace(label_join(traces_service_graph_request_total, \"id\", \"->\", \"client\", \"server\"), \"source\", \"$1\", \"client\", \"(.*)\"), \"target\", \"$1\", \"server\", \"(.*)\")",
           "format": "table",
           "instant": true,
           "legendFormat": "",

--- a/example/docker-compose/single-binary/tempo.yaml
+++ b/example/docker-compose/single-binary/tempo.yaml
@@ -43,7 +43,7 @@ storage:
 overrides:
   defaults:
     metrics_generator:
-      processors: ["span-metrics", "service-graphs", "service-graphs-connection-info"]
+      processors: ["span-metrics", "service-graphs"]
       generate_native_histograms: both
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Current dashboard for the single binary tempo docker compose is like this:
<img width="2880" height="1564" alt="image" src="https://github.com/user-attachments/assets/de53c609-7db0-4fa5-9a88-d3902caa29ac" />

Now it is like this:
<img width="1440" height="786" alt="image" src="https://github.com/user-attachments/assets/e7c3bcb6-cbd7-4ed8-85ac-382995faec53" />

Also, `service-graphs-connection-info` is not supported metrics-generator processors according to https://grafana.com/docs/tempo/latest/configuration/#overrides:
<img width="2034" height="1668" alt="image" src="https://github.com/user-attachments/assets/1f4f9246-b7e3-47c9-8d5f-817c935f3ddb" />



**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [X] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)