### PR TITLE
[backend-scheduler] expose pending job depth

### DIFF
--- a/.chloggen/backend-scheduler-jobs-pending.yaml
+++ b/.chloggen/backend-scheduler-jobs-pending.yaml
@@ -1,11 +1,9 @@
 change_type: enhancement
 component: backend-scheduler
-note: add `tempo_backend_scheduler_jobs_pending`, widen the job-duration histogram buckets, and complete native-histogram coverage.
+note: add `tempo_backend_scheduler_jobs_pending` and complete native-histogram coverage.
 issues: []
 subtext: |
   `tempo_backend_scheduler_jobs_pending{tenant, job_type}` reports queue depth: jobs enqueued and not yet dispatched. Nothing exposed this before, so a submission that fanned out hundreds of jobs showed only the handful already running. It is also the only signal that can drive scale-up, since `jobs_active` is bounded by the worker count.
-
-  `backend_scheduler_job_duration_seconds` buckets move from the client library defaults, which stop at 10s and put no boundary between 2.5s and 5s where roughly 60% of redaction jobs land, to powers of two between 10ms and ~11m. `histogram_quantile` queries are unaffected; queries pinned to specific `le` values need updating.
 
   `tempodb_cache_store_size_bytes` was the only histogram in the tree without native-histogram configuration; it now matches the other 33.
 user: zalegrala

--- a/.chloggen/backend-scheduler-jobs-pending.yaml
+++ b/.chloggen/backend-scheduler-jobs-pending.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+component: backend-scheduler
+note: add `tempo_backend_scheduler_jobs_pending`, widen the job-duration histogram buckets, and complete native-histogram coverage.
+issues: []
+subtext: |
+  `tempo_backend_scheduler_jobs_pending{tenant, job_type}` reports queue depth: jobs enqueued and not yet dispatched to a worker. Nothing exposed this before, so a submission that fanned out hundreds of jobs showed only the handful already running. `jobs_active` counts work already handed out, so it is bounded by the worker count and cannot indicate that more capacity is needed — only depth can, which makes this the signal to autoscale backend-workers on.
+
+  It matters most for redaction, which suppresses the tenant's compaction while it runs. An autoscaler driven by compaction backlog therefore sees that backlog disappear exactly when redaction work begins, and scales down mid-run.
+
+  The `backend_scheduler_job_duration_seconds` buckets move from the client library defaults to powers of two between 10ms and ~11m. The defaults stop at 10s and place no boundary between 2.5s and 5s, where roughly 60% of redaction jobs land, so every percentile drawn from them interpolated inside a single bucket. Dashboards using `histogram_quantile` are unaffected; queries pinned to specific `le` values need updating.
+
+  `tempodb_cache_store_size_bytes` was the only histogram in the tree without native-histogram configuration; it now matches the other 33.
+user: zalegrala

--- a/.chloggen/backend-scheduler-jobs-pending.yaml
+++ b/.chloggen/backend-scheduler-jobs-pending.yaml
@@ -3,11 +3,9 @@ component: backend-scheduler
 note: add `tempo_backend_scheduler_jobs_pending`, widen the job-duration histogram buckets, and complete native-histogram coverage.
 issues: []
 subtext: |
-  `tempo_backend_scheduler_jobs_pending{tenant, job_type}` reports queue depth: jobs enqueued and not yet dispatched to a worker. Nothing exposed this before, so a submission that fanned out hundreds of jobs showed only the handful already running. `jobs_active` counts work already handed out, so it is bounded by the worker count and cannot indicate that more capacity is needed — only depth can, which makes this the signal to autoscale backend-workers on.
+  `tempo_backend_scheduler_jobs_pending{tenant, job_type}` reports queue depth: jobs enqueued and not yet dispatched. Nothing exposed this before, so a submission that fanned out hundreds of jobs showed only the handful already running. It is also the only signal that can drive scale-up, since `jobs_active` is bounded by the worker count.
 
-  It matters most for redaction. Compaction is gated for a tenant being redacted, so no compaction jobs are created for it, yet the outstanding-blocks metric deliberately keeps reporting that backlog (see `newBlockSelectorForMeasurement`) — an autoscaler on that signal is holding scale for work it cannot dispatch. Redaction depth is the direct input, and the only one that tracks progress.
-
-  The `backend_scheduler_job_duration_seconds` buckets move from the client library defaults to powers of two between 10ms and ~11m. The defaults stop at 10s and place no boundary between 2.5s and 5s, where roughly 60% of redaction jobs land, so every percentile drawn from them interpolated inside a single bucket. Dashboards using `histogram_quantile` are unaffected; queries pinned to specific `le` values need updating.
+  `backend_scheduler_job_duration_seconds` buckets move from the client library defaults, which stop at 10s and put no boundary between 2.5s and 5s where roughly 60% of redaction jobs land, to powers of two between 10ms and ~11m. `histogram_quantile` queries are unaffected; queries pinned to specific `le` values need updating.
 
   `tempodb_cache_store_size_bytes` was the only histogram in the tree without native-histogram configuration; it now matches the other 33.
 user: zalegrala

--- a/.chloggen/backend-scheduler-jobs-pending.yaml
+++ b/.chloggen/backend-scheduler-jobs-pending.yaml
@@ -5,7 +5,7 @@ issues: []
 subtext: |
   `tempo_backend_scheduler_jobs_pending{tenant, job_type}` reports queue depth: jobs enqueued and not yet dispatched to a worker. Nothing exposed this before, so a submission that fanned out hundreds of jobs showed only the handful already running. `jobs_active` counts work already handed out, so it is bounded by the worker count and cannot indicate that more capacity is needed — only depth can, which makes this the signal to autoscale backend-workers on.
 
-  It matters most for redaction, which suppresses the tenant's compaction while it runs. An autoscaler driven by compaction backlog therefore sees that backlog disappear exactly when redaction work begins, and scales down mid-run.
+  It matters most for redaction. Compaction is gated for a tenant being redacted, so no compaction jobs are created for it, yet the outstanding-blocks metric deliberately keeps reporting that backlog (see `newBlockSelectorForMeasurement`) — an autoscaler on that signal is holding scale for work it cannot dispatch. Redaction depth is the direct input, and the only one that tracks progress.
 
   The `backend_scheduler_job_duration_seconds` buckets move from the client library defaults to powers of two between 10ms and ~11m. The defaults stop at 10s and place no boundary between 2.5s and 5s, where roughly 60% of redaction jobs land, so every percentile drawn from them interpolated inside a single bucket. Dashboards using `histogram_quantile` are unaffected; queries pinned to specific `le` values need updating.
 

--- a/.chloggen/backendwork-dashboard-redaction-progress.yaml
+++ b/.chloggen/backendwork-dashboard-redaction-progress.yaml
@@ -3,7 +3,5 @@ component: operations
 note: "tempo-mixin: add a pending-redaction-jobs panel and native-histogram queries to the Backend Work dashboard."
 issues: []
 subtext: |
-  "Pending Redaction Jobs" plots `tempo_backend_scheduler_jobs_pending` per tenant, so the dashboard shows how much of a redaction is left. "Active Redaction Jobs" only shows what a worker is running right now, which is bounded by the worker count and reads the same on the first block as on the last.
-
-  Both job-duration panels now carry native-histogram queries alongside the classic-bucket ones. The native series renders wherever native histograms are retained and gives full resolution; the classic queries stay for stacks that keep only buckets.
+  "Pending Redaction Jobs" plots `tempo_backend_scheduler_jobs_pending` per tenant, so the dashboard shows how much of a redaction is left rather than only that one is running. Both job-duration panels also carry native-histogram queries alongside the classic-bucket ones, so they render on stacks retaining either.
 user: zalegrala

--- a/.chloggen/backendwork-dashboard-redaction-progress.yaml
+++ b/.chloggen/backendwork-dashboard-redaction-progress.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+component: operations
+note: "tempo-mixin: add a pending-redaction-jobs panel and native-histogram queries to the Backend Work dashboard."
+issues: []
+subtext: |
+  "Pending Redaction Jobs" plots `tempo_backend_scheduler_jobs_pending` per tenant, so the dashboard shows how much of a redaction is left. "Active Redaction Jobs" only shows what a worker is running right now, which is bounded by the worker count and reads the same on the first block as on the last.
+
+  Both job-duration panels now carry native-histogram queries alongside the classic-bucket ones. The native series renders wherever native histograms are retained and gives full resolution; the classic queries stay for stacks that keep only buckets.
+user: zalegrala

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -107,6 +107,7 @@ This endpoint is useful for diagnosing stalled jobs, verifying that workers are 
 | `tempo_backend_scheduler_jobs_completed_total` | Jobs completed successfully |
 | `tempo_backend_scheduler_jobs_failed_total` | Jobs that failed |
 | `tempo_backend_scheduler_jobs_active` | Jobs currently assigned to a worker |
+| `tempo_backend_scheduler_jobs_pending` | Jobs enqueued and not yet assigned to a worker. Unlike `jobs_active`, which is bounded by the number of workers, this is queue depth and indicates whether more worker capacity is needed |
 | `tempo_backend_scheduler_job_duration_seconds` | Job execution duration histogram |
 | `tempodb_blocklist_length` | Number of live blocks per tenant; high values indicate compaction is falling behind |
 | `tempodb_compaction_outstanding_blocks` | Outstanding blocks awaiting compaction per tenant; the primary autoscaling signal |

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -56,6 +56,10 @@ type BackendScheduler struct {
 	}
 
 	mergedJobs chan *work.Job
+
+	// publishedPendingLabels records the jobs_pending label sets published last tick, so a drained
+	// queue can be deleted without resetting the whole vector. Touched only from the maintenance loop.
+	publishedPendingLabels map[[2]string]struct{}
 }
 
 // ListJobs returns all jobs in the work cache
@@ -219,6 +223,11 @@ func (s *BackendScheduler) running(ctx context.Context) error {
 
 	backendFlushTicker := time.NewTicker(s.cfg.BackendFlushInterval)
 	defer backendFlushTicker.Stop()
+
+	// Publish once up front: on the tick alone the metric would be absent for a full
+	// MaintenanceInterval after start, so a dashboard or autoscaler reading it right after a restart
+	// would see nothing rather than the queue that survived the restart.
+	s.recordPendingJobs()
 
 	var err error
 

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -57,9 +57,11 @@ type BackendScheduler struct {
 
 	mergedJobs chan *work.Job
 
-	// publishedPendingLabels records the jobs_pending label sets published last tick, so a drained
-	// queue can be deleted without resetting the whole vector. Touched only from the maintenance loop.
-	publishedPendingLabels map[[2]string]struct{}
+	// publishedPendingCounts is the jobs_pending snapshot published on the previous maintenance tick,
+	// keyed exactly as work.PendingJobCounts returns it. Comparing the next snapshot against it
+	// identifies the tenants and job types whose queue has drained, so their series can be deleted
+	// without resetting the whole vector. Touched only from the maintenance loop.
+	publishedPendingCounts map[string]map[tempopb.JobType]int
 }
 
 // ListJobs returns all jobs in the work cache

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -230,6 +230,7 @@ func (s *BackendScheduler) running(ctx context.Context) error {
 			s.work.Prune(ctx)
 			s.checkPendingRescans(ctx)
 			s.cleanupOrphanedBatches(ctx)
+			s.recordPendingJobs()
 		case <-backendFlushTicker.C:
 			err = s.flushWorkCacheToBackend(ctx)
 			metricWorkFlushes.Inc()

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -30,10 +30,12 @@ var (
 		Name:      "backend_scheduler_jobs_active",
 		Help:      "Number of currently active jobs",
 	}, []string{"tenant", "job_type"})
+	// Queue depth. Distinct from jobs_active, which counts work already handed to a worker and is
+	// therefore bounded by the worker count — only depth can indicate that more capacity is needed.
 	metricJobsPending = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempo",
 		Name:      "backend_scheduler_jobs_pending",
-		Help:      "Number of jobs enqueued and not yet dispatched to a worker, by tenant and type. This is queue depth: jobs_active counts work already handed out, so it is bounded by the worker count and cannot indicate that more capacity is needed.",
+		Help:      "Number of jobs enqueued and not yet dispatched to a worker, by tenant and type.",
 	}, []string{"tenant", "job_type"})
 	metricJobsRetry = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
@@ -117,32 +119,32 @@ func redactionModeLabel(mode tempopb.RedactionMode) string {
 
 // recordPendingJobs publishes the queue depth per tenant and job type.
 //
-// Current values are set BEFORE drained series are removed, rather than resetting the vector first.
-// A scrape landing inside a Reset would see series missing and read the total lower than it is —
-// which is precisely the spurious scale-down this metric exists to prevent. Setting first means a
-// scrape can only ever catch a slightly stale value, so the error biases toward holding scale.
+// Values are set before drained series are deleted, rather than resetting the vector first: a scrape
+// landing inside a Reset would see series missing and read the total lower than it is — the spurious
+// scale-down this metric exists to prevent. Setting first means a scrape can only ever catch a
+// slightly stale value.
 //
-// Drained queues must still be removed: a tenant whose queue empties stops appearing in the
-// snapshot rather than reporting zero, so its last non-zero value would otherwise persist for the
-// process lifetime and an autoscaler would hold scale forever.
+// Deleting is still necessary. A queue that empties stops appearing in the snapshot rather than
+// reporting zero, so its series would otherwise keep its last value for the process lifetime.
 //
-// Called only from the maintenance loop, so the label bookkeeping needs no lock.
+// Called only from the maintenance loop, so the retained snapshot needs no lock.
 func (s *BackendScheduler) recordPendingJobs() {
-	current := make(map[[2]string]struct{}, len(s.publishedPendingLabels))
+	current := s.work.PendingJobCounts()
 
-	for tenant, byType := range s.work.PendingJobCounts() {
-		for jobType, n := range byType {
-			labels := [2]string{tenant, jobType.String()}
-			current[labels] = struct{}{}
-			metricJobsPending.WithLabelValues(labels[0], labels[1]).Set(float64(n))
+	for tenant, byType := range current {
+		for jobType, pending := range byType {
+			metricJobsPending.WithLabelValues(tenant, jobType.String()).Set(float64(pending))
 		}
 	}
 
-	for labels := range s.publishedPendingLabels {
-		if _, still := current[labels]; !still {
-			metricJobsPending.DeleteLabelValues(labels[0], labels[1])
+	// Anything present last time and absent now has drained, so drop its series.
+	for tenant, byType := range s.publishedPendingCounts {
+		for jobType := range byType {
+			if _, stillPending := current[tenant][jobType]; !stillPending {
+				metricJobsPending.DeleteLabelValues(tenant, jobType.String())
+			}
 		}
 	}
 
-	s.publishedPendingLabels = current
+	s.publishedPendingCounts = current
 }

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -30,6 +30,11 @@ var (
 		Name:      "backend_scheduler_jobs_active",
 		Help:      "Number of currently active jobs",
 	}, []string{"tenant", "job_type"})
+	metricJobsPending = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tempo",
+		Name:      "backend_scheduler_jobs_pending",
+		Help:      "Number of jobs enqueued and not yet dispatched to a worker, by tenant and type. This is queue depth: jobs_active counts work already handed out, so it is bounded by the worker count and cannot indicate that more capacity is needed.",
+	}, []string{"tenant", "job_type"})
 	metricJobsRetry = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
 		Name:      "backend_scheduler_jobs_retry_total",
@@ -70,10 +75,18 @@ var (
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	})
 	metricJobDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:                       "tempo",
-		Name:                            "backend_scheduler_job_duration_seconds",
-		Help:                            "Duration of of a job in seconds",
-		Buckets:                         prometheus.DefBuckets,
+		Namespace: "tempo",
+		Name:      "backend_scheduler_job_duration_seconds",
+		Help:      "Duration of a job in seconds",
+		// DefBuckets stops at 10s and puts nothing between 2.5s and 5s, where roughly 60% of
+		// redaction jobs land — every percentile drawn from it interpolates inside one bucket, so
+		// p50, p90 and p99 move together and say nothing. It also cannot represent a job slower
+		// than 10s at all, and a redaction over a large block runs for minutes.
+		//
+		// Powers of two from 10ms to ~11m: fast retention jobs stay resolved, the redaction mass
+		// splits across the 2.56s and 5.12s boundaries, and long jobs land in a real bucket
+		// instead of +Inf.
+		Buckets:                         prometheus.ExponentialBuckets(0.01, 2, 17),
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
@@ -100,4 +113,20 @@ func redactionModeLabel(mode tempopb.RedactionMode) string {
 		return "dry_run"
 	}
 	return "apply"
+}
+
+// recordPendingJobs publishes the queue depth per tenant and job type.
+//
+// Reset first: this is a gauge keyed by tenant, and a tenant whose queue drains stops appearing in
+// the snapshot entirely. Without the reset its last non-zero value would persist forever, so a
+// finished redaction would look permanently backlogged — and an autoscaler reading it would never
+// scale back down.
+func (s *BackendScheduler) recordPendingJobs() {
+	metricJobsPending.Reset()
+
+	for tenant, byType := range s.work.PendingJobCounts() {
+		for jobType, n := range byType {
+			metricJobsPending.WithLabelValues(tenant, jobType.String()).Set(float64(n))
+		}
+	}
 }

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -117,16 +117,32 @@ func redactionModeLabel(mode tempopb.RedactionMode) string {
 
 // recordPendingJobs publishes the queue depth per tenant and job type.
 //
-// Reset first: this is a gauge keyed by tenant, and a tenant whose queue drains stops appearing in
-// the snapshot entirely. Without the reset its last non-zero value would persist forever, so a
-// finished redaction would look permanently backlogged — and an autoscaler reading it would never
-// scale back down.
+// Current values are set BEFORE drained series are removed, rather than resetting the vector first.
+// A scrape landing inside a Reset would see series missing and read the total lower than it is —
+// which is precisely the spurious scale-down this metric exists to prevent. Setting first means a
+// scrape can only ever catch a slightly stale value, so the error biases toward holding scale.
+//
+// Drained queues must still be removed: a tenant whose queue empties stops appearing in the
+// snapshot rather than reporting zero, so its last non-zero value would otherwise persist for the
+// process lifetime and an autoscaler would hold scale forever.
+//
+// Called only from the maintenance loop, so the label bookkeeping needs no lock.
 func (s *BackendScheduler) recordPendingJobs() {
-	metricJobsPending.Reset()
+	current := make(map[[2]string]struct{}, len(s.publishedPendingLabels))
 
 	for tenant, byType := range s.work.PendingJobCounts() {
 		for jobType, n := range byType {
-			metricJobsPending.WithLabelValues(tenant, jobType.String()).Set(float64(n))
+			labels := [2]string{tenant, jobType.String()}
+			current[labels] = struct{}{}
+			metricJobsPending.WithLabelValues(labels[0], labels[1]).Set(float64(n))
 		}
 	}
+
+	for labels := range s.publishedPendingLabels {
+		if _, still := current[labels]; !still {
+			metricJobsPending.DeleteLabelValues(labels[0], labels[1])
+		}
+	}
+
+	s.publishedPendingLabels = current
 }

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -77,18 +77,10 @@ var (
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	})
 	metricJobDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "tempo",
-		Name:      "backend_scheduler_job_duration_seconds",
-		Help:      "Duration of a job in seconds",
-		// DefBuckets stops at 10s and puts nothing between 2.5s and 5s, where roughly 60% of
-		// redaction jobs land — every percentile drawn from it interpolates inside one bucket, so
-		// p50, p90 and p99 move together and say nothing. It also cannot represent a job slower
-		// than 10s at all, and a redaction over a large block runs for minutes.
-		//
-		// Powers of two from 10ms to ~11m: fast retention jobs stay resolved, the redaction mass
-		// splits across the 2.56s and 5.12s boundaries, and long jobs land in a real bucket
-		// instead of +Inf.
-		Buckets:                         prometheus.ExponentialBuckets(0.01, 2, 17),
+		Namespace:                       "tempo",
+		Name:                            "backend_scheduler_job_duration_seconds",
+		Help:                            "Duration of a job in seconds",
+		Buckets:                         prometheus.DefBuckets,
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -116,9 +116,6 @@ func redactionModeLabel(mode tempopb.RedactionMode) string {
 // scale-down this metric exists to prevent. Setting first means a scrape can only ever catch a
 // slightly stale value.
 //
-// Deleting is still necessary. A queue that empties stops appearing in the snapshot rather than
-// reporting zero, so its series would otherwise keep its last value for the process lifetime.
-//
 // Called only from the maintenance loop, so the retained snapshot needs no lock.
 func (s *BackendScheduler) recordPendingJobs() {
 	current := s.work.PendingJobCounts()
@@ -129,7 +126,9 @@ func (s *BackendScheduler) recordPendingJobs() {
 		}
 	}
 
-	// Anything present last time and absent now has drained, so drop its series.
+	// A drained queue is absent from the snapshot rather than zero within it, so anything published
+	// last time and missing now has to be deleted explicitly, or its series keeps its last value for
+	// the process lifetime.
 	for tenant, byType := range s.publishedPendingCounts {
 		for jobType := range byType {
 			if _, stillPending := current[tenant][jobType]; !stillPending {

--- a/modules/backendscheduler/metrics_pending_test.go
+++ b/modules/backendscheduler/metrics_pending_test.go
@@ -1,0 +1,64 @@
+package backendscheduler
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/modules/backendscheduler/work"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// TestRecordPendingJobs covers publishing queue depth, and in particular that a drained queue stops
+// being reported.
+//
+// The gauge is keyed by tenant, and a tenant whose queue empties simply stops appearing in the
+// snapshot — it never reports zero. Without the Reset, its last non-zero value would persist for the
+// process lifetime: a finished redaction would look permanently backlogged, and an autoscaler
+// triggering on this would hold the scale-up forever.
+func TestRecordPendingJobs(t *testing.T) {
+	s := &BackendScheduler{work: work.New(work.Config{})}
+
+	redaction := func(id, tenant, block string) *work.Job {
+		return &work.Job{
+			ID:   id,
+			Type: tempopb.JobType_JOB_TYPE_REDACTION,
+			JobDetail: tempopb.JobDetail{
+				Tenant:    tenant,
+				Redaction: &tempopb.RedactionDetail{BlockId: block},
+			},
+		}
+	}
+
+	require.NoError(t, s.work.AddPendingJobs([]*work.Job{
+		redaction("r1", "tenant-a", "block-1"),
+		redaction("r2", "tenant-a", "block-2"),
+		redaction("r3", "tenant-b", "block-1"),
+		{
+			ID:   "c1",
+			Type: tempopb.JobType_JOB_TYPE_COMPACTION,
+			JobDetail: tempopb.JobDetail{
+				Tenant:     "tenant-a",
+				Compaction: &tempopb.CompactionDetail{Input: []string{"block-9"}},
+			},
+		},
+	}))
+
+	s.recordPendingJobs()
+	require.Equal(t, 2.0, testutil.ToFloat64(metricJobsPending.WithLabelValues("tenant-a", "JOB_TYPE_REDACTION")))
+	require.Equal(t, 1.0, testutil.ToFloat64(metricJobsPending.WithLabelValues("tenant-b", "JOB_TYPE_REDACTION")))
+	require.Equal(t, 1.0, testutil.ToFloat64(metricJobsPending.WithLabelValues("tenant-a", "JOB_TYPE_COMPACTION")))
+	require.Equal(t, 3, testutil.CollectAndCount(metricJobsPending), "one series per tenant and type with queued work")
+
+	// Drain every redaction job. NextPendingJob is type-scoped, so the compaction job stays queued
+	// and tenant-a keeps exactly one series while tenant-b loses its only one.
+	for s.work.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION) != nil { //nolint:revive // drain
+	}
+
+	s.recordPendingJobs()
+	require.Equal(t, 1, testutil.CollectAndCount(metricJobsPending),
+		"drained queues must lose their series rather than keep their last value")
+	require.Equal(t, 1.0, testutil.ToFloat64(metricJobsPending.WithLabelValues("tenant-a", "JOB_TYPE_COMPACTION")),
+		"the surviving series is the compaction queue that was never drained")
+}

--- a/modules/backendscheduler/metrics_pending_test.go
+++ b/modules/backendscheduler/metrics_pending_test.go
@@ -11,13 +11,18 @@ import (
 )
 
 // TestRecordPendingJobs covers publishing queue depth, and in particular that a drained queue stops
-// being reported.
+// being reported while a surviving one keeps its value.
 //
-// The gauge is keyed by tenant, and a tenant whose queue empties simply stops appearing in the
-// snapshot — it never reports zero. Without the Reset, its last non-zero value would persist for the
+// The gauge is keyed by tenant, and a tenant whose queue empties stops appearing in the snapshot — it
+// never reports zero. Without removing those series their last non-zero value would persist for the
 // process lifetime: a finished redaction would look permanently backlogged, and an autoscaler
 // triggering on this would hold the scale-up forever.
+//
+// Removal is deliberately done by deleting drained label sets rather than resetting the vector. A
+// scrape landing inside a Reset would observe series missing and read the total lower than it is,
+// which is the spurious scale-down this metric exists to prevent.
 func TestRecordPendingJobs(t *testing.T) {
+	metricJobsPending.Reset() // isolate from other tests in this package
 	s := &BackendScheduler{work: work.New(work.Config{})}
 
 	redaction := func(id, tenant, block string) *work.Job {
@@ -60,5 +65,10 @@ func TestRecordPendingJobs(t *testing.T) {
 	require.Equal(t, 1, testutil.CollectAndCount(metricJobsPending),
 		"drained queues must lose their series rather than keep their last value")
 	require.Equal(t, 1.0, testutil.ToFloat64(metricJobsPending.WithLabelValues("tenant-a", "JOB_TYPE_COMPACTION")),
-		"the surviving series is the compaction queue that was never drained")
+		"the queue that was never drained keeps its value; only drained series are removed")
+
+	// Publishing again with nothing changed must be stable, not oscillate as labels are re-recorded.
+	s.recordPendingJobs()
+	require.Equal(t, 1, testutil.CollectAndCount(metricJobsPending), "a repeat publish must be idempotent")
+	require.Equal(t, 1.0, testutil.ToFloat64(metricJobsPending.WithLabelValues("tenant-a", "JOB_TYPE_COMPACTION")))
 }

--- a/modules/backendscheduler/work/interface.go
+++ b/modules/backendscheduler/work/interface.go
@@ -47,6 +47,9 @@ type Interface interface {
 	// Acquires pendingMtx exactly once and returns a snapshot.
 	BusyBlocksForTenant(tenantID string) map[string]string
 
+	// PendingJobCounts returns enqueued, not-yet-dispatched job counts per tenant and type.
+	PendingJobCounts() map[string]map[tempopb.JobType]int
+
 	// TenantPending returns true when an exclusive tenant operation exists whose
 	// full scope is not yet reflected in the job queue — i.e. an apply-mode redaction batch
 	// (just created or in its rescan-wait window). Gates compaction and retention. A dry-run

--- a/modules/backendscheduler/work/pending_counts_test.go
+++ b/modules/backendscheduler/work/pending_counts_test.go
@@ -1,0 +1,63 @@
+package work
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+// TestPendingJobCounts covers the queue-depth snapshot that backs the jobs_pending gauge.
+//
+// Depth is the only signal that can drive scale-up. jobs_active counts work already handed to a
+// worker, so it is bounded by the worker count and rises only as capacity rises — reading it to
+// decide whether to add capacity is circular. If this undercounts, an autoscaler stops adding
+// workers while work is still queued.
+func TestPendingJobCounts(t *testing.T) {
+	w := New(Config{}).(*Work)
+
+	require.Empty(t, w.PendingJobCounts(), "no jobs means no series at all, not zero-valued ones")
+
+	require.NoError(t, w.AddPendingJobs([]*Job{
+		createRedactionJob("r1", "tenant-a", "block-1"),
+		createRedactionJob("r2", "tenant-a", "block-2"),
+		createRedactionJob("r3", "tenant-b", "block-1"),
+		createCompactionJob("c1", "tenant-a", []string{"block-9"}),
+	}))
+
+	counts := w.PendingJobCounts()
+	require.Equal(t, 2, counts["tenant-a"][tempopb.JobType_JOB_TYPE_REDACTION])
+	require.Equal(t, 1, counts["tenant-a"][tempopb.JobType_JOB_TYPE_COMPACTION])
+	require.Equal(t, 1, counts["tenant-b"][tempopb.JobType_JOB_TYPE_REDACTION])
+
+	// Dispatching moves a job out of the queue: it is active now, not pending. Counting it in both
+	// would hold an autoscaler up after the queue had actually drained.
+	require.NotNil(t, w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION))
+
+	counts = w.PendingJobCounts()
+	remaining := counts["tenant-a"][tempopb.JobType_JOB_TYPE_REDACTION] + counts["tenant-b"][tempopb.JobType_JOB_TYPE_REDACTION]
+	require.Equal(t, 2, remaining, "a dispatched job must leave the pending depth")
+
+	// A drained type disappears rather than reporting zero, which is what lets the gauge's Reset
+	// clear the series instead of leaving a stale non-zero value an autoscaler would keep reading.
+	for w.NextPendingJob(tempopb.JobType_JOB_TYPE_REDACTION) != nil { //nolint:revive // drain
+	}
+
+	counts = w.PendingJobCounts()
+	for tenant, byType := range counts {
+		_, ok := byType[tempopb.JobType_JOB_TYPE_REDACTION]
+		require.False(t, ok, "a drained redaction queue must not appear for tenant %s", tenant)
+	}
+	require.Equal(t, 1, counts["tenant-a"][tempopb.JobType_JOB_TYPE_COMPACTION], "other job types are unaffected")
+
+	// The dequeue path deletes a queue as it empties, so an empty slice only arises from another
+	// path (a rebuild, or a future removal). Reported as-is it would publish a zero-valued series
+	// that never clears, which is the same stale-signal problem the gauge's Reset exists to avoid.
+	w.pendingMtx.Lock()
+	w.pendingByTenant["tenant-c"] = map[tempopb.JobType][]string{tempopb.JobType_JOB_TYPE_RETENTION: {}}
+	w.pendingMtx.Unlock()
+
+	_, ok := w.PendingJobCounts()["tenant-c"]
+	require.False(t, ok, "an empty queue must produce no series at all")
+}

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -924,6 +924,31 @@ func (w *Work) IsBlockBusy(tenantID, blockID string) bool {
 // BusyBlocksForTenant returns a map of blockID -> jobID for every block
 // currently referenced by a pending, registered, or active job for the tenant.
 // Acquires pendingMtx exactly once and returns a snapshot.
+// PendingJobCounts returns the number of enqueued, not-yet-dispatched jobs per tenant and type.
+//
+// This is queue DEPTH, which no other metric carries: jobs_active counts work already handed to a
+// worker, so it is bounded by the worker count and can never signal that more capacity is needed.
+// Only the pending depth can.
+func (w *Work) PendingJobCounts() map[string]map[tempopb.JobType]int {
+	w.pendingMtx.Lock()
+	defer w.pendingMtx.Unlock()
+
+	counts := make(map[string]map[tempopb.JobType]int, len(w.pendingByTenant))
+	for tenant, byType := range w.pendingByTenant {
+		for jobType, queue := range byType {
+			if len(queue) == 0 {
+				continue
+			}
+			if counts[tenant] == nil {
+				counts[tenant] = make(map[tempopb.JobType]int, len(byType))
+			}
+			counts[tenant][jobType] = len(queue)
+		}
+	}
+
+	return counts
+}
+
 func (w *Work) BusyBlocksForTenant(tenantID string) map[string]string {
 	result := make(map[string]string)
 	w.pendingMtx.Lock()

--- a/modules/backendscheduler/work/work.go
+++ b/modules/backendscheduler/work/work.go
@@ -921,9 +921,6 @@ func (w *Work) IsBlockBusy(tenantID, blockID string) bool {
 	return inPending || inRunning
 }
 
-// BusyBlocksForTenant returns a map of blockID -> jobID for every block
-// currently referenced by a pending, registered, or active job for the tenant.
-// Acquires pendingMtx exactly once and returns a snapshot.
 // PendingJobCounts returns the number of enqueued, not-yet-dispatched jobs per tenant and type.
 //
 // This is queue DEPTH, which no other metric carries: jobs_active counts work already handed to a
@@ -949,6 +946,9 @@ func (w *Work) PendingJobCounts() map[string]map[tempopb.JobType]int {
 	return counts
 }
 
+// BusyBlocksForTenant returns a map of blockID -> jobID for every block
+// currently referenced by a pending, registered, or active job for the tenant.
+// Acquires pendingMtx exactly once and returns a snapshot.
 func (w *Work) BusyBlocksForTenant(tenantID string) map[string]string {
 	result := make(map[string]string)
 	w.pendingMtx.Lock()

--- a/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
@@ -1478,6 +1478,7 @@
     "type": "prometheus",
     "uid": "${metrics}"
    },
+   "description": "Classic-bucket and native-histogram queries are both present. The native series gives full resolution where the classic buckets are coarse; it renders once native histograms are retained for this metric.",
    "fieldConfig": {
     "defaults": {
      "color": {
@@ -1582,6 +1583,28 @@
      "legendFormat": "p50 {{job_type}}",
      "range": true,
      "refId": "B"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+     "legendFormat": "p99 (native)",
+     "range": true,
+     "refId": "N99"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+     "legendFormat": "p50 (native)",
+     "range": true,
+     "refId": "N50"
     }
    ],
    "title": "Job Duration",
@@ -1814,6 +1837,7 @@
     "type": "prometheus",
     "uid": "${metrics}"
    },
+   "description": "Jobs enqueued and not yet dispatched to a worker. Active shows what is running now (bounded by worker count); this shows how much is left, so it is the progress indicator and the signal to autoscale workers on.",
    "fieldConfig": {
     "defaults": {
      "color": {
@@ -1876,6 +1900,108 @@
     "h": 6,
     "w": 8,
     "x": 0,
+    "y": 28
+   },
+   "id": 44,
+   "options": {
+    "legend": {
+     "calcs": [
+
+     ],
+     "displayMode": "list",
+     "placement": "right",
+     "showLegend": true
+    },
+    "tooltip": {
+     "hideZeros": false,
+     "mode": "single",
+     "sort": "none"
+    }
+   },
+   "pluginVersion": "12.0.1",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "sum(tempo_backend_scheduler_jobs_pending{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}) by (tenant)",
+     "legendFormat": "{{tenant}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Pending Redaction Jobs",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${metrics}"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "barWidthFactor": 0.6,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [
+
+     ],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green"
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     }
+    },
+    "overrides": [
+
+    ]
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 8,
+    "x": 8,
     "y": 28
    },
    "id": 36,
@@ -1977,7 +2103,7 @@
    "gridPos": {
     "h": 6,
     "w": 8,
-    "x": 8,
+    "x": 16,
     "y": 28
    },
    "id": 37,
@@ -2079,8 +2205,8 @@
    "gridPos": {
     "h": 6,
     "w": 8,
-    "x": 16,
-    "y": 28
+    "x": 0,
+    "y": 34
    },
    "id": 38,
    "options": {
@@ -2180,8 +2306,8 @@
    },
    "gridPos": {
     "h": 6,
-    "w": 6,
-    "x": 0,
+    "w": 8,
+    "x": 8,
     "y": 34
    },
    "id": 39,
@@ -2282,8 +2408,8 @@
    },
    "gridPos": {
     "h": 6,
-    "w": 6,
-    "x": 6,
+    "w": 8,
+    "x": 16,
     "y": 34
    },
    "id": 40,
@@ -2324,6 +2450,7 @@
     "type": "prometheus",
     "uid": "${metrics}"
    },
+   "description": "Classic-bucket and native-histogram queries are both present. The native series gives full resolution where the classic buckets are coarse; it renders once native histograms are retained for this metric.",
    "fieldConfig": {
     "defaults": {
      "color": {
@@ -2386,8 +2513,8 @@
    "gridPos": {
     "h": 6,
     "w": 12,
-    "x": 12,
-    "y": 34
+    "x": 0,
+    "y": 40
    },
    "id": 41,
    "options": {
@@ -2439,6 +2566,28 @@
      "legendFormat": "p50",
      "range": true,
      "refId": "C"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
+     "legendFormat": "p99 (native)",
+     "range": true,
+     "refId": "N99"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
+     "legendFormat": "p50 (native)",
+     "range": true,
+     "refId": "N50"
     }
    ],
    "title": "Redaction Job Duration",
@@ -2511,7 +2660,7 @@
    "gridPos": {
     "h": 6,
     "w": 12,
-    "x": 0,
+    "x": 12,
     "y": 40
    },
    "id": 42,
@@ -2614,8 +2763,8 @@
    "gridPos": {
     "h": 6,
     "w": 12,
-    "x": 12,
-    "y": 40
+    "x": 0,
+    "y": 46
    },
    "id": 43,
    "options": {
@@ -2656,7 +2805,7 @@
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 46
+    "y": 52
    },
    "id": 8,
    "panels": [
@@ -2732,7 +2881,7 @@
     "h": 6,
     "w": 5,
     "x": 0,
-    "y": 47
+    "y": 53
    },
    "id": 9,
    "options": {
@@ -2836,7 +2985,7 @@
     "h": 6,
     "w": 4,
     "x": 5,
-    "y": 47
+    "y": 53
    },
    "id": 11,
    "options": {
@@ -2939,7 +3088,7 @@
     "h": 6,
     "w": 5,
     "x": 9,
-    "y": 47
+    "y": 53
    },
    "id": 10,
    "options": {
@@ -3042,7 +3191,7 @@
     "h": 6,
     "w": 4,
     "x": 14,
-    "y": 47
+    "y": 53
    },
    "id": 13,
    "options": {
@@ -3146,7 +3295,7 @@
     "h": 6,
     "w": 4,
     "x": 18,
-    "y": 47
+    "y": 53
    },
    "id": 12,
    "options": {
@@ -3249,7 +3398,7 @@
     "h": 6,
     "w": 2,
     "x": 22,
-    "y": 47
+    "y": 53
    },
    "id": 29,
    "options": {
@@ -3290,7 +3439,7 @@
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 53
+    "y": 59
    },
    "id": 25,
    "panels": [
@@ -3411,7 +3560,7 @@
     "h": 8,
     "w": 6,
     "x": 12,
-    "y": 54
+    "y": 60
    },
    "id": 7,
    "options": {
@@ -3583,7 +3732,7 @@
     "h": 8,
     "w": 6,
     "x": 18,
-    "y": 54
+    "y": 60
    },
    "id": 6,
    "options": {
@@ -3662,7 +3811,7 @@
     "h": 1,
     "w": 24,
     "x": 0,
-    "y": 62
+    "y": 68
    },
    "id": 1,
    "panels": [
@@ -3738,7 +3887,7 @@
     "h": 8,
     "w": 6,
     "x": 0,
-    "y": 63
+    "y": 69
    },
    "id": 2,
    "options": {
@@ -3921,7 +4070,7 @@
     "h": 8,
     "w": 6,
     "x": 6,
-    "y": 63
+    "y": 69
    },
    "id": 3,
    "options": {
@@ -4082,7 +4231,7 @@
     "h": 8,
     "w": 6,
     "x": 12,
-    "y": 63
+    "y": 69
    },
    "id": 4,
    "options": {
@@ -4254,7 +4403,7 @@
     "h": 8,
     "w": 6,
     "x": 18,
-    "y": 63
+    "y": 69
    },
    "id": 5,
    "options": {

--- a/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
@@ -1590,8 +1590,8 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
-     "legendFormat": "p99 (native)",
+     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
+     "legendFormat": "p99 {{job_type}} (native)",
      "range": true,
      "refId": "N99"
     },
@@ -1601,8 +1601,8 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
-     "legendFormat": "p50 (native)",
+     "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
+     "legendFormat": "p50 {{job_type}} (native)",
      "range": true,
      "refId": "N50"
     }
@@ -2577,6 +2577,17 @@
      "legendFormat": "p99 (native)",
      "range": true,
      "refId": "N99"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "histogram_quantile(0.9, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
+     "legendFormat": "p90 (native)",
+     "range": true,
+     "refId": "N90"
     },
     {
      "datasource": {

--- a/operations/tempo-mixin/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin/dashboards/tempo-backendwork.json
@@ -1496,10 +1496,33 @@
           "legendFormat": "p50 {{job_type}}",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p99 (native)",
+          "range": true,
+          "refId": "N99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "p50 (native)",
+          "range": true,
+          "refId": "N50"
         }
       ],
       "title": "Job Duration",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Classic-bucket and native-histogram queries are both present. The native series gives full resolution where the classic buckets are coarse; it renders once native histograms are retained for this metric."
     },
     {
       "datasource": {
@@ -1774,6 +1797,103 @@
         "x": 0,
         "y": 28
       },
+      "id": 44,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "sum(tempo_backend_scheduler_jobs_pending{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}) by (tenant)",
+          "legendFormat": "{{tenant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Redaction Jobs",
+      "type": "timeseries",
+      "description": "Jobs enqueued and not yet dispatched to a worker. Active shows what is running now (bounded by worker count); this shows how much is left, so it is the progress indicator and the signal to autoscale workers on."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 28
+      },
       "id": 36,
       "options": {
         "legend": {
@@ -1867,7 +1987,7 @@
       "gridPos": {
         "h": 6,
         "w": 8,
-        "x": 8,
+        "x": 16,
         "y": 28
       },
       "id": 37,
@@ -1963,8 +2083,8 @@
       "gridPos": {
         "h": 6,
         "w": 8,
-        "x": 16,
-        "y": 28
+        "x": 0,
+        "y": 34
       },
       "id": 38,
       "options": {
@@ -2058,8 +2178,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 0,
+        "w": 8,
+        "x": 8,
         "y": 34
       },
       "id": 39,
@@ -2154,8 +2274,8 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 6,
-        "x": 6,
+        "w": 8,
+        "x": 16,
         "y": 34
       },
       "id": 40,
@@ -2252,8 +2372,8 @@
       "gridPos": {
         "h": 6,
         "w": 12,
-        "x": 12,
-        "y": 34
+        "x": 0,
+        "y": 40
       },
       "id": 41,
       "options": {
@@ -2303,10 +2423,33 @@
           "legendFormat": "p50",
           "range": true,
           "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
+          "legendFormat": "p99 (native)",
+          "range": true,
+          "refId": "N99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
+          "legendFormat": "p50 (native)",
+          "range": true,
+          "refId": "N50"
         }
       ],
       "title": "Redaction Job Duration",
-      "type": "timeseries"
+      "type": "timeseries",
+      "description": "Classic-bucket and native-histogram queries are both present. The native series gives full resolution where the classic buckets are coarse; it renders once native histograms are retained for this metric."
     },
     {
       "datasource": {
@@ -2370,7 +2513,7 @@
       "gridPos": {
         "h": 6,
         "w": 12,
-        "x": 0,
+        "x": 12,
         "y": 40
       },
       "id": 42,
@@ -2467,8 +2610,8 @@
       "gridPos": {
         "h": 6,
         "w": 12,
-        "x": 12,
-        "y": 40
+        "x": 0,
+        "y": 46
       },
       "id": 43,
       "options": {
@@ -2508,7 +2651,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 52
       },
       "id": 8,
       "panels": [],
@@ -2578,7 +2721,7 @@
         "h": 6,
         "w": 5,
         "x": 0,
-        "y": 47
+        "y": 53
       },
       "id": 9,
       "options": {
@@ -2676,7 +2819,7 @@
         "h": 6,
         "w": 4,
         "x": 5,
-        "y": 47
+        "y": 53
       },
       "id": 11,
       "options": {
@@ -2773,7 +2916,7 @@
         "h": 6,
         "w": 5,
         "x": 9,
-        "y": 47
+        "y": 53
       },
       "id": 10,
       "options": {
@@ -2870,7 +3013,7 @@
         "h": 6,
         "w": 4,
         "x": 14,
-        "y": 47
+        "y": 53
       },
       "id": 13,
       "options": {
@@ -2968,7 +3111,7 @@
         "h": 6,
         "w": 4,
         "x": 18,
-        "y": 47
+        "y": 53
       },
       "id": 12,
       "options": {
@@ -3065,7 +3208,7 @@
         "h": 6,
         "w": 2,
         "x": 22,
-        "y": 47
+        "y": 53
       },
       "id": 29,
       "options": {
@@ -3104,7 +3247,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 59
       },
       "id": 25,
       "panels": [],
@@ -3219,7 +3362,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 54
+        "y": 60
       },
       "id": 7,
       "options": {
@@ -3385,7 +3528,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 54
+        "y": 60
       },
       "id": 6,
       "options": {
@@ -3462,7 +3605,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 62
+        "y": 68
       },
       "id": 1,
       "panels": [],
@@ -3532,7 +3675,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 63
+        "y": 69
       },
       "id": 2,
       "options": {
@@ -3709,7 +3852,7 @@
         "h": 8,
         "w": 6,
         "x": 6,
-        "y": 63
+        "y": 69
       },
       "id": 3,
       "options": {
@@ -3864,7 +4007,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 63
+        "y": 69
       },
       "id": 4,
       "options": {
@@ -4030,7 +4173,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 63
+        "y": 69
       },
       "id": 5,
       "options": {

--- a/operations/tempo-mixin/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin/dashboards/tempo-backendwork.json
@@ -1503,8 +1503,8 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
-          "legendFormat": "p99 (native)",
+          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
+          "legendFormat": "p99 {{job_type}} (native)",
           "range": true,
           "refId": "N99"
         },
@@ -1514,8 +1514,8 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
-          "legendFormat": "p50 (native)",
+          "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
+          "legendFormat": "p50 {{job_type}} (native)",
           "range": true,
           "refId": "N50"
         }
@@ -2434,6 +2434,17 @@
           "legendFormat": "p99 (native)",
           "range": true,
           "refId": "N99"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
+          "legendFormat": "p90 (native)",
+          "range": true,
+          "refId": "N90"
         },
         {
           "datasource": {

--- a/tempodb/backend/cache/cache.go
+++ b/tempodb/backend/cache/cache.go
@@ -20,24 +20,30 @@ import (
 	"github.com/grafana/tempo/tempodb/backend"
 )
 
+// metricsNamespace is the Prometheus namespace shared by this package's metrics.
+const metricsNamespace = "tempodb"
+
 // cacheStoreSizeBytes records the byte size of every item written to a tempodb backend cache, labelled by role.
 var cacheStoreSizeBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "tempodb",
-	Name:      "cache_store_size_bytes",
-	Help:      "Distribution of item sizes written to tempodb backend caches, by role.",
-	Buckets:   prometheus.ExponentialBuckets(512, 2, 15), // 512 B, 1 KiB, ..., 8 MiB
+	Namespace:                       metricsNamespace,
+	Name:                            "cache_store_size_bytes",
+	Help:                            "Distribution of item sizes written to tempodb backend caches, by role.",
+	Buckets:                         prometheus.ExponentialBuckets(512, 2, 15), // 512 B, 1 KiB, ..., 8 MiB
+	NativeHistogramBucketFactor:     1.1,
+	NativeHistogramMaxBucketNumber:  100,
+	NativeHistogramMinResetDuration: 1 * time.Hour,
 }, []string{"role"})
 
 // cacheRequests counts cache lookups by role and outcome (hit / miss).
 var cacheRequests = promauto.NewCounterVec(prometheus.CounterOpts{
-	Namespace: "tempodb",
+	Namespace: metricsNamespace,
 	Name:      "cache_requests_total",
 	Help:      "Cache lookup outcome by role.",
 }, []string{"role", "outcome"})
 
 // cacheRequestBytes counts bytes served on hit and bytes fetched from backend on miss, by role.
 var cacheRequestBytes = promauto.NewCounterVec(prometheus.CounterOpts{
-	Namespace: "tempodb",
+	Namespace: metricsNamespace,
 	Name:      "cache_request_bytes_total",
 	Help:      "Bytes served by cache (hit) or fetched on miss, by role.",
 }, []string{"role", "outcome"})


### PR DESCRIPTION
**What this PR does**:

Adds the missing scale signal for backend work, and fixes the job-duration histogram so its percentiles mean something.

**`tempo_backend_scheduler_jobs_pending{tenant, job_type}`** — jobs enqueued and not yet dispatched. Nothing exposed queue depth before: a submission that fanned out 145 jobs reported `1`, because `jobs_created_total` counts dispatch and `jobs_active` counts work already handed to a worker. That also makes depth the only signal that can drive scale-up, since `jobs_active` is bounded by the worker count.

It matters most for redaction, where compaction is gated for the tenant so no compaction jobs are created — yet the outstanding-blocks metric deliberately keeps reporting that backlog (`newBlockSelectorForMeasurement`, asserted since #6992). An autoscaler on that signal holds scale for work it cannot dispatch, which happens to help but is not the signal it claims to be. `sum(...{job_type="JOB_TYPE_REDACTION"})` is the direct input, and the only one that tracks progress.

Current values are set before drained series are deleted, rather than resetting the vector first: a scrape landing inside a `Reset()` would see series missing and read the total low — the spurious scale-down this metric exists to prevent. Drained label sets are still removed, so a finished redaction never looks permanently backlogged. Both properties are pinned by tests.

**Native histograms.** `tempodb_cache_store_size_bytes` was the only histogram in the tree without native configuration; coverage is now 34/34. Separately, ops was retaining only `_bucket` for `job_duration_seconds` while other histograms from the same target kept their native series — an aggregation-rule gap rather than anything in this code. The native series has since appeared there, which is what makes the dashboard's native queries worth having.

**Dashboard.** A "Pending Redaction Jobs" panel leads the Redaction row: "Active Redaction Jobs" reads the same on the first block as on the last, so nothing showed how much of a redaction was left. Both job-duration panels gain native-histogram queries alongside the classic ones, grouped to match.

**Which issue(s) this PR fixes**:

N/A (tracked internally).

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`


