### PR TITLE
tempo-mixin: guard TempoDistributorKafkaProduceFailing on a non-zero produce rate

### DIFF
--- a/.chloggen/7148-kafka-produce-alert-denominator-guard.yaml
+++ b/.chloggen/7148-kafka-produce-alert-denominator-guard.yaml
@@ -1,0 +1,10 @@
+change_type: bug_fix
+component: operations
+note: Guard `TempoDistributorKafkaProduceFailing` on a non-zero produce rate so it does not page at `+Inf%` on cells where `tempo_distributor_produce_records_total` is not incremented.
+issues: []
+subtext: |
+  The alert divided the produce-failure rate by the produce rate with no guard. On a cell where
+  `tempo_distributor_produce_records_total` is flat, that ratio divides by zero, which PromQL
+  evaluates to `+Inf`. Since `+Inf` exceeds any threshold, the alert fired as critical with a
+  meaningless `+Inf%` value as soon as a single produce failure was recorded.
+user: zalegrala

--- a/operations/tempo-mixin-compiled/alerts.yaml
+++ b/operations/tempo-mixin-compiled/alerts.yaml
@@ -295,6 +295,8 @@
       /
       sum by (cluster, namespace) (rate(tempo_distributor_produce_records_total{namespace=~".*"}[5m]))
       > 0.001
+      and
+      sum by (cluster, namespace) (rate(tempo_distributor_produce_records_total{namespace=~".*"}[5m])) > 0
     "for": "5m"
     "labels":
       "severity": "critical"

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -450,18 +450,28 @@
             //
             // The 'cancelled-before-producing' reason is excluded because it is a caller-side
             // cancellation (upstream context done) rather than a Kafka/producer problem.
+            //
+            // The trailing produce-rate guard is required. On a cell where
+            // tempo_distributor_produce_records_total is not being incremented, the ratio divides by
+            // zero and PromQL evaluates that to +Inf, which exceeds any threshold. The alert would
+            // then fire as critical at a meaningless '+Inf%' whenever a single failure is recorded.
+            // Requiring a non-zero produce rate keeps the alert to cells where the ratio is real.
             alert: 'TempoDistributorKafkaProduceFailing',
             expr: |||
               sum by (%s) (rate(tempo_distributor_produce_failures_total{namespace=~"%s", reason!="cancelled-before-producing"}[5m]))
               /
               sum by (%s) (rate(tempo_distributor_produce_records_total{namespace=~"%s"}[5m]))
               > %s
+              and
+              sum by (%s) (rate(tempo_distributor_produce_records_total{namespace=~"%s"}[5m])) > 0
             ||| % [
               $._config.group_by_cluster,
               $._config.namespace,
               $._config.group_by_cluster,
               $._config.namespace,
               $._config.alerts.distributor_kafka_produce_failure_ratio,
+              $._config.group_by_cluster,
+              $._config.namespace,
             ],
             'for': '5m',
             labels: {

--- a/operations/tempo-mixin/runbook.md
+++ b/operations/tempo-mixin/runbook.md
@@ -458,6 +458,14 @@ alerts only fire once the failures propagate back to `cortex-gw` as gRPC errors 
 than the SLO bucket. With small-but-sustained failure rates the cortex-gw signal can take hours to
 cross the SLO burn threshold; this alert fires from the producer side in minutes.
 
+The expression is guarded on a non-zero produce rate, so it deliberately does not evaluate on a cell
+where `tempo_distributor_produce_records_total` is not being incremented. Without that guard the ratio
+divides by zero, which PromQL evaluates to `+Inf`, and the alert pages as critical at a meaningless
+`+Inf%` on the first recorded failure. If this alert is unexpectedly silent while produce failures are
+visible, confirm the produce counter is live with
+`sum by (cluster, namespace) (rate(tempo_distributor_produce_records_total[5m]))` -- a flat counter
+there means the ratio cannot be computed and the failures must be investigated directly by reason.
+
 ### Failure reasons
 
 The `tempo_distributor_produce_failures_total` metric carries a `reason` label set by


### PR DESCRIPTION
## What

`TempoDistributorKafkaProduceFailing` divides the produce-failure rate by the produce rate with no guard on the denominator:

```promql
sum by (cluster, namespace) (rate(tempo_distributor_produce_failures_total{...}[5m]))
/
sum by (cluster, namespace) (rate(tempo_distributor_produce_records_total{...}[5m]))
> 0.001
```

Where `tempo_distributor_produce_records_total` is not being incremented, the denominator rate is `0`. PromQL evaluates `x/0` to `+Inf`, and `+Inf` exceeds any threshold — so the alert fires as **critical** with a meaningless `+Inf%` in its message as soon as a single produce failure is recorded. This can happen on a cluster running a release that does not increment the produce counter, where the failure counter still does.

This PR requires a non-zero produce rate, so the alert only evaluates where the ratio is actually meaningful:

```promql
...
> 0.001
and
sum by (cluster, namespace) (rate(tempo_distributor_produce_records_total{...}[5m])) > 0
```

## Verified

Checked against a live cluster exhibiting the condition (produce-failure rate ~11/s, `produce_records_total` flat at 0 increase over 24h):

| Expression | Result |
|---|---|
| Current `main` (unguarded) | **fires** — ratio confirmed `+Inf` via `clamp_max(ratio, 999999)` = `999999` and `ratio == +Inf` matching |
| With this guard | **no result** — does not fire |

Clusters with a live produce rate are unaffected: the added `and` clause is true whenever the denominator is non-zero, which is the only case the original expression could evaluate meaningfully anyway.

- `make -C operations/tempo-mixin check` passes (compiled output regenerated and in sync)
- `jsonnetfmt --test` clean

## Notes

Also documents the guard in the runbook, including how to spot the flat-counter case if the alert is unexpectedly silent while produce failures are visible.

The alert was added in #7148.
