### PR TITLE
[backend-scheduler] redaction: cap the explicit traceID list

### DIFF
--- a/.chloggen/redaction-trace-id-cap.yaml
+++ b/.chloggen/redaction-trace-id-cap.yaml
@@ -1,0 +1,7 @@
+change_type: change
+component: backend-scheduler
+note: "Cap the explicit trace-ID list on a redaction submission at 1000, rejecting larger requests with a pointer to the query selector."
+issues: []
+subtext: |
+  Each job a redaction creates carries the batch's whole trace-ID list, so submission cost scales with ids x blocks: a few million 16-byte IDs against a tenant with tens of thousands of blocks reaches terabytes of dispatch traffic from a single scheduler. The gRPC message limit already capped a submission near 5.8M, but as a failure found under load rather than a stated boundary. A query selector resolves per block on the worker and adds nothing to any job payload.
+user: zalegrala

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -993,7 +993,7 @@ Arguments:
 Options:
 
 - `--tenant <value>` **(required)** Tenant ID.
-- `--trace-id <value>` Trace ID to redact, in hex format. Specify multiple times to redact several traces in one request, up to 1000. Every job the redaction creates carries the whole list, so a longer list costs one copy per block; use `--query` instead. Mutually exclusive with `--query`.
+- `--trace-id <value>` Trace ID to redact, in hex format. Repeat the flag for several traces in one request (`--trace-id=<ID> --trace-id=<ID>`, not comma-separated), up to 1000. Every job the redaction creates carries the whole list, so a longer list costs one copy per block; use `--query` instead. Mutually exclusive with `--query`.
 - `--query <value>` TraceQL query selecting the traces to redact, for example `{ span.http.status_code = 500 }`. Mutually exclusive with `--trace-id`. The query is restricted to a single spanset filter: `=` comparisons on the matched span's own `resource.*` or `span.*` attributes, joined by `&&` or `||`. Regular expressions, `!=` or ordered comparisons, `parent.`-scoped attributes, and pipelines or aggregates aren't supported.
 - `--dry-run` Evaluate the selector and report match counts without rewriting any blocks (default: `false`).
 - `--start <value>` Start of the time window. Accepts `now`, a relative offset such as `now-7d`, or an RFC3339 timestamp. Must be given with `--end`, must be before `--end`, and cannot be combined with `--trace-id`. Omit both bounds to redact the whole tenant.
@@ -1003,6 +1003,10 @@ Options:
 - `--tls-ca <value>` Path to a PEM-encoded CA certificate file.
 
 You must provide exactly one of `--trace-id` or `--query`. Providing both, or neither, returns an error before the request is submitted.
+
+A tenant can have only one redaction in progress at a time, dry runs included.
+A submission made while an earlier one is still running, or still in its quiescence period, is rejected.
+A trace-ID list larger than the cap therefore has to be redacted as successive batches rather than several at once, which is another reason to prefer `--query`.
 
 On success, the command prints the batch ID and the number of jobs created:
 

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -993,7 +993,7 @@ Arguments:
 Options:
 
 - `--tenant <value>` **(required)** Tenant ID.
-- `--trace-id <value>` Trace ID to redact, in hex format. Specify multiple times to redact several traces in one request. Mutually exclusive with `--query`.
+- `--trace-id <value>` Trace ID to redact, in hex format. Specify multiple times to redact several traces in one request, up to 1000. Every job the redaction creates carries the whole list, so a longer list costs one copy per block; use `--query` instead. Mutually exclusive with `--query`.
 - `--query <value>` TraceQL query selecting the traces to redact, for example `{ span.http.status_code = 500 }`. Mutually exclusive with `--trace-id`. The query is restricted to a single spanset filter: `=` comparisons on the matched span's own `resource.*` or `span.*` attributes, joined by `&&` or `||`. Regular expressions, `!=` or ordered comparisons, `parent.`-scoped attributes, and pipelines or aggregates aren't supported.
 - `--dry-run` Evaluate the selector and report match counts without rewriting any blocks (default: `false`).
 - `--start <value>` Start of the time window. Accepts `now`, a relative offset such as `now-7d`, or an RFC3339 timestamp. Must be given with `--end`, must be before `--end`, and cannot be combined with `--trace-id`. Omit both bounds to redact the whole tenant.

--- a/modules/backendscheduler/redaction_idcap_test.go
+++ b/modules/backendscheduler/redaction_idcap_test.go
@@ -1,0 +1,71 @@
+package backendscheduler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/grafana/tempo/pkg/tempopb"
+)
+
+func idList(n int) [][]byte {
+	ids := make([][]byte, n)
+	for i := range ids {
+		id := make([]byte, 16)
+		id[0] = byte(i)
+		id[1] = byte(i >> 8)
+		id[2] = byte(i >> 16)
+		ids[i] = id
+	}
+	return ids
+}
+
+// TestValidateRedactionRequestCapsTraceIDs bounds the explicit trace-ID list.
+//
+// Next() assigns the batch's whole list onto every job it hands out, so the dispatch cost is
+// O(ids x blocks): a few million 16-byte IDs against a tenant with tens of thousands of blocks is
+// terabytes of gRPC traffic out of the scheduler, which is a singleton. The gRPC message limit
+// caps a single submission somewhere near 5.8M ids, which is a failure discovered under load
+// rather than a stated boundary -- and far past the point where the cost is unreasonable.
+func TestValidateRedactionRequestCapsTraceIDs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		n       int
+		wantMsg string
+	}{
+		{name: "one id", n: 1},
+		{name: "at the cap", n: maxRedactionTraceIDs},
+		{name: "one over the cap", n: maxRedactionTraceIDs + 1, wantMsg: "too many trace_ids"},
+		{name: "far over the cap", n: maxRedactionTraceIDs * 10, wantMsg: "too many trace_ids"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRedactionRequest(&tempopb.SubmitRedactionRequest{TraceIds: idList(tc.n)}, nil)
+
+			if tc.wantMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.Contains(t, err.Error(), tc.wantMsg)
+			// The rejection has to name the way out, or an operator with a large list has no next
+			// step but to split it up and pay the same dispatch cost across several batches.
+			require.Contains(t, err.Error(), "query",
+				"the error must point at the query selector, which costs nothing per job")
+		})
+	}
+}
+
+// TestValidateRedactionRequestCapDoesNotApplyToQuery pins that the cap is a property of shipping
+// an ID list, not of redaction size. A query selects an unbounded number of traces and is resolved
+// per block on the worker, so it carries no per-job payload at all.
+func TestValidateRedactionRequestCapDoesNotApplyToQuery(t *testing.T) {
+	err := validateRedactionRequest(
+		&tempopb.SubmitRedactionRequest{},
+		&tempopb.TraceQLSelector{Query: fmt.Sprintf(`{resource.namespace = %q}`, "checkout")},
+	)
+	require.NoError(t, err)
+}

--- a/modules/backendscheduler/redaction_idcap_test.go
+++ b/modules/backendscheduler/redaction_idcap_test.go
@@ -23,13 +23,8 @@ func idList(n int) [][]byte {
 	return ids
 }
 
-// TestValidateRedactionRequestCapsTraceIDs bounds the explicit trace-ID list.
-//
-// Next() assigns the batch's whole list onto every job it hands out, so the dispatch cost is
-// O(ids x blocks): a few million 16-byte IDs against a tenant with tens of thousands of blocks is
-// terabytes of gRPC traffic out of the scheduler, which is a singleton. The gRPC message limit
-// caps a single submission somewhere near 5.8M ids, which is a failure discovered under load
-// rather than a stated boundary -- and far past the point where the cost is unreasonable.
+// TestValidateRedactionRequestCapsTraceIDs bounds the explicit trace-ID list and pins that the
+// rejection names the query selector, so a refused operator has a next step.
 func TestValidateRedactionRequestCapsTraceIDs(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -51,17 +46,14 @@ func TestValidateRedactionRequestCapsTraceIDs(t *testing.T) {
 			require.Error(t, err)
 			require.Equal(t, codes.InvalidArgument, status.Code(err))
 			require.Contains(t, err.Error(), tc.wantMsg)
-			// The rejection has to name the way out, or an operator with a large list has no next
-			// step but to split it up and pay the same dispatch cost across several batches.
-			require.Contains(t, err.Error(), "query",
-				"the error must point at the query selector, which costs nothing per job")
+			require.Contains(t, err.Error(), "query", "the error must point at the query selector")
 		})
 	}
 }
 
-// TestValidateRedactionRequestCapDoesNotApplyToQuery pins that the cap is a property of shipping
-// an ID list, not of redaction size. A query selects an unbounded number of traces and is resolved
-// per block on the worker, so it carries no per-job payload at all.
+// TestValidateRedactionRequestCapDoesNotApplyToQuery pins that the cap is a property of shipping an
+// ID list, not of redaction size: a query is resolved per block on the worker and carries no
+// per-job payload.
 func TestValidateRedactionRequestCapDoesNotApplyToQuery(t *testing.T) {
 	err := validateRedactionRequest(
 		&tempopb.SubmitRedactionRequest{},

--- a/modules/backendscheduler/redaction_window.go
+++ b/modules/backendscheduler/redaction_window.go
@@ -113,6 +113,20 @@ func coveredRangeLabel(t time.Time, ok bool) string {
 	return t.UTC().Format(time.RFC3339)
 }
 
+// maxRedactionTraceIDs bounds the explicit trace-ID list on a submission.
+//
+// Next() assigns the batch's entire list onto every job it hands out, so dispatch cost is
+// O(ids x blocks) out of a singleton scheduler: 16-byte IDs at ~18 bytes each on the wire, against
+// a tenant with tens of thousands of blocks, reaches terabytes of gRPC traffic for one batch. The
+// gRPC message limit already caps a submission near 5.8M IDs, but that is a failure found under
+// load rather than a stated boundary, and it sits far past the point where the cost is defensible.
+//
+// The value is a deliberate policy choice rather than a tuned limit: an explicit list names
+// specific traces, which in practice is tens to hundreds, and anything list-shaped beyond that is
+// really a query. Not configurable for now -- the rejection names the query selector instead,
+// which resolves per block on the worker and adds nothing to any job payload.
+const maxRedactionTraceIDs = 1000
+
 // validateRedactionRequest rejects a submission the scheduler cannot honour, returning a gRPC status
 // error. Every check fails closed: on a redaction, a refused request destroys nothing while a
 // misinterpreted one cannot be undone.
@@ -130,6 +144,14 @@ func validateRedactionRequest(req *tempopb.SubmitRedactionRequest, querySel *tem
 		if err := validateRedactionQuery(querySel.Query); err != nil {
 			return status.Error(codes.InvalidArgument, err.Error())
 		}
+	}
+
+	// Bound the list before anything persists or dispatches it. Checked after the selector XOR so a
+	// request that also sets a query is told about the more fundamental problem first.
+	if len(req.TraceIds) > maxRedactionTraceIDs {
+		return status.Errorf(codes.InvalidArgument,
+			"too many trace_ids: %d exceeds the limit of %d; every job dispatch carries the whole list, so use a query selector instead",
+			len(req.TraceIds), maxRedactionTraceIDs)
 	}
 
 	// Only DRY_RUN is checked downstream, so an unrecognised mode would fall through to a destructive

--- a/modules/backendscheduler/redaction_window.go
+++ b/modules/backendscheduler/redaction_window.go
@@ -113,18 +113,8 @@ func coveredRangeLabel(t time.Time, ok bool) string {
 	return t.UTC().Format(time.RFC3339)
 }
 
-// maxRedactionTraceIDs bounds the explicit trace-ID list on a submission.
-//
-// Next() assigns the batch's entire list onto every job it hands out, so dispatch cost is
-// O(ids x blocks) out of a singleton scheduler: 16-byte IDs at ~18 bytes each on the wire, against
-// a tenant with tens of thousands of blocks, reaches terabytes of gRPC traffic for one batch. The
-// gRPC message limit already caps a submission near 5.8M IDs, but that is a failure found under
-// load rather than a stated boundary, and it sits far past the point where the cost is defensible.
-//
-// The value is a deliberate policy choice rather than a tuned limit: an explicit list names
-// specific traces, which in practice is tens to hundreds, and anything list-shaped beyond that is
-// really a query. Not configurable for now -- the rejection names the query selector instead,
-// which resolves per block on the worker and adds nothing to any job payload.
+// maxRedactionTraceIDs bounds the explicit trace-ID list on a submission: Next() copies the batch's
+// whole list onto every job, so dispatch cost is O(ids x blocks) out of a singleton scheduler.
 const maxRedactionTraceIDs = 1000
 
 // validateRedactionRequest rejects a submission the scheduler cannot honour, returning a gRPC status
@@ -146,8 +136,8 @@ func validateRedactionRequest(req *tempopb.SubmitRedactionRequest, querySel *tem
 		}
 	}
 
-	// Bound the list before anything persists or dispatches it. Checked after the selector XOR so a
-	// request that also sets a query is told about the more fundamental problem first.
+	// Checked after the selector XOR so a request that also sets a query is told about the more
+	// fundamental problem first.
 	if len(req.TraceIds) > maxRedactionTraceIDs {
 		return status.Errorf(codes.InvalidArgument,
 			"too many trace_ids: %d exceeds the limit of %d; every job dispatch carries the whole list, so use a query selector instead",


### PR DESCRIPTION
**What this PR does**:

Caps the explicit traceID list on a redaction submission at 1000, rejecting anything larger with `InvalidArgument` and a pointer to the query selector.

There was no bound. `Next()` assigns the batch's whole ID list onto every job it hands out, so submission cost scales with **ids × blocks**: at 16 bytes per ID, which could add up quickly.

1000 is a policy choice rather than a tuned limit, and the comment says so: an explicit list names *specific* traces, which in practice is tens to hundreds. Anything list-shaped beyond that is really a query, and a query selector resolves per block on the worker and adds nothing to any job payload.

Not configurable for now. Happy to add a limit if there's a real case for a larger list, but I'd rather find out what it is first than pick a second arbitrary number.

**Which issue(s) this PR fixes**:
N/A — part of the query-based redaction series (#7663, #7695, #7699, #7700, #7702, #7703, #7772).

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/`