### PR TITLE
spanmetrics: fall back to mapped attribute when no source_label matches

### DIFF
--- a/.chloggen/3256-spanmetrics-dimension-mapping-fallback.yaml
+++ b/.chloggen/3256-spanmetrics-dimension-mapping-fallback.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+component: metrics-generator
+note: Span metrics now fall back to the `dimension_mappings.name` attribute when no `source_labels` match, so spans that already use the target attribute (e.g. `http_response_status_code`) are labelled consistently with spans mapped from a legacy source (e.g. `http.status_code`).
+issues: [3256]
+subtext: |
+  Previously, a `dimension_mappings` entry such as
+  `name: http_response_status_code, source_labels: [http.status_code]` only
+  populated the `http_response_status_code` metric label when the span had the
+  legacy `http.status_code` attribute. Spans already carrying
+  `http_response_status_code` (or `http.response.status_code` after sanitization)
+  ended up on a separate series with an empty label. With this change, if no
+  `source_label` matches, the processor falls back to the mapping `name` itself,
+  letting both span conventions land on the same series.
+user: buiducnhat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 <!-- next version -->
 
+* [BUGFIX] Span metrics: include values of attributes already matching a `dimension_mappings.name` when no `source_labels` match, so spans using the target attribute directly (e.g. `http_response_status_code`) are labelled consistently with spans that get mapped from a legacy source (e.g. `http.status_code`). [#3256](https://github.com/grafana/tempo/issues/3256) (@buiducnhat)
+
 # v3.0.2
 
 * [CHANGE] Upgrade Tempo to Go 1.26.3 [#7423](https://github.com/grafana/tempo/pull/7423) (@ie-pham)

--- a/modules/generator/processor/spanmetrics/spanmetrics.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics.go
@@ -217,6 +217,14 @@ func (p *Processor) aggregateMetricsForSpan(svcName string, jobName string, inst
 				}
 			}
 		}
+		// If no source_label matched, fall back to the mapping Name itself so spans
+		// that already carry the target attribute (e.g. http.response.status_code when
+		// mapping http.status_code -> http_response_status_code) still get the label.
+		if values == "" {
+			if value, _ := processor_util.FindAttributeValue(m.Name, rs.Attributes, span.Attributes); value != "" {
+				values = value
+			}
+		}
 		builder.Add(p.dimensionMappingLabels[i], values)
 	}
 

--- a/modules/generator/processor/spanmetrics/spanmetrics_test.go
+++ b/modules/generator/processor/spanmetrics/spanmetrics_test.go
@@ -1589,6 +1589,63 @@ func TestSpanMetricsDimensionMappingMissingLabels(t *testing.T) {
 	assert.Equal(t, 10.0, testRegistry.Query("traces_spanmetrics_latency_sum", lbls))
 }
 
+func TestSpanMetricsDimensionMappingIncludesMappedAttribute(t *testing.T) {
+	// Regression for #3256: when a dimension_mapping's name matches an attribute
+	// already present on the span/resource, that value must be used as a fallback
+	// so spans carrying the new convention (e.g. http.response.status_code) still
+	// get the mapped label even though no source_label matched.
+	testRegistry := registry.NewTestRegistry()
+	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered", "span-metrics")
+	invalidUTF8SpanLabelsCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "invalid_utf8", "span-metrics")
+
+	cfg := Config{}
+	cfg.RegisterFlagsAndApplyDefaults("", nil)
+	cfg.HistogramBuckets = []float64{0.5, 1}
+	cfg.IntrinsicDimensions.SpanKind = false
+	cfg.IntrinsicDimensions.StatusMessage = true
+	cfg.DimensionMappings = []sharedconfig.DimensionMappings{
+		{
+			Name:        "http_response_status_code",
+			SourceLabel: []string{"http.status_code"},
+			Join:        "",
+		},
+	}
+
+	p, err := New(cfg, testRegistry, filteredSpansCounter, invalidUTF8SpanLabelsCounter)
+	require.NoError(t, err)
+	defer p.Shutdown(context.Background())
+
+	makeBatchWithAttr := func(key, value string) *trace_v1.ResourceSpans {
+		batch := test.MakeBatch(10, nil)
+		for _, rs := range batch.ScopeSpans {
+			for _, s := range rs.Spans {
+				s.Attributes = append(s.Attributes, &common_v1.KeyValue{
+					Key:   key,
+					Value: &common_v1.AnyValue{Value: &common_v1.AnyValue_StringValue{StringValue: value}},
+				})
+			}
+		}
+		return batch
+	}
+
+	// Batch 1: spans using the old convention (source label present)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{makeBatchWithAttr("http.status_code", "200")}})
+	// Batch 2: spans using the new convention (target attribute present directly)
+	p.PushSpans(context.Background(), &tempopb.PushSpansRequest{Batches: []*trace_v1.ResourceSpans{makeBatchWithAttr("http_response_status_code", "200")}})
+
+	lbls := labels.FromMap(map[string]string{
+		"service":                   "test-service",
+		"span_name":                 "test",
+		"status_code":               "STATUS_CODE_OK",
+		"status_message":            "OK",
+		"http_response_status_code": "200",
+	})
+
+	// Both batches should land on the same series
+	assert.Equal(t, 20.0, testRegistry.Query("traces_spanmetrics_calls_total", lbls))
+	assert.Equal(t, 20.0, testRegistry.Query("traces_spanmetrics_latency_count", lbls))
+}
+
 func TestSpanMetricsNegativeLatency(t *testing.T) {
 	testRegistry := registry.NewTestRegistry()
 	filteredSpansCounter := metricSpansDiscarded.WithLabelValues("test-tenant", "filtered", "span-metrics")


### PR DESCRIPTION
**What this PR does**:

When a span-metrics `dimension_mappings` entry's `name` matches an attribute that is already present on a span/resource (e.g. `http_response_status_code`), that value is now used as a fallback when none of the configured `source_labels` match.

**Motivation**: With a config like

```yaml
dimension_mappings:
  - name: http_response_status_code
    source_labels: [http.status_code]
```

spans that still send the legacy `http.status_code` get their value remapped to `http_response_status_code`, but spans that have already migrated to the new attribute end up with an **empty** `http_response_status_code` label and land on a different metric series. This splits a single logical signal across two series and makes migration of instrumentation conventions painful.

**Behaviour change**: only when **no** `source_label` produced a value does the processor consult the attribute named `dimension_mappings.name` directly. Existing behaviour for spans that match a `source_label` is unchanged (no double-counting, no reordering).

**Which issue(s) this PR fixes**:
Fixes #3256

**Checklist**
- [x] Tests updated (`TestSpanMetricsDimensionMappingIncludesMappedAttribute` covers both the mapped and direct-attribute paths)
- [ ] Documentation added (not applicable — behaviour now matches the documented intent of `dimension_mappings`)
- [x] Changelog entry added under `.chloggen/`
