### PR TITLE
chore: update Go to 1.26.5 to fix stdlib CVEs

### DIFF
--- a/.chloggen/security-fixes.yaml
+++ b/.chloggen/security-fixes.yaml
@@ -1,0 +1,11 @@
+change_type: security
+
+component: operations
+
+note: Update Go to 1.26.5 (CVE-2026-39822, CVE-2026-27145, CVE-2026-42504, CVE-2026-42505, CVE-2026-42507), google.golang.org/grpc to v1.82.1 (GHSA-hrxh-6v49-42gf), golang.org/x/net to v0.56.0 (CVE-2026-46600), golang.org/x/text to v0.39.0 (CVE-2026-56852), and go.opentelemetry.io/otel to v1.44.0 (CVE-2026-41178)
+
+issues: []
+
+subtext:
+
+user: mattdurham

--- a/build/tools.mk
+++ b/build/tools.mk
@@ -12,7 +12,7 @@ TOOL_DIR     ?= tools
 TOOL_CONFIG  ?= $(TOOL_DIR)/tools.go
 
 TOOLS_IMAGE ?= grafana/tempo-ci-tools
-TOOLS_IMAGE_TAG ?= main-d182bec-20260603-154614
+TOOLS_IMAGE_TAG ?= main-3f54f1c-20260716-212549
 
 GOTOOLS ?= $(shell cd $(TOOL_DIR) && go list -e -f '{{ .Imports }}' -tags tools |tr -d '[]')
 

--- a/cmd/tempo-cli/cmd-analyse-block.go
+++ b/cmd/tempo-cli/cmd-analyse-block.go
@@ -903,7 +903,8 @@ func printFullSummary(scope string, settings heuristicSettings, summary attribut
 				blobText = "(blob)"
 			}
 
-			_, err := fmt.Fprintf(w, "name: %s\t size: %s\t (%.2f%%)\tcount: %d\t distinct: %d\t avg reuse: %.2f\t avg rowgroup content (dict + body): %s %s\t%s\n",
+			_, err := fmt.Fprintf(
+				w, "name: %s\t size: %s\t (%.2f%%)\tcount: %d\t distinct: %d\t avg reuse: %.2f\t avg rowgroup content (dict + body): %s %s\t%s\n",
 				name,
 				humanize.Bytes(thisBytes),
 				percentage,

--- a/cmd/tempo-cli/cmd-list-cachesummary.go
+++ b/cmd/tempo-cli/cmd-list-cachesummary.go
@@ -45,7 +45,7 @@ func displayCacheSummary(results []blockStats) {
 		for len(bloomTable)-1 < int(row) {
 			bloomTable = append(bloomTable, make([]int, 0))
 		}
-		column := -1 * (int(time.Until(r.StartTime) / (time.Hour * 24)))
+		column := -1 * int(time.Until(r.StartTime)/(time.Hour*24))
 		// extend column of given row
 		for len(bloomTable[row])-1 < column {
 			bloomTable[row] = append(bloomTable[row], 0)

--- a/cmd/tempo-cli/cmd-migrate-tenant.go
+++ b/cmd/tempo-cli/cmd-migrate-tenant.go
@@ -50,7 +50,7 @@ blocks:
 	for _, sourceBlockMeta := range sourceTenantIndex.Meta {
 		// check for collisions
 		for _, uuidDest := range blocksDest {
-			if (uuid.UUID)(sourceBlockMeta.BlockID) == uuidDest {
+			if uuid.UUID(sourceBlockMeta.BlockID) == uuidDest {
 				fmt.Printf("UUID %s exists in source and destination, skipping block\n", sourceBlockMeta.BlockID)
 				continue blocks
 			}

--- a/cmd/tempo-cli/cmd-rewrite-blocks.go
+++ b/cmd/tempo-cli/cmd-rewrite-blocks.go
@@ -89,7 +89,7 @@ func (cmd *dropTracesCmd) Run(opts *globalOptions) error {
 		}
 
 		level.Info(logger).Log("msg", "marking block compacted", "block", block.BlockID)
-		err = c.MarkBlockCompacted((uuid.UUID)(block.BlockID), block.TenantID)
+		err = c.MarkBlockCompacted(uuid.UUID(block.BlockID), block.TenantID)
 		if err != nil {
 			level.Error(logger).Log("msg", "error marking block compacted", "block", block.BlockID, "err", err)
 		}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -104,7 +104,8 @@ var cli struct {
 }
 
 func main() {
-	ctx := kong.Parse(&cli,
+	ctx := kong.Parse(
+		&cli,
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{
 			Compact: true,

--- a/cmd/tempo-cli/shared.go
+++ b/cmd/tempo-cli/shared.go
@@ -113,14 +113,14 @@ func loadBlock(r backend.Reader, c backend.Compactor, tenantID string, id backen
 		fmt.Print(strconv.Itoa(blockNum))
 	}
 
-	meta, err := r.BlockMeta(context.Background(), (uuid.UUID)(id), tenantID)
+	meta, err := r.BlockMeta(context.Background(), uuid.UUID(id), tenantID)
 	if errors.Is(err, backend.ErrDoesNotExist) && !includeCompacted {
 		return nil, nil
 	} else if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, err
 	}
 
-	compactedMeta, err := c.CompactedBlockMeta((uuid.UUID)(id), tenantID)
+	compactedMeta, err := c.CompactedBlockMeta(uuid.UUID(id), tenantID)
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, err
 	}

--- a/cmd/tempo-vulture/main.go
+++ b/cmd/tempo-vulture/main.go
@@ -361,7 +361,8 @@ func queueFutureBatches(client util.JaegerClient, info *util.TraceInfo, config v
 
 		err := info.EmitBatches(context.Background(), client)
 		if err != nil {
-			logger.Error("failed to queue batches",
+			logger.Error(
+				"failed to queue batches",
 				zap.Error(err),
 			)
 		}
@@ -410,7 +411,8 @@ func doRead(httpClient httpclient.TempoHTTPClient, _ vultureConfiguration, info 
 	queryMetrics, err := queryTrace(httpClient, info, l)
 	if err != nil {
 		metricErrorTotal.Inc()
-		logger.Error("query for metrics failed",
+		logger.Error(
+			"query for metrics failed",
 			zap.Error(err),
 		)
 	}
@@ -422,7 +424,8 @@ func doSearch(httpClient httpclient.TempoHTTPClient, config vultureConfiguration
 	searchMetrics, err := searchTag(httpClient, info.Timestamp(), config, l)
 	if err != nil {
 		metricErrorTotal.Inc()
-		logger.Error("search tag for metrics failed",
+		logger.Error(
+			"search tag for metrics failed",
 			zap.Error(err),
 		)
 	}
@@ -432,7 +435,8 @@ func doSearch(httpClient httpclient.TempoHTTPClient, config vultureConfiguration
 	traceqlSearchMetrics, err := searchTraceql(httpClient, info.Timestamp(), config, l)
 	if err != nil {
 		metricErrorTotal.Inc()
-		logger.Error("traceql query for metrics failed",
+		logger.Error(
+			"traceql query for metrics failed",
 			zap.Error(err),
 		)
 	}
@@ -651,7 +655,8 @@ func queryTrace(client httpclient.TempoHTTPClient, info *util.TraceInfo, l *zap.
 		tm.incorrectResult++
 		if diff := deep.Equal(expected, trace); diff != nil {
 			for _, d := range diff {
-				logger.Error("incorrect result",
+				logger.Error(
+					"incorrect result",
 					zap.String("expected -> response", d),
 				)
 			}

--- a/cmd/tempo-vulture/validation.go
+++ b/cmd/tempo-vulture/validation.go
@@ -46,7 +46,8 @@ func RunValidationMode(
 		os.Exit(1)
 	}
 
-	logger.Info("Running in validation mode",
+	logger.Info(
+		"Running in validation mode",
 		zap.Int("cycles", validationCycles),
 		zap.Duration("timeout", validationTimeout),
 		zap.String("org_id", vultureConfig.tempoOrgID),
@@ -65,7 +66,8 @@ func RunValidationMode(
 	result := service.RunValidation(ctx, authJaegerClient, httpClient, httpClient)
 
 	// Log detailed results before exiting
-	logger.Info("Validation completed",
+	logger.Info(
+		"Validation completed",
 		zap.Int("total_traces", result.TotalTraces),
 		zap.Int("validations_passed", result.SuccessCount),
 		zap.Int("validations_failed", len(result.Failures)),
@@ -74,7 +76,8 @@ func RunValidationMode(
 
 	// Optionally log each failure for debugging
 	for _, failure := range result.Failures {
-		logger.Error("validation failure",
+		logger.Error(
+			"validation failure",
 			zap.String("phase", failure.Phase),
 			zap.String("traceID", failure.TraceID),
 			zap.Int("cycle", failure.Cycle),
@@ -182,7 +185,7 @@ func (vs *ValidationService) RunValidation(
 				Timestamp: vs.clock.Now(),
 			})
 			result.Duration = vs.clock.Now().Sub(start)
-			result.SuccessCount = (result.TotalTraces) - len(result.Failures)
+			result.SuccessCount = result.TotalTraces - len(result.Failures)
 			return result
 		}
 		vs.logger.Info("Wrote trace", zap.String("id", trace.HexID()))
@@ -240,7 +243,7 @@ func (vs *ValidationService) RunValidation(
 	}
 
 	result.Duration = vs.clock.Now().Sub(start)
-	result.SuccessCount = (result.TotalTraces) - len(result.Failures) // update this to 2 validations per trace when we enable search
+	result.SuccessCount = result.TotalTraces - len(result.Failures) // update this to 2 validations per trace when we enable search
 	return result
 }
 
@@ -333,7 +336,8 @@ func (vs *ValidationService) validateTraceSearch(
 	}
 
 	searchQuery := fmt.Sprintf(`{.%s = "%s"}`, attr.Key, util.StringifyAnyValue(attr.Value))
-	vs.logger.Info("Searching for trace",
+	vs.logger.Info(
+		"Searching for trace",
 		zap.String("traceID", writtenTrace.HexID()),
 		zap.String("searchQuery", searchQuery),
 	)
@@ -346,7 +350,8 @@ func (vs *ValidationService) validateTraceSearch(
 		return fmt.Errorf("search API failed: %w", searchErr)
 	}
 
-	vs.logger.Info("Search response received",
+	vs.logger.Info(
+		"Search response received",
 		zap.Int("traces_found", len(searchResp.Traces)),
 	)
 
@@ -402,7 +407,8 @@ func (vs *ValidationService) logTraceAttributes(trace *tempopb.Trace, traceID st
 		vs.logger.Info("Resource attributes", zap.Int("resourceSpan", i))
 		if resourceSpan.Resource != nil {
 			for _, attr := range resourceSpan.Resource.Attributes {
-				vs.logger.Info("  Resource attr",
+				vs.logger.Info(
+					"  Resource attr",
 					zap.String("key", attr.Key),
 					zap.String("value", util.StringifyAnyValue(attr.Value)),
 				)
@@ -412,12 +418,14 @@ func (vs *ValidationService) logTraceAttributes(trace *tempopb.Trace, traceID st
 		for j, scopeSpan := range resourceSpan.ScopeSpans {
 			vs.logger.Info("Scope spans", zap.Int("scopeSpan", j))
 			for k, span := range scopeSpan.Spans {
-				vs.logger.Info("  Span",
+				vs.logger.Info(
+					"  Span",
 					zap.Int("spanIndex", k),
 					zap.String("name", span.Name),
 				)
 				for _, attr := range span.Attributes {
-					vs.logger.Info("    Span attr",
+					vs.logger.Info(
+						"    Span attr",
 						zap.String("key", attr.Key),
 						zap.String("value", util.StringifyAnyValue(attr.Value)),
 					)

--- a/cmd/tempo/app/modules.go
+++ b/cmd/tempo/app/modules.go
@@ -643,7 +643,8 @@ func (t *App) initStore() (services.Service, error) {
 func (t *App) initMemberlistKV() (services.Service, error) {
 	reg := prometheus.DefaultRegisterer
 	t.cfg.MemberlistKV.MetricsNamespace = metricsNamespace
-	t.cfg.MemberlistKV.Codecs = append(t.cfg.MemberlistKV.Codecs,
+	t.cfg.MemberlistKV.Codecs = append(
+		t.cfg.MemberlistKV.Codecs,
 		ring.GetCodec(),
 		ring.GetPartitionRingCodec(),
 		usagestats.JSONCodec,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo
 
-go 1.26.3
+go 1.26.5
 
 require (
 	cloud.google.com/go/storage v1.62.1

--- a/integration/api/query_range_test.go
+++ b/integration/api/query_range_test.go
@@ -71,26 +71,32 @@ func TestQueryRangeExemplars(t *testing.T) {
 		for {
 			select {
 			case <-ticker.C:
-				require.NoError(t, h.WriteJaegerBatch(
-					util.MakeThriftBatchWithSpanCountAttributeAndName(
-						1, "my operation",
-						"res_val", "span_val",
-						"res_attr", "span_attr",
-					), ""),
+				require.NoError(
+					t, h.WriteJaegerBatch(
+						util.MakeThriftBatchWithSpanCountAttributeAndName(
+							1, "my operation",
+							"res_val", "span_val",
+							"res_attr", "span_attr",
+						), "",
+					),
 				)
-				require.NoError(t, h.WriteJaegerBatch(
-					util.MakeThriftBatchWithSpanCountAttributeAndName(
-						1, "my operation",
-						"res_val2", "span_val2",
-						"res_attr", "span_attr",
-					), ""),
+				require.NoError(
+					t, h.WriteJaegerBatch(
+						util.MakeThriftBatchWithSpanCountAttributeAndName(
+							1, "my operation",
+							"res_val2", "span_val2",
+							"res_attr", "span_attr",
+						), "",
+					),
 				)
-				require.NoError(t, h.WriteJaegerBatch(
-					util.MakeThriftBatchWithSpanCountAttributeAndName(
-						1, "operation with high cardinality",
-						uuid.New().String(), uuid.New().String(),
-						"res_high_cardinality", "span_high_cardinality",
-					), ""),
+				require.NoError(
+					t, h.WriteJaegerBatch(
+						util.MakeThriftBatchWithSpanCountAttributeAndName(
+							1, "operation with high cardinality",
+							uuid.New().String(), uuid.New().String(),
+							"res_high_cardinality", "span_high_cardinality",
+						), "",
+					),
 				)
 				tracesSent += 3
 			case <-timer.C:

--- a/integration/limits/limits_test.go
+++ b/integration/limits/limits_test.go
@@ -71,19 +71,22 @@ func TestIngestionLimits(t *testing.T) {
 
 		// test limit metrics
 		liveStore := h.Services[util.ServiceLiveStoreZoneA]
-		err = liveStore.WaitSumMetricsWithOptions(e2e.Equals(2),
+		err = liveStore.WaitSumMetricsWithOptions(
+			e2e.Equals(2),
 			[]string{"tempo_discarded_spans_total"},
 			e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "trace_too_large")),
 			e2e.WaitMissingMetrics,
 		)
 		require.NoError(t, err)
-		err = liveStore.WaitSumMetricsWithOptions(e2e.Equals(1),
+		err = liveStore.WaitSumMetricsWithOptions(
+			e2e.Equals(1),
 			[]string{"tempo_discarded_spans_total"},
 			e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "live_traces_exceeded")),
 			e2e.WaitMissingMetrics,
 		)
 		require.NoError(t, err)
-		err = h.Services[util.ServiceDistributor].WaitSumMetricsWithOptions(e2e.Equals(10),
+		err = h.Services[util.ServiceDistributor].WaitSumMetricsWithOptions(
+			e2e.Equals(10),
 			[]string{"tempo_discarded_spans_total"},
 			e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "rate_limited")),
 			e2e.WaitMissingMetrics,
@@ -220,7 +223,8 @@ func TestQueryLimits(t *testing.T) {
 
 		// wait for live store to complete the block
 		liveStore := h.Services[util.ServiceLiveStoreZoneA]
-		err = liveStore.WaitSumMetricsWithOptions(e2e.Greater(0),
+		err = liveStore.WaitSumMetricsWithOptions(
+			e2e.Greater(0),
 			[]string{"tempo_live_store_blocks_completed_total"},
 			e2e.WaitMissingMetrics,
 		)
@@ -270,7 +274,8 @@ func TestLimitsPartialSuccess(t *testing.T) {
 		// test metrics
 		// 3 traces with trace_too_large each with 4+5+6 spans
 		liveStore := h.Services[util.ServiceLiveStoreZoneA]
-		err := liveStore.WaitSumMetricsWithOptions(e2e.Equals(15),
+		err := liveStore.WaitSumMetricsWithOptions(
+			e2e.Equals(15),
 			[]string{"tempo_discarded_spans_total"},
 			e2e.WithLabelMatchers(labels.MustNewMatcher(labels.MatchEqual, "reason", "trace_too_large")),
 			e2e.WaitMissingMetrics,

--- a/integration/operations/livestore_test.go
+++ b/integration/operations/livestore_test.go
@@ -331,7 +331,8 @@ func waitActivePartitions(t *testing.T, service *e2e.HTTPService, count int) {
 	require.NoError(t, service.WaitSumMetricsWithOptions(
 		e2e.Equals(float64(count)),
 		[]string{"tempo_partition_ring_partitions"},
-		e2e.WithLabelMatchers(matchers...)), "distributor failed to see the partition ring")
+		e2e.WithLabelMatchers(matchers...),
+	), "distributor failed to see the partition ring")
 }
 
 func newLiveStore(name string, zone string) *e2e.HTTPService {

--- a/integration/operations/operational_metrics_test.go
+++ b/integration/operations/operational_metrics_test.go
@@ -51,7 +51,8 @@ func TestWriteMetrics(t *testing.T) {
 		assertMetricEquals(t, livestore, "tempo_live_store_partition_owned", float64(1), nil)
 
 		// we may not have yet completed a block so wait for this one
-		err = livestore.WaitSumMetricsWithOptions(e2e.Greater(0),
+		err = livestore.WaitSumMetricsWithOptions(
+			e2e.Greater(0),
 			[]string{"tempo_live_store_blocks_completed_total"},
 			e2e.WaitMissingMetrics,
 		)

--- a/integration/storage/backend_scheduler_test.go
+++ b/integration/storage/backend_scheduler_test.go
@@ -111,7 +111,8 @@ func TestBackendScheduler(t *testing.T) {
 
 					t.Logf("Waiting for %d blocks in the blocklist for tenant: %s", expectedBlocks, tenantID)
 
-					require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Equals(float64(expectedBlocks)), []string{"tempodb_blocklist_length"},
+					require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+						e2e.Equals(float64(expectedBlocks)), []string{"tempodb_blocklist_length"},
 						e2e.WaitMissingMetrics,
 						tenantMatcher,
 						printMetricValue(t, fmt.Sprintf("%d", expectedBlocks), "tempodb_blocklist_length"),
@@ -173,7 +174,8 @@ func TestBackendScheduler(t *testing.T) {
 				tenantMatcher := e2e.WithLabelMatchers(&labels.Matcher{Type: labels.MatchEqual, Name: "tenant", Value: tenantID})
 
 				// We should have at least 1 block for each tenant
-				require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.GreaterOrEqual(1.0), []string{"tempodb_blocklist_length"},
+				require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+					e2e.GreaterOrEqual(1.0), []string{"tempodb_blocklist_length"},
 					e2e.WaitMissingMetrics,
 					tenantMatcher,
 					printMetricValue(t, fmt.Sprintf("%f+", 1.0), "tempodb_blocklist_length"),
@@ -215,7 +217,8 @@ func TestBackendScheduler(t *testing.T) {
 
 				t.Logf("Waiting for blocklist metric: %s: %d-%d", tenantID, expectedMin.blocks, expectedMax.blocks)
 
-				require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.blocks), float64(expectedMax.blocks)), []string{"tempodb_blocklist_length"},
+				require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+					e2e.Between(float64(expectedMin.blocks), float64(expectedMax.blocks)), []string{"tempodb_blocklist_length"},
 					e2e.WaitMissingMetrics,
 					tenantMatcher,
 					printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.blocks, expectedMax.blocks), "tempodb_blocklist_length"),
@@ -223,7 +226,8 @@ func TestBackendScheduler(t *testing.T) {
 
 				t.Logf("Waiting for outstanding blocks metric: %s: %d-%d", tenantID, expectedMin.outstanding, expectedMax.outstanding)
 
-				require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.outstanding), float64(expectedMax.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
+				require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+					e2e.Between(float64(expectedMin.outstanding), float64(expectedMax.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
 					e2e.WaitMissingMetrics,
 					tenantMatcher,
 					printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.outstanding, expectedMax.outstanding), "tempodb_compaction_outstanding_blocks"),
@@ -245,7 +249,8 @@ func TestBackendScheduler(t *testing.T) {
 
 				t.Logf("Waiting for blocklist metric: %s: %d-%d", tenantID, expectedMin.blocks, expectedMax.blocks)
 
-				require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.blocks), float64(expectedMax.blocks)), []string{"tempodb_blocklist_length"},
+				require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+					e2e.Between(float64(expectedMin.blocks), float64(expectedMax.blocks)), []string{"tempodb_blocklist_length"},
 					e2e.WaitMissingMetrics,
 					tenantMatcher,
 					printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.blocks, expectedMax.blocks), "tempodb_blocklist_length"),
@@ -253,7 +258,8 @@ func TestBackendScheduler(t *testing.T) {
 
 				t.Logf("Waiting for outstanding blocks metric: %s: %d-%d", tenantID, expectedMin.outstanding, expectedMax.outstanding)
 
-				require.NoError(t, scheduler.WaitSumMetricsWithOptions(e2e.Between(float64(expectedMin.outstanding), float64(expectedMax.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
+				require.NoError(t, scheduler.WaitSumMetricsWithOptions(
+					e2e.Between(float64(expectedMin.outstanding), float64(expectedMax.outstanding)), []string{"tempodb_compaction_outstanding_blocks"},
 					e2e.WaitMissingMetrics,
 					tenantMatcher,
 					printMetricValue(t, fmt.Sprintf("%d-%d", expectedMin.outstanding, expectedMax.outstanding), "tempodb_compaction_outstanding_blocks"),

--- a/integration/storage/poller_test.go
+++ b/integration/storage/poller_test.go
@@ -145,7 +145,7 @@ func TestPollerOwnership(t *testing.T) {
 
 					actual := []uuid.UUID{}
 					for _, m := range metas {
-						actual = append(actual, (uuid.UUID)(m.BlockID))
+						actual = append(actual, uuid.UUID(m.BlockID))
 					}
 
 					sort.Slice(actual, func(i, j int) bool { return actual[i].String() < actual[j].String() })
@@ -287,7 +287,7 @@ func TestTenantDeletion(t *testing.T) {
 
 func found(id uuid.UUID, blockMetas []*backend.BlockMeta) bool {
 	for _, b := range blockMetas {
-		if (uuid.UUID)(b.BlockID) == id {
+		if uuid.UUID(b.BlockID) == id {
 			return true
 		}
 	}
@@ -344,7 +344,8 @@ func writeBadBlockFiles(t *testing.T, ww backend.RawWriter, rr backend.RawReader
 		vparquet3.DataFileName,
 		backend.KeyPath([]string{tenant, uuid.New().String()}),
 		bytes.NewReader(token),
-		int64(len(token)), nil)
+		int64(len(token)), nil,
+	)
 
 	require.NoError(t, err)
 

--- a/integration/util/harness.go
+++ b/integration/util/harness.go
@@ -364,7 +364,8 @@ func (h *TempoHarness) WaitTracesWritable(t *testing.T) {
 	require.NoError(t, distributor.WaitSumMetricsWithOptions(
 		e2e.Equals(float64(1)),
 		[]string{"tempo_partition_ring_partitions"},
-		e2e.WithLabelMatchers(matchers...)), "distributor failed to see the partition ring")
+		e2e.WithLabelMatchers(matchers...),
+	), "distributor failed to see the partition ring")
 }
 
 func (h *TempoHarness) WaitTracesQueryable(t *testing.T, traces int) {
@@ -477,7 +478,8 @@ func (h *TempoHarness) startMicroservices(t *testing.T, config TestHarnessConfig
 	}
 
 	if config.Components&componentsDistributor != 0 {
-		h.Services[ServiceDistributor] = NewTempoService("distributor", "distributor",
+		h.Services[ServiceDistributor] = NewTempoService(
+			"distributor", "distributor",
 			readinessProbe,
 			[]int{14250, 4317, 4318, 9411}, // jaeger grpc ingest, otlp grpc, otlp http, zipkin ingest
 		)

--- a/modules/blockbuilder/blockbuilder.go
+++ b/modules/blockbuilder/blockbuilder.go
@@ -211,7 +211,8 @@ func (b *BlockBuilder) starting(ctx context.Context) (err error) {
 		b.logger,
 		b.cfg.IngestStorageConfig,
 		b.getAssignedPartitions,
-		b.kafkaClient.ForceMetadataRefresh)
+		b.kafkaClient.ForceMetadataRefresh,
+	)
 
 	return nil
 }
@@ -419,7 +420,8 @@ outer:
 					b.cfg.BlockConfig,
 					b.overrides,
 					b.wal,
-					b.enc)
+					b.enc,
+				)
 				init = true
 
 				// TODO(mapno): This call creates a link to the parent span in this trace.
@@ -447,9 +449,11 @@ outer:
 					"partition", ps.partition,
 					"timestamp", rec.Timestamp,
 				)
-				span.AddEvent("max bytes per cycle reached", trace.WithAttributes(
-					attribute.Int64("maxBytesPerCycle", int64(maxBytesPerCycle)),
-					attribute.Int64("consumedBytes", int64(consumedBytes))),
+				span.AddEvent(
+					"max bytes per cycle reached", trace.WithAttributes(
+						attribute.Int64("maxBytesPerCycle", int64(maxBytesPerCycle)),
+						attribute.Int64("consumedBytes", int64(consumedBytes)),
+					),
 				)
 				break outer
 			}

--- a/modules/blockbuilder/tenant_store.go
+++ b/modules/blockbuilder/tenant_store.go
@@ -122,7 +122,7 @@ func (s *tenantStore) Flush(ctx context.Context, r tempodb.Reader, w tempodb.Wri
 	}
 
 	// Initial meta for creating the block
-	meta := backend.NewBlockMeta(s.tenantID, (uuid.UUID)(blockID), s.enc.Version(), backend.EncNone, "")
+	meta := backend.NewBlockMeta(s.tenantID, uuid.UUID(blockID), s.enc.Version(), backend.EncNone, "")
 	meta.DedicatedColumns = s.overrides.DedicatedColumns(s.tenantID)
 	meta.ReplicationFactor = 1
 	meta.TotalObjects = int64(s.liveTraces.Len())
@@ -166,7 +166,7 @@ func (s *tenantStore) Flush(ctx context.Context, r tempodb.Reader, w tempodb.Wri
 
 	metricBlockBuilderFlushedBlocks.WithLabelValues(s.tenantID).Inc()
 
-	if err := s.wal.LocalBackend().ClearBlock((uuid.UUID)(newMeta.BlockID), s.tenantID); err != nil {
+	if err := s.wal.LocalBackend().ClearBlock(uuid.UUID(newMeta.BlockID), s.tenantID); err != nil {
 		return err
 	}
 	span.AddEvent("cleared block from wal", trace.WithAttributes(attribute.String("block_id", newMeta.BlockID.String())))

--- a/modules/blockbuilder/writeable_block.go
+++ b/modules/blockbuilder/writeable_block.go
@@ -61,7 +61,7 @@ func (b *WriteableBlock) setFlushed(ctx context.Context) error {
 		return fmt.Errorf("error marshalling flush time to text: %w", err)
 	}
 
-	err = b.writer.Write(ctx, nameFlushed, (uuid.UUID)(b.BlockMeta().BlockID), b.BlockMeta().TenantID, flushedBytes, nil)
+	err = b.writer.Write(ctx, nameFlushed, uuid.UUID(b.BlockMeta().BlockID), b.BlockMeta().TenantID, flushedBytes, nil)
 	if err != nil {
 		return fmt.Errorf("error writing ingester block flushed file: %w", err)
 	}

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -994,7 +994,8 @@ func logSpans(batches []*v1.ResourceSpans, cfg *LogSpansConfig, logger log.Logge
 				loggerWithAtts = log.With(
 					loggerWithAtts,
 					"span_"+strutil.SanitizeLabelName(a.GetKey()),
-					util.StringifyAnyValue(a.GetValue()))
+					util.StringifyAnyValue(a.GetValue()),
+				)
 			}
 		}
 
@@ -1016,7 +1017,8 @@ func logSpan(s *v1.Span, allAttributes bool, logger log.Logger) {
 			logger = log.With(
 				logger,
 				"span_"+strutil.SanitizeLabelName(a.GetKey()),
-				util.StringifyAnyValue(a.GetValue()))
+				util.StringifyAnyValue(a.GetValue()),
+			)
 		}
 
 		latencySeconds := float64(s.GetEndTimeUnixNano()-s.GetStartTimeUnixNano()) / float64(time.Second.Nanoseconds())
@@ -1025,7 +1027,8 @@ func logSpan(s *v1.Span, allAttributes bool, logger log.Logger) {
 			"span_name", s.Name,
 			"span_duration_seconds", latencySeconds,
 			"span_kind", s.GetKind().String(),
-			"span_status", s.GetStatus().GetCode().String())
+			"span_status", s.GetStatus().GetCode().String(),
+		)
 	}
 
 	level.Info(logger).Log("spanid", hex.EncodeToString(s.SpanId), "traceid", hex.EncodeToString(s.TraceId))

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -975,23 +975,28 @@ func TestProcessAttributes(t *testing.T) {
 	longString := strings.Repeat("t", 1100)
 
 	// add long attributes to the resource level
-	trace.ResourceSpans[0].Resource.Attributes = append(trace.ResourceSpans[0].Resource.Attributes,
+	trace.ResourceSpans[0].Resource.Attributes = append(
+		trace.ResourceSpans[0].Resource.Attributes,
 		test.MakeAttribute("long value", longString),
 	)
-	trace.ResourceSpans[0].Resource.Attributes = append(trace.ResourceSpans[0].Resource.Attributes,
+	trace.ResourceSpans[0].Resource.Attributes = append(
+		trace.ResourceSpans[0].Resource.Attributes,
 		test.MakeAttribute(longString, "long key"),
 	)
 
 	// add long attributes to the span level
-	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes = append(trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes,
+	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes = append(
+		trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes,
 		test.MakeAttribute("long value", longString),
 	)
-	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes = append(trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes,
+	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes = append(
+		trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Attributes,
 		test.MakeAttribute(longString, "long key"),
 	)
 
 	// add long attributes to the event level
-	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Events = append(trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Events,
+	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Events = append(
+		trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Events,
 		&v1.Span_Event{
 			TimeUnixNano: 0,
 			Attributes: []*v1_common.KeyValue{
@@ -1002,7 +1007,8 @@ func TestProcessAttributes(t *testing.T) {
 	)
 
 	// add long attributes to the link level
-	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Links = append(trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Links,
+	trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Links = append(
+		trace.ResourceSpans[0].ScopeSpans[0].Spans[0].Links,
 		&v1.Span_Link{
 			TraceId: []byte{0x0A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
 			SpanId:  []byte{0x0A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
@@ -1164,7 +1170,8 @@ func TestLogReceivedSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil),
+					),
 				}),
 			},
 			expectedLogsSpan: []testLogSpan{},
@@ -1176,13 +1183,16 @@ func TestLogReceivedSpans(t *testing.T) {
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
 						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil),
-						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", nil)),
+						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", nil),
+					),
 					makeScope(
-						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
+						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil),
+					),
 				}),
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", nil)),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", nil),
+					),
 				}),
 			},
 			expectedLogsSpan: []testLogSpan{
@@ -1219,13 +1229,16 @@ func TestLogReceivedSpans(t *testing.T) {
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
 						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil),
-						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR}),
+					),
 					makeScope(
-						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
+						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil),
+					),
 				}),
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR}),
+					),
 				}),
 			},
 			expectedLogsSpan: []testLogSpan{
@@ -1254,13 +1267,16 @@ func TestLogReceivedSpans(t *testing.T) {
 							makeAttribute("tag1", "value1")),
 						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR},
 							makeAttribute("tag1", "value1"),
-							makeAttribute("tag2", "value2"))),
+							makeAttribute("tag2", "value2")),
+					),
 					makeScope(
-						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
+						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil),
+					),
 				}, makeAttribute("resource_attribute1", "value1")),
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR}),
+					),
 				}, makeAttribute("resource_attribute2", "value2")),
 			},
 			expectedLogsSpan: []testLogSpan{
@@ -1297,7 +1313,8 @@ func TestLogReceivedSpans(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil, makeAttribute("tag1", "value1"))),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil, makeAttribute("tag1", "value1")),
+					),
 				}),
 			},
 			expectedLogsSpan: []testLogSpan{
@@ -1353,7 +1370,8 @@ func TestLogDiscardedSpansWhenContextCancelled(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil),
+					),
 				}),
 			},
 			expectedLogsSpan: []testLogSpan{},
@@ -1363,7 +1381,8 @@ func TestLogDiscardedSpansWhenContextCancelled(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil),
+					),
 				}),
 			},
 			expectedLogsSpan: []testLogSpan{
@@ -1382,7 +1401,8 @@ func TestLogDiscardedSpansWhenContextCancelled(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR}),
+					),
 				}, makeAttribute("resource_attribute2", "value2")),
 			},
 			expectedLogsSpan: []testLogSpan{
@@ -1407,13 +1427,16 @@ func TestLogDiscardedSpansWhenContextCancelled(t *testing.T) {
 				makeResourceSpans("test-service", []*v1.ScopeSpans{
 					makeScope(
 						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil),
-						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR}),
+					),
 					makeScope(
-						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
+						makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil),
+					),
 				}),
 				makeResourceSpans("test-service2", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+						makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR}),
+					),
 				}),
 			},
 			expectedLogsSpan: []testLogSpan{
@@ -1475,7 +1498,8 @@ func TestLogDiscardedSpansWhenPushToIngesterFails(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil),
+					),
 				}),
 			},
 			pushErrorByTrace: []tempopb.PushErrorReason{traceTooLargeError},
@@ -1486,7 +1510,8 @@ func TestLogDiscardedSpansWhenPushToIngesterFails(t *testing.T) {
 			batches: []*v1.ResourceSpans{
 				makeResourceSpans("test", []*v1.ScopeSpans{
 					makeScope(
-						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil)),
+						makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span", nil),
+					),
 				}),
 			},
 			pushErrorByTrace: []tempopb.PushErrorReason{traceTooLargeError},
@@ -1567,13 +1592,16 @@ func TestRateLimitRespected(t *testing.T) {
 					makeAttribute("tag1", "value1")),
 				makeSpan("e3210a2b38097332d1fe43083ea93d29", "6c21c48da4dbd1a7", "Test Span2", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR},
 					makeAttribute("tag1", "value1"),
-					makeAttribute("tag2", "value2"))),
+					makeAttribute("tag2", "value2")),
+			),
 			makeScope(
-				makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
+				makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil),
+			),
 		}, makeAttribute("resource_attribute1", "value1")),
 		makeResourceSpans("test-service2", []*v1.ScopeSpans{
 			makeScope(
-				makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR})),
+				makeSpan("b1c792dea27d511c145df8402bdd793a", "56afb9fe18b6c2d6", "Test Span", &v1.Status{Code: v1.Status_STATUS_CODE_ERROR}),
+			),
 		}, makeAttribute("resource_attribute2", "value2")),
 	}
 	traces := batchesToTraces(t, batches)
@@ -1978,9 +2006,11 @@ func TestArtificialLatency(t *testing.T) {
 	batches := []*v1.ResourceSpans{
 		makeResourceSpans("test-service", []*v1.ScopeSpans{
 			makeScope(
-				makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil)),
+				makeSpan("0a0102030405060708090a0b0c0d0e0f", "dad44adc9a83b370", "Test Span1", nil),
+			),
 			makeScope(
-				makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil)),
+				makeSpan("bb42ec04df789ff04b10ea5274491685", "1b3a296034f4031e", "Test Span3", nil),
+			),
 		}),
 	}
 

--- a/modules/distributor/forwarder/manager.go
+++ b/modules/distributor/forwarder/manager.go
@@ -26,7 +26,7 @@ type Overrides interface {
 	Forwarders(tenantID string) []string
 }
 
-var _ Overrides = (overrides.Interface)(nil)
+var _ Overrides = overrides.Interface(nil)
 
 type Manager struct {
 	services.Service

--- a/modules/frontend/frontend.go
+++ b/modules/frontend/frontend.go
@@ -150,7 +150,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			newAsyncTraceIDSharder(&cfg.TraceByID, logger),
 		},
 		[]pipeline.Middleware{traceIDStatusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	searchPipeline := pipeline.Build(
 		[]pipeline.AsyncMiddleware[combiner.PipelineResponse]{
@@ -164,7 +165,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			newAsyncSearchSharder(reader, o, cfg.Search.Sharder, logger),
 		},
 		[]pipeline.Middleware{cacheWare, statusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	searchTagsPipeline := pipeline.Build(
 		[]pipeline.AsyncMiddleware[combiner.PipelineResponse]{
@@ -177,7 +179,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			newAsyncTagSharder(reader, o, cfg.Search.Sharder, parseTagsRequest, logger),
 		},
 		[]pipeline.Middleware{cacheWare, statusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	searchTagValuesPipeline := pipeline.Build(
 		[]pipeline.AsyncMiddleware[combiner.PipelineResponse]{
@@ -190,7 +193,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			newAsyncTagSharder(reader, o, cfg.Search.Sharder, parseTagValuesRequest, logger),
 		},
 		[]pipeline.Middleware{cacheWare, statusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	searchTagValuesV2Pipeline := pipeline.Build(
 		[]pipeline.AsyncMiddleware[combiner.PipelineResponse]{
@@ -203,7 +207,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			newAsyncTagSharder(reader, o, cfg.Search.Sharder, parseTagValuesRequestV2, logger),
 		},
 		[]pipeline.Middleware{cacheWare, statusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	// metrics summary
 	metricsPipeline := pipeline.Build(
@@ -216,7 +221,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			tenantValidatorWare,
 		},
 		[]pipeline.Middleware{statusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	// traceql metrics
 	queryRangePipeline := pipeline.Build(
@@ -233,7 +239,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			newAsyncQueryRangeSharder(reader, o, cfg.Metrics.Sharder, false, logger),
 		},
 		[]pipeline.Middleware{cacheWare, statusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	queryInstantPipeline := pipeline.Build(
 		[]pipeline.AsyncMiddleware[combiner.PipelineResponse]{
@@ -247,7 +254,8 @@ func New(cfg Config, next pipeline.RoundTripper, o overrides.Interface, reader t
 			newAsyncQueryRangeSharder(reader, o, cfg.Metrics.Sharder, true, logger),
 		},
 		[]pipeline.Middleware{cacheWare, statusCodeWare, retryWare},
-		next)
+		next,
+	)
 
 	traces := newTraceIDHandler(cfg, tracePipeline, o, combiner.NewTypedTraceByID, logger, dataAccessController)
 	tracesV2 := newTraceIDV2Handler(cfg, tracePipeline, o, combiner.NewTypedTraceByIDV2, logger, dataAccessController)
@@ -354,7 +362,8 @@ func newMetricsSummaryHandler(next pipeline.AsyncRoundTripper[combiner.PipelineR
 		level.Info(logger).Log(
 			"msg", "metrics summary request",
 			"tenant", tenant,
-			"path", req.URL.Path)
+			"path", req.URL.Path,
+		)
 
 		resps, err := next.RoundTrip(pipeline.NewHTTPRequest(req))
 		if err != nil {
@@ -367,7 +376,8 @@ func newMetricsSummaryHandler(next pipeline.AsyncRoundTripper[combiner.PipelineR
 			"msg", "metrics summary response",
 			"tenant", tenant,
 			"path", req.URL.Path,
-			"err", err)
+			"err", err,
+		)
 
 		return resp.HTTPResponse(), err
 	})

--- a/modules/frontend/mcp.go
+++ b/modules/frontend/mcp.go
@@ -202,31 +202,39 @@ func (s *MCPServer) setupResources() {
 // setupTools registers MCP tools for trace operations
 func (s *MCPServer) setupTools() {
 	// api tools
-	searchTool := newReadOnlyTool(toolTraceQLSearch,
+	searchTool := newReadOnlyTool(
+		toolTraceQLSearch,
 		mcp.WithDescription("Search for traces using TraceQL queries"),
-		mcp.WithString("query",
+		mcp.WithString(
+			"query",
 			mcp.Required(),
 			mcp.Description("TraceQL query string"),
 		),
-		mcp.WithString("start",
+		mcp.WithString(
+			"start",
 			mcp.Description("Start time for the search (RFC3339 format). If not provided will search the past 1 hour. If provided, must be before end."),
 		),
-		mcp.WithString("end",
+		mcp.WithString(
+			"end",
 			mcp.Description("End time for the search (RFC3339 format). If not provided will search the past 1 hour. If provided, must be after start."),
 		),
 	)
 	s.mcpServer.AddTool(searchTool, s.handleSearch)
 
-	instantQueryTool := newReadOnlyTool(toolTraceQLMetricsInstant,
+	instantQueryTool := newReadOnlyTool(
+		toolTraceQLMetricsInstant,
 		mcp.WithDescription("Retrieve a single metric value given a TraceQL metrics query. The value is at the current instant or end. Most metrics questions can be answered with instant values."),
-		mcp.WithString("query",
+		mcp.WithString(
+			"query",
 			mcp.Required(),
 			mcp.Description("TraceQL query string."),
 		),
-		mcp.WithString("start",
+		mcp.WithString(
+			"start",
 			mcp.Description("Start time for the search (RFC3339 format). If not provided will search the past 1 hour. If provided, must be before end."),
 		),
-		mcp.WithString("end",
+		mcp.WithString(
+			"end",
 			mcp.Description("End time for the search (RFC3339 format). If not provided will search the past 1 hour. If provided, must be after start."),
 		),
 		mcp.WithDestructiveHintAnnotation(false),
@@ -234,25 +242,31 @@ func (s *MCPServer) setupTools() {
 	s.mcpServer.AddTool(instantQueryTool, s.handleInstantQuery)
 
 	// TODO: should we even expose this? the LLM would be better at using the instant query tool and giving accurate answers.
-	rangeQueryTool := newReadOnlyTool(toolTraceQLMetricsRange,
+	rangeQueryTool := newReadOnlyTool(
+		toolTraceQLMetricsRange,
 		mcp.WithDescription("Retrieve a metric series given a TraceQL metrics query. The series ranges from start to end."),
-		mcp.WithString("query",
+		mcp.WithString(
+			"query",
 			mcp.Required(),
 			mcp.Description("TraceQL metrics query string."),
 		),
-		mcp.WithString("start",
+		mcp.WithString(
+			"start",
 			mcp.Description("Start time for the search (RFC3339 format). If not provided will search the past 1 hour. If provided, must be before end."),
 		),
-		mcp.WithString("end",
+		mcp.WithString(
+			"end",
 			mcp.Description("End time for the search (RFC3339 format). If not provided will search the past 1 hour. If provided, must be after start."),
 		),
 		mcp.WithDestructiveHintAnnotation(false),
 	)
 	s.mcpServer.AddTool(rangeQueryTool, s.handleRangeQuery)
 
-	traceTool := newReadOnlyTool(toolGetTrace,
+	traceTool := newReadOnlyTool(
+		toolGetTrace,
 		mcp.WithDescription("Retrieve a specific trace by ID"),
-		mcp.WithString("trace_id",
+		mcp.WithString(
+			"trace_id",
 			mcp.Required(),
 			mcp.Description("Trace ID to retrieve"),
 		),
@@ -260,22 +274,27 @@ func (s *MCPServer) setupTools() {
 	)
 	s.mcpServer.AddTool(traceTool, s.handleGetTrace)
 
-	attributeNamesTool := newReadOnlyTool(toolGetAttributeNames,
+	attributeNamesTool := newReadOnlyTool(
+		toolGetAttributeNames,
 		mcp.WithDescription("Get a list of available attribute names that can be used in TraceQL queries. This is useful for finding the names of attributes that can be used in a query."),
-		mcp.WithString("scope",
+		mcp.WithString(
+			"scope",
 			mcp.Description("Optional scope to filter attributes by (span, resource, event, link, instrumentation). If not provided, returns all attributes."),
 		),
 		mcp.WithDestructiveHintAnnotation(false),
 	)
 	s.mcpServer.AddTool(attributeNamesTool, s.handleGetAttributeNames)
 
-	attributeValuesTool := newReadOnlyTool(toolGetAttributeValues,
+	attributeValuesTool := newReadOnlyTool(
+		toolGetAttributeValues,
 		mcp.WithDescription("Get a list of values for a fully scoped attribute name. This is useful for finding the values of a specific attribute. i.e. you can find all the services in the data by asking for resource.service.name"),
-		mcp.WithString("name",
+		mcp.WithString(
+			"name",
 			mcp.Required(),
 			mcp.Description("The attribute name to get values for (e.g. 'span.http.method', 'resource.service.name')"),
 		),
-		mcp.WithString("filter-query",
+		mcp.WithString(
+			"filter-query",
 			mcp.Description("Filter query to apply to the attribute values. It can only have one spanset and only &&'ed conditions like { <cond> && <cond> && ... }.This is useful for filtering the values to a specific set of values. i.e. you can find all endpoints for a given service by asking for span.http.endpoint and filtering resource.service.name."),
 		),
 		mcp.WithDestructiveHintAnnotation(false),
@@ -285,9 +304,11 @@ func (s *MCPServer) setupTools() {
 
 	// docs tools - these are defined as tools as well as resources b/c claude code never asks for resources but it will nicely
 	// request the content from these docs tools.
-	traceQLDocs := newReadOnlyTool(toolDocsTraceQL,
+	traceQLDocs := newReadOnlyTool(
+		toolDocsTraceQL,
 		mcp.WithDescription(docsTraceQLQueryDescription),
-		mcp.WithString("name",
+		mcp.WithString(
+			"name",
 			mcp.Required(),
 			mcp.Description("The type of TraceQL documentation to retrieve"),
 			mcp.Enum(frontendDocs.DocsTypeBasic, frontendDocs.DocsTypeAggregates, frontendDocs.DocsTypeStructural, frontendDocs.DocsTypeMetrics),

--- a/modules/frontend/metrics_query_handler.go
+++ b/modules/frontend/metrics_query_handler.go
@@ -207,7 +207,8 @@ func logQueryInstantResult(logger log.Logger, tenantID string, durationSeconds f
 			"msg", "query instant results - no resp",
 			"tenant", tenantID,
 			"duration_seconds", durationSeconds,
-			"error", err)
+			"error", err,
+		)
 
 		return
 	}
@@ -219,7 +220,8 @@ func logQueryInstantResult(logger log.Logger, tenantID string, durationSeconds f
 			"query", req.Query,
 			"range_nanos", req.End-req.Start,
 			"duration_seconds", durationSeconds,
-			"error", err)
+			"error", err,
+		)
 		return
 	}
 
@@ -240,7 +242,8 @@ func logQueryInstantResult(logger log.Logger, tenantID string, durationSeconds f
 		"partial_status", resp.Status,
 		"partial_message", resp.Message,
 		"num_response_series", len(resp.Series),
-		"error", err)
+		"error", err,
+	)
 }
 
 func logQueryInstantRequest(logger log.Logger, tenantID string, req *tempopb.QueryInstantRequest) {
@@ -248,5 +251,6 @@ func logQueryInstantRequest(logger log.Logger, tenantID string, req *tempopb.Que
 		"msg", "query instant request",
 		"tenant", tenantID,
 		"query", req.Query,
-		"range_seconds", req.End-req.Start)
+		"range_seconds", req.End-req.Start,
+	)
 }

--- a/modules/frontend/metrics_query_range_handler.go
+++ b/modules/frontend/metrics_query_range_handler.go
@@ -209,7 +209,8 @@ func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds flo
 			"msg", "query range response - no resp",
 			"tenant", tenantID,
 			"duration_seconds", durationSeconds,
-			"error", err)
+			"error", err,
+		)
 
 		return
 	}
@@ -221,7 +222,8 @@ func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds flo
 			"query", req.Query,
 			"range_nanos", req.End-req.Start,
 			"duration_seconds", durationSeconds,
-			"error", err)
+			"error", err,
+		)
 		return
 	}
 
@@ -243,7 +245,8 @@ func logQueryRangeResult(logger log.Logger, tenantID string, durationSeconds flo
 		"partial_status", resp.Status,
 		"partial_message", resp.Message,
 		"num_response_series", len(resp.Series),
-		"error", err)
+		"error", err,
+	)
 }
 
 func logQueryRangeRequest(logger log.Logger, tenantID string, req *tempopb.QueryRangeRequest) {
@@ -253,7 +256,8 @@ func logQueryRangeRequest(logger log.Logger, tenantID string, req *tempopb.Query
 		"query", req.Query,
 		"range_nanos", req.End-req.Start,
 		"mode", req.QueryMode,
-		"step", req.Step)
+		"step", req.Step,
+	)
 }
 
 func httpInvalidRequest(err error) *http.Response {

--- a/modules/frontend/search_handlers.go
+++ b/modules/frontend/search_handlers.go
@@ -185,7 +185,8 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 			"tenant", tenantID,
 			"duration_seconds", durationSeconds,
 			"status_code", statusCode,
-			"error", err)
+			"error", err,
+		)
 
 		return
 	}
@@ -198,7 +199,8 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 			"range_seconds", req.End-req.Start,
 			"duration_seconds", durationSeconds,
 			"status_code", statusCode,
-			"error", err)
+			"error", err,
+		)
 		return
 	}
 
@@ -217,7 +219,8 @@ func logResult(logger log.Logger, tenantID string, durationSeconds float64, req 
 		"inspected_traces", resp.Metrics.InspectedTraces,
 		"inspected_spans", resp.Metrics.InspectedSpans,
 		"status_code", statusCode,
-		"error", err)
+		"error", err,
+	)
 }
 
 func logRequest(logger log.Logger, tenantID string, req *tempopb.SearchRequest) {
@@ -227,5 +230,6 @@ func logRequest(logger log.Logger, tenantID string, req *tempopb.SearchRequest) 
 		"query", req.Query,
 		"range_seconds", req.End-req.Start,
 		"limit", req.Limit,
-		"spans_per_spanset", req.SpansPerSpanSet)
+		"spans_per_spanset", req.SpansPerSpanSet,
+	)
 }

--- a/modules/frontend/tag_handlers.go
+++ b/modules/frontend/tag_handlers.go
@@ -520,7 +520,8 @@ func logTagsRequest(logger log.Logger, tenantID, handler, scope string, rangeSec
 		"tenant", tenantID,
 		"handler", handler,
 		"scope", scope,
-		"range_seconds", rangeSeconds)
+		"range_seconds", rangeSeconds,
+	)
 }
 
 func logTagsResult(logger log.Logger, tenantID, handler, scope string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
@@ -533,7 +534,8 @@ func logTagsResult(logger log.Logger, tenantID, handler, scope string, rangeSeco
 		"duration_seconds", durationSeconds,
 		"inspected_bytes", inspectedBytes,
 		"request_throughput", float64(inspectedBytes)/durationSeconds,
-		"error", err)
+		"error", err,
+	)
 }
 
 func logTagValuesRequest(logger log.Logger, tenantID, handler, tagName, query string, rangeSeconds uint32) {
@@ -543,7 +545,8 @@ func logTagValuesRequest(logger log.Logger, tenantID, handler, tagName, query st
 		"handler", handler,
 		"tag", tagName,
 		"query", query,
-		"range_seconds", rangeSeconds)
+		"range_seconds", rangeSeconds,
+	)
 }
 
 func logTagValuesResult(logger log.Logger, tenantID, handler, tagName, query string, rangeSeconds uint32, durationSeconds float64, inspectedBytes uint64, err error) {
@@ -557,7 +560,8 @@ func logTagValuesResult(logger log.Logger, tenantID, handler, tagName, query str
 		"duration_seconds", durationSeconds,
 		"inspected_bytes", inspectedBytes,
 		"request_throughput", float64(inspectedBytes)/durationSeconds,
-		"error", err)
+		"error", err,
+	)
 }
 
 // parseParams parses optional 'start', 'end', 'scope', and 'q' params from a http.Request

--- a/modules/frontend/traceid_handlers.go
+++ b/modules/frontend/traceid_handlers.go
@@ -44,7 +44,8 @@ func newTraceIDHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pipe
 		level.Info(logger).Log(
 			"msg", "trace id request",
 			"tenant", tenant,
-			"path", req.URL.Path)
+			"path", req.URL.Path,
+		)
 
 		var traceRedactor combiner.TraceRedactor
 		if dataAccessController != nil {
@@ -75,7 +76,8 @@ func newTraceIDHandler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pipe
 			"duration_seconds", elapsed.Seconds(),
 			"inspected_bytes", inspectBytes,
 			"request_throughput", float64(inspectBytes)/elapsed.Seconds(),
-			"err", err)
+			"err", err,
+		)
 
 		return resp, err
 	})
@@ -112,7 +114,8 @@ func newTraceIDV2Handler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pi
 		level.Info(logger).Log(
 			"msg", "trace id request",
 			"tenant", tenant,
-			"path", req.URL.Path)
+			"path", req.URL.Path,
+		)
 
 		var traceRedactor combiner.TraceRedactor
 		if dataAccessController != nil {
@@ -145,7 +148,8 @@ func newTraceIDV2Handler(cfg Config, next pipeline.AsyncRoundTripper[combiner.Pi
 			"inspected_bytes", bytesProcessed,
 			"request_throughput", float64(bytesProcessed)/elapsed.Seconds(),
 			"duration_seconds", elapsed.Seconds(),
-			"err", err)
+			"err", err,
+		)
 
 		return resp, err
 	})

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -167,7 +167,7 @@ func (i *instance) watchOverrides() {
 func (i *instance) updateSubprocessors(desiredProcessors map[string]struct{}, desiredCfg ProcessorConfig) (map[string]struct{}, ProcessorConfig) {
 	desiredProcessorsFound := false
 	for d := range desiredProcessors {
-		if (d == processor.SpanMetricsName) || (spanmetrics.ParseSubprocessor(d)) {
+		if (d == processor.SpanMetricsName) || spanmetrics.ParseSubprocessor(d) {
 			desiredProcessorsFound = true
 		}
 	}

--- a/modules/generator/overrides.go
+++ b/modules/generator/overrides.go
@@ -47,4 +47,4 @@ type metricsGeneratorOverrides interface {
 	UnsafeQueryHints(userID string) bool
 }
 
-var _ metricsGeneratorOverrides = (overrides.Interface)(nil)
+var _ metricsGeneratorOverrides = overrides.Interface(nil)

--- a/modules/generator/processor/localblocks/processor.go
+++ b/modules/generator/processor/localblocks/processor.go
@@ -457,7 +457,7 @@ func (p *Processor) completeBlock(id uuid.UUID) error {
 
 	// Queue for flushing
 	if p.Cfg.FlushToStorage {
-		if _, err := p.flushqueue.Enqueue(newFlushOp((uuid.UUID)(newMeta.BlockID))); err != nil {
+		if _, err := p.flushqueue.Enqueue(newFlushOp(uuid.UUID(newMeta.BlockID))); err != nil {
 			_ = level.Error(p.logger).Log("msg", "local blocks processor failed to enqueue block for flushing", "err", err)
 		}
 	}
@@ -466,7 +466,7 @@ func (p *Processor) completeBlock(id uuid.UUID) error {
 	if err != nil {
 		return err
 	}
-	delete(p.walBlocks, (uuid.UUID)(b.BlockMeta().BlockID))
+	delete(p.walBlocks, uuid.UUID(b.BlockMeta().BlockID))
 
 	return nil
 }
@@ -781,7 +781,7 @@ func (p *Processor) cutBlocks(immediate bool) error {
 		return fmt.Errorf("failed to flush head block: %w", err)
 	}
 
-	id := (uuid.UUID)(p.headBlock.BlockMeta().BlockID)
+	id := uuid.UUID(p.headBlock.BlockMeta().BlockID)
 	p.walBlocks[id] = p.headBlock
 	metricCutBlocks.WithLabelValues(p.tenant).Inc()
 
@@ -825,7 +825,7 @@ func (p *Processor) reloadBlocks() error {
 		meta := blk.BlockMeta()
 		if meta.TenantID == p.tenant {
 			level.Info(p.logger).Log("msg", "reloading wal block", "block", meta.BlockID.String())
-			p.walBlocks[(uuid.UUID)(meta.BlockID)] = blk
+			p.walBlocks[uuid.UUID(meta.BlockID)] = blk
 
 			level.Info(p.logger).Log("msg", "queueing replayed wal block for completion", "block", meta.BlockID.String())
 			if err := enqueueCompleteOp(p.ctx, p, uuid.UUID(meta.BlockID)); err != nil {

--- a/modules/generator/processor/localblocks/processor_test.go
+++ b/modules/generator/processor/localblocks/processor_test.go
@@ -296,7 +296,8 @@ func TestBadBlocks(t *testing.T) {
 	u1 := uuid.New().String()
 
 	// Write some bad wal data
-	writeBadJSON(t,
+	writeBadJSON(
+		t,
 		filepath.Join(
 			wal.GetFilepath(),
 			u1+"+test-tenant+"+vparquet3.VersionString,
@@ -304,7 +305,8 @@ func TestBadBlocks(t *testing.T) {
 		),
 	)
 
-	writeBadJSON(t,
+	writeBadJSON(
+		t,
 		filepath.Join(
 			wal.GetFilepath(),
 			u1+"+test-tenant+"+vparquet3.VersionString,
@@ -312,7 +314,8 @@ func TestBadBlocks(t *testing.T) {
 		),
 	)
 
-	writeBadJSON(t,
+	writeBadJSON(
+		t,
 		filepath.Join(
 			wal.GetFilepath(),
 			uuid.New().String()+"+test-tenant+"+vparquet3.VersionString,
@@ -321,7 +324,8 @@ func TestBadBlocks(t *testing.T) {
 	)
 
 	// write a bad block meta for a completed block
-	writeBadJSON(t,
+	writeBadJSON(
+		t,
 		filepath.Join(
 			wal.GetFilepath(),
 			"blocks",

--- a/modules/generator/processor/localblocks/query_range.go
+++ b/modules/generator/processor/localblocks/query_range.go
@@ -219,7 +219,7 @@ func (p *Processor) queryRangeCacheGet(ctx context.Context, m *backend.BlockMeta
 
 	name := fmt.Sprintf("cache_query_range_%v.buf", hash)
 
-	data, err := p.walR.Read(ctx, name, (uuid.UUID)(m.BlockID), m.TenantID, nil)
+	data, err := p.walR.Read(ctx, name, uuid.UUID(m.BlockID), m.TenantID, nil)
 	if err != nil {
 		if errors.Is(err, backend.ErrDoesNotExist) {
 			// Not cached, but return the name/keypath so it can be set after
@@ -243,7 +243,7 @@ func (p *Processor) queryRangeCacheSet(ctx context.Context, m *backend.BlockMeta
 		return err
 	}
 
-	return p.walW.Write(ctx, name, (uuid.UUID)(m.BlockID), m.TenantID, data, nil)
+	return p.walW.Write(ctx, name, uuid.UUID(m.BlockID), m.TenantID, data, nil)
 }
 
 func queryRangeHashForBlock(req tempopb.QueryRangeRequest) uint64 {

--- a/modules/generator/registry/overrides.go
+++ b/modules/generator/registry/overrides.go
@@ -19,4 +19,4 @@ type Overrides interface {
 	MetricsGeneratorNativeHistogramMinResetDuration(userID string) time.Duration
 }
 
-var _ Overrides = (overrides.Interface)(nil)
+var _ Overrides = overrides.Interface(nil)

--- a/modules/generator/storage/overrides.go
+++ b/modules/generator/storage/overrides.go
@@ -10,4 +10,4 @@ type Overrides interface {
 	MetricsGeneratorGenerateNativeHistograms(userID string) histograms.HistogramMethod
 }
 
-var _ Overrides = (overrides.Interface)(nil)
+var _ Overrides = overrides.Interface(nil)

--- a/modules/ingester/ingester.go
+++ b/modules/ingester/ingester.go
@@ -141,7 +141,8 @@ func New(cfg Config, store storage.Store, overrides overrides.Interface, reg pro
 			PartitionRingKey,
 			partitionRingKV,
 			log.Logger,
-			prometheus.WrapRegistererWithPrefix("cortex_", reg))
+			prometheus.WrapRegistererWithPrefix("cortex_", reg),
+		)
 	}
 
 	// Now that the lifecycler has been created, we can create the limiter
@@ -434,7 +435,7 @@ func (i *Ingester) replayWal() error {
 		// deleted (because it was rescanned above). This can happen for reasons
 		// such as a crash or restart. In this situation we err on the side of
 		// caution and replay the wal block.
-		err = instance.local.ClearBlock((uuid.UUID)(b.BlockMeta().BlockID), tenantID)
+		err = instance.local.ClearBlock(uuid.UUID(b.BlockMeta().BlockID), tenantID)
 		if err != nil {
 			return err
 		}
@@ -443,7 +444,7 @@ func (i *Ingester) replayWal() error {
 		i.enqueue(&flushOp{
 			kind:    opKindComplete,
 			userID:  tenantID,
-			blockID: (uuid.UUID)(b.BlockMeta().BlockID),
+			blockID: uuid.UUID(b.BlockMeta().BlockID),
 		}, i.replayJitter)
 	}
 
@@ -491,7 +492,7 @@ func (i *Ingester) rediscoverLocalBlocks() error {
 					i.enqueue(&flushOp{
 						kind:    opKindFlush,
 						userID:  t,
-						blockID: (uuid.UUID)(b.BlockMeta().BlockID),
+						blockID: uuid.UUID(b.BlockMeta().BlockID),
 					}, i.replayJitter)
 				}
 			}

--- a/modules/ingester/ingester_test.go
+++ b/modules/ingester/ingester_test.go
@@ -411,7 +411,8 @@ func TestIngesterStartingReadOnly(t *testing.T) {
 		defaultIngesterStore(t, t.TempDir()),
 		limits,
 		prometheus.NewPedanticRegistry(),
-		false)
+		false,
+	)
 	require.NoError(t, err)
 
 	_, err = ingester.PushBytesV2(ctx, &tempopb.PushBytesRequest{})

--- a/modules/ingester/instance.go
+++ b/modules/ingester/instance.go
@@ -287,7 +287,7 @@ func (i *instance) CutBlockIfReady(maxBlockLifetime time.Duration, maxBlockBytes
 		}
 
 		completingBlock := i.headBlock
-		blockID := (uuid.UUID)(completingBlock.BlockMeta().BlockID)
+		blockID := uuid.UUID(completingBlock.BlockMeta().BlockID)
 		blockSize := completingBlock.DataLength()
 
 		level.Info(i.logger).Log("msg", "head block cut", "block", blockID, "size", blockSize)
@@ -319,7 +319,7 @@ func (i *instance) CompleteBlock(ctx context.Context, blockID uuid.UUID) error {
 	i.blocksMtx.Lock()
 	var completingBlock common.WALBlock
 	for _, iterBlock := range i.completingBlocks {
-		if (uuid.UUID)(iterBlock.BlockMeta().BlockID) == blockID {
+		if uuid.UUID(iterBlock.BlockMeta().BlockID) == blockID {
 			completingBlock = iterBlock
 			break
 		}
@@ -350,7 +350,7 @@ func (i *instance) ClearCompletingBlock(blockID uuid.UUID) error {
 
 	var completingBlock common.WALBlock
 	for j, iterBlock := range i.completingBlocks {
-		if (uuid.UUID)(iterBlock.BlockMeta().BlockID) == blockID {
+		if uuid.UUID(iterBlock.BlockMeta().BlockID) == blockID {
 			completingBlock = iterBlock
 			i.completingBlocks = append(i.completingBlocks[:j], i.completingBlocks[j+1:]...)
 			break
@@ -370,7 +370,7 @@ func (i *instance) GetBlockToBeFlushed(blockID uuid.UUID) *LocalBlock {
 	defer i.blocksMtx.RUnlock()
 
 	for _, c := range i.completeBlocks {
-		if (uuid.UUID)(c.BlockMeta().BlockID) == blockID && c.FlushedTime().IsZero() {
+		if uuid.UUID(c.BlockMeta().BlockID) == blockID && c.FlushedTime().IsZero() {
 			return c
 		}
 	}
@@ -397,7 +397,7 @@ func (i *instance) ClearOldBlocks(flushObjectStorage bool, completeBlockTimeout 
 		}
 
 		// This block can be deleted.
-		err := i.local.ClearBlock((uuid.UUID)(b.BlockMeta().BlockID), i.instanceID)
+		err := i.local.ClearBlock(uuid.UUID(b.BlockMeta().BlockID), i.instanceID)
 		if err != nil {
 			return err
 		}
@@ -619,7 +619,7 @@ func (i *instance) rediscoverLocalBlocks(ctx context.Context) ([]*LocalBlock, er
 		i.blocksMtx.RLock()
 		defer i.blocksMtx.RUnlock()
 		for _, b := range i.completingBlocks {
-			if (uuid.UUID)(b.BlockMeta().BlockID) == id {
+			if uuid.UUID(b.BlockMeta().BlockID) == id {
 				return true
 			}
 		}

--- a/modules/ingester/instance_search_test.go
+++ b/modules/ingester/instance_search_test.go
@@ -929,11 +929,11 @@ func BenchmarkInstanceSearchUnderLoad(b *testing.B) {
 		"Instance search throughput under load: %v elapsed %.2f MB = %.2f MiB/s throughput inspected %.2f traces/s pushed %.2f traces/s %.2f searches/s %.2f cuts/s\n",
 		elapsed,
 		float64(bytesInspected.Load())/(1024*1024),
-		float64(bytesInspected.Load())/(elapsed.Seconds())/(1024*1024),
-		float64(tracesInspected.Load())/(elapsed.Seconds()),
-		float64(tracesPushed.Load())/(elapsed.Seconds()),
-		float64(searches.Load())/(elapsed.Seconds()),
-		float64(cuts)/(elapsed.Seconds()),
+		float64(bytesInspected.Load())/elapsed.Seconds()/(1024*1024),
+		float64(tracesInspected.Load())/elapsed.Seconds(),
+		float64(tracesPushed.Load())/elapsed.Seconds(),
+		float64(searches.Load())/elapsed.Seconds(),
+		float64(cuts)/elapsed.Seconds(),
 	)
 
 	b.StopTimer()

--- a/modules/ingester/local_block.go
+++ b/modules/ingester/local_block.go
@@ -42,7 +42,7 @@ func NewLocalBlock(ctx context.Context, existingBlock common.BackendBlock, l *lo
 		writer:       backend.NewWriter(l),
 	}
 
-	flushedBytes, err := c.reader.Read(ctx, nameFlushed, (uuid.UUID)(c.BlockMeta().BlockID), c.BlockMeta().TenantID, nil)
+	flushedBytes, err := c.reader.Read(ctx, nameFlushed, uuid.UUID(c.BlockMeta().BlockID), c.BlockMeta().TenantID, nil)
 	if err == nil {
 		flushedTime := time.Time{}
 		err = flushedTime.UnmarshalText(flushedBytes)
@@ -120,7 +120,7 @@ func (c *LocalBlock) SetFlushed(ctx context.Context) error {
 		return fmt.Errorf("error marshalling flush time to text: %w", err)
 	}
 
-	err = c.writer.Write(ctx, nameFlushed, (uuid.UUID)(c.BlockMeta().BlockID), c.BlockMeta().TenantID, flushedBytes, nil)
+	err = c.writer.Write(ctx, nameFlushed, uuid.UUID(c.BlockMeta().BlockID), c.BlockMeta().TenantID, flushedBytes, nil)
 	if err != nil {
 		return fmt.Errorf("error writing ingester block flushed file: %w", err)
 	}
@@ -140,11 +140,11 @@ func (c *LocalBlock) Write(ctx context.Context, w backend.Writer) error {
 }
 
 func (c *LocalBlock) SetDiskCache(ctx context.Context, cacheKey string, data []byte) error {
-	return c.writer.Write(ctx, cacheKey, (uuid.UUID)(c.BlockMeta().BlockID), c.BlockMeta().TenantID, data, nil)
+	return c.writer.Write(ctx, cacheKey, uuid.UUID(c.BlockMeta().BlockID), c.BlockMeta().TenantID, data, nil)
 }
 
 func (c *LocalBlock) GetDiskCache(ctx context.Context, cacheKey string) ([]byte, error) {
-	data, err := c.reader.Read(ctx, cacheKey, (uuid.UUID)(c.BlockMeta().BlockID), c.BlockMeta().TenantID, nil)
+	data, err := c.reader.Read(ctx, cacheKey, uuid.UUID(c.BlockMeta().BlockID), c.BlockMeta().TenantID, nil)
 	if errors.Is(err, backend.ErrDoesNotExist) {
 		// file doesn't exist, so it's a cache miss
 		return nil, nil

--- a/modules/ingester/overrides.go
+++ b/modules/ingester/overrides.go
@@ -13,4 +13,4 @@ type ingesterOverrides interface {
 	UnsafeQueryHints(userID string) bool
 }
 
-var _ ingesterOverrides = (overrides.Interface)(nil)
+var _ ingesterOverrides = overrides.Interface(nil)

--- a/modules/livestore/instance.go
+++ b/modules/livestore/instance.go
@@ -395,7 +395,7 @@ func (i *instance) cutBlocks(immediate bool) (uuid.UUID, error) {
 		return uuid.Nil, err
 	}
 
-	id := (uuid.UUID)(i.headBlock.BlockMeta().BlockID)
+	id := uuid.UUID(i.headBlock.BlockMeta().BlockID)
 	blockSize := i.headBlock.DataLength()
 	i.walBlocks[id] = i.headBlock
 
@@ -478,7 +478,7 @@ func (i *instance) completeBlock(ctx context.Context, id uuid.UUID) error {
 		level.Error(i.logger).Log("msg", "failed to clear WAL block", "id", id, "err", err)
 		span.RecordError(err)
 	}
-	delete(i.walBlocks, (uuid.UUID)(walBlock.BlockMeta().BlockID))
+	delete(i.walBlocks, uuid.UUID(walBlock.BlockMeta().BlockID))
 
 	level.Info(i.logger).Log("msg", "completed block", "id", id.String())
 	span.AddEvent("block completed successfully")

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -815,7 +815,7 @@ func (i *instance) queryRangeCacheGet(ctx context.Context, m *backend.BlockMeta,
 
 	name := fmt.Sprintf("cache_query_range_%v.buf", hash)
 
-	keyPath := backend.KeyPathForBlock((uuid.UUID)(m.BlockID), m.TenantID)
+	keyPath := backend.KeyPathForBlock(uuid.UUID(m.BlockID), m.TenantID)
 	reader, size, err := i.wal.LocalBackend().Read(ctx, name, keyPath, nil)
 	if err != nil {
 		if errors.Is(err, backend.ErrDoesNotExist) {
@@ -846,7 +846,7 @@ func (i *instance) queryRangeCacheSet(ctx context.Context, m *backend.BlockMeta,
 		return err
 	}
 
-	keyPath := backend.KeyPathForBlock((uuid.UUID)(m.BlockID), m.TenantID)
+	keyPath := backend.KeyPathForBlock(uuid.UUID(m.BlockID), m.TenantID)
 	return i.wal.LocalBackend().Write(ctx, name, keyPath, bytes.NewReader(data), int64(len(data)), nil)
 }
 

--- a/modules/livestore/live_store.go
+++ b/modules/livestore/live_store.go
@@ -182,7 +182,8 @@ func New(cfg Config, overridesService overrides.Interface, logger log.Logger, re
 		PartitionRingKey,
 		partitionRingKV,
 		logger,
-		prometheus.WrapRegistererWithPrefix("tempo_", reg))
+		prometheus.WrapRegistererWithPrefix("tempo_", reg),
+	)
 
 	// setup live store read ring
 	ringStore := cfg.Ring.KVStore.Mock

--- a/modules/livestore/live_store_background.go
+++ b/modules/livestore/live_store_background.go
@@ -233,7 +233,7 @@ func (s *LiveStore) reloadBlocks() error {
 			defer inst.blocksMtx.Unlock()
 
 			level.Info(s.logger).Log("msg", "reloaded wal block", "block", meta.BlockID.String())
-			inst.walBlocks[(uuid.UUID)(meta.BlockID)] = blk
+			inst.walBlocks[uuid.UUID(meta.BlockID)] = blk
 
 			level.Info(s.logger).Log("msg", "queueing replayed wal block for completion", "block", meta.BlockID.String())
 			if err := s.enqueueCompleteOp(meta.TenantID, uuid.UUID(meta.BlockID), true); err != nil {

--- a/modules/querier/querier.go
+++ b/modules/querier/querier.go
@@ -353,7 +353,8 @@ func (q *Querier) FindTraceByID(ctx context.Context, req *tempopb.TraceByIDReque
 		}
 
 		span.AddEvent("done searching store", oteltrace.WithAttributes(
-			attribute.Int("foundPartialTraces", len(partialTraces))))
+			attribute.Int("foundPartialTraces", len(partialTraces)),
+		))
 
 		for _, partialTrace := range partialTraces {
 			if partialTrace == nil {

--- a/pkg/ingest/reader_client.go
+++ b/pkg/ingest/reader_client.go
@@ -20,7 +20,8 @@ func NewReaderClient(kafkaCfg KafkaConfig, metrics *kprom.Metrics, logger log.Lo
 	const fetchMaxBytes = 100_000_000
 
 	opts = append(opts, commonKafkaClientOptions(kafkaCfg, metrics, logger)...)
-	opts = append(opts,
+	opts = append(
+		opts,
 		kgo.FetchMinBytes(1),
 		kgo.FetchMaxBytes(fetchMaxBytes),
 		kgo.FetchMaxWait(5*time.Second),
@@ -51,7 +52,8 @@ type Client struct {
 }
 
 func NewGroupReaderClient(kafkaCfg KafkaConfig, partitionRing ring.PartitionRingReader, metrics *kprom.Metrics, logger log.Logger, opts ...kgo.Opt) (*Client, error) {
-	opts = append(opts,
+	opts = append(
+		opts,
 		kgo.ConsumerGroup(kafkaCfg.ConsumerGroup),
 		kgo.ConsumeTopics(kafkaCfg.Topic),
 		kgo.SessionTimeout(3*time.Minute),

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -31,7 +31,8 @@ func NewWriterClient(kafkaCfg KafkaConfig, maxInflightProduceRequests int, logge
 	metrics := kprom.NewMetrics(
 		"", // No prefix. We expect the input prometheus.Registered to be wrapped with a prefix.
 		kprom.Registerer(reg),
-		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes))
+		kprom.FetchAndProduceDetail(kprom.Batches, kprom.Records, kprom.CompressedBytes, kprom.UncompressedBytes),
+	)
 
 	opts := append(
 		commonKafkaClientOptions(kafkaCfg, metrics, logger),
@@ -129,7 +130,7 @@ func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger lo
 		kgo.WithLogger(newLogger(logger)),
 
 		kgo.RetryTimeoutFn(func(key int16) time.Duration {
-			if key == ((*kmsg.ListOffsetsRequest)(nil)).Key() {
+			if key == (*kmsg.ListOffsetsRequest)(nil).Key() {
 				return cfg.LastProducedOffsetRetryTimeout
 			}
 
@@ -214,14 +215,16 @@ func NewProducer(client *kgo.Client, maxBufferedBytes int64, reg prometheus.Regi
 				Objectives: map[float64]float64{0.5: 0.05, 0.99: 0.001, 1: 0.001},
 				MaxAge:     time.Minute,
 				AgeBuckets: 6,
-			}),
+			},
+		),
 		bufferedProduceBytesLimit: promauto.With(reg).NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: "tempo",
 				Subsystem: "distributor",
 				Name:      "buffered_produce_bytes_limit",
 				Help:      "The bytes limit on buffered produce records. Produce requests fail once this limit is reached.",
-			}),
+			},
+		),
 
 		produceRecordsFailuresTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Namespace: "tempo",

--- a/pkg/parquetquery/predicate_test.go
+++ b/pkg/parquetquery/predicate_test.go
@@ -31,9 +31,11 @@ func newAlwaysFalsePredicate() *mockPredicate {
 	return &mockPredicate{ret: false}
 }
 
-func (p *mockPredicate) String() string                          { return "mockPredicate{}" }
-func (p *mockPredicate) KeepValue(parquet.Value) bool            { p.valCalled = true; return p.ret }
-func (p *mockPredicate) KeepPage(parquet.Page) bool              { p.pageCalled = true; return p.ret }
+func (p *mockPredicate) String() string               { return "mockPredicate{}" }
+func (p *mockPredicate) KeepValue(parquet.Value) bool { p.valCalled = true; return p.ret }
+
+func (p *mockPredicate) KeepPage(parquet.Page) bool { p.pageCalled = true; return p.ret }
+
 func (p *mockPredicate) KeepColumnChunk(*ColumnChunkHelper) bool { p.chunkCalled = true; return p.ret }
 
 type predicateTestCase struct {

--- a/pkg/spanfilter/splitpolicy_test.go
+++ b/pkg/spanfilter/splitpolicy_test.go
@@ -35,7 +35,8 @@ func Test_newSplitPolicy(t *testing.T) {
 				IntrinsicMatch: policymatch.NewIntrinsicPolicyMatch(
 					[]policymatch.IntrinsicFilter{
 						policymatch.NewKindIntrinsicFilter(tracev1.Span_SPAN_KIND_CLIENT),
-					}),
+					},
+				),
 			},
 		},
 		{
@@ -53,7 +54,8 @@ func Test_newSplitPolicy(t *testing.T) {
 				IntrinsicMatch: policymatch.NewIntrinsicPolicyMatch(
 					[]policymatch.IntrinsicFilter{
 						policymatch.NewStatusIntrinsicFilter(tracev1.Status_STATUS_CODE_OK),
-					}),
+					},
+				),
 			},
 		},
 		{

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -332,7 +332,8 @@ func (set SeriesSet) ToProto(req *tempopb.QueryRangeRequest) []*tempopb.TimeSeri
 	for _, s := range set {
 		labels := make([]commonv1proto.KeyValue, 0, len(s.Labels))
 		for _, label := range s.Labels {
-			labels = append(labels,
+			labels = append(
+				labels,
 				commonv1proto.KeyValue{
 					Key:   label.Name,
 					Value: label.Value.AsAnyValue(),
@@ -373,7 +374,8 @@ func (set SeriesSet) ToProto(req *tempopb.QueryRangeRequest) []*tempopb.TimeSeri
 
 			labels := make([]commonv1proto.KeyValue, 0, len(e.Labels))
 			for _, label := range e.Labels {
-				labels = append(labels,
+				labels = append(
+					labels,
 					commonv1proto.KeyValue{
 						Key:   label.Name,
 						Value: label.Value.AsAnyValue(),
@@ -1826,7 +1828,7 @@ func (h *HistogramAggregator) Results() SeriesSet {
 		// For each input series, we create a new series for each quantile.
 		for qIdx, q := range h.qs {
 			// Append label for the quantile
-			labels := append((Labels)(nil), in.labels...)
+			labels := append(Labels(nil), in.labels...)
 			labels = append(labels, Label{"p", NewStaticFloat(q)})
 
 			ts := TimeSeries{

--- a/pkg/traceql/engine_metrics_compare_test.go
+++ b/pkg/traceql/engine_metrics_compare_test.go
@@ -136,10 +136,12 @@ func TestMetricsCompareObserveExemplarLimit(t *testing.T) {
 	}
 
 	a := newMetricsCompare(newSpansetFilter(
-		newBinaryOperation(OpEqual,
+		newBinaryOperation(
+			OpEqual,
 			NewAttribute("service"),
 			NewStaticString("selected"),
-		)), 10, 0, 0)
+		),
+	), 10, 0, 0)
 	a.init(req, AggregateModeRaw)
 
 	// Alternate baseline and selection spans so both slices fill up.
@@ -167,10 +169,12 @@ func TestCompareScalesResults(t *testing.T) {
 	}
 
 	a := newMetricsCompare(newSpansetFilter(
-		newBinaryOperation(OpEqual,
+		newBinaryOperation(
+			OpEqual,
 			NewAttribute("service"),
 			NewStaticString("selected"),
-		)), 10, 0, 0)
+		),
+	), 10, 0, 0)
 	a.init(req, AggregateModeRaw)
 
 	// Test data with clear baseline vs selection distinction

--- a/pkg/traceql/engine_test.go
+++ b/pkg/traceql/engine_test.go
@@ -408,7 +408,7 @@ type MockSpanSetFetcher struct {
 	capturedRequest FetchSpansRequest
 }
 
-var _ = (SpansetFetcher)(&MockSpanSetFetcher{})
+var _ = SpansetFetcher(&MockSpanSetFetcher{})
 
 func (m *MockSpanSetFetcher) Fetch(_ context.Context, request FetchSpansRequest) (FetchSpansResponse, error) {
 	m.capturedRequest = request

--- a/pkg/traceql/parse_test.go
+++ b/pkg/traceql/parse_test.go
@@ -38,8 +38,10 @@ func TestPipelineOperatorPrecedence(t *testing.T) {
 	}{
 		{
 			in: "({ .a } | { .b }) > ({ .a } | { .b }) && ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetAnd,
-				newSpansetOperation(OpSpansetChild,
+			expected: newSpansetOperation(
+				OpSpansetAnd,
+				newSpansetOperation(
+					OpSpansetChild,
 					newPipeline(
 						newSpansetFilter(NewAttribute("a")),
 						newSpansetFilter(NewAttribute("b")),
@@ -57,12 +59,14 @@ func TestPipelineOperatorPrecedence(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) > (({ .a } | { .b }) && ({ .a } | { .b }))",
-			expected: newSpansetOperation(OpSpansetChild,
+			expected: newSpansetOperation(
+				OpSpansetChild,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
 				),
-				newSpansetOperation(OpSpansetAnd,
+				newSpansetOperation(
+					OpSpansetAnd,
 					newPipeline(
 						newSpansetFilter(NewAttribute("a")),
 						newSpansetFilter(NewAttribute("b")),
@@ -76,12 +80,14 @@ func TestPipelineOperatorPrecedence(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) < (({ .a } | { .b }) && ({ .a } | { .b }))",
-			expected: newSpansetOperation(OpSpansetParent,
+			expected: newSpansetOperation(
+				OpSpansetParent,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
 				),
-				newSpansetOperation(OpSpansetAnd,
+				newSpansetOperation(
+					OpSpansetAnd,
 					newPipeline(
 						newSpansetFilter(NewAttribute("a")),
 						newSpansetFilter(NewAttribute("b")),
@@ -112,7 +118,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 	}{
 		{
 			in: "({ .a } | { .b }) > ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetChild,
+			expected: newSpansetOperation(
+				OpSpansetChild,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -125,7 +132,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) < ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetParent,
+			expected: newSpansetOperation(
+				OpSpansetParent,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -138,7 +146,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) ~ ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetSibling,
+			expected: newSpansetOperation(
+				OpSpansetSibling,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -151,7 +160,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) && ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetAnd,
+			expected: newSpansetOperation(
+				OpSpansetAnd,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -164,7 +174,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) >> ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetDescendant,
+			expected: newSpansetOperation(
+				OpSpansetDescendant,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -177,7 +188,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) << ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetAncestor,
+			expected: newSpansetOperation(
+				OpSpansetAncestor,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -190,7 +202,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) !> ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetNotChild,
+			expected: newSpansetOperation(
+				OpSpansetNotChild,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -203,7 +216,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) !< ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetNotParent,
+			expected: newSpansetOperation(
+				OpSpansetNotParent,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -216,7 +230,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) !~ ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetNotSibling,
+			expected: newSpansetOperation(
+				OpSpansetNotSibling,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -229,7 +244,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) !>> ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetNotDescendant,
+			expected: newSpansetOperation(
+				OpSpansetNotDescendant,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -242,7 +258,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) !<< ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetNotAncestor,
+			expected: newSpansetOperation(
+				OpSpansetNotAncestor,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -255,7 +272,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) &> ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetUnionChild,
+			expected: newSpansetOperation(
+				OpSpansetUnionChild,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -268,7 +286,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) &< ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetUnionParent,
+			expected: newSpansetOperation(
+				OpSpansetUnionParent,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -281,7 +300,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) &~ ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetUnionSibling,
+			expected: newSpansetOperation(
+				OpSpansetUnionSibling,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -294,7 +314,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) &>> ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetUnionDescendant,
+			expected: newSpansetOperation(
+				OpSpansetUnionDescendant,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -307,7 +328,8 @@ func TestPipelineSpansetOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | { .b }) &<< ({ .a } | { .b })",
-			expected: newSpansetOperation(OpSpansetUnionAncestor,
+			expected: newSpansetOperation(
+				OpSpansetUnionAncestor,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newSpansetFilter(NewAttribute("b")),
@@ -337,7 +359,8 @@ func TestPipelineScalarOperators(t *testing.T) {
 	}{
 		{
 			in: "({ .a } | count()) = ({ .a } | count())",
-			expected: newScalarFilter(OpEqual,
+			expected: newScalarFilter(
+				OpEqual,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newAggregate(aggregateCount, nil),
@@ -350,7 +373,8 @@ func TestPipelineScalarOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | count()) != ({ .a } | count())",
-			expected: newScalarFilter(OpNotEqual,
+			expected: newScalarFilter(
+				OpNotEqual,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newAggregate(aggregateCount, nil),
@@ -363,7 +387,8 @@ func TestPipelineScalarOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | count()) < ({ .a } | count())",
-			expected: newScalarFilter(OpLess,
+			expected: newScalarFilter(
+				OpLess,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newAggregate(aggregateCount, nil),
@@ -376,7 +401,8 @@ func TestPipelineScalarOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | count()) <= ({ .a } | count())",
-			expected: newScalarFilter(OpLessEqual,
+			expected: newScalarFilter(
+				OpLessEqual,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newAggregate(aggregateCount, nil),
@@ -389,7 +415,8 @@ func TestPipelineScalarOperators(t *testing.T) {
 		},
 		{
 			in: "({ .a } | count()) >= ({ .a } | count())",
-			expected: newScalarFilter(OpGreaterEqual,
+			expected: newScalarFilter(
+				OpGreaterEqual,
 				newPipeline(
 					newSpansetFilter(NewAttribute("a")),
 					newAggregate(aggregateCount, nil),
@@ -551,35 +578,40 @@ func TestSpansetExpressionPrecedence(t *testing.T) {
 	}{
 		{
 			in: "{ true } && { false } >> { `a` }",
-			expected: newSpansetOperation(OpSpansetAnd,
+			expected: newSpansetOperation(
+				OpSpansetAnd,
 				newSpansetFilter(NewStaticBool(true)),
 				newSpansetOperation(OpSpansetDescendant, newSpansetFilter(NewStaticBool(false)), newSpansetFilter(NewStaticString("a"))),
 			),
 		},
 		{
 			in: "{ true } >> { false } && { `a` }",
-			expected: newSpansetOperation(OpSpansetAnd,
+			expected: newSpansetOperation(
+				OpSpansetAnd,
 				newSpansetOperation(OpSpansetDescendant, newSpansetFilter(NewStaticBool(true)), newSpansetFilter(NewStaticBool(false))),
 				newSpansetFilter(NewStaticString("a")),
 			),
 		},
 		{
 			in: "({ true } >> { false }) && { `a` }",
-			expected: newSpansetOperation(OpSpansetAnd,
+			expected: newSpansetOperation(
+				OpSpansetAnd,
 				newSpansetOperation(OpSpansetDescendant, newSpansetFilter(NewStaticBool(true)), newSpansetFilter(NewStaticBool(false))),
 				newSpansetFilter(NewStaticString("a")),
 			),
 		},
 		{
 			in: "{ true } >> { false } ~ { `a` }",
-			expected: newSpansetOperation(OpSpansetSibling,
+			expected: newSpansetOperation(
+				OpSpansetSibling,
 				newSpansetOperation(OpSpansetDescendant, newSpansetFilter(NewStaticBool(true)), newSpansetFilter(NewStaticBool(false))),
 				newSpansetFilter(NewStaticString("a")),
 			),
 		},
 		{
 			in: "{ true } ~ { false } >> { `a` }",
-			expected: newSpansetOperation(OpSpansetDescendant,
+			expected: newSpansetOperation(
+				OpSpansetDescendant,
 				newSpansetOperation(OpSpansetSibling, newSpansetFilter(NewStaticBool(true)), newSpansetFilter(NewStaticBool(false))),
 				newSpansetFilter(NewStaticString("a")),
 			),
@@ -659,9 +691,11 @@ func TestScalarExpressionPrecedence(t *testing.T) {
 	}{
 		{
 			in: "avg(.foo) > count() + sum(.bar)",
-			expected: newScalarFilter(OpGreater,
+			expected: newScalarFilter(
+				OpGreater,
 				newAggregate(aggregateAvg, NewAttribute("foo")),
-				newScalarOperation(OpAdd,
+				newScalarOperation(
+					OpAdd,
 					newAggregate(aggregateCount, nil),
 					newAggregate(aggregateSum, NewAttribute("bar")),
 				),
@@ -669,8 +703,10 @@ func TestScalarExpressionPrecedence(t *testing.T) {
 		},
 		{
 			in: "avg(.foo) + count() > sum(.bar)",
-			expected: newScalarFilter(OpGreater,
-				newScalarOperation(OpAdd,
+			expected: newScalarFilter(
+				OpGreater,
+				newScalarOperation(
+					OpAdd,
 					newAggregate(aggregateAvg, NewAttribute("foo")),
 					newAggregate(aggregateCount, nil),
 				),
@@ -1111,7 +1147,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    false,
 					Name:      tc.in,
 					Intrinsic: tc.expected,
-				}))), actual)
+				}),
+			)), actual)
 
 			// as attribute e.g .duration
 			s = "{ ." + tc.in + "}"
@@ -1124,7 +1161,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    false,
 					Name:      tc.in,
 					Intrinsic: IntrinsicNone,
-				}))), actual)
+				}),
+			)), actual)
 
 			// as span scoped attribute e.g span.duration
 			s = "{ span." + tc.in + "}"
@@ -1137,7 +1175,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    false,
 					Name:      tc.in,
 					Intrinsic: IntrinsicNone,
-				}))), actual)
+				}),
+			)), actual)
 
 			// as resource scoped attribute e.g resource.duration
 			s = "{ resource." + tc.in + "}"
@@ -1150,7 +1189,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    false,
 					Name:      tc.in,
 					Intrinsic: IntrinsicNone,
-				}))), actual)
+				}),
+			)), actual)
 
 			// as parent scoped intrinsic e.g parent.duration
 			s = "{ parent." + tc.in + "}"
@@ -1163,7 +1203,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    true,
 					Name:      tc.in,
 					Intrinsic: IntrinsicNone,
-				}))), actual)
+				}),
+			)), actual)
 
 			// as nested parent scoped intrinsic e.g. parent.duration.foo
 			// this becomes lookup on attribute named "duration.foo"
@@ -1177,7 +1218,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    true,
 					Name:      tc.in + ".foo",
 					Intrinsic: IntrinsicNone,
-				}))), actual)
+				}),
+			)), actual)
 
 			// as parent resource scoped attribute e.g. parent.resource.duration
 			s = "{ parent.resource." + tc.in + "}"
@@ -1190,7 +1232,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    true,
 					Name:      tc.in,
 					Intrinsic: IntrinsicNone,
-				}))), actual)
+				}),
+			)), actual)
 
 			// as parent span scoped attribute e.g. praent.span.duration
 			s = "{ parent.span." + tc.in + "}"
@@ -1203,7 +1246,8 @@ func TestIntrinsics(t *testing.T) {
 					Parent:    true,
 					Name:      tc.in,
 					Intrinsic: IntrinsicNone,
-				}))), actual)
+				}),
+			)), actual)
 		})
 	}
 }
@@ -1256,7 +1300,8 @@ func TestScopedIntrinsics(t *testing.T) {
 						Parent:    false,
 						Name:      tc.expected.String(),
 						Intrinsic: tc.expected,
-					}))), actual)
+					}),
+				)), actual)
 			}
 		})
 	}
@@ -1576,7 +1621,8 @@ func TestMetrics(t *testing.T) {
 					[]Attribute{
 						NewIntrinsic(IntrinsicName),
 						NewScopedAttribute(AttributeScopeSpan, false, "http.status_code"),
-					}),
+					},
+				),
 			),
 		},
 		{
@@ -1601,7 +1647,8 @@ func TestMetrics(t *testing.T) {
 					[]Attribute{
 						NewIntrinsic(IntrinsicName),
 						NewScopedAttribute(AttributeScopeSpan, false, "http.status_code"),
-					}),
+					},
+				),
 			),
 		},
 	}

--- a/pkg/traceql/storage.go
+++ b/pkg/traceql/storage.go
@@ -313,7 +313,7 @@ type SpansetFetcherWrapper struct {
 	f func(ctx context.Context, req FetchSpansRequest) (FetchSpansResponse, error)
 }
 
-var _ = (SpansetFetcher)(&SpansetFetcherWrapper{})
+var _ = SpansetFetcher(&SpansetFetcherWrapper{})
 
 func NewSpansetFetcherWrapper(f func(ctx context.Context, req FetchSpansRequest) (FetchSpansResponse, error)) SpansetFetcher {
 	return SpansetFetcherWrapper{f}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -26,7 +26,8 @@ func InstallOpenTelemetryTracer(appName, target string) (func(), error) {
 		return nil, fmt.Errorf("failed to create OTEL exporter: %w", err)
 	}
 
-	resources, err := resource.New(context.Background(),
+	resources, err := resource.New(
+		context.Background(),
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String(fmt.Sprintf("%s-%s", appName, target)),
 			semconv.ServiceVersionKey.String(fmt.Sprintf("%s-%s", version.Version, version.Revision)),

--- a/tempodb/backend/block_meta.go
+++ b/tempodb/backend/block_meta.go
@@ -177,7 +177,7 @@ type DedicatedColumn struct {
 func (dc *DedicatedColumn) MarshalJSON() ([]byte, error) {
 	type dcAlias DedicatedColumn // alias required to avoid recursive calls of MarshalJSON
 
-	cpy := (dcAlias)(*dc)
+	cpy := dcAlias(*dc)
 	if cpy.Scope == DefaultDedicatedColumnScope {
 		cpy.Scope = ""
 	}

--- a/tempodb/backend/block_meta_test.go
+++ b/tempodb/backend/block_meta_test.go
@@ -26,7 +26,7 @@ func TestNewBlockMeta(t *testing.T) {
 	id := uuid.New()
 	b := NewBlockMeta(testTenantID, id, testVersion, testEncoding, testDataEncoding)
 
-	assert.Equal(t, id, (uuid.UUID)(b.BlockID))
+	assert.Equal(t, id, uuid.UUID(b.BlockID))
 	assert.Equal(t, testTenantID, b.TenantID)
 	assert.Equal(t, testVersion, b.Version)
 	assert.Equal(t, testEncoding, b.Encoding)

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -52,7 +52,8 @@ func NewCache(cfgBloom *BloomConfig, nextReader backend.RawReader, nextWriter ba
 		nextWriter: nextWriter,
 	}
 
-	level.Info(logger).Log("msg", "caches available to storage backend",
+	level.Info(logger).Log(
+		"msg", "caches available to storage backend",
 		cache.RoleParquetFooter, rw.footerCache != nil,
 		cache.RoleBloom, rw.bloomCache != nil,
 		cache.RoleParquetOffsetIdx, rw.offsetIdxCache != nil,

--- a/tempodb/backend/local/local_test.go
+++ b/tempodb/backend/local/local_test.go
@@ -49,12 +49,12 @@ func TestReadWrite(t *testing.T) {
 	ctx := context.Background()
 	for _, id := range tenantIDs {
 		fakeMeta.TenantID = id
-		err = w.Write(ctx, objectName, backend.KeyPathForBlock((uuid.UUID)(fakeMeta.BlockID), id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
+		err = w.Write(ctx, objectName, backend.KeyPathForBlock(uuid.UUID(fakeMeta.BlockID), id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
 		assert.NoError(t, err, "unexpected error writing")
 
-		err = w.Write(ctx, backend.MetaName, backend.KeyPathForBlock((uuid.UUID)(fakeMeta.BlockID), id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
+		err = w.Write(ctx, backend.MetaName, backend.KeyPathForBlock(uuid.UUID(fakeMeta.BlockID), id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
 		assert.NoError(t, err, "unexpected error meta.json")
-		err = w.Write(ctx, backend.CompactedMetaName, backend.KeyPathForBlock((uuid.UUID)(fakeMeta.BlockID), id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
+		err = w.Write(ctx, backend.CompactedMetaName, backend.KeyPathForBlock(uuid.UUID(fakeMeta.BlockID), id), bytes.NewReader(fakeObject), int64(len(fakeObject)), nil)
 		assert.NoError(t, err, "unexpected error meta.compacted.json")
 	}
 
@@ -92,7 +92,7 @@ func TestShutdownLeavesTenantsWithBlocks(t *testing.T) {
 	tenant := "fake"
 
 	// write a "block"
-	err = w.Write(ctx, "test", backend.KeyPathForBlock((uuid.UUID)(blockID), tenant), contents, contents.Size(), nil)
+	err = w.Write(ctx, "test", backend.KeyPathForBlock(uuid.UUID(blockID), tenant), contents, contents.Size(), nil)
 	require.NoError(t, err)
 
 	tenantExists(t, tenant, r)
@@ -117,14 +117,14 @@ func TestShutdownRemovesTenantsWithoutBlocks(t *testing.T) {
 	tenant := "tenant"
 
 	// write a "block"
-	err = w.Write(ctx, "test", backend.KeyPathForBlock((uuid.UUID)(blockID), tenant), contents, contents.Size(), nil)
+	err = w.Write(ctx, "test", backend.KeyPathForBlock(uuid.UUID(blockID), tenant), contents, contents.Size(), nil)
 	require.NoError(t, err)
 
 	tenantExists(t, tenant, r)
 	blockExists(t, blockID, tenant, r)
 
 	// clear the block
-	err = c.ClearBlock((uuid.UUID)(blockID), tenant)
+	err = c.ClearBlock(uuid.UUID(blockID), tenant)
 	require.NoError(t, err)
 
 	tenantExists(t, tenant, r)

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -116,7 +116,7 @@ func (w *writer) WriteBlockMeta(ctx context.Context, meta *BlockMeta) error {
 		return err
 	}
 
-	return w.w.Write(ctx, MetaName, KeyPathForBlock((uuid.UUID)(blockID), tenantID), bytes.NewReader(bMeta), int64(len(bMeta)), nil)
+	return w.w.Write(ctx, MetaName, KeyPathForBlock(uuid.UUID(blockID), tenantID), bytes.NewReader(bMeta), int64(len(bMeta)), nil)
 }
 
 // Write implements backend.Writer

--- a/tempodb/backend/readerat.go
+++ b/tempodb/backend/readerat.go
@@ -36,13 +36,13 @@ func NewContextReader(meta *BlockMeta, name string, r Reader) ContextReader {
 
 // ReadAt implements ContextReader
 func (b *backendReader) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
-	err := b.r.ReadRange(ctx, b.name, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, uint64(off), p, nil)
+	err := b.r.ReadRange(ctx, b.name, uuid.UUID(b.meta.BlockID), b.meta.TenantID, uint64(off), p, nil)
 	return len(p), err
 }
 
 // ReadAll implements ContextReader
 func (b *backendReader) ReadAll(ctx context.Context) ([]byte, error) {
-	return b.r.Read(ctx, b.name, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, nil)
+	return b.r.Read(ctx, b.name, uuid.UUID(b.meta.BlockID), b.meta.TenantID, nil)
 }
 
 // Reader implements ContextReader

--- a/tempodb/backend/s3/compactor.go
+++ b/tempodb/backend/s3/compactor.go
@@ -25,7 +25,8 @@ func (rw *readerWriter) MarkBlockCompacted(blockID uuid.UUID, tenantID string) e
 
 	// copy meta.json to meta.compacted.json
 	// core.CopyObject does not support SSE on src object
-	_, err := rw.core.Client.CopyObject(context.TODO(),
+	_, err := rw.core.Client.CopyObject(
+		context.TODO(),
 		minio.CopyDestOptions{
 			Bucket:     rw.cfg.Bucket,
 			Object:     backend.CompactedMetaFileName(blockID, tenantID, rw.cfg.Prefix),

--- a/tempodb/backend/uuid.go
+++ b/tempodb/backend/uuid.go
@@ -34,11 +34,11 @@ func ParseUUID(s string) (UUID, error) {
 }
 
 func (u UUID) String() string {
-	return ((google_uuid.UUID)(u)).String()
+	return google_uuid.UUID(u).String()
 }
 
 func (u UUID) Marshal() ([]byte, error) {
-	return ((google_uuid.UUID)(u)).MarshalBinary()
+	return google_uuid.UUID(u).MarshalBinary()
 }
 
 func (u UUID) MarshalTo(data []byte) (n int, err error) {
@@ -46,7 +46,7 @@ func (u UUID) MarshalTo(data []byte) (n int, err error) {
 }
 
 func (u *UUID) Unmarshal(data []byte) error {
-	err := ((*google_uuid.UUID)(u)).UnmarshalBinary(data)
+	err := (*google_uuid.UUID)(u).UnmarshalBinary(data)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (u *UUID) Size() int {
 }
 
 func (u UUID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(((google_uuid.UUID)(u)).String())
+	return json.Marshal(google_uuid.UUID(u).String())
 }
 
 func (u *UUID) UnmarshalJSON(data []byte) error {

--- a/tempodb/backend/uuid_test.go
+++ b/tempodb/backend/uuid_test.go
@@ -49,11 +49,11 @@ func Test_roundTrip(t *testing.T) {
 func Test_helpers(t *testing.T) {
 	u := google_uuid.New()
 	s := MustParse(u.String())
-	require.Equal(t, u, (google_uuid.UUID)(s))
+	require.Equal(t, u, google_uuid.UUID(s))
 
 	s2, err := ParseUUID(u.String())
 	require.NoError(t, err)
-	require.Equal(t, u, (google_uuid.UUID)(s2))
+	require.Equal(t, u, google_uuid.UUID(s2))
 
 	_, err = ParseUUID("x")
 	require.Error(t, err)

--- a/tempodb/blocklist/poller_test.go
+++ b/tempodb/blocklist/poller_test.go
@@ -375,7 +375,7 @@ func TestPollBlock(t *testing.T) {
 				PollFallback:          testPollFallback,
 				TenantIndexBuilders:   testBuilders,
 			}, &mockJobSharder{}, r, c, w, log.NewNopLogger())
-			actualMeta, actualCompactedMeta, err := poller.pollBlock(context.Background(), tc.pollTenantID, (uuid.UUID)(tc.pollBlockID), false)
+			actualMeta, actualCompactedMeta, err := poller.pollBlock(context.Background(), tc.pollTenantID, uuid.UUID(tc.pollBlockID), false)
 
 			assert.Equal(t, tc.expectedMeta, actualMeta)
 			assert.Equal(t, tc.expectedCompactedMeta, actualCompactedMeta)
@@ -823,12 +823,12 @@ func TestPollComparePreviousResults(t *testing.T) {
 			},
 			expectedBlockMetaCalls: map[string]map[uuid.UUID]int{
 				"test": {
-					(uuid.UUID)(zero): 1,
+					uuid.UUID(zero): 1,
 				},
 			},
 			expectedCompactedBlockMetaCalls: map[string]map[uuid.UUID]int{
 				"test": {
-					(uuid.UUID)(eff): 1,
+					uuid.UUID(eff): 1,
 				},
 			},
 		},
@@ -892,13 +892,13 @@ func TestPollComparePreviousResults(t *testing.T) {
 			},
 			expectedBlockMetaCalls: map[string]map[uuid.UUID]int{
 				"test": {
-					(uuid.UUID)(eff): 1,
+					uuid.UUID(eff): 1,
 				},
 			},
 			expectedCompactedBlockMetaCalls: map[string]map[uuid.UUID]int{
 				"test": {
-					(uuid.UUID)(aaa):  1,
-					(uuid.UUID)(zero): 1,
+					uuid.UUID(aaa):  1,
+					uuid.UUID(zero): 1,
 				},
 			},
 		},
@@ -1375,7 +1375,7 @@ func newMockCompactor(list PerTenantCompacted, expectsError bool) backend.Compac
 			}
 
 			for _, m := range l {
-				if (uuid.UUID)(m.BlockID) == blockID {
+				if uuid.UUID(m.BlockID) == blockID {
 					return m, nil
 				}
 			}
@@ -1410,11 +1410,11 @@ func newMockReader(list PerTenant, compactedList PerTenantCompacted, expectsErro
 			uuids := []uuid.UUID{}
 			compactedUUIDs := []uuid.UUID{}
 			for _, b := range blocks {
-				uuids = append(uuids, (uuid.UUID)(b.BlockID))
+				uuids = append(uuids, uuid.UUID(b.BlockID))
 			}
 			compactedBlocks := compactedList[tenantID]
 			for _, b := range compactedBlocks {
-				compactedUUIDs = append(compactedUUIDs, (uuid.UUID)(b.BlockID))
+				compactedUUIDs = append(compactedUUIDs, uuid.UUID(b.BlockID))
 			}
 
 			return uuids, compactedUUIDs, nil
@@ -1431,7 +1431,7 @@ func newMockReader(list PerTenant, compactedList PerTenantCompacted, expectsErro
 			}
 
 			for _, m := range l {
-				if (uuid.UUID)(m.BlockID) == blockID {
+				if uuid.UUID(m.BlockID) == blockID {
 					return m, nil
 				}
 			}

--- a/tempodb/blockselector/compaction_block_selector.go
+++ b/tempodb/blockselector/compaction_block_selector.go
@@ -46,7 +46,7 @@ type timeWindowBlockEntry struct {
 	hash  string // hash string used for sharding ownership, preserves backwards compatibility
 }
 
-var _ (CompactionBlockSelector) = (*timeWindowBlockSelector)(nil)
+var _ CompactionBlockSelector = (*timeWindowBlockSelector)(nil)
 
 func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRange time.Duration, maxCompactionObjects int, maxBlockBytes uint64, minInputBlocks, maxInputBlocks, maxCompactionLevel int) CompactionBlockSelector {
 	twbs := &timeWindowBlockSelector{

--- a/tempodb/compactor.go
+++ b/tempodb/compactor.go
@@ -127,7 +127,8 @@ func (rw *readerWriter) compactOneTenant(ctx context.Context) {
 	//   Favoring lower compaction levels, and compacting blocks only from the same tenant.
 	//  2. If blocks are outside the active window, they're grouped only by windows, ignoring compaction level.
 	//   It picks more recent windows first, and compacting blocks only from the same tenant.
-	blockSelector := blockselector.NewTimeWindowBlockSelector(blocklist,
+	blockSelector := blockselector.NewTimeWindowBlockSelector(
+		blocklist,
 		window,
 		rw.compactorCfg.MaxCompactionObjects,
 		rw.compactorCfg.MaxBlockBytes,
@@ -278,7 +279,7 @@ func (rw *readerWriter) CompactWithConfig(ctx context.Context, blockMetas []*bac
 		totalRecords += int(blockMeta.TotalObjects)
 
 		// Make sure block still exists
-		_, err = rw.r.BlockMeta(ctx, (uuid.UUID)(blockMeta.BlockID), tenantID)
+		_, err = rw.r.BlockMeta(ctx, uuid.UUID(blockMeta.BlockID), tenantID)
 		if err != nil {
 			return nil, err
 		}
@@ -383,7 +384,7 @@ func markCompacted(rw *readerWriter, tenantID string, oldBlocks, newBlocks []*ba
 	var errCount int
 	for _, meta := range oldBlocks {
 		// Mark in the backend
-		if err := rw.c.MarkBlockCompacted((uuid.UUID)(meta.BlockID), tenantID); err != nil {
+		if err := rw.c.MarkBlockCompacted(uuid.UUID(meta.BlockID), tenantID); err != nil {
 			errCount++
 			level.Error(rw.logger).Log("msg", "unable to mark block compacted", "blockID", meta.BlockID, "tenantID", tenantID, "err", err)
 			metricCompactionErrors.Inc()

--- a/tempodb/encoding/v2/backend_block.go
+++ b/tempodb/encoding/v2/backend_block.go
@@ -57,7 +57,7 @@ func (b *BackendBlock) find(ctx context.Context, id common.ID) ([]byte, error) {
 	tenantID := b.meta.TenantID
 
 	nameBloom := common.BloomName(shardKey)
-	bloomBytes, err := b.reader.Read(ctx, nameBloom, (uuid.UUID)(blockID), tenantID, &backend.CacheInfo{
+	bloomBytes, err := b.reader.Read(ctx, nameBloom, uuid.UUID(blockID), tenantID, &backend.CacheInfo{
 		Meta: b.meta,
 		Role: cache.RoleBloom,
 	})

--- a/tempodb/encoding/v2/backend_block_test.go
+++ b/tempodb/encoding/v2/backend_block_test.go
@@ -52,7 +52,7 @@ func testLegacyBlock(t *testing.T, ids [][]byte, objs [][]byte, meta *backend.Bl
 	require.NoError(t, err, "error creating backend")
 
 	reader := backend.NewReader(r)
-	meta, err = reader.BlockMeta(context.Background(), (uuid.UUID)(meta.BlockID), meta.TenantID)
+	meta, err = reader.BlockMeta(context.Background(), uuid.UUID(meta.BlockID), meta.TenantID)
 	require.NoError(t, err, "error retrieving meta")
 
 	backendBlock, err := NewBackendBlock(meta, reader)

--- a/tempodb/encoding/v2/block.go
+++ b/tempodb/encoding/v2/block.go
@@ -18,7 +18,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	}
 
 	// index
-	err = w.Write(ctx, common.NameIndex, (uuid.UUID)(meta.BlockID), meta.TenantID, indexBytes, nil)
+	err = w.Write(ctx, common.NameIndex, uuid.UUID(meta.BlockID), meta.TenantID, indexBytes, nil)
 	if err != nil {
 		return fmt.Errorf("unexpected error writing index: %w", err)
 	}
@@ -30,7 +30,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	// bloom
 	for i, bloom := range blooms {
 		nameBloom := common.BloomName(i)
-		err := w.Write(ctx, nameBloom, (uuid.UUID)(meta.BlockID), meta.TenantID, bloom, cacheInfo)
+		err := w.Write(ctx, nameBloom, uuid.UUID(meta.BlockID), meta.TenantID, bloom, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("unexpected error writing bloom-%d: %w", i, err)
 		}
@@ -47,20 +47,20 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 
 // appendBlockData appends the bytes passed to the block data
 func appendBlockData(ctx context.Context, w backend.Writer, meta *backend.BlockMeta, tracker backend.AppendTracker, buffer []byte) (backend.AppendTracker, error) {
-	return w.Append(ctx, common.NameObjects, (uuid.UUID)(meta.BlockID), meta.TenantID, tracker, buffer)
+	return w.Append(ctx, common.NameObjects, uuid.UUID(meta.BlockID), meta.TenantID, tracker, buffer)
 }
 
 // CopyBlock copies a block from one backend to another.   It is done at a low level, all encoding/formatting is preserved.
 func CopyBlock(ctx context.Context, srcMeta, destMeta *backend.BlockMeta, src backend.Reader, dest backend.Writer) error {
 	// Copy streams, efficient but can't cache.
 	copyStream := func(name string) error {
-		reader, size, err := src.StreamReader(ctx, name, (uuid.UUID)(srcMeta.BlockID), srcMeta.TenantID)
+		reader, size, err := src.StreamReader(ctx, name, uuid.UUID(srcMeta.BlockID), srcMeta.TenantID)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 		defer reader.Close()
 
-		return dest.StreamWriter(ctx, name, (uuid.UUID)(destMeta.BlockID), destMeta.TenantID, reader, size)
+		return dest.StreamWriter(ctx, name, uuid.UUID(destMeta.BlockID), destMeta.TenantID, reader, size)
 	}
 
 	cacheInfo := &backend.CacheInfo{
@@ -70,13 +70,13 @@ func CopyBlock(ctx context.Context, srcMeta, destMeta *backend.BlockMeta, src ba
 	// Read entire object and attempt to cache
 	cpyBloom := func(name string) error {
 		cacheInfo.Meta = srcMeta
-		b, err := src.Read(ctx, name, (uuid.UUID)(srcMeta.BlockID), srcMeta.TenantID, cacheInfo)
+		b, err := src.Read(ctx, name, uuid.UUID(srcMeta.BlockID), srcMeta.TenantID, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 
 		cacheInfo.Meta = destMeta
-		return dest.Write(ctx, name, (uuid.UUID)(destMeta.BlockID), destMeta.TenantID, b, cacheInfo)
+		return dest.Write(ctx, name, uuid.UUID(destMeta.BlockID), destMeta.TenantID, b, cacheInfo)
 	}
 
 	// Data
@@ -100,10 +100,10 @@ func CopyBlock(ctx context.Context, srcMeta, destMeta *backend.BlockMeta, src ba
 	}
 
 	// no-compact flag
-	if hasNoCompactFlag, err := src.HasNoCompactFlag(ctx, (uuid.UUID)(srcMeta.BlockID), srcMeta.TenantID); err != nil {
+	if hasNoCompactFlag, err := src.HasNoCompactFlag(ctx, uuid.UUID(srcMeta.BlockID), srcMeta.TenantID); err != nil {
 		return err
 	} else if hasNoCompactFlag {
-		err = dest.WriteNoCompactFlag(ctx, (uuid.UUID)(destMeta.BlockID), destMeta.TenantID)
+		err = dest.WriteNoCompactFlag(ctx, uuid.UUID(destMeta.BlockID), destMeta.TenantID)
 		if err != nil {
 			return err
 		}

--- a/tempodb/encoding/v2/block_test.go
+++ b/tempodb/encoding/v2/block_test.go
@@ -57,12 +57,12 @@ func TestWriteBlockMetaWithNoCompactFlag(t *testing.T) {
 				CreateWithNoCompactFlag: withNoCompactFlag,
 				Encoding:                backend.EncLZ4_64k,
 			}
-			streamingBlock, err := NewStreamingBlock(cfg, (uuid.UUID)(meta.BlockID), meta.TenantID, []*backend.BlockMeta{meta}, 100)
+			streamingBlock, err := NewStreamingBlock(cfg, uuid.UUID(meta.BlockID), meta.TenantID, []*backend.BlockMeta{meta}, 100)
 			require.NoError(t, err)
 
 			go func() {
 				<-waitChan // writing block meta started, stopping it to emulate a slow write
-				hasFlag, err := reader.HasNoCompactFlag(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+				hasFlag, err := reader.HasNoCompactFlag(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 				require.NoError(t, err)
 				assert.Equal(t, withNoCompactFlag, hasFlag, fmt.Sprintf("nocompact flag should be %t in the middle of writing", withNoCompactFlag))
 				waitChan <- struct{}{} // we checked flag, proceed with writing
@@ -73,12 +73,12 @@ func TestWriteBlockMetaWithNoCompactFlag(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify nocompact flag remains after successful Complete (flag removal is done at higher level)
-			hasFlag, err := reader.HasNoCompactFlag(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+			hasFlag, err := reader.HasNoCompactFlag(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 			require.NoError(t, err)
 			assert.Equal(t, withNoCompactFlag, hasFlag, fmt.Sprintf("nocompact flag should be %t after successful Complete", withNoCompactFlag))
 
 			// Verify meta.json was written
-			blockMeta, err := reader.BlockMeta(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+			blockMeta, err := reader.BlockMeta(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 			require.NoError(t, err)
 			assert.Equal(t, meta.BlockID, blockMeta.BlockID)
 			assert.Equal(t, meta.TenantID, blockMeta.TenantID)

--- a/tempodb/encoding/v2/create_block.go
+++ b/tempodb/encoding/v2/create_block.go
@@ -20,7 +20,7 @@ func CreateBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.Blo
 		meta.DataEncoding = model.CurrentEncoding
 	}
 
-	newBlock, err := NewStreamingBlock(cfg, (uuid.UUID)(meta.BlockID), meta.TenantID, []*backend.BlockMeta{meta}, int(meta.TotalObjects))
+	newBlock, err := NewStreamingBlock(cfg, uuid.UUID(meta.BlockID), meta.TenantID, []*backend.BlockMeta{meta}, int(meta.TotalObjects))
 	if err != nil {
 		return nil, fmt.Errorf("error creating streaming block: %w", err)
 	}

--- a/tempodb/encoding/v2/streaming_block.go
+++ b/tempodb/encoding/v2/streaming_block.go
@@ -152,7 +152,7 @@ func (c *StreamingBlock) Complete(ctx context.Context, tracker backend.AppendTra
 
 	if c.withNoCompactFlag {
 		// write nocompact flag first to prevent compaction before completion
-		err := w.WriteNoCompactFlag(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+		err := w.WriteNoCompactFlag(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 		if err != nil {
 			return 0, fmt.Errorf("unexpected error writing nocompact flag: %w", err)
 		}

--- a/tempodb/encoding/v2/streaming_block_test.go
+++ b/tempodb/encoding/v2/streaming_block_test.go
@@ -140,7 +140,8 @@ func TestStreamingBlockAll(t *testing.T) {
 
 		for _, enc := range backend.SupportedEncoding {
 			t.Run(enc.String(), func(t *testing.T) {
-				testStreamingBlockToBackendBlock(t,
+				testStreamingBlockToBackendBlock(
+					t,
 					&common.BlockConfig{
 						IndexDownsampleBytes: indexDownsampleBytes,
 						BloomFP:              bloomFP,
@@ -254,7 +255,7 @@ func streamingBlock(t *testing.T, cfg *common.BlockConfig, w backend.Writer) (*S
 		dataReader,
 		NewObjectReaderWriter())
 
-	block, err := NewStreamingBlock(cfg, (uuid.UUID)(originatingMeta.BlockID), originatingMeta.TenantID, []*backend.BlockMeta{originatingMeta}, int(originatingMeta.TotalObjects))
+	block, err := NewStreamingBlock(cfg, uuid.UUID(originatingMeta.BlockID), originatingMeta.TenantID, []*backend.BlockMeta{originatingMeta}, int(originatingMeta.TotalObjects))
 	require.NoError(t, err, "unexpected error completing block")
 
 	expectedBloomShards := block.bloom.GetShardCount()

--- a/tempodb/encoding/v2/wal_block.go
+++ b/tempodb/encoding/v2/wal_block.go
@@ -55,7 +55,7 @@ func createWALBlock(meta *backend.BlockMeta, filepath, dataEncoding string, inge
 	}
 
 	h := &walBlock{
-		meta:           backend.NewBlockMeta(meta.TenantID, (uuid.UUID)(meta.BlockID), meta.Version, meta.Encoding, dataEncoding),
+		meta:           backend.NewBlockMeta(meta.TenantID, uuid.UUID(meta.BlockID), meta.Version, meta.Encoding, dataEncoding),
 		filepath:       filepath,
 		ingestionSlack: ingestionSlack,
 		encoder:        enc,

--- a/tempodb/encoding/vparquet3/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet3/block_findtracebyid.go
@@ -45,7 +45,7 @@ func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool
 	nameBloom := common.BloomName(shardKey)
 	span.SetAttributes(attribute.String("bloom", nameBloom))
 
-	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
+	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, uuid.UUID(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
 		Meta: b.meta,
 		Role: cache.RoleBloom,
 	})
@@ -75,7 +75,7 @@ func (b *backendBlock) checkIndex(ctx context.Context, id common.ID) (bool, int,
 		))
 	defer span.End()
 
-	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
+	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, uuid.UUID(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
 		Meta: b.meta,
 		Role: cache.RoleTraceIDIdx,
 	})
@@ -229,7 +229,8 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 	}
 
 	// Now iterate the matching row group
-	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
+	iter := parquetquery.NewSyncIterator(
+		ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
 		parquetquery.SyncIteratorOptPredicate(parquetquery.NewStringInPredicate([]string{string(traceID)})),
 		parquetquery.SyncIteratorOptMaxDefinitionLevel(maxDef),
 	)

--- a/tempodb/encoding/vparquet3/compactor.go
+++ b/tempodb/encoding/vparquet3/compactor.go
@@ -259,7 +259,8 @@ func (c *Compactor) finishBlock(ctx context.Context, block *streamingBlock, l lo
 		return fmt.Errorf("error completing block: %w", err)
 	}
 
-	level.Info(l).Log("msg", "wrote compacted block",
+	level.Info(l).Log(
+		"msg", "wrote compacted block",
 		"version", block.meta.Version,
 		"tenantID", block.meta.TenantID,
 		"blockID", block.meta.BlockID.String(),

--- a/tempodb/encoding/vparquet3/compactor_test.go
+++ b/tempodb/encoding/vparquet3/compactor_test.go
@@ -261,7 +261,7 @@ func TestWriteBlockMetaWithNoCompactFlag(t *testing.T) {
 
 			go func() {
 				<-waitChan // writing block meta started, stopping it to emulate a slow write
-				hasFlag, err := reader.HasNoCompactFlag(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+				hasFlag, err := reader.HasNoCompactFlag(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 				require.NoError(t, err)
 				assert.Equal(t, withNoCompactFlag, hasFlag, fmt.Sprintf("nocompact flag should be %t in the middle of writing", withNoCompactFlag))
 				waitChan <- struct{}{} // we checked flag, proceed with writing
@@ -272,12 +272,12 @@ func TestWriteBlockMetaWithNoCompactFlag(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify nocompact flag remains after successful Complete (flag removal is done at higher level)
-			hasFlag, err := reader.HasNoCompactFlag(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+			hasFlag, err := reader.HasNoCompactFlag(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 			require.NoError(t, err)
 			assert.Equal(t, withNoCompactFlag, hasFlag, fmt.Sprintf("nocompact flag should be %t after successful Complete", withNoCompactFlag))
 
 			// Verify meta.json was written
-			blockMeta, err := reader.BlockMeta(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+			blockMeta, err := reader.BlockMeta(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 			require.NoError(t, err)
 			assert.Equal(t, meta.BlockID, blockMeta.BlockID)
 			assert.Equal(t, meta.TenantID, blockMeta.TenantID)

--- a/tempodb/encoding/vparquet3/copy.go
+++ b/tempodb/encoding/vparquet3/copy.go
@@ -14,25 +14,25 @@ import (
 func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from backend.Reader, to backend.Writer) error {
 	// Copy streams, efficient but can't cache.
 	copyStream := func(name string) error {
-		reader, size, err := from.StreamReader(ctx, name, (uuid.UUID)(fromMeta.BlockID), fromMeta.TenantID)
+		reader, size, err := from.StreamReader(ctx, name, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 		defer reader.Close()
 
-		return to.StreamWriter(ctx, name, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID, reader, size)
+		return to.StreamWriter(ctx, name, uuid.UUID(toMeta.BlockID), toMeta.TenantID, reader, size)
 	}
 
 	// Read entire object and attempt to cache
 	cpy := func(name string, cacheInfo *backend.CacheInfo) error {
 		cacheInfo.Meta = fromMeta
-		b, err := from.Read(ctx, name, (uuid.UUID)(fromMeta.BlockID), fromMeta.TenantID, cacheInfo)
+		b, err := from.Read(ctx, name, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 
 		cacheInfo.Meta = toMeta
-		return to.Write(ctx, name, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID, b, cacheInfo)
+		return to.Write(ctx, name, uuid.UUID(toMeta.BlockID), toMeta.TenantID, b, cacheInfo)
 	}
 
 	// Data
@@ -57,10 +57,10 @@ func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from ba
 	}
 
 	// no-compact flag
-	if hasNoCompactFlag, err := from.HasNoCompactFlag(ctx, (uuid.UUID)(fromMeta.BlockID), fromMeta.TenantID); err != nil {
+	if hasNoCompactFlag, err := from.HasNoCompactFlag(ctx, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID); err != nil {
 		return err
 	} else if hasNoCompactFlag {
-		err = to.WriteNoCompactFlag(ctx, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID)
+		err = to.WriteNoCompactFlag(ctx, uuid.UUID(toMeta.BlockID), toMeta.TenantID)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	}
 	for i, bloom := range blooms {
 		nameBloom := common.BloomName(i)
-		err := w.Write(ctx, nameBloom, (uuid.UUID)(meta.BlockID), meta.TenantID, bloom, cacheInfo)
+		err := w.Write(ctx, nameBloom, uuid.UUID(meta.BlockID), meta.TenantID, bloom, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("unexpected error writing bloom-%d: %w", i, err)
 		}
@@ -95,7 +95,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	if err != nil {
 		return err
 	}
-	err = w.Write(ctx, common.NameIndex, (uuid.UUID)(meta.BlockID), meta.TenantID, i, &backend.CacheInfo{
+	err = w.Write(ctx, common.NameIndex, uuid.UUID(meta.BlockID), meta.TenantID, i, &backend.CacheInfo{
 		Meta: meta,
 		Role: cache.RoleTraceIDIdx,
 	})

--- a/tempodb/encoding/vparquet3/create.go
+++ b/tempodb/encoding/vparquet3/create.go
@@ -109,7 +109,7 @@ type streamingBlock struct {
 }
 
 func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, r backend.Reader, to backend.Writer, createBufferedWriter func(w io.Writer) tempo_io.BufferedWriteFlusher) *streamingBlock {
-	newMeta := backend.NewBlockMeta(meta.TenantID, (uuid.UUID)(meta.BlockID), VersionString, backend.EncNone, "")
+	newMeta := backend.NewBlockMeta(meta.TenantID, uuid.UUID(meta.BlockID), VersionString, backend.EncNone, "")
 	newMeta.StartTime = meta.StartTime
 	newMeta.EndTime = meta.EndTime
 	newMeta.ReplicationFactor = meta.ReplicationFactor
@@ -120,7 +120,7 @@ func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backe
 	// The real number of objects is tracked below.
 	bloom := common.NewBloom(cfg.BloomFP, uint(cfg.BloomShardSizeBytes), uint(meta.TotalObjects))
 
-	w := &backendWriter{ctx, to, DataFileName, (uuid.UUID)(meta.BlockID), meta.TenantID, nil}
+	w := &backendWriter{ctx, to, DataFileName, uuid.UUID(meta.BlockID), meta.TenantID, nil}
 	bw := createBufferedWriter(w)
 	pw := parquet.NewGenericWriter[*Trace](bw)
 
@@ -231,7 +231,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	// Read the footer size out of the parquet footer
 	buf := make([]byte, 8)
-	err = b.r.ReadRange(b.ctx, DataFileName, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, b.meta.Size_-8, buf, nil)
+	err = b.r.ReadRange(b.ctx, DataFileName, uuid.UUID(b.meta.BlockID), b.meta.TenantID, b.meta.Size_-8, buf, nil)
 	if err != nil {
 		return 0, fmt.Errorf("error reading parquet file footer: %w", err)
 	}
@@ -244,7 +244,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	if b.withNoCompactFlag {
 		// write nocompact flag first to prevent compaction before completion
-		err := b.to.WriteNoCompactFlag(b.ctx, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID)
+		err := b.to.WriteNoCompactFlag(b.ctx, uuid.UUID(b.meta.BlockID), b.meta.TenantID)
 		if err != nil {
 			return 0, fmt.Errorf("unexpected error writing nocompact flag: %w", err)
 		}

--- a/tempodb/encoding/vparquet3/readers.go
+++ b/tempodb/encoding/vparquet3/readers.go
@@ -38,7 +38,7 @@ func (b *BackendReaderAt) ReadAt(p []byte, off int64) (int, error) {
 }
 
 func (b *BackendReaderAt) ReadAtWithCache(p []byte, off int64, role cache.Role) (int, error) {
-	err := b.r.ReadRange(b.ctx, b.name, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, uint64(off), p, &backend.CacheInfo{
+	err := b.r.ReadRange(b.ctx, b.name, uuid.UUID(b.meta.BlockID), b.meta.TenantID, uint64(off), p, &backend.CacheInfo{
 		Role: role,
 		Meta: b.meta,
 	})

--- a/tempodb/encoding/vparquet4/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet4/block_findtracebyid.go
@@ -45,7 +45,7 @@ func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool
 	nameBloom := common.BloomName(shardKey)
 	span.SetAttributes(attribute.String("bloom", nameBloom))
 
-	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
+	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, uuid.UUID(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
 		Meta: b.meta,
 		Role: cache.RoleBloom,
 	})
@@ -75,7 +75,7 @@ func (b *backendBlock) checkIndex(ctx context.Context, id common.ID) (bool, int,
 		))
 	defer span.End()
 
-	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
+	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, uuid.UUID(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
 		Meta: b.meta,
 		Role: cache.RoleTraceIDIdx,
 	})
@@ -236,7 +236,8 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 	}
 
 	// Now iterate the matching row group
-	iter := parquetquery.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
+	iter := parquetquery.NewSyncIterator(
+		ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
 		parquetquery.SyncIteratorOptPredicate(parquetquery.NewStringInPredicate([]string{string(traceID)})),
 		parquetquery.SyncIteratorOptMaxDefinitionLevel(maxDef),
 	)

--- a/tempodb/encoding/vparquet4/block_traceql_test.go
+++ b/tempodb/encoding/vparquet4/block_traceql_test.go
@@ -1772,7 +1772,8 @@ func TestSamplingError(t *testing.T) {
 					err = math.Log(err)
 				}
 
-				fmt.Fprintln(w,
+				fmt.Fprintln(
+					w,
 					query,
 					"\t"+option,
 					"\t"+fmt.Sprintf("%.2f", err),

--- a/tempodb/encoding/vparquet4/compactor.go
+++ b/tempodb/encoding/vparquet4/compactor.go
@@ -274,7 +274,8 @@ func (c *Compactor) finishBlock(ctx context.Context, block *streamingBlock, l lo
 		return fmt.Errorf("error completing block: %w", err)
 	}
 
-	level.Info(l).Log("msg", "wrote compacted block",
+	level.Info(l).Log(
+		"msg", "wrote compacted block",
 		"version", block.meta.Version,
 		"tenantID", block.meta.TenantID,
 		"blockID", block.meta.BlockID.String(),

--- a/tempodb/encoding/vparquet4/compactor_test.go
+++ b/tempodb/encoding/vparquet4/compactor_test.go
@@ -261,7 +261,7 @@ func TestWriteBlockMetaWithNoCompactFlag(t *testing.T) {
 
 			go func() {
 				<-waitChan // writing block meta started, stopping it to emulate a slow write
-				hasFlag, err := reader.HasNoCompactFlag(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+				hasFlag, err := reader.HasNoCompactFlag(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 				require.NoError(t, err)
 				assert.Equal(t, withNoCompactFlag, hasFlag, fmt.Sprintf("nocompact flag should be %t in the middle of writing", withNoCompactFlag))
 				waitChan <- struct{}{} // we checked flag, proceed with writing
@@ -272,12 +272,12 @@ func TestWriteBlockMetaWithNoCompactFlag(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify nocompact flag remains after successful Complete (flag removal is done at higher level)
-			hasFlag, err := reader.HasNoCompactFlag(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+			hasFlag, err := reader.HasNoCompactFlag(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 			require.NoError(t, err)
 			assert.Equal(t, withNoCompactFlag, hasFlag, fmt.Sprintf("nocompact flag should be %t after successful Complete", withNoCompactFlag))
 
 			// Verify meta.json was written
-			blockMeta, err := reader.BlockMeta(ctx, (uuid.UUID)(meta.BlockID), meta.TenantID)
+			blockMeta, err := reader.BlockMeta(ctx, uuid.UUID(meta.BlockID), meta.TenantID)
 			require.NoError(t, err)
 			assert.Equal(t, meta.BlockID, blockMeta.BlockID)
 			assert.Equal(t, meta.TenantID, blockMeta.TenantID)

--- a/tempodb/encoding/vparquet4/copy.go
+++ b/tempodb/encoding/vparquet4/copy.go
@@ -14,25 +14,25 @@ import (
 func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from backend.Reader, to backend.Writer) error {
 	// Copy streams, efficient but can't cache.
 	copyStream := func(name string) error {
-		reader, size, err := from.StreamReader(ctx, name, (uuid.UUID)(fromMeta.BlockID), fromMeta.TenantID)
+		reader, size, err := from.StreamReader(ctx, name, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 		defer reader.Close()
 
-		return to.StreamWriter(ctx, name, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID, reader, size)
+		return to.StreamWriter(ctx, name, uuid.UUID(toMeta.BlockID), toMeta.TenantID, reader, size)
 	}
 
 	// Read entire object and attempt to cache
 	cpy := func(name string, cacheInfo *backend.CacheInfo) error {
 		cacheInfo.Meta = fromMeta
-		b, err := from.Read(ctx, name, (uuid.UUID)(fromMeta.BlockID), fromMeta.TenantID, cacheInfo)
+		b, err := from.Read(ctx, name, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 
 		cacheInfo.Meta = toMeta
-		return to.Write(ctx, name, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID, b, cacheInfo)
+		return to.Write(ctx, name, uuid.UUID(toMeta.BlockID), toMeta.TenantID, b, cacheInfo)
 	}
 
 	// Data
@@ -57,10 +57,10 @@ func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from ba
 	}
 
 	// no-compact flag
-	if hasNoCompactFlag, err := from.HasNoCompactFlag(ctx, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID); err != nil {
+	if hasNoCompactFlag, err := from.HasNoCompactFlag(ctx, uuid.UUID(toMeta.BlockID), toMeta.TenantID); err != nil {
 		return err
 	} else if hasNoCompactFlag {
-		err = to.WriteNoCompactFlag(ctx, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID)
+		err = to.WriteNoCompactFlag(ctx, uuid.UUID(toMeta.BlockID), toMeta.TenantID)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	}
 	for i, bloom := range blooms {
 		nameBloom := common.BloomName(i)
-		err := w.Write(ctx, nameBloom, (uuid.UUID)(meta.BlockID), meta.TenantID, bloom, cacheInfo)
+		err := w.Write(ctx, nameBloom, uuid.UUID(meta.BlockID), meta.TenantID, bloom, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("unexpected error writing bloom-%d: %w", i, err)
 		}
@@ -94,7 +94,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	if err != nil {
 		return err
 	}
-	err = w.Write(ctx, common.NameIndex, (uuid.UUID)(meta.BlockID), meta.TenantID, i, &backend.CacheInfo{
+	err = w.Write(ctx, common.NameIndex, uuid.UUID(meta.BlockID), meta.TenantID, i, &backend.CacheInfo{
 		Meta: meta,
 		Role: cache.RoleTraceIDIdx,
 	})

--- a/tempodb/encoding/vparquet4/create.go
+++ b/tempodb/encoding/vparquet4/create.go
@@ -140,7 +140,7 @@ type streamingBlock struct {
 }
 
 func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, r backend.Reader, to backend.Writer, createBufferedWriter func(w io.Writer) tempo_io.BufferedWriteFlusher) *streamingBlock {
-	newMeta := backend.NewBlockMeta(meta.TenantID, (uuid.UUID)(meta.BlockID), VersionString, backend.EncNone, "")
+	newMeta := backend.NewBlockMeta(meta.TenantID, uuid.UUID(meta.BlockID), VersionString, backend.EncNone, "")
 	newMeta.StartTime = meta.StartTime
 	newMeta.EndTime = meta.EndTime
 	newMeta.ReplicationFactor = meta.ReplicationFactor
@@ -151,7 +151,7 @@ func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backe
 	// The real number of objects is tracked below.
 	bloom := common.NewBloom(cfg.BloomFP, uint(cfg.BloomShardSizeBytes), uint(meta.TotalObjects))
 
-	w := &backendWriter{ctx, to, DataFileName, (uuid.UUID)(meta.BlockID), meta.TenantID, nil}
+	w := &backendWriter{ctx, to, DataFileName, uuid.UUID(meta.BlockID), meta.TenantID, nil}
 	bw := createBufferedWriter(w)
 	pw := parquet.NewGenericWriter[*Trace](bw)
 
@@ -262,7 +262,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	// Read the footer size out of the parquet footer
 	buf := make([]byte, 8)
-	err = b.r.ReadRange(b.ctx, DataFileName, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, b.meta.Size_-8, buf, nil)
+	err = b.r.ReadRange(b.ctx, DataFileName, uuid.UUID(b.meta.BlockID), b.meta.TenantID, b.meta.Size_-8, buf, nil)
 	if err != nil {
 		return 0, fmt.Errorf("error reading parquet file footer: %w", err)
 	}
@@ -275,7 +275,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	if b.withNoCompactFlag {
 		// write nocompact flag first to prevent compaction before completion
-		err := b.to.WriteNoCompactFlag(b.ctx, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID)
+		err := b.to.WriteNoCompactFlag(b.ctx, uuid.UUID(b.meta.BlockID), b.meta.TenantID)
 		if err != nil {
 			return 0, fmt.Errorf("unexpected error writing nocompact flag: %w", err)
 		}

--- a/tempodb/encoding/vparquet4/readers.go
+++ b/tempodb/encoding/vparquet4/readers.go
@@ -39,7 +39,7 @@ func (b *BackendReaderAt) ReadAt(p []byte, off int64) (int, error) {
 }
 
 func (b *BackendReaderAt) ReadAtWithCache(p []byte, off int64, role cache.Role) (int, error) {
-	err := b.r.ReadRange(b.ctx, b.name, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, uint64(off), p, &backend.CacheInfo{
+	err := b.r.ReadRange(b.ctx, b.name, uuid.UUID(b.meta.BlockID), b.meta.TenantID, uint64(off), p, &backend.CacheInfo{
 		Role: role,
 		Meta: b.meta,
 	})

--- a/tempodb/encoding/vparquet5/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete_test.go
@@ -771,7 +771,8 @@ func TestFetchTagValues(t *testing.T) {
 				distinctValues  = collector.NewDistinctValue(1_000_000, 0, 0, func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) })
 				autocompleteReq = traceql.FetchTagValuesRequest{
 					TagName: tag,
-					Conditions: append(req.Conditions,
+					Conditions: append(
+						req.Conditions,
 						traceql.Condition{
 							Attribute: tagAtrr,
 							Op:        traceql.OpNone,

--- a/tempodb/encoding/vparquet5/block_findtracebyid.go
+++ b/tempodb/encoding/vparquet5/block_findtracebyid.go
@@ -45,7 +45,7 @@ func (b *backendBlock) checkBloom(ctx context.Context, id common.ID) (found bool
 	nameBloom := common.BloomName(shardKey)
 	span.SetAttributes(attribute.String("bloom", nameBloom))
 
-	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
+	bloomBytes, err := b.r.Read(derivedCtx, nameBloom, uuid.UUID(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
 		Meta: b.meta,
 		Role: cache.RoleBloom,
 	})
@@ -75,7 +75,7 @@ func (b *backendBlock) checkIndex(ctx context.Context, id common.ID) (bool, int,
 		))
 	defer span.End()
 
-	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
+	indexBytes, err := b.r.Read(derivedCtx, common.NameIndex, uuid.UUID(b.meta.BlockID), b.meta.TenantID, &backend.CacheInfo{
 		Meta: b.meta,
 		Role: cache.RoleTraceIDIdx,
 	})
@@ -236,7 +236,8 @@ func findTraceByID(ctx context.Context, traceID common.ID, meta *backend.BlockMe
 	}
 
 	// Now iterate the matching row group
-	iter := pq.NewSyncIterator(ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
+	iter := pq.NewSyncIterator(
+		ctx, pf.RowGroups()[rowGroup:rowGroup+1], colIndex,
 		pq.SyncIteratorOptPredicate(pq.NewStringInPredicate([]string{string(traceID)})),
 		pq.SyncIteratorOptMaxDefinitionLevel(maxDef),
 	)

--- a/tempodb/encoding/vparquet5/block_traceql_test.go
+++ b/tempodb/encoding/vparquet5/block_traceql_test.go
@@ -1949,7 +1949,8 @@ func TestSamplingError(t *testing.T) {
 					err = math.Log(err)
 				}
 
-				fmt.Fprintln(w,
+				fmt.Fprintln(
+					w,
 					query,
 					"\t"+option,
 					"\t"+fmt.Sprintf("%.2f", err),

--- a/tempodb/encoding/vparquet5/compactor.go
+++ b/tempodb/encoding/vparquet5/compactor.go
@@ -274,7 +274,8 @@ func (c *Compactor) finishBlock(ctx context.Context, block *streamingBlock, l lo
 		return fmt.Errorf("error completing block: %w", err)
 	}
 
-	level.Info(l).Log("msg", "wrote compacted block",
+	level.Info(l).Log(
+		"msg", "wrote compacted block",
 		"version", block.meta.Version,
 		"tenantID", block.meta.TenantID,
 		"blockID", block.meta.BlockID.String(),

--- a/tempodb/encoding/vparquet5/copy.go
+++ b/tempodb/encoding/vparquet5/copy.go
@@ -14,25 +14,25 @@ import (
 func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from backend.Reader, to backend.Writer) error {
 	// Copy streams, efficient but can't cache.
 	copyStream := func(name string) error {
-		reader, size, err := from.StreamReader(ctx, name, (uuid.UUID)(fromMeta.BlockID), fromMeta.TenantID)
+		reader, size, err := from.StreamReader(ctx, name, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 		defer reader.Close()
 
-		return to.StreamWriter(ctx, name, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID, reader, size)
+		return to.StreamWriter(ctx, name, uuid.UUID(toMeta.BlockID), toMeta.TenantID, reader, size)
 	}
 
 	// Read entire object and attempt to cache
 	cpy := func(name string, cacheInfo *backend.CacheInfo) error {
 		cacheInfo.Meta = fromMeta
-		b, err := from.Read(ctx, name, (uuid.UUID)(fromMeta.BlockID), fromMeta.TenantID, cacheInfo)
+		b, err := from.Read(ctx, name, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("error reading %s: %w", name, err)
 		}
 
 		cacheInfo.Meta = toMeta
-		return to.Write(ctx, name, (uuid.UUID)(toMeta.BlockID), toMeta.TenantID, b, cacheInfo)
+		return to.Write(ctx, name, uuid.UUID(toMeta.BlockID), toMeta.TenantID, b, cacheInfo)
 	}
 
 	// Data
@@ -74,7 +74,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	}
 	for i, bloom := range blooms {
 		nameBloom := common.BloomName(i)
-		err := w.Write(ctx, nameBloom, (uuid.UUID)(meta.BlockID), meta.TenantID, bloom, cacheInfo)
+		err := w.Write(ctx, nameBloom, uuid.UUID(meta.BlockID), meta.TenantID, bloom, cacheInfo)
 		if err != nil {
 			return fmt.Errorf("unexpected error writing bloom-%d: %w", i, err)
 		}
@@ -85,7 +85,7 @@ func writeBlockMeta(ctx context.Context, w backend.Writer, meta *backend.BlockMe
 	if err != nil {
 		return err
 	}
-	err = w.Write(ctx, common.NameIndex, (uuid.UUID)(meta.BlockID), meta.TenantID, i, &backend.CacheInfo{
+	err = w.Write(ctx, common.NameIndex, uuid.UUID(meta.BlockID), meta.TenantID, i, &backend.CacheInfo{
 		Meta: meta,
 		Role: cache.RoleTraceIDIdx,
 	})

--- a/tempodb/encoding/vparquet5/create.go
+++ b/tempodb/encoding/vparquet5/create.go
@@ -141,7 +141,7 @@ type streamingBlock struct {
 }
 
 func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backend.BlockMeta, r backend.Reader, to backend.Writer, createBufferedWriter func(w io.Writer) tempo_io.BufferedWriteFlusher) *streamingBlock {
-	newMeta := backend.NewBlockMeta(meta.TenantID, (uuid.UUID)(meta.BlockID), VersionString, backend.EncNone, "")
+	newMeta := backend.NewBlockMeta(meta.TenantID, uuid.UUID(meta.BlockID), VersionString, backend.EncNone, "")
 	newMeta.StartTime = meta.StartTime
 	newMeta.EndTime = meta.EndTime
 	newMeta.ReplicationFactor = meta.ReplicationFactor
@@ -152,7 +152,7 @@ func newStreamingBlock(ctx context.Context, cfg *common.BlockConfig, meta *backe
 	bloom := common.NewBloom(cfg.BloomFP, uint(cfg.BloomShardSizeBytes), uint(meta.TotalObjects))
 
 	var (
-		w                   = &backendWriter{ctx, to, DataFileName, (uuid.UUID)(meta.BlockID), meta.TenantID, nil}
+		w                   = &backendWriter{ctx, to, DataFileName, uuid.UUID(meta.BlockID), meta.TenantID, nil}
 		bw                  = createBufferedWriter(w)
 		_, writerOptions, _ = SchemaWithDynamicChanges(meta.DedicatedColumns)
 		pw                  = parquet.NewGenericWriter[*Trace](bw, writerOptions...)
@@ -264,7 +264,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	// Read the footer size out of the parquet footer
 	buf := make([]byte, 8)
-	err = b.r.ReadRange(b.ctx, DataFileName, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, b.meta.Size_-8, buf, nil)
+	err = b.r.ReadRange(b.ctx, DataFileName, uuid.UUID(b.meta.BlockID), b.meta.TenantID, b.meta.Size_-8, buf, nil)
 	if err != nil {
 		return 0, fmt.Errorf("error reading parquet file footer: %w", err)
 	}
@@ -277,7 +277,7 @@ func (b *streamingBlock) Complete() (int, error) {
 
 	if b.withNoCompactFlag {
 		// write nocompact flag first to prevent compaction before completion
-		err := b.to.WriteNoCompactFlag(b.ctx, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID)
+		err := b.to.WriteNoCompactFlag(b.ctx, uuid.UUID(b.meta.BlockID), b.meta.TenantID)
 		if err != nil {
 			return 0, fmt.Errorf("unexpected error writing nocompact flag: %w", err)
 		}

--- a/tempodb/encoding/vparquet5/readers.go
+++ b/tempodb/encoding/vparquet5/readers.go
@@ -39,7 +39,7 @@ func (b *BackendReaderAt) ReadAt(p []byte, off int64) (int, error) {
 }
 
 func (b *BackendReaderAt) ReadAtWithCache(p []byte, off int64, role cache.Role) (int, error) {
-	err := b.r.ReadRange(b.ctx, b.name, (uuid.UUID)(b.meta.BlockID), b.meta.TenantID, uint64(off), p, &backend.CacheInfo{
+	err := b.r.ReadRange(b.ctx, b.name, uuid.UUID(b.meta.BlockID), b.meta.TenantID, uint64(off), p, &backend.CacheInfo{
 		Role: role,
 		Meta: b.meta,
 	})

--- a/tempodb/retention.go
+++ b/tempodb/retention.go
@@ -82,7 +82,7 @@ func (rw *readerWriter) retainTenant(ctx context.Context, tenantID string, compa
 		default:
 			if b.EndTime.Before(cutoff) && compactorSharder.Owns(b.BlockID.String()) {
 				level.Info(rw.logger).Log("msg", "marking block for deletion", "blockID", b.BlockID, "tenantID", tenantID)
-				err := rw.c.MarkBlockCompacted((uuid.UUID)(b.BlockID), tenantID)
+				err := rw.c.MarkBlockCompacted(uuid.UUID(b.BlockID), tenantID)
 				if err != nil {
 					level.Error(rw.logger).Log("msg", "failed to mark block compacted during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
 					metricRetentionErrors.Inc()
@@ -111,7 +111,7 @@ func (rw *readerWriter) retainTenant(ctx context.Context, tenantID string, compa
 			level.Debug(rw.logger).Log("owns", compactorSharder.Owns(b.BlockID.String()), "blockID", b.BlockID, "tenantID", tenantID)
 			if b.CompactedTime.Before(cutoff) && compactorSharder.Owns(b.BlockID.String()) {
 				level.Info(rw.logger).Log("msg", "deleting block", "blockID", b.BlockID, "tenantID", tenantID)
-				err := rw.c.ClearBlock((uuid.UUID)(b.BlockID), tenantID)
+				err := rw.c.ClearBlock(uuid.UUID(b.BlockID), tenantID)
 				if err != nil {
 					level.Error(rw.logger).Log("msg", "failed to clear compacted block during retention", "blockID", b.BlockID, "tenantID", tenantID, "err", err)
 					metricRetentionErrors.Inc()

--- a/tempodb/retention_test.go
+++ b/tempodb/retention_test.go
@@ -70,17 +70,17 @@ func TestRetention(t *testing.T) {
 
 	rw := r.(*readerWriter)
 	// poll
-	checkBlocklists(ctx, t, (uuid.UUID)(blockID), 1, 0, rw)
+	checkBlocklists(ctx, t, uuid.UUID(blockID), 1, 0, rw)
 
 	// retention should mark it compacted
 	rw.compactorCfg.BlockRetention = 0
 	r.(*readerWriter).doRetention(ctx)
-	checkBlocklists(ctx, t, (uuid.UUID)(blockID), 0, 1, rw)
+	checkBlocklists(ctx, t, uuid.UUID(blockID), 0, 1, rw)
 
 	// retention again should clear it
 	rw.compactorCfg.CompactedBlockRetention = 0
 	r.(*readerWriter).doRetention(ctx)
-	checkBlocklists(ctx, t, (uuid.UUID)(blockID), 0, 0, rw)
+	checkBlocklists(ctx, t, uuid.UUID(blockID), 0, 0, rw)
 }
 
 func TestRetentionUpdatesBlocklistImmediately(t *testing.T) {
@@ -369,7 +369,8 @@ func testRetainWithConfig(t *testing.T, targetBlockVersion string) {
 	require.Len(t, rw.blocklist.Metas(testTenantID), 1)
 	require.Len(t, rw.blocklist.CompactedMetas(testTenantID), 10)
 
-	c.RetainWithConfig(ctx,
+	c.RetainWithConfig(
+		ctx,
 		compactorCfg,
 		&mockSharder{},
 		&mockOverrides{},

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -297,7 +297,7 @@ func (rw *readerWriter) CompleteBlockWithBackend(ctx context.Context, block comm
 }
 
 func (rw *readerWriter) DeleteNoCompactFlag(ctx context.Context, tenantID string, blockID backend.UUID) error {
-	return rw.w.DeleteNoCompactFlag(ctx, (uuid.UUID)(blockID), tenantID)
+	return rw.w.DeleteNoCompactFlag(ctx, uuid.UUID(blockID), tenantID)
 }
 
 func (rw *readerWriter) WAL() *wal.WAL {
@@ -305,7 +305,7 @@ func (rw *readerWriter) WAL() *wal.WAL {
 }
 
 func (rw *readerWriter) BlockMeta(ctx context.Context, tenantID string, blockID backend.UUID) (*backend.BlockMeta, *backend.CompactedBlockMeta, error) {
-	meta, err := rw.r.BlockMeta(ctx, (uuid.UUID)(blockID), tenantID)
+	meta, err := rw.r.BlockMeta(ctx, uuid.UUID(blockID), tenantID)
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, nil, err
 	}
@@ -314,7 +314,7 @@ func (rw *readerWriter) BlockMeta(ctx context.Context, tenantID string, blockID 
 		return meta, nil, nil
 	}
 
-	compactedMeta, err := rw.c.CompactedBlockMeta((uuid.UUID)(blockID), tenantID)
+	compactedMeta, err := rw.c.CompactedBlockMeta(uuid.UUID(blockID), tenantID)
 	if err != nil && !errors.Is(err, backend.ErrDoesNotExist) {
 		return nil, nil, err
 	}
@@ -604,7 +604,7 @@ func (rw *readerWriter) EnableCompaction(ctx context.Context, cfg *CompactorConf
 }
 
 func (rw *readerWriter) MarkBlockCompacted(tenantID string, blockID backend.UUID) error {
-	return rw.c.MarkBlockCompacted((uuid.UUID)(blockID), tenantID)
+	return rw.c.MarkBlockCompacted(uuid.UUID(blockID), tenantID)
 }
 
 // EnablePolling activates the polling loop. Pass nil if this component

--- a/tempodb/tempodb_search_test.go
+++ b/tempodb/tempodb_search_test.go
@@ -49,7 +49,8 @@ func TestSearchCompleteBlock(t *testing.T) {
 		vers := v.Version()
 		t.Run(vers, func(t *testing.T) {
 			t.Parallel()
-			runCompleteBlockSearchTest(t, vers,
+			runCompleteBlockSearchTest(
+				t, vers,
 				searchRunner,
 				traceQLRunner,
 				advancedTraceQLRunner,

--- a/tempodb/tempodb_test.go
+++ b/tempodb/tempodb_test.go
@@ -251,13 +251,13 @@ func checkBlocklists(ctx context.Context, t *testing.T, expectedID uuid.UUID, ex
 	blocklist := rw.blocklist.Metas(testTenantID)
 	require.Len(t, blocklist, expectedB)
 	if expectedB > 0 && expectedID != uuid.Nil {
-		require.Equal(t, expectedID, (uuid.UUID)(blocklist[0].BlockID))
+		require.Equal(t, expectedID, uuid.UUID(blocklist[0].BlockID))
 	}
 
 	compactedBlocklist := rw.blocklist.CompactedMetas(testTenantID)
 	require.Len(t, compactedBlocklist, expectedCB)
 	if expectedCB > 0 && expectedID != uuid.Nil {
-		require.Equal(t, expectedID, (uuid.UUID)(compactedBlocklist[0].BlockID))
+		require.Equal(t, expectedID, uuid.UUID(compactedBlocklist[0].BlockID))
 	}
 }
 
@@ -925,7 +925,7 @@ func TestNoCompactFlag(t *testing.T) {
 
 			// Verify the nocompact flag
 			rw := r.(*readerWriter)
-			hasFlag, err := rw.r.HasNoCompactFlag(ctx, (uuid.UUID)(completedBlockID), testTenantID)
+			hasFlag, err := rw.r.HasNoCompactFlag(ctx, uuid.UUID(completedBlockID), testTenantID)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedNoCompactFlag, hasFlag, "nocompact flag should remain after successful writeBlockMeta")
 
@@ -941,7 +941,7 @@ func TestNoCompactFlag(t *testing.T) {
 			}
 
 			// Remove the nocompact flag
-			err = rw.w.DeleteNoCompactFlag(ctx, (uuid.UUID)(completedBlockID), testTenantID)
+			err = rw.w.DeleteNoCompactFlag(ctx, uuid.UUID(completedBlockID), testTenantID)
 			require.NoError(t, err)
 
 			// Poll blocklist again

--- a/tools/chloggen/internal/chlog/entry_test.go
+++ b/tools/chloggen/internal/chlog/entry_test.go
@@ -35,7 +35,8 @@ func TestEntry(t *testing.T) {
 			New("summary.tmpl").
 			Funcs(TemplateFuncMap()).
 			Option("missingkey=error").
-			Parse(string(defaultTmpl)))
+			Parse(string(defaultTmpl)),
+	)
 
 	testCases := []struct {
 		name             string

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/tempo/tools
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.8.0


### PR DESCRIPTION
## What

- Bump `go` directive in `go.mod` and `tools/go.mod` from 1.26.3 to 1.26.5
- Fixes CVE-2026-39822, CVE-2026-27145, CVE-2026-42504, CVE-2026-42505, CVE-2026-42507 (all resolved by the Go 1.26.5 stdlib)
- `.chloggen` entries for this fix plus retroactive entries for grpc/x-net/x-text/otel security bumps already merged on this branch via Renovate without changelog entries
- Bump `TOOLS_IMAGE_TAG` to main's current tag - the pinned tools image predated the Go bump and golangci-lint refused to run against the new `go 1.26.5` requirement under `GOTOOLCHAIN=local`. Pulls in gofumpt 0.9.2->0.10.0 and golangci-lint 2.11.4->2.12.2, which reformats files and regenerates `pkg/traceql/expr.y.go` via the newer goyacc - purely mechanical, no logic changes. Same split as main (#7643 alongside #7641).

`tools/Dockerfile` was already on `golang:1.26.5-alpine`; only the go.mod directives were stale. `golang.org/x/net`/`x/text` were already bumped on this branch via separate Renovate PRs.

## Testing

- `go build ./...` passes (main module and `tools/`)
- `make chlog-validate` passes
- `golangci-lint run --new-from-rev=origin/release-v2.10` passes (0 issues) with the new tools image