### PR TITLE
Include the block format in usage stats

### DIFF
--- a/.chloggen/usage-stats-block-format.yaml
+++ b/.chloggen/usage-stats-block-format.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Report the configured block format in anonymous usage statistics
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: The new `storage_block_format` field reports the effective `storage.trace.block.version` used for newly written blocks. Older Tempo versions omit the field.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: javiermolinar

--- a/cmd/tempo/app/app.go
+++ b/cmd/tempo/app/app.go
@@ -57,6 +57,7 @@ const (
 var (
 	statFeatureEnabledAuth         = usagestats.NewInt("feature_enabled_auth_stats")
 	statFeatureEnabledMultitenancy = usagestats.NewInt("feature_enabled_multitenancy")
+	statStorageBlockFormat         = usagestats.NewString("storage_block_format")
 )
 
 // App is the root datastructure.
@@ -104,6 +105,11 @@ func New(cfg Config) (*App, error) {
 	}
 
 	usagestats.Edition("oss")
+
+	statStorageBlockFormat.Set("")
+	if cfg.StorageConfig.Trace.Block != nil {
+		statStorageBlockFormat.Set(cfg.StorageConfig.Trace.Block.Version)
+	}
 
 	statFeatureEnabledAuth.Set(0)
 	if cfg.AuthEnabled {

--- a/cmd/tempo/app/app_test.go
+++ b/cmd/tempo/app/app_test.go
@@ -8,10 +8,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util"
 	"github.com/grafana/tempo/tempodb/backend"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAppNewSetsStorageBlockFormatUsageStat(t *testing.T) {
+	config := NewDefaultConfig()
+	config.StorageConfig.Trace.Block.Version = "vParquet4"
+
+	_, err := New(*config)
+	require.NoError(t, err)
+
+	report := usagestats.BuildStats()
+	require.Equal(t, "vParquet4", report.Metrics["storage_block_format"])
+}
 
 func TestApp_RunStop(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "tempo-test-app-*")

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -2856,7 +2856,7 @@ For guidance on sizing these limits for your workload, refer to [Manage trace in
 
 By default, Tempo reports anonymous usage data about the shape of a deployment to Grafana Labs.
 This data is used to determine how common the deployment of certain features are, if a feature flag has been enabled,
-and which replication factor or compression levels are used.
+and which replication factors or block formats are used.
 
 By providing information on how people use Tempo, usage reporting helps the Tempo team decide where to focus their development and documentation efforts. No private information is collected, and all reports are completely anonymous.
 
@@ -2864,7 +2864,7 @@ The following configuration values are used:
 
 - Receivers enabled
 - Frontend concurrency and version
-- Storage cache, backend, WAL and block encodings
+- Storage cache, backend, and configured block format
 - Ring replication factor, and `kvstore`
 - Features toggles enabled
 

--- a/docs/sources/tempo/configuration/anonymous-usage-reporting.md
+++ b/docs/sources/tempo/configuration/anonymous-usage-reporting.md
@@ -7,7 +7,8 @@ weight: 950
 # Anonymous usage reporting
 
 By default, Tempo reports anonymous usage data about itself to Grafana Labs.
-This data is used to understand which features are commonly enabled, as well as which deployment modes, replication factors, and compression levels are most popular, etc.
+This data is used to understand which features are commonly enabled,
+as well as which deployment modes, replication factors, and block formats are most popular.
 
 By providing information on how people use Tempo, usage reporting helps the Tempo team decide where to focus their development and documentation efforts.
 
@@ -15,7 +16,7 @@ The following configuration values are used:
 
 - Receivers enabled
 - Frontend concurrency and version
-- Storage cache, backend, WAL and block encodings
+- Storage cache, backend, and configured block format
 - Ring replication factor, and `kvstore`
 - Features toggles enabled
 
@@ -42,7 +43,7 @@ An example report output looks like this:
   "intervalPeriod": 14400,
   "target": "all",
   "version": {
-    "version": "v2.8.0",
+    "version": "v3.0.0",
     "revision": "31e2dddb5",
     "branch": "main",
     "buildUser": "",
@@ -68,16 +69,13 @@ An example report output looks like this:
     "num_cpu": 8,
     "feature_enabled_multitenancy": 0,
     "receiver_enabled_jaeger": 0,
-    "storage_block_encoding": "zstd",
-    "storage_block_search_encoding": "snappy",
+    "storage_block_format": "vParquet5",
     "storage_cache": "",
     "feature_enabled_auth_stats": 0,
     "frontend_version": "v1",
     "storage_backend": "local",
     "receiver_enabled_otlp": 0,
     "ring_replication_factor": 1,
-    "storage_wal_encoding": "snappy",
-    "storage_wal_search_encoding": "none",
     "num_goroutine": 813,
     "cache_memcached": 1,
     "cache_redis": 0,
@@ -118,7 +116,7 @@ Tempo maintainers commit to keeping the list of tracked information updated over
 
 - **`target`**: The deployment mode or target for the Tempo instance, such as `all` for monolithic mode.
 - **`version`**: An object containing detailed version information:
-  - **`version`**: The Tempo version, for example `v2.8.0`.
+  - **`version`**: The Tempo version, for example `v3.0.0`.
   - **`revision`**: The Git commit hash or revision used to build the binary.
   - **`branch`**: The Git branch used for the build.
   - **`buildUser`**: The user who built the binary.
@@ -139,7 +137,9 @@ Tempo maintainers commit to keeping the list of tracked information updated over
   - **`num_cpu`**: The number of logical CPU cores available.
   - **`feature_enabled_multitenancy`**: Indicates if multitenancy is enabled (`1`) or not (`0`).
   - **`receiver_enabled_jaeger`**, **`receiver_enabled_otlp`**, **`receiver_enabled_kafka`**, **`receiver_enabled_zipkin`**: Flags indicating if each trace receiver is enabled (`1`) or not (`0`).
-  - **`storage_block_encoding`**, **`storage_block_search_encoding`**, **`storage_wal_encoding`**, **`storage_wal_search_encoding`**: The encoding or compression algorithms used for storage blocks and write-ahead logs.
+  - **`storage_block_format`**: The effective `storage.trace.block.version` value used for newly written blocks.
+    Existing blocks may use older formats,
+    and older Tempo versions omit this field.
   - **`storage_cache`**: The cache backend used for storage, if any.
   - **`feature_enabled_auth_stats`**: Indicates if authentication statistics are enabled.
   - **`frontend_version`**: The version of the frontend component.


### PR DESCRIPTION
**What this PR does**:
It adds a new field to the usage stats to track the configured block format. This will be handy for us to know when a format can be deprecated

**Which issue(s) this PR fixes**:
n/a

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
