### PR TITLE
Correct PR numbers in changelog files

### DIFF
--- a/.chloggen/7404-reenable-darwin-builds.yaml
+++ b/.chloggen/7404-reenable-darwin-builds.yaml
@@ -1,6 +1,6 @@
 change_type: enhancement
 component: tempo
 note: re-enable darwin release builds again
-issues: [7404]
+issues: [7407]
 subtext:
 user: electron0zero

--- a/.chloggen/kafka-sasl-mechanism.yaml
+++ b/.chloggen/kafka-sasl-mechanism.yaml
@@ -12,7 +12,7 @@ note: Add Kafka SASL mechanism selection and TLS support. The `sasl_mechanism` o
 
 # (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
 # .chloggen/README.md.
-issues: [7580]
+issues: [7586]
 
 # (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
 subtext: |


### PR DESCRIPTION
**What this PR does**:

Fixes two `.chloggen` entries whose issues field pointed to a GitHub tracking issue number instead of the actual merged PR, so the generated `CHANGELOG.md` links to the right PR.

* kafka-sasl-mechanism.yaml: 7580 to 7586
* 7404-reenable-darwin-builds.yaml: 7404 to 7407

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)