### PR TITLE
tempo-mixin: select namespace before cluster on Backend Work dashboard

### DIFF
--- a/.chloggen/backendwork-namespace-first-var.yaml
+++ b/.chloggen/backendwork-namespace-first-var.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: operations
+
+note: Reorder the Backend Work mixin dashboard variables so Namespace is selected before Cluster and filters the Cluster query, instead of the two being independent.
+
+issues: []
+
+subtext:
+
+user: zalegrala

--- a/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
@@ -4370,8 +4370,8 @@
    {
     "allValue": ".*",
     "current": {
-     "text": "tempo-ops-01",
-     "value": "tempo-ops-01"
+     "text": "All",
+     "value": "$__all"
     },
     "datasource": {
      "type": "prometheus",
@@ -4396,8 +4396,8 @@
    {
     "allValue": ".*",
     "current": {
-     "text": "ops-eu-south-0",
-     "value": "ops-eu-south-0"
+     "text": "All",
+     "value": "$__all"
     },
     "datasource": {
      "type": "prometheus",

--- a/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
@@ -4370,32 +4370,6 @@
    {
     "allValue": ".*",
     "current": {
-     "text": "ops-eu-south-0",
-     "value": "ops-eu-south-0"
-    },
-    "datasource": {
-     "type": "prometheus",
-     "uid": "${metrics}"
-    },
-    "definition": "label_values(tempo_build_info,cluster)",
-    "includeAll": true,
-    "label": "Cluster",
-    "name": "cluster",
-    "options": [
-
-    ],
-    "query": {
-     "qryType": 1,
-     "query": "label_values(tempo_build_info,cluster)",
-     "refId": "PrometheusVariableQueryEditor-VariableQuery"
-    },
-    "refresh": 1,
-    "regex": "",
-    "type": "query"
-   },
-   {
-    "allValue": ".*",
-    "current": {
      "text": "tempo-ops-01",
      "value": "tempo-ops-01"
     },
@@ -4413,6 +4387,32 @@
     "query": {
      "qryType": 1,
      "query": "label_values(tempo_build_info,namespace)",
+     "refId": "PrometheusVariableQueryEditor-VariableQuery"
+    },
+    "refresh": 1,
+    "regex": "",
+    "type": "query"
+   },
+   {
+    "allValue": ".*",
+    "current": {
+     "text": "ops-eu-south-0",
+     "value": "ops-eu-south-0"
+    },
+    "datasource": {
+     "type": "prometheus",
+     "uid": "${metrics}"
+    },
+    "definition": "label_values(tempo_build_info{namespace=~\"$namespace\"},cluster)",
+    "includeAll": true,
+    "label": "Cluster",
+    "name": "cluster",
+    "options": [
+
+    ],
+    "query": {
+     "qryType": 1,
+     "query": "label_values(tempo_build_info{namespace=~\"$namespace\"},cluster)",
      "refId": "PrometheusVariableQueryEditor-VariableQuery"
     },
     "refresh": 1,

--- a/operations/tempo-mixin/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin/dashboards/tempo-backendwork.json
@@ -4140,8 +4140,8 @@
       {
         "allValue": ".*",
         "current": {
-          "text": "tempo-ops-01",
-          "value": "tempo-ops-01"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",
@@ -4164,8 +4164,8 @@
       {
         "allValue": ".*",
         "current": {
-          "text": "ops-eu-south-0",
-          "value": "ops-eu-south-0"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": {
           "type": "prometheus",

--- a/operations/tempo-mixin/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin/dashboards/tempo-backendwork.json
@@ -4140,30 +4140,6 @@
       {
         "allValue": ".*",
         "current": {
-          "text": "ops-eu-south-0",
-          "value": "ops-eu-south-0"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${metrics}"
-        },
-        "definition": "label_values(tempo_build_info,cluster)",
-        "includeAll": true,
-        "label": "Cluster",
-        "name": "cluster",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(tempo_build_info,cluster)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
           "text": "tempo-ops-01",
           "value": "tempo-ops-01"
         },
@@ -4179,6 +4155,30 @@
         "query": {
           "qryType": 1,
           "query": "label_values(tempo_build_info,namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "ops-eu-south-0",
+          "value": "ops-eu-south-0"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${metrics}"
+        },
+        "definition": "label_values(tempo_build_info{namespace=~\"$namespace\"},cluster)",
+        "includeAll": true,
+        "label": "Cluster",
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(tempo_build_info{namespace=~\"$namespace\"},cluster)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
**What this PR does**:
Reorders the Backend Work mixin dashboard's `Namespace` and `Cluster` template variables so `Namespace` is selected first and drives (filters) `Cluster`'s query, instead of the two being independent. This matches the chaining already used by the dashboard's `Container` variable, which filters on both `namespace` and `cluster`.

Without this, picking a namespace doesn't narrow the cluster list, so on multi-cluster fleets it's easy to end up with a cluster/namespace combination that has no data. Chaining namespace -> cluster avoids that dead-end and matches a pattern we've found useful internally.

`operations/tempo-mixin-compiled/` was regenerated via `make all` in `operations/tempo-mixin` and `make check` passes with no diff.

**Which issue(s) this PR fixes**:
None filed; small, self-contained dashboard UX change.

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)