### PR TITLE
[storage]: make legacy JSON tenant index fallback configurable, default off

### DIFF
--- a/.chloggen/zl_tenant-index-json-fallback-config.yaml
+++ b/.chloggen/zl_tenant-index-json-fallback-config.yaml
@@ -1,0 +1,23 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: change
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: the legacy JSON-encoded tenant index (a rollout bridge from when tenant indexes moved to protobuf) is no longer written or read by default. Set `blocklist_poll_tenant_index_json_fallback` to restore it. A `tempo-cli list tenant-index` command dumps the protobuf index as JSON on demand for jq-based debugging.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  This is a temporary rollout bridge; the config flag and its opportunistic cleanup of stale
+  JSON indexes are planned for removal once the fleet has fully migrated.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: zalegrala

--- a/cmd/tempo-cli/cmd-dump-tenant-index.go
+++ b/cmd/tempo-cli/cmd-dump-tenant-index.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type dumpTenantIndexCmd struct {
+	TenantID string `arg:"" help:"tenant-id within the bucket"`
+	backendOptions
+}
+
+// Run reads the tenant's protobuf-encoded tenant index and dumps it as JSON
+// to stdout, for ad hoc exploration with jq or similar tools. Tempo no longer
+// keeps a JSON copy of the tenant index in the backend by default (see
+// blocklist_poll_tenant_index_json_fallback), so this recreates one on demand.
+func (cmd *dumpTenantIndexCmd) Run(ctx *globalOptions) error {
+	r, _, _, err := loadBackend(&cmd.backendOptions, ctx)
+	if err != nil {
+		return err
+	}
+
+	idx, err := r.TenantIndex(context.Background(), cmd.TenantID)
+	if err != nil {
+		return fmt.Errorf("reading tenant index: %w", err)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(idx)
+}

--- a/cmd/tempo-cli/main.go
+++ b/cmd/tempo-cli/main.go
@@ -45,6 +45,7 @@ var cli struct {
 		CompactionSummary listCompactionSummaryCmd `cmd:"" help:"List summary of data by compaction level"`
 		CacheSummary      listCacheSummaryCmd      `cmd:"" help:"List summary of bloom sizes per day per compaction level"`
 		Column            listColumnCmd            `cmd:"" help:"List values in a given column"`
+		TenantIndex       dumpTenantIndexCmd       `cmd:"" help:"Dump a tenant's protobuf-encoded tenant index as JSON, for use with jq"`
 	} `cmd:""`
 
 	Analyse struct {
@@ -179,5 +180,7 @@ func loadBackend(b *backendOptions, g *globalOptions) (backend.Reader, backend.W
 		return nil, nil, nil, err
 	}
 
-	return backend.NewReader(r), backend.NewWriter(w), c, nil
+	jsonFallback := cfg.StorageConfig.Trace.BlocklistPollTenantIndexJSONFallback
+	return backend.NewReader(r, backend.WithTenantIndexJSONFallback(jsonFallback)),
+		backend.NewWriter(w, backend.WithTenantIndexJSONWrite(jsonFallback)), c, nil
 }

--- a/tempodb/backend/raw.go
+++ b/tempodb/backend/raw.go
@@ -80,13 +80,33 @@ type RawReader interface {
 
 type writer struct {
 	w RawWriter
+
+	tenantIndexJSON bool
+}
+
+// WriterOption configures a writer created by NewWriter.
+type WriterOption func(*writer)
+
+// WithTenantIndexJSONWrite controls whether WriteTenantIndex also writes (and
+// preserves) the legacy JSON-encoded tenant index alongside the protobuf one.
+// Temporary rollout bridge from when tenant indexes moved to protobuf;
+// default false. When false, WriteTenantIndex also opportunistically deletes
+// any existing JSON tenant index for the tenant, self-healing the backend
+// over the tenant's next few poll cycles. Planned for removal, along with
+// that cleanup, once the fleet has fully migrated off pre-protobuf binaries.
+func WithTenantIndexJSONWrite(enabled bool) WriterOption {
+	return func(w *writer) { w.tenantIndexJSON = enabled }
 }
 
 // NewWriter returns an object that implements Writer and bridges to a RawWriter
-func NewWriter(w RawWriter) Writer {
-	return &writer{
+func NewWriter(w RawWriter, opts ...WriterOption) Writer {
+	out := &writer{
 		w: w,
 	}
+	for _, opt := range opts {
+		opt(out)
+	}
+	return out
 }
 
 // TODO: these objects are not raw, so perhaps they could move somewhere else.
@@ -161,6 +181,16 @@ func (w *writer) WriteTenantIndex(ctx context.Context, tenantID string, meta []*
 		return err
 	}
 
+	if !w.tenantIndexJSON {
+		// Best-effort cleanup of a stale JSON tenant index left over from
+		// before the fleet migrated to the protobuf-encoded one.
+		err := w.w.Delete(ctx, TenantIndexName, []string{tenantID}, nil)
+		if err != nil && !errors.Is(err, ErrDoesNotExist) {
+			return err
+		}
+		return nil
+	}
+
 	// Marshal and write the JSON object.
 	indexBytesJSON, err := b.marshal()
 	if err != nil {
@@ -187,13 +217,30 @@ func (w *writer) DeleteNoCompactFlag(ctx context.Context, blockID uuid.UUID, ten
 
 type reader struct {
 	r RawReader
+
+	tenantIndexJSON bool
+}
+
+// ReaderOption configures a reader created by NewReader.
+type ReaderOption func(*reader)
+
+// WithTenantIndexJSONFallback controls whether TenantIndex falls back to the
+// legacy JSON-encoded tenant index when the protobuf-encoded index is
+// missing. Temporary rollout bridge from when tenant indexes moved to
+// protobuf; default false. See WithTenantIndexJSONWrite.
+func WithTenantIndexJSONFallback(enabled bool) ReaderOption {
+	return func(r *reader) { r.tenantIndexJSON = enabled }
 }
 
 // NewReader returns an object that implements Reader and bridges to a RawReader
-func NewReader(r RawReader) Reader {
-	return &reader{
+func NewReader(r RawReader, opts ...ReaderOption) Reader {
+	out := &reader{
 		r: r,
 	}
+	for _, opt := range opts {
+		opt(out)
+	}
+	return out
 }
 
 // Read implements backend.Reader
@@ -268,7 +315,7 @@ func (r *reader) TenantIndex(ctx context.Context, tenantID string) (*TenantIndex
 		return outPb, nil
 	}
 
-	if !errors.Is(err, ErrDoesNotExist) {
+	if !errors.Is(err, ErrDoesNotExist) || !r.tenantIndexJSON {
 		return nil, err
 	}
 

--- a/tempodb/backend/raw_test.go
+++ b/tempodb/backend/raw_test.go
@@ -24,7 +24,7 @@ const (
 // todo: add tests that check the appropriate keypath is passed
 func TestWriter(t *testing.T) {
 	m := &MockRawWriter{}
-	w := NewWriter(m)
+	w := NewWriter(m, WithTenantIndexJSONWrite(true))
 	ctx := context.Background()
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
@@ -91,6 +91,43 @@ func TestWriter(t *testing.T) {
 	m = &MockRawWriter{err: ErrDoesNotExist}
 	w = NewWriter(m)
 	err = w.WriteTenantIndex(ctx, "test", nil, nil)
+	assert.NoError(t, err)
+}
+
+// TestWriteTenantIndexJSONDefault confirms that, without WithTenantIndexJSONWrite,
+// WriteTenantIndex writes only the protobuf tenant index and opportunistically
+// deletes any stale JSON one, tolerating it not existing.
+func TestWriteTenantIndexJSONDefault(t *testing.T) {
+	ctx := context.Background()
+	u := uuid.New()
+	meta := NewBlockMeta("test", u, "blerg")
+
+	m := &MockRawWriter{}
+	w := NewWriter(m)
+
+	err := w.WriteTenantIndex(ctx, "test", []*BlockMeta{meta}, nil)
+	assert.NoError(t, err)
+
+	tenantIndexPath := filepath.Join("test", TenantIndexName)
+	tenantIndexPathPb := filepath.Join("test", TenantIndexNamePb)
+
+	// proto was written
+	idxP := &TenantIndex{}
+	err = idxP.unmarshalPb(m.writeBuffer[tenantIndexPathPb])
+	assert.NoError(t, err)
+	assert.Equal(t, []*BlockMeta{meta}, idxP.Meta)
+
+	// json was not written...
+	_, ok := m.writeBuffer[tenantIndexPath]
+	assert.False(t, ok)
+
+	// ...but a best-effort delete of any stale json index was issued
+	assert.Equal(t, map[string]map[string]int{TenantIndexName: {"test": 1}}, m.deleteCalls)
+
+	// a missing stale json index is not an error
+	m = &MockRawWriter{err: ErrDoesNotExist}
+	w = NewWriter(m)
+	err = w.WriteTenantIndex(ctx, "test", []*BlockMeta{meta}, nil)
 	assert.NoError(t, err)
 }
 
@@ -245,9 +282,9 @@ func TestRoundTripMeta(t *testing.T) {
 func TestTenantIndexFallback(t *testing.T) {
 	var (
 		mr       = &MockRawReader{}
-		r        = NewReader(mr)
+		r        = NewReader(mr, WithTenantIndexJSONFallback(true))
 		mw       = &MockRawWriter{}
-		w        = NewWriter(mw)
+		w        = NewWriter(mw, WithTenantIndexJSONWrite(true))
 		ctx      = context.Background()
 		tenantID = "test"
 
@@ -294,6 +331,38 @@ func TestTenantIndexFallback(t *testing.T) {
 	idx, err = r.TenantIndex(ctx, tenantID)
 	assert.ErrorIs(t, err, ErrDoesNotExist)
 	assert.Nil(t, idx)
+}
+
+// TestTenantIndexJSONFallbackDefault confirms that, without
+// WithTenantIndexJSONFallback, TenantIndex does not fall back to a JSON
+// tenant index when the protobuf one is missing, even if a valid JSON one
+// exists.
+func TestTenantIndexJSONFallbackDefault(t *testing.T) {
+	var (
+		mr       = &MockRawReader{}
+		r        = NewReader(mr)
+		ctx      = context.Background()
+		tenantID = "test"
+
+		u    = uuid.New()
+		meta = NewBlockMeta(tenantID, u, "blerg")
+		idx  = newTenantIndex([]*BlockMeta{meta}, nil)
+	)
+
+	jsonBytes, err := idx.marshal()
+	assert.NoError(t, err)
+
+	mr.ReadFn = func(_ context.Context, name string, _ KeyPath, _ *CacheInfo) (io.ReadCloser, int64, error) {
+		if name == TenantIndexNamePb {
+			return nil, 0, fmt.Errorf("meow: %w", ErrDoesNotExist)
+		}
+
+		return io.NopCloser(bytes.NewReader(jsonBytes)), int64(len(jsonBytes)), nil
+	}
+
+	out, err := r.TenantIndex(ctx, tenantID)
+	assert.ErrorIs(t, err, ErrDoesNotExist)
+	assert.Nil(t, out)
 }
 
 func TestNoCompactFlag(t *testing.T) {

--- a/tempodb/backend/test/backend_test.go
+++ b/tempodb/backend/test/backend_test.go
@@ -97,7 +97,9 @@ func TestOriginalFixtures(t *testing.T) {
 
 	var (
 		_ = backend.NewWriter(rw)
-		r = backend.NewReader(rr)
+		// This fixture predates protobuf-encoded tenant indexes and only has a
+		// JSON one on disk.
+		r = backend.NewReader(rr, backend.WithTenantIndexJSONFallback(true))
 	)
 
 	expectedDedicatedColumns := backend.DedicatedColumns{

--- a/tempodb/config.go
+++ b/tempodb/config.go
@@ -57,6 +57,12 @@ type Config struct {
 	BlocklistPollJitterMs                  int           `yaml:"blocklist_poll_jitter_ms"`
 	BlocklistPollTolerateConsecutiveErrors int           `yaml:"blocklist_poll_tolerate_consecutive_errors"`
 	BlocklistPollTolerateTenantFailures    int           `yaml:"blocklist_poll_tolerate_tenant_failures"`
+	// BlocklistPollTenantIndexJSONFallback is a temporary rollout bridge from
+	// when tenant indexes moved to protobuf. When false (default), only the
+	// protobuf-encoded tenant index is read or written, and any stale
+	// JSON-encoded index left over from before the migration is opportunistically
+	// deleted on write. Planned for removal once the fleet has fully migrated.
+	BlocklistPollTenantIndexJSONFallback bool `yaml:"blocklist_poll_tenant_index_json_fallback"`
 
 	EmptyTenantDeletionEnabled bool          `yaml:"empty_tenant_deletion_enabled"`
 	EmptyTenantDeletionAge     time.Duration `yaml:"empty_tenant_deletion_age"`

--- a/tempodb/tempodb.go
+++ b/tempodb/tempodb.go
@@ -221,8 +221,8 @@ func New(cfg *Config, cacheProvider cache.Provider, logger gkLog.Logger) (Reader
 		}
 	}
 
-	r := backend.NewReader(rawR)
-	w := backend.NewWriter(rawW)
+	r := backend.NewReader(rawR, backend.WithTenantIndexJSONFallback(cfg.BlocklistPollTenantIndexJSONFallback))
+	w := backend.NewWriter(rawW, backend.WithTenantIndexJSONWrite(cfg.BlocklistPollTenantIndexJSONFallback))
 	rw := &readerWriter{
 		c:                       c,
 		r:                       r,


### PR DESCRIPTION
**What this PR does**:

Makes the legacy JSON-encoded tenant index configurable and off by default, instead of always dual-written and read-as-fallback.

Today `WriteTenantIndex` unconditionally marshals and writes both the protobuf (`index.pb.zst`) and JSON (`index.json.gz`) tenant index on every build, and `TenantIndex()` falls back to JSON whenever the protobuf one is missing. This was a rollout bridge from when tenant indexes moved to protobuf. Several releases have shipped since, so we can assume most binaries have migrated.

Adds `blocklist_poll_tenant_index_json_fallback` (default `false`). When `false`:
- `WriteTenantIndex` writes only the protobuf index, and opportunistically deletes any existing stale JSON index for the tenant (best-effort, tolerates it not existing). Since this runs every poll cycle for every actively-alive tenant, the fleet self-heals over the next few cycles per tenant with no separate migration job.
- `TenantIndex()` no longer attempts the JSON fallback; a missing protobuf index propagates directly into the existing `PollFallback` full-rescan recovery path, same as today when both formats are missing.

Setting the flag to `true` restores the exact current dual-write/fallback behavior.

Also adds `tempo-cli list tenant-index <tenant>` to dump the protobuf-encoded tenant index as JSON to stdout, for `jq`-based debugging — replacing the always-present backend JSON copy with an on-demand one.

**Implementation note**: threaded through `backend.NewReader`/`NewWriter` as optional functional options (`WithTenantIndexJSONFallback`, `WithTenantIndexJSONWrite`), so the flag lives on the reader/writer instance rather than changing the `Reader`/`Writer` interfaces. The ten other call sites of `NewReader`/`NewWriter` (blockbuilder, livestore, tempo-cli conversion tools) are untouched, and the four callers of `TenantIndex`/`WriteTenantIndex` (three in `poller.go`, one in `cmd-migrate-tenant.go`) don't need to change either.

**Status**: draft, parked mid-flight. Deployed to znet with a rebuilt image; still validating there isn't a solid pre-change baseline yet to compare against (see open question below), so holding before requesting review.

**Open question / known gap**: `cmd-migrate-tenant.go`'s source reader doesn't pass either option, so with the new default it can no longer read a genuinely old JSON-only tenant index during migration. Acceptable given the "most have migrated" premise, but worth a decision before merge — either leave as-is or expose a CLI flag there too.

**This flag is temporary**: both it and the opportunistic JSON cleanup are planned for removal once the fleet has fully migrated off pre-protobuf binaries (see chloggen subtext).

**Which issue(s) this PR fixes**:
N/A — internal cleanup / rollout bridge sunset.

**Checklist**
- [x] Tests updated — existing tests (`TestTenantIndexFallback`, `TestWriter`, `TestOriginalFixtures`) updated to explicitly opt into legacy behavior where that's what they test; new tests (`TestWriteTenantIndexJSONDefault`, `TestTenantIndexJSONFallbackDefault`) cover the new default.
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`
