### PR TITLE
chore: fix time-dependent flake in TestTimeWindowBlockSelectorBlocksToCompact

### DIFF
--- a/tempodb/blockselector/compaction_block_selector.go
+++ b/tempodb/blockselector/compaction_block_selector.go
@@ -21,6 +21,13 @@ const (
 	DefaultMaxCompactionLevel = 0
 )
 
+// timeNow is the clock used to decide which time windows are active. It is a
+// variable so tests can pin it: window membership is computed by integer
+// division on Unix seconds, so a test that captures its own reference time and
+// then lets the selector read the wall clock separately depends on both landing
+// in the same window.
+var timeNow = time.Now
+
 /*************************** Time Window Block Selector **************************/
 
 // Sharding will be based on time slot - not level. Since each compactor works on two levels.
@@ -58,7 +65,7 @@ func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRan
 		MaxCompactionLevel:   uint32(maxCompactionLevel),
 	}
 
-	now := time.Now()
+	now := timeNow()
 	currWindow := twbs.windowForTime(now)
 	activeWindow := twbs.windowForTime(now.Add(-activeWindowDuration))
 

--- a/tempodb/blockselector/compaction_block_selector_test.go
+++ b/tempodb/blockselector/compaction_block_selector_test.go
@@ -12,6 +12,15 @@ import (
 
 func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 	now := time.Now()
+	// The cases below build block end times and expected hashes from now, and run
+	// with a one second compaction range, so a window is one Unix second wide.
+	// Pin the selector to the same reference time: otherwise any case that
+	// depends on a block landing exactly on the active window boundary fails
+	// whenever a second elapses between here and the selector reading the clock,
+	// which happens routinely under a slow or instrumented test run.
+	timeNow = func() time.Time { return now }
+	t.Cleanup(func() { timeNow = time.Now })
+
 	timeWindow := 12 * time.Hour
 	tenantID := ""
 


### PR DESCRIPTION
## What

`TestTimeWindowBlockSelectorBlocksToCompact` flakes in the coverage job:

```
--- FAIL: TestTimeWindowBlockSelectorBlocksToCompact/doesn't_select_blocks_in_last_active_window
    expected: ""
    actual  : "-1786372653-0"
```

## Why

`windowForTime` is integer division on Unix seconds, and the test constructs the selector with `MaxCompactionRange = time.Second`, so a window is one second wide:

```go
return t.Unix() / int64(twbs.MaxCompactionRange/time.Second)
```

The test derives block end times and expected hashes from a reference time captured at the top of the function, while the selector read the wall clock separately. This case asserts that a block on the active window boundary is skipped (`w == activeWindow`), which only holds while both reads land in the same second. Once a second elapses in between, the block is selected and the hash is non-empty.

That elapsed time is routine under a slow or instrumented run — the coverage job runs ~3269 tests in ~526s — which is why the test passes locally and fails there.

## Change

Make the clock used for window membership a package-level variable and pin it in the test, so window selection no longer depends on how long the test takes to reach a case. Default behaviour is unchanged.
