### PR TITLE
fix: reject path-like tenant IDs before WAL join

### DIFF
--- a/.chloggen/reject-path-like-generator-tenant.yaml
+++ b/.chloggen/reject-path-like-generator-tenant.yaml
@@ -1,0 +1,6 @@
+change_type: security
+component: metrics-generator
+note: Reject path-like tenant IDs before the metrics-generator WAL Join and RemoveAll.
+issues: []
+subtext:
+user: SashaMIT

--- a/modules/generator/storage/instance.go
+++ b/modules/generator/storage/instance.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/grafana/tempo/modules/overrides"
+	dskittenant "github.com/grafana/dskit/tenant"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
@@ -19,6 +19,8 @@ import (
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/prometheus/prometheus/tsdb/agent"
+
+	"github.com/grafana/tempo/modules/overrides"
 )
 
 var metricStorageRemoteWriteUpdateFailed = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -60,9 +62,14 @@ var _ Storage = (*storageImpl)(nil)
 func New(cfg *Config, o Overrides, tenant string, reg prometheus.Registerer, _ log.Logger) (Storage, error) {
 	// TODO move this to the generator.go
 
-	// Validate empty tenant to prevent WAL directory deletion only when org ID header is required
+	// Reject empty and path-like tenants before filepath.Join + os.RemoveAll.
+	// Kafka ingest uses the record key as the tenant and skips HTTP extraction,
+	// so this is the last gate before a tenant of ".." deletes cfg.Path's parent.
 	if tenant == "" {
 		return nil, errors.New("tenant cannot be empty")
+	}
+	if err := dskittenant.ValidTenantID(tenant); err != nil {
+		return nil, fmt.Errorf("invalid tenant ID: %w", err)
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/modules/generator/storage/instance_test.go
+++ b/modules/generator/storage/instance_test.go
@@ -414,3 +414,34 @@ func TestInstance_emptyTenantValidation(t *testing.T) {
 		instance.Close()
 	})
 }
+
+func TestInstance_pathTenantValidation(t *testing.T) {
+	t.Parallel()
+
+	o := &mockOverrides{}
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout))
+
+	for _, tenantID := range []string{"..", "../x", "foo/bar", "."} {
+		t.Run(tenantID, func(t *testing.T) {
+			parent := t.TempDir()
+			walRoot := filepath.Join(parent, "wal")
+			require.NoError(t, os.MkdirAll(walRoot, 0o700))
+
+			marker := filepath.Join(parent, "marker")
+			require.NoError(t, os.WriteFile(marker, []byte("keep"), 0o600))
+
+			var cfg Config
+			cfg.RegisterFlagsAndApplyDefaults("", nil)
+			cfg.Path = walRoot
+			reg := prometheus.NewRegistry()
+
+			instance, err := New(&cfg, o, tenantID, reg, logger)
+			require.Error(t, err)
+			require.Nil(t, instance)
+			assert.Contains(t, err.Error(), "invalid tenant ID")
+
+			_, statErr := os.Stat(marker)
+			assert.NoError(t, statErr, "path-like tenant must not RemoveAll the WAL parent")
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does**:

`storage.New` already rejects an empty tenant because `filepath.Join(cfg.Path, "")` plus `os.RemoveAll` would wipe the metrics-generator WAL root. A tenant of `..` still escapes: `Join` resolves to the parent of `cfg.Path`, then `RemoveAll` deletes that parent.

HTTP `PushSpans` is already covered. `validation.ExtractValidTenantID` goes through `dskit/tenant.TenantID`, which calls `ValidTenantID` and rejects `.` / `..` / `/`. Kafka ingest does not. `generator_kafka.go` takes `string(r.Key)` and calls `getOrCreateInstance` with no tenant check, so a record keyed `..` still reaches `storage.New`.

This PR runs the same `dskit/tenant.ValidTenantID` check in `storage.New` before the Join. Empty stays the existing error. `.`, `..`, and IDs with unsupported characters (including `/`) return `invalid tenant ID`.

I used Cursor while writing the change and tests. I reviewed every line and ran the new cases locally.

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)

Made with [Cursor](https://cursor.com)