### PR TITLE
fix: serialize DRAIN pruning with training

### DIFF
--- a/.chloggen/fix-drain-prune-race.yaml
+++ b/.chloggen/fix-drain-prune-race.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: metrics-generator
+note: Prevent metrics-generator crashes when span-name sanitization prunes DRAIN clusters while processing spans.
+issues: [7787]
+subtext:
+user: carles-grafana

--- a/modules/generator/registry/drain_sanitizer.go
+++ b/modules/generator/registry/drain_sanitizer.go
@@ -68,10 +68,10 @@ func (s *DrainSanitizer) Sanitize(lbls labels.Labels) labels.Labels {
 		return lbls
 	}
 
-	s.doPeriodicMaintenance()
-
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
+	s.doPeriodicMaintenanceLocked()
 
 	spanName := lbls.Get(labelSpanName)
 	// drain.Train retains substrings of spanName in long-lived cluster tokens
@@ -110,7 +110,7 @@ func (s *DrainSanitizer) Sanitize(lbls labels.Labels) labels.Labels {
 	return newLbls
 }
 
-func (s *DrainSanitizer) doPeriodicMaintenance() {
+func (s *DrainSanitizer) doPeriodicMaintenanceLocked() {
 	select {
 	case <-s.demandUpdateChan:
 		s.demandGauge.Set(float64(s.demand.Estimate()))

--- a/modules/generator/registry/drain_sanitizer_test.go
+++ b/modules/generator/registry/drain_sanitizer_test.go
@@ -146,6 +146,41 @@ func TestDrainSanitizer_ConcurrentAccess(t *testing.T) {
 	// No panics or race conditions should occur
 }
 
+func TestDrainSanitizer_ConcurrentPrune(t *testing.T) {
+	sanitizer := newTestDrainSanitizer(SpanNameSanitizationEnabled)
+
+	const (
+		numGoroutines        = 10
+		numCallsPerGoroutine = 100
+	)
+	pruneChan := make(chan time.Time, numGoroutines*numCallsPerGoroutine)
+	for range cap(pruneChan) {
+		pruneChan <- time.Time{}
+	}
+	sanitizer.demandUpdateChan = nil
+	sanitizer.pruneChan = pruneChan
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for i := range numGoroutines {
+		go func() {
+			defer wg.Done()
+			for j := range numCallsPerGoroutine {
+				// Digit-bearing suffixes collapse into DRAIN's data wildcard and stop growing the tree.
+				n := i*numCallsPerGoroutine + j
+				suffix := string([]rune{
+					rune('a' + n%26),
+					rune('a' + (n/26)%26),
+					rune('a' + (n/676)%26),
+				})
+				sanitizer.Sanitize(labels.FromStrings("span_name", "GET /api/users/"+suffix))
+			}
+		}()
+	}
+	wg.Wait()
+	require.Empty(t, pruneChan)
+}
+
 func TestDrainSanitizer_DemandTracking(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/drain/drain_benchmark_test.go
+++ b/pkg/drain/drain_benchmark_test.go
@@ -41,3 +41,57 @@ func BenchmarkDrain_TrainExtractsPatterns(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkDrain_Prune(b *testing.B) {
+	tests := []struct {
+		name       string
+		clusters   int
+		tokenCount int
+	}{
+		{name: "clusters=1000/tokens=4", clusters: 1_000, tokenCount: 4},
+		{name: "clusters=10000/tokens=4", clusters: 10_000, tokenCount: 4},
+		{name: "clusters=100000/tokens=4", clusters: 100_000, tokenCount: 4},
+		{name: "clusters=10000/tokens=30", clusters: 10_000, tokenCount: 30},
+		{name: "clusters=100000/tokens=30", clusters: 100_000, tokenCount: 30},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			config := DefaultConfig()
+			config.MaxClusters = tt.clusters
+			drain := New("benchmark-prune-"+tt.name, config)
+
+			side := 1
+			for side*side < tt.clusters {
+				side++
+			}
+			tokens := make([]string, tt.tokenCount)
+			for i := range tokens {
+				tokens[i] = benchmarkAlphaToken(i)
+			}
+			for i := range tt.clusters {
+				tokens[0] = benchmarkAlphaToken(i / side)
+				tokens[1] = benchmarkAlphaToken(i % side)
+				drain.train(tokens)
+			}
+			require.Len(b, drain.Clusters(), tt.clusters)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				drain.Prune()
+			}
+		})
+	}
+}
+
+func benchmarkAlphaToken(n int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+	var token [4]byte
+	for i := range token {
+		token[i] = alphabet[n%len(alphabet)]
+		n /= len(alphabet)
+	}
+	return string(token[:])
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

DRAIN pruning and training mutate the same prefix tree. Periodic pruning ran before the sanitizer mutex was acquired, allowing concurrent map access and metrics-generator crashes.

Run maintenance under the existing mutex, cover concurrent prune and train calls, and benchmark pruning across shallow and maximum-depth trees to make the added hot-path lock cost explicit.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)