### PR TITLE
docs: backfill v2.9.5/v2.10.8/v3.0.3 changelog and release notes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 <!-- next version -->
 
+# v3.0.3
+
+* [SECURITY] Update Go to 1.26.5 to fix CVE-2026-39822, CVE-2026-27145, CVE-2026-42504, CVE-2026-42505, and CVE-2026-42507; update google.golang.org/grpc to v1.82.1 to fix GHSA-hrxh-6v49-42gf; update golang.org/x/net to v0.56.0 to fix CVE-2026-46600; update golang.org/x/text to v0.39.0 to fix CVE-2026-56852; update go.opentelemetry.io/otel to v1.44.0 to fix CVE-2026-41178 [#7726](https://github.com/grafana/tempo/pull/7726) (@mattdurham)
+* [ENHANCEMENT] Add Tempo configuration documentation to the MCP server [#7521](https://github.com/grafana/tempo/pull/7521) (@knylander-grafana)
+* [ENHANCEMENT] Update the TraceQL and metrics documentation served by the MCP server [#7375](https://github.com/grafana/tempo/pull/7375) (@knylander-grafana)
+* [BUGFIX] Fix incorrect version reported by `--version`, the build-info metric, and `/api/status/buildinfo` [#7469](https://github.com/grafana/tempo/pull/7469) (@zhxiaogg)
+* [CHANGE] Remove guidance on running multiple monolithic instances [#7636](https://github.com/grafana/tempo/pull/7636) (@mattdurham)
+
 # v3.0.2
 
 * [CHANGE] Upgrade Tempo to Go 1.26.3 [#7423](https://github.com/grafana/tempo/pull/7423) (@ie-pham)
@@ -143,6 +151,10 @@
 * [CHANGE] **BREAKING CHANGE** Sets the `all` target to be 3.0 compatible and removes the `scalable-single-binary` target [#6283](https://github.com/grafana/tempo/pull/6283) (@joe-elliott)
 * [CHANGE] **BREAKING CHANGE** Clean up enterprise jsonnet [#6505](https://github.com/grafana/tempo/pull/6505) (@javiermolinar)
 * [CHANGE] Expose otlp http and grpc ports for Docker examples [#6296](https://github.com/grafana/tempo/pull/6296) (@javiermolinar)
+
+# v2.10.8
+
+* [SECURITY] Update Go to 1.26.5 to fix CVE-2026-39822, CVE-2026-27145, CVE-2026-42504, CVE-2026-42505, and CVE-2026-42507; update google.golang.org/grpc to v1.82.1 to fix GHSA-hrxh-6v49-42gf; update golang.org/x/net to v0.56.0 to fix CVE-2026-46600; update golang.org/x/text to v0.39.0 to fix CVE-2026-56852; update go.opentelemetry.io/otel to v1.44.0 to fix CVE-2026-41178 [#7725](https://github.com/grafana/tempo/pull/7725) (@mattdurham)
 
 # v2.10.7
 
@@ -303,6 +315,10 @@
 * [BUGFIX] Correctly track and reject too large traces in live stores. [#5757](https://github.com/grafana/tempo/pull/5757) (@joe-elliott)
 * [BUGFIX] Jsonnet: Correctly add tempo-gossip-member: true labels to block-builders and live-stores [#6125](https://github.com/grafana/tempo/pull/6125) (@joe-elliott)
 * [BUGFIX] Fix wrong sleep duration in block-builder if one of partitions is inactive [#5855](https://github.com/grafana/tempo/pull/5855) (@ruslan-mikhailov)
+
+# v2.9.5
+
+* [SECURITY] Update google.golang.org/grpc to v1.82.1 to fix GHSA-hrxh-6v49-42gf and go.opentelemetry.io/otel to v1.44.0 to fix CVE-2026-41178 [#7724](https://github.com/grafana/tempo/pull/7724) (@mattdurham)
 
 # v2.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # v3.0.3
 
-* [SECURITY] Update Go to 1.26.5 to fix CVE-2026-39822, CVE-2026-27145, CVE-2026-42504, CVE-2026-42505, and CVE-2026-42507; update google.golang.org/grpc to v1.82.1 to fix GHSA-hrxh-6v49-42gf; update golang.org/x/net to v0.56.0 to fix CVE-2026-46600; update golang.org/x/text to v0.39.0 to fix CVE-2026-56852; update go.opentelemetry.io/otel to v1.44.0 to fix CVE-2026-41178 [#7726](https://github.com/grafana/tempo/pull/7726) (@mattdurham)
+* [SECURITY] Update Go to 1.26.5 to fix [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822), [CVE-2026-27145](https://nvd.nist.gov/vuln/detail/CVE-2026-27145), [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504), [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505), and [CVE-2026-42507](https://nvd.nist.gov/vuln/detail/CVE-2026-42507); update google.golang.org/grpc to v1.82.1 to fix [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf); update golang.org/x/net to v0.56.0 to fix [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600); update golang.org/x/text to v0.39.0 to fix [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852); update go.opentelemetry.io/otel to v1.44.0 to fix [CVE-2026-41178](https://nvd.nist.gov/vuln/detail/CVE-2026-41178) [#7726](https://github.com/grafana/tempo/pull/7726) (@mattdurham)
 * [ENHANCEMENT] Add Tempo configuration documentation to the MCP server [#7521](https://github.com/grafana/tempo/pull/7521) (@knylander-grafana)
 * [ENHANCEMENT] Update the TraceQL and metrics documentation served by the MCP server [#7375](https://github.com/grafana/tempo/pull/7375) (@knylander-grafana)
 * [BUGFIX] Fix incorrect version reported by `--version`, the build-info metric, and `/api/status/buildinfo` [#7469](https://github.com/grafana/tempo/pull/7469) (@zhxiaogg)
@@ -154,7 +154,7 @@
 
 # v2.10.8
 
-* [SECURITY] Update Go to 1.26.5 to fix CVE-2026-39822, CVE-2026-27145, CVE-2026-42504, CVE-2026-42505, and CVE-2026-42507; update google.golang.org/grpc to v1.82.1 to fix GHSA-hrxh-6v49-42gf; update golang.org/x/net to v0.56.0 to fix CVE-2026-46600; update golang.org/x/text to v0.39.0 to fix CVE-2026-56852; update go.opentelemetry.io/otel to v1.44.0 to fix CVE-2026-41178 [#7725](https://github.com/grafana/tempo/pull/7725) (@mattdurham)
+* [SECURITY] Update Go to 1.26.5 to fix [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822), [CVE-2026-27145](https://nvd.nist.gov/vuln/detail/CVE-2026-27145), [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504), [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505), and [CVE-2026-42507](https://nvd.nist.gov/vuln/detail/CVE-2026-42507); update google.golang.org/grpc to v1.82.1 to fix [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf); update golang.org/x/net to v0.56.0 to fix [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600); update golang.org/x/text to v0.39.0 to fix [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852); update go.opentelemetry.io/otel to v1.44.0 to fix [CVE-2026-41178](https://nvd.nist.gov/vuln/detail/CVE-2026-41178) [#7725](https://github.com/grafana/tempo/pull/7725) (@mattdurham)
 
 # v2.10.7
 
@@ -318,7 +318,7 @@
 
 # v2.9.5
 
-* [SECURITY] Update google.golang.org/grpc to v1.82.1 to fix GHSA-hrxh-6v49-42gf and go.opentelemetry.io/otel to v1.44.0 to fix CVE-2026-41178 [#7724](https://github.com/grafana/tempo/pull/7724) (@mattdurham)
+* [SECURITY] Update google.golang.org/grpc to v1.82.1 to fix [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) and go.opentelemetry.io/otel to v1.44.0 to fix [CVE-2026-41178](https://nvd.nist.gov/vuln/detail/CVE-2026-41178) [#7724](https://github.com/grafana/tempo/pull/7724) (@mattdurham)
 
 # v2.9.0
 

--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -316,6 +316,8 @@ Tempo 3.0 upgrades to Go 1.26.2. [[PR 6443](https://github.com/grafana/tempo/pul
 
 ## Security fixes
 
+The following security issues are addressed.
+
 ### 3.0.3
 
 - Updated Go to 1.26.5 to address [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822), [CVE-2026-27145](https://nvd.nist.gov/vuln/detail/CVE-2026-27145), [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504), [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505), and [CVE-2026-42507](https://nvd.nist.gov/vuln/detail/CVE-2026-42507). [[PR 7726](https://github.com/grafana/tempo/pull/7726)]

--- a/docs/sources/tempo/release-notes/v3-0.md
+++ b/docs/sources/tempo/release-notes/v3-0.md
@@ -316,6 +316,14 @@ Tempo 3.0 upgrades to Go 1.26.2. [[PR 6443](https://github.com/grafana/tempo/pul
 
 ## Security fixes
 
+### 3.0.3
+
+- Updated Go to 1.26.5 to address [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822), [CVE-2026-27145](https://nvd.nist.gov/vuln/detail/CVE-2026-27145), [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504), [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505), and [CVE-2026-42507](https://nvd.nist.gov/vuln/detail/CVE-2026-42507). [[PR 7726](https://github.com/grafana/tempo/pull/7726)]
+- Updated `google.golang.org/grpc` to v1.82.1 to address [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf). [[PR 7726](https://github.com/grafana/tempo/pull/7726)]
+- Updated `golang.org/x/net` to v0.56.0 to address [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600). [[PR 7726](https://github.com/grafana/tempo/pull/7726)]
+- Updated `golang.org/x/text` to v0.39.0 to address [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852). [[PR 7726](https://github.com/grafana/tempo/pull/7726)]
+- Updated `go.opentelemetry.io/otel` to v1.44.0 to address [CVE-2026-41178](https://nvd.nist.gov/vuln/detail/CVE-2026-41178). [[PR 7726](https://github.com/grafana/tempo/pull/7726)]
+
 ### 3.0.2
 
 - Built Tempo with Go 1.26.3, which includes upstream security and bug fixes. [[PR 7423](https://github.com/grafana/tempo/pull/7423)]
@@ -330,6 +338,10 @@ Tempo 3.0 upgrades to Go 1.26.2. [[PR 6443](https://github.com/grafana/tempo/pul
 ## Bug fixes
 
 For a complete list, refer to the [Tempo CHANGELOG](https://github.com/grafana/tempo/releases).
+
+### 3.0.3
+
+- Fixed the version reported by `--version`, the build-info metric, and `/api/status/buildinfo`. The build version is now read from the top-level `VERSION` file instead of the most recently created git tag, which could belong to a different release. [[PR 7469](https://github.com/grafana/tempo/pull/7469)]
 
 - Fixed panic in livestore search when iterating blocks encounters an unexpected error. [[PR 7134](https://github.com/grafana/tempo/pull/7134)]
 - Fixed panic in old tag-style search when querying integer dedicated columns on vParquet5 blocks. [[PR 7135](https://github.com/grafana/tempo/pull/7135)]

--- a/docs/sources/tempo/release-notes/version-2/v2-10.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-10.md
@@ -320,6 +320,14 @@ Refer to the [Tempo rearchitecture](https://github.com/grafana/tempo/releases/ta
 
 The following updates were made to address security issues.
 
+### 2.10.8
+
+- Updated Go to 1.26.5 to address [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822), [CVE-2026-27145](https://nvd.nist.gov/vuln/detail/CVE-2026-27145), [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504), [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505), and [CVE-2026-42507](https://nvd.nist.gov/vuln/detail/CVE-2026-42507). [[PR 7725](https://github.com/grafana/tempo/pull/7725)]
+- Updated `google.golang.org/grpc` to v1.82.1 to address [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf). [[PR 7725](https://github.com/grafana/tempo/pull/7725)]
+- Updated `golang.org/x/net` to v0.56.0 to address [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600). [[PR 7725](https://github.com/grafana/tempo/pull/7725)]
+- Updated `golang.org/x/text` to v0.39.0 to address [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852). [[PR 7725](https://github.com/grafana/tempo/pull/7725)]
+- Updated `go.opentelemetry.io/otel` to v1.44.0 to address [CVE-2026-41178](https://nvd.nist.gov/vuln/detail/CVE-2026-41178). [[PR 7725](https://github.com/grafana/tempo/pull/7725)]
+
 ### 2.10.6
 
 - Updated `github.com/apache/thrift` to v0.23.0, `golang.org/x/crypto` to v0.52.0, and `golang.org/x/net` to v0.55.0 to pick up upstream security fixes. (PRs [#7120](https://github.com/grafana/tempo/pull/7120), [#7262](https://github.com/grafana/tempo/pull/7262), [#7129](https://github.com/grafana/tempo/pull/7129), [#7263](https://github.com/grafana/tempo/pull/7263))

--- a/docs/sources/tempo/release-notes/version-2/v2-9.md
+++ b/docs/sources/tempo/release-notes/version-2/v2-9.md
@@ -246,6 +246,10 @@ Project Rhythm works as follows:
 
 The following updates were made to address security issues.
 
+### 2.9.5
+
+- Updated `google.golang.org/grpc` to v1.82.1 to address [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) and `go.opentelemetry.io/otel` to v1.44.0 to address [CVE-2026-41178](https://nvd.nist.gov/vuln/detail/CVE-2026-41178). [[PR 7724](https://github.com/grafana/tempo/pull/7724)]
+
 ### 2.9.4
 
 - Updated Go to 1.26.5 and bumped the vendored `golang.org/x/net` and `golang.org/x/text` modules to address [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822), [CVE-2026-42504](https://nvd.nist.gov/vuln/detail/CVE-2026-42504), [CVE-2026-27145](https://nvd.nist.gov/vuln/detail/CVE-2026-27145), [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505), [CVE-2026-42507](https://nvd.nist.gov/vuln/detail/CVE-2026-42507), [CVE-2026-46600](https://nvd.nist.gov/vuln/detail/CVE-2026-46600), and [CVE-2026-56852](https://nvd.nist.gov/vuln/detail/CVE-2026-56852). [[PR 7641](https://github.com/grafana/tempo/pull/7641)]


### PR DESCRIPTION
**What this PR does**:
`main` was missing the `v2.9.5`, `v2.10.8`, and `v3.0.3` sections that already shipped on the release branches, so the released notes aren't reflected on `main` (per `RELEASES.MD` Patch Releases step 8). This backfills:

- `CHANGELOG.md`: adds the `v3.0.3`, `v2.10.8`, and `v2.9.5` sections, converted to main's entry style.
- `release-notes/version-2/v2-9.md`: adds a `### 2.9.5` security-fixes entry (grpc, otel).
- `release-notes/version-2/v2-10.md`: adds a `### 2.10.8` security-fixes entry (Go 1.26.5, grpc, x/net, x/text, otel).
- `release-notes/v3-0.md`: adds a `### 3.0.3` security-fixes entry (same CVEs as 2.10.8) and a `### 3.0.3` bug-fixes entry (build-version reporting fix, #7469 — first appearing in the 3.0 line in this release).

Formatted per `.claude/skills/shared/release-notes-workflow.md`'s "Patch releases" section. Note: `main`'s CHANGELOG.md was already missing `v2.9.1`-`v2.9.4` sections before this PR (pre-existing gap, out of scope here).

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] Changelog entry added under `.chloggen/` (N/A — backfills already-released sections onto `main`)