### PR TITLE
feat(mcp): add trace diff tool

### DIFF
--- a/.chloggen/mcp-trace-diff.yaml
+++ b/.chloggen/mcp-trace-diff.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: query-frontend
+note: Add a `trace-diff` tool to the Tempo MCP server for comparing complete traces
+issues: [7785]
+subtext: The default composed response includes a compact summary and conditionally includes patches up to 64 KiB. Native summary and full patch formats remain available on request; full patches have no output-size guarantee.
+user: carles-grafana

--- a/docs/sources/tempo/api_docs/_index.md
+++ b/docs/sources/tempo/api_docs/_index.md
@@ -805,12 +805,15 @@ Parameters:
 - `format`
   Optional. Output format. The default is `trace-patch-v0`. Use
   `trace-summary-v0-native` for only the compact summary or
-  `trace-summary-v0-composed` for the summary with a size-bounded patch.
+  `trace-summary-v0-composed` for the summary with a patch attachment limited to
+  64 KiB.
 
-The composed response always includes a native summary. It includes the full
-patch when the serialized patch is no larger than 64 KiB. Otherwise,
-`patchOmitted` reports the patch size and the reason `over_budget`; send another
-request with `format` set to `trace-patch-v0` to retrieve it.
+The composed response always includes a native summary. If the full patch is larger
+than 64 KiB, `patchOmitted` reports its serialized size and the reason `over_budget`.
+Request `trace-patch-v0` only when span-level evidence is required and the client can
+accept the reported patch size. The 64 KiB limit applies only to the attached patch;
+neither the complete composed response nor the full patch response has a hard output
+size limit.
 
 When `start` and `end` are provided, the request validates that `start` is
 before `end` and limits the block search to that time range. If omitted, Tempo

--- a/docs/sources/tempo/api_docs/mcp-server.md
+++ b/docs/sources/tempo/api_docs/mcp-server.md
@@ -41,10 +41,32 @@ The MCP server exposes the following tools that AI assistants can use to interac
 | `traceql-metrics-instant` | Retrieve a single metric value given a TraceQL metrics query            |
 | `traceql-metrics-range`   | Retrieve a metric series given a TraceQL metrics query                  |
 | `get-trace`               | Retrieve a specific trace by ID                                         |
+| `trace-diff`              | Compare two complete traces and return their differences                |
 | `get-attribute-names`     | Get available attribute names for use in TraceQL queries                |
 | `get-attribute-values`    | Get values for a specific scoped attribute name                         |
 | `docs-traceql`            | Retrieve TraceQL documentation (basic, aggregates, structural, metrics) |
 | `docs-config`             | Retrieve Tempo configuration documentation (overview, reference)        |
+
+### Compare traces
+
+The experimental `trace-diff` tool compares a baseline trace with another complete trace.
+Provide `base_trace_id` and `compare_trace_id`. By default, the tool returns
+`trace-summary-v0-composed`, which always contains a compact summary and includes the full
+span-level patch when the patch is no larger than 64 KiB. The 64 KiB limit applies only
+to the attached patch, not to the complete composed response.
+
+Omit `format` to use the composed response. Set it to `trace-summary-v0-native` to
+return only the compact summary, or to `trace-patch-v0` when you need the complete
+span-level patch. An explicitly empty `format` is invalid. If a composed response
+contains `patchOmitted`, use the summary for initial analysis. Request `trace-patch-v0`
+only when span-level evidence is required and the client can accept a patch of
+`patchOmitted.bytes` bytes. Full patch responses have no output-size guarantee.
+
+The optional `base_start` and `base_end` arguments limit the baseline lookup to an
+RFC3339 time range; both must be provided together. The same rule applies to
+`compare_start` and `compare_end` for the comparison trace. Tempo searches all blocks
+for a trace when its range is omitted. Partial traces are rejected because their
+comparison could be inaccurate.
 
 ## Available resources
 

--- a/docs/sources/tempo/introduction/tempo-ai-tooling.svg
+++ b/docs/sources/tempo/introduction/tempo-ai-tooling.svg
@@ -18,7 +18,7 @@
   <!-- MCP server box -->
   <rect x="300" y="54" width="340" height="60" rx="6" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>
   <text x="470" y="76" text-anchor="middle" font-weight="600" font-size="12" fill="#1a1a1a">MCP server  /api/mcp</text>
-  <text x="470" y="102" text-anchor="middle" font-size="10" fill="#6e6e6e">7 tools | 4 doc resources | TraceQL | metrics | attributes</text>
+  <text x="470" y="102" text-anchor="middle" font-size="10" fill="#6e6e6e">9 tools | 6 doc resources | TraceQL | metrics | attributes | diff</text>
 
   <!-- HTTP API box -->
   <rect x="300" y="124" width="340" height="60" rx="6" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"/>

--- a/docs/sources/tempo/introduction/tempo-and-ai.md
+++ b/docs/sources/tempo/introduction/tempo-and-ai.md
@@ -14,14 +14,14 @@ weight: 450
 
 # Tempo and AI
 
-Tempo exposes a Model Context Protocol (MCP) server and LLM-optimized API endpoints that let AI agents query traces, compute metrics, and discover attributes directly.
+Tempo exposes a Model Context Protocol (MCP) server and LLM-optimized API endpoints that let AI agents query and compare traces, compute metrics, and discover attributes directly.
 Grafana also provides command-line tools that connect agents to the broader observability platform.
 
 ![AI agent entry points for Tempo and Grafana tools](tempo-ai-tooling.svg)
 
 ## Model Context Protocol server
 
-The [MCP server](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/mcp-server/) at `/api/mcp` lets agents search for traces with TraceQL, retrieve a trace by ID, compute metrics from span data, and discover available attributes.
+The [MCP server](https://grafana.com/docs/tempo/<TEMPO_VERSION>/api_docs/mcp-server/) at `/api/mcp` lets agents search for traces with TraceQL, retrieve or compare traces by ID, compute metrics from span data, and discover available attributes.
 The server also serves TraceQL syntax documentation as MCP resources, so agents can look up query syntax on demand instead of relying on training data.
 
 The MCP server uses the `streamable-http` transport and supports the same authentication and [multi-tenancy](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/manage-advanced-systems/multitenancy/) as other Tempo API endpoints.

--- a/integration/api/mcp_test.go
+++ b/integration/api/mcp_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"path"
 	"sort"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/grafana/e2e"
 	"github.com/grafana/tempo/integration/util"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	tempoUtil "github.com/grafana/tempo/pkg/util"
 	"github.com/stretchr/testify/require"
 
@@ -60,6 +62,7 @@ func TestMCP(t *testing.T) {
 			"traceql-metrics-instant",
 			"traceql-metrics-range",
 			"get-trace",
+			"trace-diff",
 			"get-attribute-names",
 			"get-attribute-values",
 			"docs-traceql",
@@ -77,6 +80,7 @@ func TestMCP(t *testing.T) {
 		require.Equal(t, expectedTools, actualTools)
 
 		assertTraceOverMCP(t, mcpClient, info.HexID())
+		assertTraceDiffOverMCP(t, mcpClient, info.HexID())
 	})
 }
 
@@ -126,6 +130,26 @@ func assertTraceOverMCP(t *testing.T, mcpClient mcpclient.MCPClient, traceID str
 	if !strings.Contains(str, traceID) {
 		t.Fatalf("expected trace ID %s not found in response", traceID)
 	}
+}
+
+func assertTraceDiffOverMCP(t *testing.T, mcpClient mcpclient.MCPClient, traceID string) {
+	resp, err := mcpClient.CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "trace-diff",
+			Arguments: map[string]any{
+				"base_trace_id":    traceID,
+				"compare_trace_id": traceID,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var result tracediff.ComposedResult
+	require.NoError(t, json.Unmarshal([]byte(toolResult(t, resp)), &result))
+	require.Equal(t, tracediff.VersionTraceSummaryV0Composed, result.Version)
+	require.NotNil(t, result.Summary)
+	require.Equal(t, traceID, result.Summary.Base.TraceID)
+	require.Equal(t, traceID, result.Summary.Compare.TraceID)
 }
 
 func toolResult(t *testing.T, resp *mcp.CallToolResult) string {

--- a/modules/frontend/mcp.go
+++ b/modules/frontend/mcp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/dskit/middleware"
 	frontendDocs "github.com/grafana/tempo/modules/frontend/docs"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -39,6 +40,7 @@ const (
 	toolTraceQLMetricsInstant = "traceql-metrics-instant"
 	toolTraceQLMetricsRange   = "traceql-metrics-range"
 	toolGetTrace              = "get-trace"
+	toolTraceDiff             = "trace-diff"
 	toolGetAttributeNames     = "get-attribute-names"
 	toolGetAttributeValues    = "get-attribute-values"
 	toolDocsTraceQL           = "docs-traceql"
@@ -324,6 +326,49 @@ func (s *MCPServer) setupTools() {
 		mcp.WithDestructiveHintAnnotation(false),
 	)
 	s.mcpServer.AddTool(traceTool, s.handleGetTrace)
+
+	traceDiffTool := newReadOnlyTool(
+		toolTraceDiff,
+		mcp.WithDescription("Compare two complete traces. Returns a compact summary and includes the full span-level patch when it is at most 64 KiB. Request trace-patch-v0 only when full details are required; full patches are not size-bounded."),
+		mcp.WithString(
+			"base_trace_id",
+			mcp.Required(),
+			mcp.Description("Trace ID for the baseline trace"),
+		),
+		mcp.WithString(
+			"compare_trace_id",
+			mcp.Required(),
+			mcp.Description("Trace ID for the comparison trace"),
+		),
+		mcp.WithString(
+			"base_start",
+			mcp.Description("Optional start of the baseline trace search range in RFC3339 format. Must be provided with base_end."),
+			mcp.MinLength(1),
+		),
+		mcp.WithString(
+			"base_end",
+			mcp.Description("Optional end of the baseline trace search range in RFC3339 format. Must be provided with base_start."),
+			mcp.MinLength(1),
+		),
+		mcp.WithString(
+			"compare_start",
+			mcp.Description("Optional start of the comparison trace search range in RFC3339 format. Must be provided with compare_end."),
+			mcp.MinLength(1),
+		),
+		mcp.WithString(
+			"compare_end",
+			mcp.Description("Optional end of the comparison trace search range in RFC3339 format. Must be provided with compare_start."),
+			mcp.MinLength(1),
+		),
+		mcp.WithString(
+			"format",
+			mcp.Description("Output format. The composed format returns a compact summary and attaches the full patch only when it is at most 64 KiB. trace-patch-v0 has no output-size guarantee."),
+			mcp.Enum(tracediff.VersionTraceSummaryV0Composed, tracediff.VersionTraceSummaryV0Native, tracediff.VersionTracePatchV0),
+			mcp.DefaultString(tracediff.VersionTraceSummaryV0Composed),
+			mcp.MinLength(1),
+		),
+	)
+	s.mcpServer.AddTool(traceDiffTool, s.handleTraceDiff)
 
 	attributeNamesTool := newReadOnlyTool(
 		toolGetAttributeNames,

--- a/modules/frontend/mcp_functional_test.go
+++ b/modules/frontend/mcp_functional_test.go
@@ -2,11 +2,15 @@ package frontend
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
@@ -29,6 +33,12 @@ func newTestMCPClient(t *testing.T) *mcpclient.Client {
 
 	mcpServer, ok := qf.MCPHandler.(*MCPServer)
 	require.True(t, ok, "expected MCP handler to be enabled")
+
+	return newInProcessMCPClient(t, mcpServer)
+}
+
+func newInProcessMCPClient(t *testing.T, mcpServer *MCPServer) *mcpclient.Client {
+	t.Helper()
 
 	client, err := mcpclient.NewInProcessClient(mcpServer.mcpServer)
 	require.NoError(t, err)
@@ -97,6 +107,96 @@ func TestMCPConfigDocsTool(t *testing.T) {
 
 	// unknown doc types fall back to the overview instead of erroring
 	require.Equal(t, overview, callDocsConfig(t, client, "does-not-exist"))
+}
+
+func TestMCPTraceDiffTool(t *testing.T) {
+	var receivedRequest *http.Request
+	var receivedBody api.TraceDiffRequest
+	handlerCalls := 0
+	frontend := &QueryFrontend{
+		TraceDiffHandler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handlerCalls++
+			receivedRequest = r
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&receivedBody))
+			_, err := w.Write([]byte(`{"version":"trace-summary-v0-composed"}`))
+			require.NoError(t, err)
+		}),
+	}
+	mcpServer := NewMCPServer(frontend, "", log.NewNopLogger(), fakeHTTPAuthMiddleware, 0)
+	client := newInProcessMCPClient(t, mcpServer)
+
+	toolsResp, err := client.ListTools(context.Background(), mcp.ListToolsRequest{})
+	require.NoError(t, err)
+
+	var traceDiffTool *mcp.Tool
+	for i := range toolsResp.Tools {
+		if toolsResp.Tools[i].Name == toolTraceDiff {
+			traceDiffTool = &toolsResp.Tools[i]
+		}
+	}
+	require.NotNil(t, traceDiffTool, "trace-diff tool should be listed")
+	require.NotNil(t, traceDiffTool.Annotations.ReadOnlyHint)
+	require.True(t, *traceDiffTool.Annotations.ReadOnlyHint)
+	require.NotNil(t, traceDiffTool.Annotations.DestructiveHint)
+	require.False(t, *traceDiffTool.Annotations.DestructiveHint)
+	require.NotNil(t, traceDiffTool.Annotations.OpenWorldHint)
+	require.False(t, *traceDiffTool.Annotations.OpenWorldHint)
+	require.ElementsMatch(t, []string{"base_trace_id", "compare_trace_id"}, traceDiffTool.InputSchema.Required)
+
+	formatSchema, ok := traceDiffTool.InputSchema.Properties["format"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, tracediff.VersionTraceSummaryV0Composed, formatSchema["default"])
+	require.Equal(t, float64(1), formatSchema["minLength"])
+	enumJSON, err := json.Marshal(formatSchema["enum"])
+	require.NoError(t, err)
+	require.JSONEq(t, `[
+		"trace-summary-v0-composed",
+		"trace-summary-v0-native",
+		"trace-patch-v0"
+	]`, string(enumJSON))
+
+	resp, err := client.CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: toolTraceDiff,
+			Arguments: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, resp.IsError)
+	require.NotNil(t, receivedRequest)
+	require.Equal(t, http.MethodPost, receivedRequest.Method)
+	require.Equal(t, api.PathTraceDiffV2, receivedRequest.URL.Path)
+	require.Equal(t, api.HeaderAcceptJSON, receivedRequest.Header.Get(api.HeaderContentType))
+	require.Equal(t, api.HeaderAcceptLLM, receivedRequest.Header.Get(api.HeaderAccept))
+	require.Equal(t, "12345678abcdef90", receivedBody.Base.TraceID)
+	require.Equal(t, "abcdef9012345678", receivedBody.Compare.TraceID)
+	require.Equal(t, tracediff.VersionTraceSummaryV0Composed, receivedBody.Format)
+	require.Equal(t, map[string]any{
+		"type":     MetaTypeTraceDiff,
+		"encoding": "json",
+		"version":  "2",
+	}, resp.Meta.AdditionalFields)
+	require.Len(t, resp.Content, 1)
+	textContent, ok := resp.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	require.JSONEq(t, `{"version":"trace-summary-v0-composed"}`, textContent.Text)
+
+	emptyFormatResp, err := client.CallTool(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: toolTraceDiff,
+			Arguments: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+				"format":           "",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, emptyFormatResp.IsError)
+	require.Equal(t, 1, handlerCalls)
 }
 
 // TestMCPConfigDocsResources exercises the docs://config resources over the real MCP protocol.

--- a/modules/frontend/mcp_tools.go
+++ b/modules/frontend/mcp_tools.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/tempo/modules/frontend/docs"
 	"github.com/grafana/tempo/modules/frontend/pipeline"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/traceql"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -35,6 +37,7 @@ const (
 	MetaTypeMetricsRange    = "metrics-range"
 	MetaTypeMetricsInstant  = "metrics-instant"
 	MetaTypeTrace           = "trace"
+	MetaTypeTraceDiff       = "trace-diff"
 	MetaTypeAttributeNames  = "attribute-names"
 	MetaTypeAttributeValues = "attribute-values"
 )
@@ -288,6 +291,123 @@ func (s *MCPServer) handleGetTrace(ctx context.Context, request mcp.CallToolRequ
 	}
 
 	return toolResult(body, MetaTypeTrace, "json", "2"), nil
+}
+
+func (s *MCPServer) handleTraceDiff(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	metricMCPToolCalls.WithLabelValues(toolTraceDiff).Inc()
+
+	baseTraceID, err := request.RequireString("base_trace_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	compareTraceID, err := request.RequireString("compare_trace_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	format, err := traceDiffFormat(request)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	baseStart, baseEnd, err := parseTraceDiffRange(request, "base_start", "base_end")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	compareStart, compareEnd, err := parseTraceDiffRange(request, "compare_start", "compare_end")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	level.Info(s.logger).Log(
+		"msg", "comparing traces",
+		"base_trace_id", baseTraceID,
+		"compare_trace_id", compareTraceID,
+		"format", format,
+	)
+
+	diffReq := api.TraceDiffRequest{
+		Base: api.TraceDiffTraceRequest{
+			TraceID: baseTraceID,
+			Start:   baseStart,
+			End:     baseEnd,
+		},
+		Compare: api.TraceDiffTraceRequest{
+			TraceID: compareTraceID,
+			Start:   compareStart,
+			End:     compareEnd,
+		},
+		Format: format,
+	}
+	reqBody, err := json.Marshal(diffReq)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to build trace diff request: %v", err)), nil
+	}
+
+	httpReq := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Path: s.buildPath(api.PathTraceDiffV2)},
+		Header: http.Header{api.HeaderContentType: {api.HeaderAcceptJSON}},
+		Body:   io.NopCloser(bytes.NewReader(reqBody)),
+	}
+	body, err := handleHTTP(ctx, s.frontend.TraceDiffHandler, httpReq)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return toolResult(body, MetaTypeTraceDiff, "json", "2"), nil
+}
+
+func traceDiffFormat(request mcp.CallToolRequest) (string, error) {
+	if _, ok := request.GetArguments()["format"]; !ok {
+		return tracediff.VersionTraceSummaryV0Composed, nil
+	}
+
+	format, err := request.RequireString("format")
+	if err != nil {
+		return "", err
+	}
+	if format == "" {
+		return "", fmt.Errorf("argument %q must not be empty", "format")
+	}
+	return format, nil
+}
+
+func parseTraceDiffRange(request mcp.CallToolRequest, startName, endName string) (*int64, *int64, error) {
+	args := request.GetArguments()
+	_, hasStart := args[startName]
+	_, hasEnd := args[endName]
+	if hasStart != hasEnd {
+		return nil, nil, fmt.Errorf("arguments %q and %q must be provided together", startName, endName)
+	}
+	if !hasStart {
+		return nil, nil, nil
+	}
+
+	startValue, err := request.RequireString(startName)
+	if err != nil {
+		return nil, nil, err
+	}
+	endValue, err := request.RequireString(endName)
+	if err != nil {
+		return nil, nil, err
+	}
+	start, err := parseTraceDiffTime(startValue, startName)
+	if err != nil {
+		return nil, nil, err
+	}
+	end, err := parseTraceDiffTime(endValue, endName)
+	if err != nil {
+		return nil, nil, err
+	}
+	return start, end, nil
+}
+
+func parseTraceDiffTime(value, name string) (*int64, error) {
+	timestamp, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", name, err)
+	}
+	epoch := timestamp.Unix()
+	return &epoch, nil
 }
 
 // handleGetAttributeNames handles the get-attribute-names tool

--- a/modules/frontend/mcp_tools_test.go
+++ b/modules/frontend/mcp_tools_test.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/grafana/tempo/pkg/api"
+	"github.com/grafana/tempo/pkg/model/tracediff"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 )
@@ -369,6 +371,148 @@ func TestHandleGetTrace(t *testing.T) {
 	}
 }
 
+func TestHandleTraceDiff(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         map[string]any
+		expectedBody string
+		expectedErr  string
+	}{
+		{
+			name: "required arguments use composed format",
+			args: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+			},
+			expectedBody: `{
+				"base": {"traceId": "12345678abcdef90"},
+				"compare": {"traceId": "abcdef9012345678"},
+				"format": "trace-summary-v0-composed"
+			}`,
+		},
+		{
+			name: "explicit format and time ranges",
+			args: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+				"base_start":       "2022-01-01T00:00:00Z",
+				"base_end":         "2022-01-02T00:00:00Z",
+				"compare_start":    "2022-01-03T00:00:00Z",
+				"compare_end":      "2022-01-04T00:00:00Z",
+				"format":           tracediff.VersionTracePatchV0,
+			},
+			expectedBody: `{
+				"base": {"traceId": "12345678abcdef90", "start": 1640995200, "end": 1641081600},
+				"compare": {"traceId": "abcdef9012345678", "start": 1641168000, "end": 1641254400},
+				"format": "trace-patch-v0"
+			}`,
+		},
+		{
+			name:        "missing base trace ID",
+			args:        map[string]any{"compare_trace_id": "abcdef9012345678"},
+			expectedErr: `required argument "base_trace_id" not found`,
+		},
+		{
+			name:        "missing compare trace ID",
+			args:        map[string]any{"base_trace_id": "12345678abcdef90"},
+			expectedErr: `required argument "compare_trace_id" not found`,
+		},
+		{
+			name: "empty format",
+			args: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+				"format":           "",
+			},
+			expectedErr: `argument "format" must not be empty`,
+		},
+		{
+			name: "non-string format",
+			args: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+				"format":           1,
+			},
+			expectedErr: `argument "format" is not a string`,
+		},
+		{
+			name: "incomplete time range",
+			args: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+				"base_start":       "2022-01-01T00:00:00Z",
+			},
+			expectedErr: `arguments "base_start" and "base_end" must be provided together`,
+		},
+		{
+			name: "non-string time",
+			args: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+				"compare_start":    1641168000,
+				"compare_end":      "2022-01-04T00:00:00Z",
+			},
+			expectedErr: `argument "compare_start" is not a string`,
+		},
+		{
+			name: "invalid time",
+			args: map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+				"base_start":       "not-a-time",
+				"base_end":         "2022-01-02T00:00:00Z",
+			},
+			expectedErr: "invalid base_start: parsing time",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedRequest *http.Request
+			var capturedBody []byte
+			mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedRequest = r
+				var err error
+				capturedBody, err = io.ReadAll(r.Body)
+				require.NoError(t, err)
+				_, err = w.Write([]byte(`{"version":"trace-summary-v0-composed"}`))
+				require.NoError(t, err)
+			})
+			server := &MCPServer{
+				frontend:   &QueryFrontend{TraceDiffHandler: mockHandler},
+				logger:     log.NewNopLogger(),
+				pathPrefix: "",
+			}
+
+			result, err := server.handleTraceDiff(context.Background(), callToolRequest(tt.args))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			if tt.expectedErr != "" {
+				require.True(t, result.IsError)
+				require.Len(t, result.Content, 1)
+				textContent, ok := result.Content[0].(mcp.TextContent)
+				require.True(t, ok)
+				require.Contains(t, textContent.Text, tt.expectedErr)
+				require.Nil(t, capturedRequest)
+				return
+			}
+
+			require.False(t, result.IsError)
+			require.NotNil(t, capturedRequest)
+			require.Equal(t, http.MethodPost, capturedRequest.Method)
+			require.Equal(t, api.PathTraceDiffV2, capturedRequest.URL.Path)
+			require.Equal(t, api.HeaderAcceptJSON, capturedRequest.Header.Get(api.HeaderContentType))
+			require.JSONEq(t, tt.expectedBody, string(capturedBody))
+			require.Equal(t, map[string]any{
+				"type":     MetaTypeTraceDiff,
+				"encoding": "json",
+				"version":  "2",
+			}, result.Meta.AdditionalFields)
+		})
+	}
+}
+
 func TestHandleGetAttributeNames(t *testing.T) {
 	server, callAndTestResults := testFrontend()
 
@@ -529,6 +673,13 @@ func TestAcceptHeaderIsSet(t *testing.T) {
 			}),
 		},
 		{
+			name: "handleTraceDiff sets Accept header",
+			request: callToolRequest(map[string]any{
+				"base_trace_id":    "12345678abcdef90",
+				"compare_trace_id": "abcdef9012345678",
+			}),
+		},
+		{
 			name:    "handleGetAttributeNames sets Accept header",
 			request: callToolRequest(map[string]any{}),
 		},
@@ -554,6 +705,7 @@ func TestAcceptHeaderIsSet(t *testing.T) {
 				frontend: &QueryFrontend{
 					SearchHandler:              mockHandler,
 					TraceByIDHandlerV2:         mockHandler,
+					TraceDiffHandler:           mockHandler,
 					SearchTagsV2Handler:        mockHandler,
 					SearchTagsValuesV2Handler:  mockHandler,
 					MetricsQueryInstantHandler: mockHandler,
@@ -578,6 +730,8 @@ func TestAcceptHeaderIsSet(t *testing.T) {
 				result, err = server.handleRangeQuery(ctx, tt.request)
 			case "handleGetTrace sets Accept header":
 				result, err = server.handleGetTrace(ctx, tt.request)
+			case "handleTraceDiff sets Accept header":
+				result, err = server.handleTraceDiff(ctx, tt.request)
 			case "handleGetAttributeNames sets Accept header":
 				result, err = server.handleGetAttributeNames(ctx, tt.request)
 			case "handleGetAttributeValues sets Accept header":
@@ -615,6 +769,7 @@ func testFrontend() (*MCPServer, func(t *testing.T, req mcp.CallToolRequest, han
 		frontend: &QueryFrontend{
 			SearchHandler:              mockHandler,
 			TraceByIDHandlerV2:         mockHandler,
+			TraceDiffHandler:           mockHandler,
 			SearchTagsV2Handler:        mockHandler,
 			SearchTagsValuesV2Handler:  mockHandler,
 			MetricsQueryInstantHandler: mockHandler,

--- a/pkg/model/tracediff/composed.go
+++ b/pkg/model/tracediff/composed.go
@@ -9,12 +9,12 @@ import (
 
 const (
 	// VersionTraceSummaryV0Composed is an optional diff response shape: the
-	// native summary is always present, plus the full trace-patch-v0
-	// attached iff it fits the byte budget, omitted whole with a disclosure
-	// otherwise. Never truncated: a truncated change list lies by omission.
-	// Consumers needing the full patch when it exceeds the budget re-request
-	// with format trace-patch-v0; the two-request cost is accepted for the
-	// experimental endpoint rather than adding a bypass knob.
+	// native summary is always present, plus the full trace-patch-v0 attached
+	// iff it fits the byte budget. The budget applies only to the patch, not
+	// the complete composed response. Never truncated: a truncated change list
+	// lies by omission. Consumers can use PatchOmitted.Bytes to decide whether
+	// full span-level evidence justifies requesting trace-patch-v0, which has no
+	// output-size guarantee.
 	VersionTraceSummaryV0Composed = "trace-summary-v0-composed"
 
 	// DefaultPatchBudgetBytes bounds the patch attached to a composed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

Expose complete-trace comparisons through MCP with optional lookup ranges and native summary, composed, and full patch formats.

Default to a compact composed summary with patches attached up to 64 KiB, and document that callers should request unbounded full patches only when span-level evidence is required.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)