### PR TITLE
tempodb: tolerate blocks removed during local listing

### DIFF
--- a/tempodb/backend/local/local.go
+++ b/tempodb/backend/local/local.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -199,6 +200,12 @@ func (rw *Backend) ListBlocks(_ context.Context, tenant string) (metas []uuid.UU
 	fff := os.DirFS(rootPath)
 	err = fs.WalkDir(fff, ".", func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
+			// Blocks can be deleted by retention while the blocklist is being
+			// walked. A vanished child is no longer part of the blocklist, so
+			// skip it instead of failing the entire tenant poll.
+			if path != "." && errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -79,6 +80,39 @@ func TestReadWrite(t *testing.T) {
 	assert.NoError(t, err, "unexpected error listing blocks")
 	assert.Len(t, m, 1)
 	assert.Len(t, cm, 1)
+}
+
+func TestListBlocksAllowsConcurrentBlockDeletion(t *testing.T) {
+	path := t.TempDir()
+	r, _, _, err := New(&Config{Path: path})
+	require.NoError(t, err)
+
+	tenant := "tenant"
+	blockID := uuid.New()
+	blockPath := filepath.Join(path, tenant, blockID.String())
+	require.NoError(t, os.MkdirAll(blockPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(blockPath, backend.MetaName), []byte("meta"), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			_ = os.RemoveAll(blockPath)
+			_ = os.MkdirAll(blockPath, 0o700)
+			_ = os.WriteFile(filepath.Join(blockPath, backend.MetaName), []byte("meta"), 0o600)
+		}
+	}()
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	for range 1_000 {
+		_, _, err = r.ListBlocks(context.Background(), tenant)
+		require.NoError(t, err)
+	}
 }
 
 func TestShutdownLeavesTenantsWithBlocks(t *testing.T) {


### PR DESCRIPTION
## What this fixes

The local backend blocklist poll and retention run on the same interval. When retention removes a compacted block directory while ListBlocks is walking the tenant directory, fs.WalkDir reports fs.ErrNotExist for that child and the entire tenant poll fails.

A concurrently removed child is no longer part of the blocklist, so this change skips only fs.ErrNotExist below the tenant root. Errors opening the tenant root and all other filesystem errors still fail the poll.

This was observed on v2.9.0, and the affected ListBlocks implementation is also present on release-v2.9. A backport would make the fix available to 2.9 users.

## Testing

- Added a regression test that continuously removes and recreates a block while ListBlocks runs. It reliably fails before this change with open UUID: no such file or directory.
- go test -race ./tempodb/backend/local -run TestListBlocks -count=20
- go test ./tempodb/backend/...