### PR TITLE
[blockselector]: cache DedicatedColumnsHash per entry

### DIFF
--- a/.chloggen/zl_blockselector-dedicated-columns-hash-cache.yaml
+++ b/.chloggen/zl_blockselector-dedicated-columns-hash-cache.yaml
@@ -1,0 +1,18 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: cache each block's dedicated-columns hash in the time-window block selector instead of recomputing it on every comparison in `BlocksToCompact`'s hot loop.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: zalegrala

--- a/tempodb/blockselector/compaction_block_selector.go
+++ b/tempodb/blockselector/compaction_block_selector.go
@@ -47,10 +47,11 @@ type timeWindowBlockSelector struct {
 }
 
 type timeWindowBlockEntry struct {
-	meta  *backend.BlockMeta
-	group string // Blocks in the same group will be compacted together. Sort order also determines group priority.
-	order string // Individual block priority within the group.
-	hash  string // hash string used for sharding ownership, preserves backwards compatibility
+	meta                 *backend.BlockMeta
+	group                string // Blocks in the same group will be compacted together. Sort order also determines group priority.
+	order                string // Individual block priority within the group.
+	hash                 string // hash string used for sharding ownership, preserves backwards compatibility
+	dedicatedColumnsHash uint64 // precomputed meta.DedicatedColumnsHash(), reused in BlocksToCompact's comparison loop
 }
 
 var _ CompactionBlockSelector = (*timeWindowBlockSelector)(nil)
@@ -95,7 +96,8 @@ func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRan
 		}
 
 		entry := timeWindowBlockEntry{
-			meta: b,
+			meta:                 b,
+			dedicatedColumnsHash: b.DedicatedColumnsHash(),
 		}
 
 		age := currWindow - w
@@ -108,7 +110,7 @@ func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRan
 			// Within group choose smallest blocks first.
 			// update after parquet: we want to make sure blocks of the same version end up together
 			// update afert vParquet3: we want to make sure blocks of the same dedicated columns end up together
-			entry.order = fmt.Sprintf("%016X-%v-%016X", entry.meta.TotalObjects, entry.meta.Version, entry.meta.DedicatedColumnsHash())
+			entry.order = fmt.Sprintf("%016X-%v-%016X", entry.meta.TotalObjects, entry.meta.Version, entry.dedicatedColumnsHash)
 
 			entry.hash = fmt.Sprintf("%v-%v-%v-%v", b.TenantID, b.CompactionLevel, w, b.ReplicationFactor)
 		} else {
@@ -119,7 +121,7 @@ func NewTimeWindowBlockSelector(blocklist []*backend.BlockMeta, maxCompactionRan
 			// Within group chose lowest compaction lvl and smallest blocks first.
 			// update after parquet: we want to make sure blocks of the same version end up together
 			// update afert vParquet3: we want to make sure blocks of the same dedicated columns end up together
-			entry.order = fmt.Sprintf("%v-%016X-%v-%016X", b.CompactionLevel, entry.meta.TotalObjects, entry.meta.Version, entry.meta.DedicatedColumnsHash())
+			entry.order = fmt.Sprintf("%v-%016X-%v-%016X", b.CompactionLevel, entry.meta.TotalObjects, entry.meta.Version, entry.dedicatedColumnsHash)
 
 			entry.hash = fmt.Sprintf("%v-%v-%v", b.TenantID, w, b.ReplicationFactor)
 		}
@@ -154,7 +156,7 @@ func (twbs *timeWindowBlockSelector) BlocksToCompact() ([]*backend.BlockMeta, st
 
 				if twbs.entries[i].group == twbs.entries[j].group &&
 					twbs.entries[i].meta.Version == twbs.entries[j].meta.Version && // update after parquet: only compact blocks of the same version
-					twbs.entries[i].meta.DedicatedColumnsHash() == twbs.entries[j].meta.DedicatedColumnsHash() && // update after vParquet3: only compact blocks of the same dedicated columns
+					twbs.entries[i].dedicatedColumnsHash == twbs.entries[j].dedicatedColumnsHash && // update after vParquet3: only compact blocks of the same dedicated columns
 					len(stripe) <= twbs.MaxInputBlocks &&
 					totalObjects(stripe) <= twbs.MaxCompactionObjects &&
 					totalSize(stripe) <= twbs.MaxBlockBytes {

--- a/tempodb/blockselector/compaction_block_selector_test.go
+++ b/tempodb/blockselector/compaction_block_selector_test.go
@@ -936,3 +936,65 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 		})
 	}
 }
+
+func benchmarkBlocklist(n int, withDedicatedColumns bool) []*backend.BlockMeta {
+	now := time.Now()
+	version := encoding.DefaultEncoding().Version()
+
+	var dcs backend.DedicatedColumns
+	if withDedicatedColumns {
+		dcs = backend.DedicatedColumns{
+			{Scope: backend.DedicatedColumnScopeSpan, Name: "http.method", Type: backend.DedicatedColumnTypeString},
+			{Scope: backend.DedicatedColumnScopeSpan, Name: "http.status_code", Type: backend.DedicatedColumnTypeString},
+			{Scope: backend.DedicatedColumnScopeSpan, Name: "http.route", Type: backend.DedicatedColumnTypeString},
+			{Scope: backend.DedicatedColumnScopeResource, Name: "service.name", Type: backend.DedicatedColumnTypeString},
+			{Scope: backend.DedicatedColumnScopeResource, Name: "k8s.pod.name", Type: backend.DedicatedColumnTypeString},
+		}
+	}
+
+	blocklist := make([]*backend.BlockMeta, 0, n)
+	for i := 0; i < n; i++ {
+		blocklist = append(blocklist, &backend.BlockMeta{
+			BlockID:           backend.MustParse(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+			EndTime:           now,
+			TotalObjects:      int64(1000 + i%500),
+			Version:           version,
+			DedicatedColumns:  dcs,
+			ReplicationFactor: 1,
+		})
+	}
+	return blocklist
+}
+
+// BenchmarkBlocksToCompact_WithDedicatedColumns guards against regressing the
+// per-entry DedicatedColumnsHash caching: prod max_input_blocks runs 6-8, and
+// BlocksToCompact's comparison loop re-checks hash equality on every candidate
+// stripe, so an uncached hash would show up here as a large gap against the
+// no-dedicated-columns case.
+func BenchmarkBlocksToCompact_NoDedicatedColumns(b *testing.B) {
+	blocklist := benchmarkBlocklist(1000, false)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		selector := NewTimeWindowBlockSelector(blocklist, time.Hour, 6_000_000, 100*1024*1024*1024, DefaultMinInputBlocks, 7, DefaultMaxCompactionLevel)
+		for {
+			blocks, _ := selector.BlocksToCompact()
+			if blocks == nil {
+				break
+			}
+		}
+	}
+}
+
+func BenchmarkBlocksToCompact_WithDedicatedColumns(b *testing.B) {
+	blocklist := benchmarkBlocklist(1000, true)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		selector := NewTimeWindowBlockSelector(blocklist, time.Hour, 6_000_000, 100*1024*1024*1024, DefaultMinInputBlocks, 7, DefaultMaxCompactionLevel)
+		for {
+			blocks, _ := selector.BlocksToCompact()
+			if blocks == nil {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does**:

Caches each block's `DedicatedColumnsHash()` on `timeWindowBlockEntry` instead of recomputing it every time `BlocksToCompact`'s comparison loop checks whether two candidate blocks belong together.

`DedicatedColumnsHash()` is not memoized (`tempodb/backend/block_meta.go`) — every call builds an `xxhash` state and re-hashes the block's `DedicatedColumns` slice. `entry.order`'s construction in `NewTimeWindowBlockSelector` already calls it once per block, but `BlocksToCompact`'s inner loop calls it again on both `entries[i]` and `entries[j]` for every candidate stripe it considers — including `entries[i]` repeatedly across every `j`, even though `i` never changes within that loop. Prod `max_input_blocks` runs 6-8 (OSS default is 4), so this is a real, bounded-but-nonzero amount of redundant hashing per group-run, not a one-off.

The fix: compute the hash once in `NewTimeWindowBlockSelector` (reusing the existing call site for `entry.order`), store it on the entry, and compare the cached values in `BlocksToCompact`. No other logic changes — grouping, sort order, and all limit checks are untouched.

**Why this is safe**: `DedicatedColumns` never changes for the lifetime of a `BlockMeta`, and a `timeWindowBlockSelector` is single-use per timeslot (rebuilt fresh from a new blocklist every compaction cycle, per its own doc comment) — so caching per-entry can never go stale. All 24 existing subtests pass byte-identically, including the dedicated-columns-specific test case ("blocks with different dedicated columns are not selected together").

**Performance**: `DedicatedColumnsHash()` early-returns for tenants with no dedicated columns configured (near-free, ~1.3ns), so this only matters for tenants that use the feature. For those tenants, a new benchmark (`BenchmarkBlocksToCompact_{No,With}DedicatedColumns`, 1000 blocks, `max_input_blocks=7` matching prod) shows:

| | before | after |
|---|---|---|
| with dedicated columns | ~900µs/op | ~692µs/op |
| no dedicated columns | ~591µs/op | ~577µs/op |
| dedicated-columns-specific overhead | ~310µs | ~115µs |

That's a ~63-66% reduction in the redundant overhead (consistent at 5000 blocks too), converging to the theoretical floor of one unavoidable hash per block. A ~23% reduction in total wall-clock time for tenants using dedicated columns, on the function at the heart of compaction.

**Which issue(s) this PR fixes**:
N/A — internal optimization.

**Checklist**
- [x] Tests updated — no behavior change; existing `TestTimeWindowBlockSelectorBlocksToCompact` (all 24 cases) passes byte-identically. Added `BenchmarkBlocksToCompact_{No,With}DedicatedColumns` as permanent regression coverage against this caching.
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
