### PR TITLE
[backend-scheduler] report when a tenant's maintenance is paused by a redaction

### DIFF
--- a/.chloggen/redaction-maintenance-paused-metric.yaml
+++ b/.chloggen/redaction-maintenance-paused-metric.yaml
@@ -1,7 +1,7 @@
 change_type: enhancement
 component: backend-scheduler
-note: "Add `tempo_backend_scheduler_tenant_maintenance_paused`, reporting whether a tenant's compaction and retention are paused by an exclusive operation."
+note: "Add `tempo_backend_scheduler_tenant_maintenance_paused` and a Backend Work panel, reporting whether a tenant's compaction and retention are paused by an exclusive operation."
 issues: []
 subtext: |
-  Set to 1 while an apply-mode redaction holds a tenant, including the quiescence period after its last block job, and back to 0 once the batch is torn down. This is the signal for whether a redaction has fully finished; job dispatch counters are not a substitute, because they keep draining a queue built before the redaction started and so dip rather than stopping.
+  "Maintenance Paused by Redaction" plots it per tenant. Set to 1 while an apply-mode redaction holds a tenant, including the quiescence period after its last block job, and back to 0 once the batch is torn down. This is the signal for whether a redaction has fully finished; job dispatch counters are not a substitute, because they keep draining a queue built before the redaction started and so dip rather than stopping.
 user: zalegrala

--- a/.chloggen/redaction-maintenance-paused-metric.yaml
+++ b/.chloggen/redaction-maintenance-paused-metric.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: backend-scheduler
+note: "Add `tempo_backend_scheduler_tenant_maintenance_paused`, reporting whether a tenant's compaction and retention are paused by an exclusive operation."
+issues: []
+subtext: |
+  Set to 1 while an apply-mode redaction holds a tenant, including the quiescence period after its last block job, and back to 0 once the batch is torn down. This is the signal for whether a redaction has fully finished; job dispatch counters are not a substitute, because they keep draining a queue built before the redaction started and so dip rather than stopping.
+user: zalegrala

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -1053,7 +1053,19 @@ cannot be recovered. Wait until every worker for the cell supports the window be
 redaction; an unwindowed redaction is unaffected.
 {{< /admonition >}}
 
-Monitor job progress through the [`/status/backendscheduler`](/docs/tempo/<TEMPO_VERSION>/api_docs/#backend-scheduler-job-status) endpoint.
+Monitor job progress through the [`/status/backendscheduler`](/docs/tempo/<TEMPO_VERSION>/api_docs/#backend-scheduler-job-status)
+endpoint, or from metrics:
+
+- `tempo_backend_scheduler_jobs_pending{job_type="JOB_TYPE_REDACTION"}` is the number of blocks still queued.
+  Progress is this against its peak for the run, since the queue only drains: `1 - (jobs_pending / max_over_time(jobs_pending[6h]))`.
+  It counts blocks not yet handed to a worker, so it reaches zero slightly before the last blocks finish.
+- `tempo_backend_scheduler_tenant_maintenance_paused` is `1` while the tenant's compaction and retention are held
+  off, and `0` once the batch is torn down after its quiescence period. This is how to tell that a redaction is
+  fully finished rather than still holding the tenant.
+
+Do not use `tempo_backend_scheduler_jobs_created_total` as a progress denominator. It counts jobs as they are
+assigned to a worker rather than as they are enqueued, so it tracks completions almost exactly and stays near
+100% for the whole run.
 
 ### Examples
 

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -109,6 +109,7 @@ This endpoint is useful for diagnosing stalled jobs, verifying that workers are 
 | `tempo_backend_scheduler_jobs_active` | Jobs currently assigned to a worker |
 | `tempo_backend_scheduler_jobs_pending` | Jobs enqueued and not yet assigned to a worker. Unlike `jobs_active`, which is bounded by the number of workers, this is queue depth and indicates whether more worker capacity is needed |
 | `tempo_backend_scheduler_job_duration_seconds` | Job execution duration histogram |
+| `tempo_backend_scheduler_tenant_maintenance_paused` | `1` while compaction and retention are paused for a tenant by an exclusive operation (an apply-mode redaction, including the quiescence period after its last block job), `0` once they resume. Job dispatch is not a substitute signal: it keeps draining a queue built before the operation started, so it dips rather than stopping |
 | `tempodb_blocklist_length` | Number of live blocks per tenant; high values indicate compaction is falling behind |
 | `tempodb_compaction_outstanding_blocks` | Outstanding blocks awaiting compaction per tenant; the primary autoscaling signal |
 

--- a/modules/backendscheduler/backendscheduler.go
+++ b/modules/backendscheduler/backendscheduler.go
@@ -62,6 +62,10 @@ type BackendScheduler struct {
 	// identifies the tenants and job types whose queue has drained, so their series can be deleted
 	// without resetting the whole vector. Touched only from the maintenance loop.
 	publishedPendingCounts map[string]map[tempopb.JobType]int
+
+	// publishedMaintenancePaused is the set of tenants reported as gated on the previous maintenance
+	// tick, so a tenant that has resumed can be set back to 0 rather than left reading 1 forever.
+	publishedMaintenancePaused map[string]struct{}
 }
 
 // ListJobs returns all jobs in the work cache
@@ -230,6 +234,7 @@ func (s *BackendScheduler) running(ctx context.Context) error {
 	// MaintenanceInterval after start, so a dashboard or autoscaler reading it right after a restart
 	// would see nothing rather than the queue that survived the restart.
 	s.recordPendingJobs()
+	s.recordMaintenancePaused()
 
 	var err error
 
@@ -242,6 +247,7 @@ func (s *BackendScheduler) running(ctx context.Context) error {
 			s.checkPendingRescans(ctx)
 			s.cleanupOrphanedBatches(ctx)
 			s.recordPendingJobs()
+			s.recordMaintenancePaused()
 		case <-backendFlushTicker.C:
 			err = s.flushWorkCacheToBackend(ctx)
 			metricWorkFlushes.Inc()

--- a/modules/backendscheduler/metrics.go
+++ b/modules/backendscheduler/metrics.go
@@ -32,6 +32,11 @@ var (
 	}, []string{"tenant", "job_type"})
 	// Queue depth. Distinct from jobs_active, which counts work already handed to a worker and is
 	// therefore bounded by the worker count — only depth can indicate that more capacity is needed.
+	metricTenantMaintenancePaused = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "tempo",
+		Name:      "backend_scheduler_tenant_maintenance_paused",
+		Help:      "1 while compaction and retention are paused for a tenant by an exclusive operation, 0 once they resume.",
+	}, []string{"tenant"})
 	metricJobsPending = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "tempo",
 		Name:      "backend_scheduler_jobs_pending",
@@ -138,4 +143,40 @@ func (s *BackendScheduler) recordPendingJobs() {
 	}
 
 	s.publishedPendingCounts = current
+}
+
+// recordMaintenancePaused publishes, per tenant, whether an exclusive operation is currently holding
+// compaction and retention off. Today that means an apply-mode redaction batch, for its whole
+// lifetime including the quiescence window that follows the last block job.
+//
+// Nothing else reports this. Compaction job dispatch is not a substitute: the gate stops the provider
+// *creating* jobs while the dispatch counter keeps draining a queue built before the batch was
+// submitted, so a real apply-mode redaction shows a dip rather than a stop.
+//
+// A tenant that resumes is set to 0 rather than deleted, unlike jobs_pending. The question an
+// operator asks is "has the quiet period elapsed", and a 1 -> 0 edge answers it on a graph or in an
+// alert, where a vanished series needs absent(). The label set stays small because it only ever holds
+// tenants that have taken the gate during this process's lifetime.
+//
+// Called only from the maintenance loop, so the retained snapshot needs no lock.
+func (s *BackendScheduler) recordMaintenancePaused() {
+	paused := make(map[string]struct{})
+
+	for _, batch := range s.work.ListBatches() {
+		tenant := batch.TenantId
+		// TenantPending is the same predicate compaction and retention gate on, rather than a second
+		// reading of "is there an apply-mode batch", so this cannot drift from what it reports.
+		if s.work.TenantPending(tenant) {
+			paused[tenant] = struct{}{}
+			metricTenantMaintenancePaused.WithLabelValues(tenant).Set(1)
+		}
+	}
+
+	for tenant := range s.publishedMaintenancePaused {
+		if _, stillPaused := paused[tenant]; !stillPaused {
+			metricTenantMaintenancePaused.WithLabelValues(tenant).Set(0)
+		}
+	}
+
+	s.publishedMaintenancePaused = paused
 }

--- a/modules/backendscheduler/metrics_maintenance_test.go
+++ b/modules/backendscheduler/metrics_maintenance_test.go
@@ -1,0 +1,77 @@
+package backendscheduler
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/tempo/modules/backendscheduler/work"
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+func applyBatch(tenant string) *tempopb.RedactionBatch {
+	return &tempopb.RedactionBatch{BatchId: "b-" + tenant, TenantId: tenant}
+}
+
+func dryRunBatch(tenant string) *tempopb.RedactionBatch {
+	return &tempopb.RedactionBatch{
+		BatchId:  "b-" + tenant,
+		TenantId: tenant,
+		Mode:     tempopb.RedactionMode_REDACTION_MODE_DRY_RUN,
+	}
+}
+
+// TestRecordMaintenancePausedApplyBatch covers the reason the gauge exists: while an apply-mode
+// redaction holds a tenant, that tenant's compaction and retention are paused, and nothing else
+// reports it. Compaction job dispatch is not a usable substitute — it keeps draining a queue built
+// before the batch was submitted, so it dips rather than stopping.
+func TestRecordMaintenancePausedApplyBatch(t *testing.T) {
+	metricTenantMaintenancePaused.Reset()
+	s := &BackendScheduler{work: work.New(work.Config{})}
+
+	require.NoError(t, s.work.AddBatch(applyBatch("tenant-a")))
+	s.recordMaintenancePaused()
+
+	require.Equal(t, 1.0, testutil.ToFloat64(metricTenantMaintenancePaused.WithLabelValues("tenant-a")))
+}
+
+// TestRecordMaintenancePausedIgnoresDryRun pins that a dry-run gets no series at all. A dry-run
+// rewrites nothing and never pauses maintenance, so reporting it as paused would send an operator
+// looking for a compaction stall that is not happening.
+func TestRecordMaintenancePausedIgnoresDryRun(t *testing.T) {
+	metricTenantMaintenancePaused.Reset()
+	s := &BackendScheduler{work: work.New(work.Config{})}
+
+	require.NoError(t, s.work.AddBatch(dryRunBatch("tenant-dry")))
+	s.recordMaintenancePaused()
+
+	require.Equal(t, 0, testutil.CollectAndCount(metricTenantMaintenancePaused),
+		"a dry-run never pauses maintenance, so it should not appear at all")
+}
+
+// TestRecordMaintenancePausedReportsResume is the operator's actual question — has the quiet period
+// elapsed and is compaction running again. The series must survive at 0 rather than being deleted:
+// a deleted series can only be detected with absent(), whereas a 1 -> 0 edge is directly visible on
+// a graph and alertable. This is a deliberate difference from jobs_pending, which deletes drained
+// series because its label set is per (tenant, job_type) and unbounded; the set of tenants holding a
+// redaction gate in one process lifetime is a handful.
+func TestRecordMaintenancePausedReportsResume(t *testing.T) {
+	metricTenantMaintenancePaused.Reset()
+	s := &BackendScheduler{work: work.New(work.Config{})}
+
+	require.NoError(t, s.work.AddBatch(applyBatch("tenant-a")))
+	s.recordMaintenancePaused()
+	require.Equal(t, 1.0, testutil.ToFloat64(metricTenantMaintenancePaused.WithLabelValues("tenant-a")))
+
+	// Teardown after quiescence removes the batch, which re-enables compaction and retention.
+	s.work.RemoveBatch("tenant-a")
+	s.recordMaintenancePaused()
+
+	// Counted before reading the value: ToFloat64(WithLabelValues(...)) would re-create a deleted
+	// series at 0 and assert successfully against its own side effect.
+	require.Equal(t, 1, testutil.CollectAndCount(metricTenantMaintenancePaused),
+		"the series is retained so the 1 -> 0 transition can be seen and alerted on")
+	require.Equal(t, 0.0, testutil.ToFloat64(metricTenantMaintenancePaused.WithLabelValues("tenant-a")),
+		"resume must be observable as a value, not as a missing series")
+}

--- a/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin-compiled/dashboards/tempo-backendwork.json
@@ -2811,6 +2811,112 @@
    "type": "timeseries"
   },
   {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${metrics}"
+   },
+   "description": "1 while an apply-mode redaction holds the tenant, including the quiescence period after its last block job; 0 once the batch is torn down and compaction and retention resume. Use the 1 to 0 edge to confirm a redaction is fully finished -- a drained job queue is not the same state. Dry-runs never pause maintenance and so never appear here.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisBorderShow": false,
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "barWidthFactor": 0.6,
+      "drawStyle": "line",
+      "fillOpacity": 20,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "stepAfter",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [
+
+     ],
+     "max": 1,
+     "min": 0,
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green"
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     }
+    },
+    "overrides": [
+
+    ]
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 12,
+    "x": 12,
+    "y": 46
+   },
+   "id": 45,
+   "options": {
+    "legend": {
+     "calcs": [
+
+     ],
+     "displayMode": "list",
+     "placement": "right",
+     "showLegend": true
+    },
+    "tooltip": {
+     "hideZeros": false,
+     "mode": "single",
+     "sort": "none"
+    }
+   },
+   "pluginVersion": "12.0.1",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${metrics}"
+     },
+     "editorMode": "code",
+     "expr": "max by (tenant) (tempo_backend_scheduler_tenant_maintenance_paused{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+     "hide": false,
+     "legendFormat": "{{tenant}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Maintenance Paused by Redaction",
+   "type": "timeseries"
+  },
+  {
    "collapsed": false,
    "gridPos": {
     "h": 1,

--- a/operations/tempo-mixin/dashboards/tempo-backendwork.json
+++ b/operations/tempo-mixin/dashboards/tempo-backendwork.json
@@ -2657,6 +2657,106 @@
       "description": "Traces a dry-run redaction matched but did NOT remove (mode=dry_run), by tenant. Preview of a query selector’s blast radius before applying."
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${metrics}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "id": 45,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${metrics}"
+          },
+          "editorMode": "code",
+          "expr": "max by (tenant) (tempo_backend_scheduler_tenant_maintenance_paused{cluster=~\"$cluster\", namespace=~\"$namespace\"})",
+          "hide": false,
+          "legendFormat": "{{tenant}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Maintenance Paused by Redaction",
+      "type": "timeseries",
+      "description": "1 while an apply-mode redaction holds the tenant, including the quiescence period after its last block job; 0 once the batch is torn down and compaction and retention resume. Use the 1 to 0 edge to confirm a redaction is fully finished -- a drained job queue is not the same state. Dry-runs never pause maintenance and so never appear here."
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,


### PR DESCRIPTION
**What this PR does**:

Adds `tempo_backend_scheduler_tenant_maintenance_paused{tenant}` — `1` while an exclusive operation is holding a tenant's compaction and retention off, `0` once they resume. Today that means an apply-mode redaction, for its whole lifetime including the quiescence period after its last block job.

This is the one thing an operator cannot currently determine about a running redaction: whether it has *fully* finished, or whether the batch is still holding the tenant.

**Why job counters do not answer it.** `tempo_backend_scheduler_jobs_created_total` increments when a job is assigned to a worker, not when it is enqueued. The gate stops the compaction provider *creating* jobs, so dispatch keeps draining the queue that already existed and merely dips. Measured on a real apply-mode redaction, per-tenant compaction dispatch went 12.2 → 11.2 → 10.2 → 12.2 jobs/30m across the run: a shallow dip with no clean edge to detect. The same property means `completed/created` is not a progress signal either — it sat at ~1.0 for the entire run (created 600/2271/1531 per 30m against completed 597/2274/1531), because jobs complete seconds after dispatch. Queue depth (`jobs_pending`, #7772) is what carries progress; this gauge covers the part queue depth cannot, since a drained queue and a torn-down batch are not the same state.

The value is read from `TenantPending` — the same predicate compaction and retention actually gate on — rather than re-deriving "is there an apply-mode batch", so it cannot drift from what it reports. A dry-run gets no series at all, since it never pauses anything.

**One deliberate asymmetry with `jobs_pending`:** a tenant that resumes is set to `0` rather than having its series deleted. The operator question is "has the quiet period elapsed", and a `1 → 0` edge answers that on a graph or in an alert where a vanished series needs `absent()`. That is safe here because the label set only ever holds tenants that took the gate during a process lifetime — a handful — whereas `jobs_pending` is per `(tenant, job_type)` and deletes for cardinality reasons.

Published from the maintenance loop alongside `jobs_pending`, including once at startup so the metric is not absent for a full interval after a restart.

**Notes for review**

- A "Maintenance Paused by Redaction" panel is included, in the free slot beside Dry-run Blast Radius, so no other panel moves. It merges cleanly with #7795, which is also open against `tempo-backendwork.json` — verified with `git merge-tree` in both directions rather than assumed.
- A redaction *progress* panel is not included: `jobs_pending` is not deployed to any cell yet, so its queries cannot be validated against real series. That belongs with the dashboard work that follows #7795.
- Docs now also warn against using `jobs_created_total` as a progress denominator, since its name invites exactly that.
- Supersedes #7796, which took this on with a new RPC and CLI command; closed in favour of this after measuring how much the metrics already answer.

**Which issue(s) this PR fixes**:
N/A — part of the query-based redaction series (#7663, #7695, #7699, #7700, #7702, #7703, #7772).

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`
