### PR TITLE
Update for TraceQL metrics and queriers for 3.1 features

### DIFF
--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2454,9 +2454,10 @@ overrides:
       # bypass safety checks.
       [unsafe_query_hints: <bool> | default = false]
 
-      # Per-user toggle for the span-only fetch layer for TraceQL metrics queries.
-      # When not set, the default behavior is used. May be overridden by query hints.
-      [metrics_spanonly_fetch: <bool>]
+      # Per-user toggle for the span-only fetch layer for TraceQL metrics queries,
+      # which is enabled by default. Set to false to opt out for the tenant.
+      # May be overridden by query hints.
+      [metrics_spanonly_fetch: <bool> | default = true]
 
       # EXPERIMENTAL
       # When enabled, queries report an additional metric indicating whether the

--- a/docs/sources/tempo/metrics-from-traces/metrics-queries/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/metrics-queries/_index.md
@@ -110,13 +110,17 @@ Example:
 
 ### Faster read path
 
-In vParquet5, TraceQL metrics queries use a span-only fetch layer by default, which significantly improves performance for most metrics queries. This optimized read path processes individual spans instead of full traces, reducing latency and memory usage. It applies to metrics queries that don't require knowledge of the full trace structure. Queries using structural operators like `>>`, `<<`, `~`, `!>>`, `!<<`, or `!~` still use the standard fetch layer.
+In vParquet5, TraceQL metrics queries use a span-only fetch layer by default, which significantly improves performance for most metrics queries. 
+This optimized read path processes individual spans instead of full traces, reducing latency and memory usage. 
+It applies to metrics queries that don't require knowledge of the full trace structure. 
+Queries using structural operators like `>>`, `<<`, `~`, `!>>`, `!<<`, or `!~` still use the standard fetch layer.
 
 You can opt out of the faster read path using a query hint or a per-tenant override.
 
 #### Opt out with a query hint
 
-Add the `spanonly_fetch=false` hint to your query to disable the faster read path for that query. This hint requires [`unsafe_query_hints`](/docs/tempo/<TEMPO_VERSION>/configuration/#overrides) to be enabled for the tenant.
+Add the `spanonly_fetch=false` hint to your query to disable the faster read path for that query.
+This hint requires [`unsafe_query_hints`](/docs/tempo/<TEMPO_VERSION>/configuration/#overrides) to be enabled for the tenant.
 
 ```
 { resource.service.name = "frontend" } | rate() by (status) with (spanonly_fetch=false)
@@ -124,7 +128,9 @@ Add the `spanonly_fetch=false` hint to your query to disable the faster read pat
 
 #### Opt out with a per-tenant override
 
-Operators can disable the faster read path by default for a tenant using the `metrics_spanonly_fetch` override. When set to `false`, all eligible metrics queries for that tenant use the standard fetch layer instead. This override doesn't require `unsafe_query_hints`.
+Operators can disable the faster read path by default for a tenant using the `metrics_spanonly_fetch` override. 
+When set to `false`, all eligible metrics queries for that tenant use the standard fetch layer instead.
+This override doesn't require `unsafe_query_hints`.
 
 ```yaml
 overrides:
@@ -133,4 +139,5 @@ overrides:
       metrics_spanonly_fetch: false
 ```
 
-When `unsafe_query_hints` is also enabled for the tenant, the `spanonly_fetch` query hint takes precedence over the per-tenant override. Users can set `spanonly_fetch=false` to opt out, or `spanonly_fetch=true` to opt back in even when the override disables it for the tenant.
+When `unsafe_query_hints` is also enabled for the tenant, the `spanonly_fetch` query hint takes precedence over the per-tenant override. 
+You can set `spanonly_fetch=false` to opt out, or `spanonly_fetch=true` to opt back in even when the override disables it for the tenant.

--- a/docs/sources/tempo/metrics-from-traces/metrics-queries/_index.md
+++ b/docs/sources/tempo/metrics-from-traces/metrics-queries/_index.md
@@ -108,31 +108,29 @@ Example:
 { span:name = "GET /:endpoint" } | quantile_over_time(duration, .99) by (span.http.target) with (exemplars=true)
 ```
 
-### Faster read path (experimental)
+### Faster read path
 
-{{< docs/experimental product="Tempo" >}}
+In vParquet5, TraceQL metrics queries use a span-only fetch layer by default, which significantly improves performance for most metrics queries. This optimized read path processes individual spans instead of full traces, reducing latency and memory usage. It applies to metrics queries that don't require knowledge of the full trace structure. Queries using structural operators like `>>`, `<<`, `~`, `!>>`, `!<<`, or `!~` still use the standard fetch layer.
 
-In vParquet5, you can use an experimental span-only fetch layer to significantly improve performance for most metrics queries. This optimized read path processes individual spans instead of full traces, reducing latency and memory usage.
+You can opt out of the faster read path using a query hint or a per-tenant override.
 
-You must enable the faster read path explicitly using a query hint or a per-tenant override. Once enabled, it applies to metrics queries that don't require knowledge of the full trace structure. Queries using structural operators like `>>`, `<<`, `~`, `!>>`, `!<<`, or `!~` still use the standard fetch layer.
+#### Opt out with a query hint
 
-#### Enable with a query hint
-
-Add the `spanonly_fetch=true` hint to your query. This hint requires [`unsafe_query_hints`](/docs/tempo/<TEMPO_VERSION>/configuration/#overrides) to be enabled for the tenant.
+Add the `spanonly_fetch=false` hint to your query to disable the faster read path for that query. This hint requires [`unsafe_query_hints`](/docs/tempo/<TEMPO_VERSION>/configuration/#overrides) to be enabled for the tenant.
 
 ```
-{ resource.service.name = "frontend" } | rate() by (status) with (spanonly_fetch=true)
+{ resource.service.name = "frontend" } | rate() by (status) with (spanonly_fetch=false)
 ```
 
-#### Enable with a per-tenant override
+#### Opt out with a per-tenant override
 
-Operators can enable the faster read path by default for a tenant using the `metrics_spanonly_fetch` override. When set, it applies to all eligible metrics queries for that tenant without requiring a query hint. This override doesn't require `unsafe_query_hints`.
+Operators can disable the faster read path by default for a tenant using the `metrics_spanonly_fetch` override. When set to `false`, all eligible metrics queries for that tenant use the standard fetch layer instead. This override doesn't require `unsafe_query_hints`.
 
 ```yaml
 overrides:
   'tenant-id':
     read:
-      metrics_spanonly_fetch: true
+      metrics_spanonly_fetch: false
 ```
 
-When `unsafe_query_hints` is also enabled for the tenant, the `spanonly_fetch` query hint takes precedence over the per-tenant override. Users can set `spanonly_fetch=false` to opt out, or `spanonly_fetch=true` to opt in even when the override is disabled.
+When `unsafe_query_hints` is also enabled for the tenant, the `spanonly_fetch` query hint takes precedence over the per-tenant override. Users can set `spanonly_fetch=false` to opt out, or `spanonly_fetch=true` to opt back in even when the override disables it for the tenant.

--- a/docs/sources/tempo/reference-tempo-architecture/components/querier.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/querier.md
@@ -59,9 +59,7 @@ Querier memory usage roughly scales with: `job_size * querier_concurrency + buff
 
 | Metric | Description |
 |---|---|
-| `tempo_querier_backend_processing_duration_seconds` | Time the querier spends processing backend blocks (object-store scan and interleaved I/O), labeled by `operation` (`traces`, `search`, `search-tags`, `search-tag-values`, `metrics`) and `tenant`. Excludes recent (live-store) data. |
-
-`tempo_querier_backend_processing_duration_seconds` isolates the time a querier spends on backend-block work from the time it spends on live-store queries or other request handling, which is useful for capacity planning and autoscaling decisions. It complements `tempodb_backend_request_duration_seconds`, which only times the underlying object-store GET I/O.
+| `tempo_querier_backend_processing_duration_seconds` | Time the querier spends processing backend blocks (object-store scan and interleaved I/O), labeled by `operation` (`traces`, `search`, `search-tags`, `search-tag-values`, `metrics`) and `tenant`. Excludes recent (live-store) data. Complements `tempodb_backend_request_duration_seconds`, which only times the underlying object-store GET I/O. Use this metric for capacity planning and autoscaling. |
 
 ## Related resources
 

--- a/docs/sources/tempo/reference-tempo-architecture/components/querier.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/querier.md
@@ -55,6 +55,14 @@ Increasing concurrency makes queriers process more jobs in parallel but increase
 
 Querier memory usage roughly scales with: `job_size * querier_concurrency + buffer`. You can tune this by adjusting `target_bytes_per_job` (at the frontend), `max_concurrent_queries` (at the querier), and `frontend_worker.parallelism` (which affects how many batches the querier processes at once).
 
+## Key metrics
+
+| Metric | Description |
+|---|---|
+| `tempo_querier_backend_processing_duration_seconds` | Time the querier spends processing backend blocks (object-store scan and interleaved I/O), labeled by `operation` (`traces`, `search`, `search-tags`, `search-tag-values`, `metrics`) and `tenant`. Excludes recent (live-store) data. |
+
+`tempo_querier_backend_processing_duration_seconds` isolates the time a querier spends on backend-block work from the time it spends on live-store queries or other request handling, which is useful for capacity planning and autoscaling decisions. It complements `tempodb_backend_request_duration_seconds`, which only times the underlying object-store GET I/O.
+
 ## Related resources
 
 Refer to the [querier configuration](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/#querier) for the full list of options.


### PR DESCRIPTION
**What this PR does**:

Adds and updates doc for the span-only-fetch default change and `tempo_querier_backend_processing_duration_seconds` metric. 

* #7179
* #7525 

PR created with the help of Claude. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)