### PR TITLE
Make vParquet5 the default block format

### DIFF
--- a/.chloggen/vparquet5-default-block-version.yaml
+++ b/.chloggen/vparquet5-default-block-version.yaml
@@ -1,0 +1,24 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: change
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Make `vParquet5` the default block format for newly written blocks (was `vParquet4`).
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  No data migration is required. After upgrading, Tempo writes new blocks in
+  vParquet5 while continuing to read existing vParquet4 and vParquet3 blocks. To
+  keep writing vParquet4, set `storage.trace.block.version: vParquet4` explicitly.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolinar

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2095,7 +2095,7 @@ Defines re-used configuration blocks.
 
 ```yaml
 # block format version. options: vParquet4, vParquet5
-[version: <string> | default = vParquet4]
+[version: <string> | default = vParquet5]
 
 # bloom filter false positive rate. lower values create larger filters but fewer false positives
 [bloom_filter_false_positive: <float> | default = 0.01]

--- a/docs/sources/tempo/configuration/manifest.md
+++ b/docs/sources/tempo/configuration/manifest.md
@@ -589,7 +589,7 @@ storage:
         block:
             bloom_filter_false_positive: 0.01
             bloom_filter_shard_size_bytes: 102400
-            version: vParquet4
+            version: vParquet5
             parquet_row_group_size_bytes: 100000000
             parquet_dedicated_columns:
                 - scope: resource

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -23,21 +23,21 @@ As soon as a block format version is enabled, Tempo starts writing data in that 
 
 {{< admonition type="warning" >}}
 The `v2` and `vParquet3` block formats have been removed in Tempo 3.0.
-Use `vParquet4` (default) or `vParquet5`. 
+Use `vParquet5` (default) or `vParquet4`. 
 {{< /admonition >}}
 
 Only Parquet-based formats are supported. 
 
 ### vParquet4 
 
-The default block format is `vParquet4`.
+`vParquet4` is available as an opt-in alternative to the default `vParquet5` format.
 
 `vParquet4` introduces columns that enable querying for data in array attributes as well as events and links.
 For more information, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
 
 ### vParquet5
 
-`vParquet5` is production-ready and available as an opt-in alternative to `vParquet4`.
+`vParquet5` is the default block format.
 It builds on vParquet4 with the following improvements:
 
 - Expanded dedicated columns: Up to 20 dedicated string columns and 5 dedicated integer columns per scope (span, resource, and event), compared with 10 string columns per scope in vParquet4.
@@ -60,7 +60,7 @@ storage:
 
 Replace `<version>` with `vParquet4` or `vParquet5`.
 
-To restore the default `vParquet4` format, remove the `version` option from the configuration file or set it to `vParquet4`.
+To keep writing the previous `vParquet4` format, set the `version` option to `vParquet4`.
 
 ## Parquet configuration parameters
 

--- a/docs/sources/tempo/operations/schema.md
+++ b/docs/sources/tempo/operations/schema.md
@@ -21,7 +21,7 @@ This document describes the schema used with the Parquet block format.
 
 ## Version applicability
 
-Tempo defaults to the vParquet4 schema. vParquet5 is production-ready and differs in some schema details.
+Tempo defaults to the vParquet5 schema. vParquet4 remains available and differs in some schema details.
 Unless otherwise noted, the sections below describe vParquet4.
 
 The following sections apply to both vParquet4 and vParquet5:

--- a/docs/sources/tempo/reference-tempo-architecture/block-format.md
+++ b/docs/sources/tempo/reference-tempo-architecture/block-format.md
@@ -87,8 +87,8 @@ Tempo uses versioned block formats.
 | Version   | Status                             |
 | --------- | ---------------------------------- |
 | vParquet3 | Deprecated in 2.10, removed in 3.0 |
-| vParquet4 | Default and latest in Tempo 3.0    |
-| vParquet5 | Production-ready, opt-in           |
+| vParquet4 | Production-ready, opt-in            |
+| vParquet5 | Default and latest                 |
 
 The block format is configured in:
 

--- a/modules/frontend/docs/config-reference.md
+++ b/modules/frontend/docs/config-reference.md
@@ -585,7 +585,7 @@ storage:
         block:
             bloom_filter_false_positive: 0.01
             bloom_filter_shard_size_bytes: 102400
-            version: vParquet4
+            version: vParquet5
             parquet_row_group_size_bytes: 100000000
             parquet_dedicated_columns:
                 - scope: resource

--- a/tempodb/encoding/versioned.go
+++ b/tempodb/encoding/versioned.go
@@ -95,13 +95,18 @@ func FromVersionForWrites(v string) (VersionedEncoding, error) {
 }
 
 // DefaultEncoding for newly written blocks.
+//
+// The default is vParquet5. Existing vParquet3 and vParquet4 blocks are still
+// read without migration; only newly written blocks use this default. Pin
+// storage.trace.block.version to vParquet4 to opt out. See CHANGELOG.md for
+// migration guidance.
 func DefaultEncoding() VersionedEncoding {
-	return vparquet4.Encoding{}
+	return vparquet5.Encoding{}
 }
 
 // LatestEncoding returns the most recent encoding.
 func LatestEncoding() VersionedEncoding {
-	return vparquet4.Encoding{}
+	return vparquet5.Encoding{}
 }
 
 // AllEncodings returns all encodings


### PR DESCRIPTION
## What this PR does

Makes `vParquet5` the default block format for newly written blocks. `DefaultEncoding()` and `LatestEncoding()` in `tempodb/encoding/versioned.go` now return `vParquet5` instead of `vParquet4`.

The default propagates automatically through `modules/storage/config.go`, which derives `storage.trace.block.version` from `DefaultEncoding().Version()`. Regenerated config docs (`manifest.md`, `config-reference.md`) and updated related prose docs.

## Checklist
- [x] Tests updated (existing tests derive the default dynamically; encoding/tempodb/wal suites pass locally)
- [x] `CHANGELOG.md` updated via `.chloggen/` entry
- [x] Documentation updated