### PR TITLE
Preserve no-compact flag when copying vParquet5 blocks

### DIFF
--- a/.chloggen/vparquet5-copy-nocompact-flag.yaml
+++ b/.chloggen/vparquet5-copy-nocompact-flag.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Preserve the no-compact flag when copying vParquet5 blocks so freshly flushed blocks are not compacted or polled before completion.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolinar

--- a/tempodb/encoding/vparquet5/copy.go
+++ b/tempodb/encoding/vparquet5/copy.go
@@ -56,6 +56,16 @@ func CopyBlock(ctx context.Context, fromMeta, toMeta *backend.BlockMeta, from ba
 		return err
 	}
 
+	// no-compact flag
+	if hasNoCompactFlag, err := from.HasNoCompactFlag(ctx, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID); err != nil {
+		return err
+	} else if hasNoCompactFlag {
+		err = to.WriteNoCompactFlag(ctx, uuid.UUID(toMeta.BlockID), toMeta.TenantID)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Meta
 	err = to.WriteBlockMeta(ctx, toMeta)
 	return err

--- a/tempodb/encoding/vparquet5/copy_test.go
+++ b/tempodb/encoding/vparquet5/copy_test.go
@@ -1,0 +1,59 @@
+package vparquet5
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	tempo_io "github.com/grafana/tempo/pkg/io"
+	"github.com/grafana/tempo/pkg/util/test"
+	"github.com/grafana/tempo/tempodb/backend"
+	"github.com/grafana/tempo/tempodb/backend/local"
+	"github.com/grafana/tempo/tempodb/encoding/common"
+)
+
+// TestCopyBlockPreservesNoCompactFlag verifies that CopyBlock propagates the
+// no-compact flag from the source block to the destination. The block-builder
+// writes a block with this flag set and then copies it to the backend; the flag
+// must survive the copy so the block is not compacted or polled before the
+// block-builder calls AllowCompaction.
+func TestCopyBlockPreservesNoCompactFlag(t *testing.T) {
+	ctx := context.Background()
+
+	rawR, rawW, _, err := local.New(&local.Config{Path: t.TempDir()})
+	require.NoError(t, err)
+	r := backend.NewReader(rawR)
+	w := backend.NewWriter(rawW)
+
+	cfg := &common.BlockConfig{
+		BloomFP:             0.01,
+		BloomShardSizeBytes: 100 * 1024,
+	}
+
+	// Build a source block.
+	fromMeta := backend.NewBlockMeta("fake", uuid.New(), VersionString)
+	fromMeta.TotalObjects = 1
+
+	s, fromMeta := newStreamingBlock(ctx, cfg, fromMeta, r, w, tempo_io.NewBufferedWriter)
+
+	id := test.ValidTraceID(nil)
+	tr, _ := traceToParquet(&backend.BlockMeta{}, id, test.MakeTrace(1, id), nil)
+	require.NoError(t, s.Add(tr, 0, 0))
+	_, err = s.Complete()
+	require.NoError(t, err)
+
+	// Simulate the block-builder writing the no-compact flag on the source block.
+	require.NoError(t, w.WriteNoCompactFlag(ctx, uuid.UUID(fromMeta.BlockID), fromMeta.TenantID))
+
+	// Copy the block to a new location.
+	toMeta := backend.NewBlockMeta(fromMeta.TenantID, uuid.New(), VersionString)
+	toMeta.TotalObjects = fromMeta.TotalObjects
+	require.NoError(t, CopyBlock(ctx, fromMeta, toMeta, r, w))
+
+	// The flag must be preserved on the destination block.
+	has, err := r.HasNoCompactFlag(ctx, uuid.UUID(toMeta.BlockID), toMeta.TenantID)
+	require.NoError(t, err)
+	require.True(t, has, "CopyBlock must preserve the no-compact flag")
+}


### PR DESCRIPTION
## What this PR does

This PR adds the flag propagation to `vparquet5/copy.go` (matching vParquet3/4) and a regression test.

## Checklist
- [x] Tests added
- [x] `CHANGELOG.md` updated via `.chloggen/` entry (bug_fix)
- [x] No docs changes needed