### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,4 @@ Before writing or editing Markdown prose (docs, READMEs, design docs), read [`.a
 ## Pre-Commit Checklist
 
 Before pushing or opening a PR, read [`.agents/guidance/precommit.md`](.agents/guidance/precommit.md).
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
