### PR TITLE
[tempo-mixin] gate Backend Work histogram panels on a latency_metrics variable

### DIFF
--- a/.chloggen/backendwork-dashboard-latency-metrics-variable.yaml
+++ b/.chloggen/backendwork-dashboard-latency-metrics-variable.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: operations
+note: "tempo-mixin: add a Latency metrics variable to the Backend Work dashboard to switch its histogram panels between classic and native."
+issues: []
+subtext: |
+  Every histogram panel on the dashboard now carries a gated classic/native query pair, matching the control the Operational dashboard already has. Previously the job-duration panels drew both families at once on stacks retaining both, and the blocklist-poll and retention panels queried native only, leaving them blank on stacks retaining only classic.
+user: zalegrala

--- a/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
@@ -250,12 +250,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(.99, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
      "hide": false,
-     "interval": "",
      "legendFormat": ".99",
      "range": true,
-     "refId": "D"
+     "refId": "A_classic"
     },
     {
      "datasource": {
@@ -263,11 +262,23 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(.9, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": ".99",
+     "range": true,
+     "refId": "A_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
      "hide": false,
      "legendFormat": ".9",
      "range": true,
-     "refId": "E"
+     "refId": "B_classic"
     },
     {
      "datasource": {
@@ -275,12 +286,35 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(.5, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
      "hide": false,
-     "interval": "",
+     "legendFormat": ".9",
+     "range": true,
+     "refId": "B_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": ".5",
      "range": true,
-     "refId": "F"
+     "refId": "C_classic"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": ".5",
+     "range": true,
+     "refId": "C_native"
     }
    ],
    "title": "Blocklist Poll Duration",
@@ -380,12 +414,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(.99, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
      "hide": false,
-     "interval": "",
      "legendFormat": ".99",
      "range": true,
-     "refId": "D"
+     "refId": "A_classic"
     },
     {
      "datasource": {
@@ -393,12 +426,23 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(.9, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
      "hide": false,
-     "interval": "",
+     "legendFormat": ".99",
+     "range": true,
+     "refId": "A_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": ".9",
      "range": true,
-     "refId": "E"
+     "refId": "B_classic"
     },
     {
      "datasource": {
@@ -406,12 +450,35 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(.5, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) )",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
      "hide": false,
-     "interval": "",
+     "legendFormat": ".9",
+     "range": true,
+     "refId": "B_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": ".5",
      "range": true,
-     "refId": "F"
+     "refId": "C_classic"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": ".5",
+     "range": true,
+     "refId": "C_native"
     }
    ],
    "title": "Retention duration",
@@ -1338,10 +1405,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": "__auto",
      "range": true,
-     "refId": "A"
+     "refId": "A_classic"
     },
     {
      "datasource": {
@@ -1349,11 +1417,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.90, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (route, namespace, cluster))) and on() (vector($latency_metrics) == -1)",
      "hide": false,
      "legendFormat": "__auto",
      "range": true,
-     "refId": "B"
+     "refId": "A_native"
     },
     {
      "datasource": {
@@ -1361,11 +1429,47 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))) and on() (vector($latency_metrics) == 1)",
      "hide": false,
      "legendFormat": "__auto",
      "range": true,
-     "refId": "C"
+     "refId": "B_classic"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempo_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (route, namespace, cluster))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "B_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "C_classic"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (route, namespace, cluster))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "C_native"
     }
    ],
    "title": "Backend-scheduler request latency",
@@ -1568,10 +1672,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": "p99 {{job_type}}",
      "range": true,
-     "refId": "A"
+     "refId": "A_classic"
     },
     {
      "datasource": {
@@ -1579,10 +1684,23 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": "p99 {{job_type}}",
+     "range": true,
+     "refId": "A_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": "p50 {{job_type}}",
      "range": true,
-     "refId": "B"
+     "refId": "B_classic"
     },
     {
      "datasource": {
@@ -1590,21 +1708,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
-     "legendFormat": "p99 {{job_type}} (native)",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": "p50 {{job_type}}",
      "range": true,
-     "refId": "N99"
-    },
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "${metrics}"
-     },
-     "editorMode": "code",
-     "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
-     "legendFormat": "p50 {{job_type}} (native)",
-     "range": true,
-     "refId": "N50"
+     "refId": "B_native"
     }
    ],
    "title": "Job Duration",
@@ -2540,10 +2648,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": "p99",
      "range": true,
-     "refId": "A"
+     "refId": "A_classic"
     },
     {
      "datasource": {
@@ -2551,10 +2660,23 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.90, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))",
+     "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": "p99",
+     "range": true,
+     "refId": "A_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": "p90",
      "range": true,
-     "refId": "B"
+     "refId": "B_classic"
     },
     {
      "datasource": {
@@ -2562,10 +2684,23 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))",
+     "expr": "(histogram_quantile(0.90, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": "p90",
+     "range": true,
+     "refId": "B_native"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+     "hide": false,
      "legendFormat": "p50",
      "range": true,
-     "refId": "C"
+     "refId": "C_classic"
     },
     {
      "datasource": {
@@ -2573,32 +2708,11 @@
       "uid": "${metrics}"
      },
      "editorMode": "code",
-     "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
-     "legendFormat": "p99 (native)",
+     "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+     "hide": false,
+     "legendFormat": "p50",
      "range": true,
-     "refId": "N99"
-    },
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "${metrics}"
-     },
-     "editorMode": "code",
-     "expr": "histogram_quantile(0.9, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
-     "legendFormat": "p90 (native)",
-     "range": true,
-     "refId": "N90"
-    },
-    {
-     "datasource": {
-      "type": "prometheus",
-      "uid": "${metrics}"
-     },
-     "editorMode": "code",
-     "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
-     "legendFormat": "p50 (native)",
-     "range": true,
-     "refId": "N50"
+     "refId": "C_native"
     }
    ],
    "title": "Redaction Job Duration",
@@ -4578,6 +4692,30 @@
     "refresh": 1,
     "regex": "",
     "type": "query"
+   },
+   {
+    "current": {
+     "text": "native",
+     "value": "-1"
+    },
+    "description": "Choose between showing latencies based on low precision classic or high precision native histogram metrics.",
+    "includeAll": false,
+    "label": "Latency metrics",
+    "name": "latency_metrics",
+    "options": [
+     {
+      "selected": true,
+      "text": "native",
+      "value": "-1"
+     },
+     {
+      "selected": false,
+      "text": "classic",
+      "value": "1"
+     }
+    ],
+    "query": "native : -1,classic : 1",
+    "type": "custom"
    }
   ]
  },

--- a/operations/tempo-mixin/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin/dashboards/tempo-backendwork.json
@@ -236,12 +236,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(.99, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
           "hide": false,
-          "interval": "",
           "legendFormat": ".99",
           "range": true,
-          "refId": "D"
+          "refId": "A_classic"
         },
         {
           "datasource": {
@@ -249,11 +248,23 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(.9, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": ".99",
+          "range": true,
+          "refId": "A_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
           "hide": false,
           "legendFormat": ".9",
           "range": true,
-          "refId": "E"
+          "refId": "B_classic"
         },
         {
           "datasource": {
@@ -261,12 +272,35 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(.5, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
           "hide": false,
-          "interval": "",
+          "legendFormat": ".9",
+          "range": true,
+          "refId": "B_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempodb_blocklist_poll_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": ".5",
           "range": true,
-          "refId": "F"
+          "refId": "C_classic"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempodb_blocklist_poll_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": ".5",
+          "range": true,
+          "refId": "C_native"
         }
       ],
       "title": "Blocklist Poll Duration",
@@ -360,12 +394,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(.99, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
           "hide": false,
-          "interval": "",
           "legendFormat": ".99",
           "range": true,
-          "refId": "D"
+          "refId": "A_classic"
         },
         {
           "datasource": {
@@ -373,12 +406,23 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(.9, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
           "hide": false,
-          "interval": "",
+          "legendFormat": ".99",
+          "range": true,
+          "refId": "A_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": ".9",
           "range": true,
-          "refId": "E"
+          "refId": "B_classic"
         },
         {
           "datasource": {
@@ -386,12 +430,35 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(.5, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) )",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
           "hide": false,
-          "interval": "",
+          "legendFormat": ".9",
+          "range": true,
+          "refId": "B_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempodb_retention_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": ".5",
           "range": true,
-          "refId": "F"
+          "refId": "C_classic"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempodb_retention_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": ".5",
+          "range": true,
+          "refId": "C_native"
         }
       ],
       "title": "Retention duration",
@@ -1264,10 +1331,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "A_classic"
         },
         {
           "datasource": {
@@ -1275,11 +1343,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempo_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (route, namespace, cluster))) and on() (vector($latency_metrics) == -1)",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
-          "refId": "B"
+          "refId": "A_native"
         },
         {
           "datasource": {
@@ -1287,11 +1355,47 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))) and on() (vector($latency_metrics) == 1)",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
-          "refId": "C"
+          "refId": "B_classic"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempo_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (route, namespace, cluster))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (le, route, namespace, cluster))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C_classic"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempo_request_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", container=~\"backend-scheduler\", route!~\"debug_pprof|metrics|ready\"}[$__rate_interval])) by (route, namespace, cluster))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C_native"
         }
       ],
       "title": "Backend-scheduler request latency",
@@ -1481,10 +1585,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": "p99 {{job_type}}",
           "range": true,
-          "refId": "A"
+          "refId": "A_classic"
         },
         {
           "datasource": {
@@ -1492,10 +1597,23 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": "p99 {{job_type}}",
+          "range": true,
+          "refId": "A_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (le, job_type))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": "p50 {{job_type}}",
           "range": true,
-          "refId": "B"
+          "refId": "B_classic"
         },
         {
           "datasource": {
@@ -1503,21 +1621,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
-          "legendFormat": "p99 {{job_type}} (native)",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": "p50 {{job_type}}",
           "range": true,
-          "refId": "N99"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${metrics}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (job_type))",
-          "legendFormat": "p50 {{job_type}} (native)",
-          "range": true,
-          "refId": "N50"
+          "refId": "B_native"
         }
       ],
       "title": "Job Duration",
@@ -2397,10 +2505,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": "p99",
           "range": true,
-          "refId": "A"
+          "refId": "A_classic"
         },
         {
           "datasource": {
@@ -2408,10 +2517,23 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))",
+          "expr": "(histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "A_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": "p90",
           "range": true,
-          "refId": "B"
+          "refId": "B_classic"
         },
         {
           "datasource": {
@@ -2419,10 +2541,23 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))",
+          "expr": "(histogram_quantile(0.90, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B_native"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])) by (le))) and on() (vector($latency_metrics) == 1)",
+          "hide": false,
           "legendFormat": "p50",
           "range": true,
-          "refId": "C"
+          "refId": "C_classic"
         },
         {
           "datasource": {
@@ -2430,32 +2565,11 @@
             "uid": "${metrics}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
-          "legendFormat": "p99 (native)",
+          "expr": "(histogram_quantile(0.50, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "hide": false,
+          "legendFormat": "p50",
           "range": true,
-          "refId": "N99"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${metrics}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.9, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
-          "legendFormat": "p90 (native)",
-          "range": true,
-          "refId": "N90"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${metrics}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.5, sum(rate(tempo_backend_scheduler_job_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job_type=\"JOB_TYPE_REDACTION\"}[$__rate_interval])))",
-          "legendFormat": "p50 (native)",
-          "range": true,
-          "refId": "N50"
+          "refId": "C_native"
         }
       ],
       "title": "Redaction Job Duration",
@@ -4338,6 +4452,30 @@
         "refresh": 1,
         "regex": "",
         "type": "query"
+      },
+      {
+        "current": {
+          "text": "native",
+          "value": "-1"
+        },
+        "description": "Choose between showing latencies based on low precision classic or high precision native histogram metrics.",
+        "includeAll": false,
+        "label": "Latency metrics",
+        "name": "latency_metrics",
+        "options": [
+          {
+            "selected": true,
+            "text": "native",
+            "value": "-1"
+          },
+          {
+            "selected": false,
+            "text": "classic",
+            "value": "1"
+          }
+        ],
+        "query": "native : -1,classic : 1",
+        "type": "custom"
       }
     ]
   },


### PR DESCRIPTION
**What this PR does**:

Adds a `Latency metrics` variable to the Backend Work dashboard and gates every histogram panel on it, so the whole dashboard switches between classic-bucket and native-histogram queries together. This is the control the Operational dashboard already carries.

The dashboard was inconsistent in three different ways before this:

| Panel | Before | After |
|---|---|---|
| Job Duration, Redaction Job Duration | classic **and** native drawn at once | one or the other |
| Blocklist Poll Duration, Retention duration | native only, so blank without native retention | either |
| Backend-scheduler request latency | classic only | either |

Why native matters here: the classic buckets on `tempo_backend_scheduler_job_duration_seconds` are `prometheus.DefBuckets`, which tops out at 10s. On `tempo-ops-01` the p99 compaction job currently reads **10s** classic against **~429s** native — the classic series is pinned to the bucket ceiling. Redaction jobs (p99 ~9s) sit inside `DefBuckets` and the two agree there, so no one static bucket set serves both job types. Native is the way out rather than re-bucketing.

All 28 targets now use the `and on() (vector($latency_metrics) == ±1)` gate that `mixin-utils` generates, in place of the hand-written variants. Metric names, selectors, quantiles and legends are otherwise unchanged. The native queries drop `le` from their grouping, since a native histogram carries its buckets in the sample rather than in a label.

Follow-ups, kept separate to stay reviewable: the Operational dashboard has the variable but 14 of its 17 histogram panels still ignore it, and the generated dashboards (live-store, writes, rollout-progress) still hand-write their quantile queries instead of calling the `mixin-utils` helpers.

**Which issue(s) this PR fixes**:
N/A — follow-up to #7772.

**Checklist**
- [ ] Tests updated — n/a, dashboard JSON
- [ ] Documentation added — n/a
- [x] Changelog entry added under `.chloggen/`
