### PR TITLE
metrics-generator: only register span-sanitizer metrics when enabled or dry_run

### DIFF
--- a/.chloggen/electron0zero_fix-drain-sanitizer-metric-registration.yaml
+++ b/.chloggen/electron0zero_fix-drain-sanitizer-metric-registration.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: metrics-generator
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Only register span-sanitizer metrics when span_name_sanitization is enabled or dry_run
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: electron0zero

--- a/modules/generator/registry/drain_sanitizer.go
+++ b/modules/generator/registry/drain_sanitizer.go
@@ -37,6 +37,8 @@ type DrainSanitizer struct {
 	tenant        string
 	sanitizeModeF sanitizeModeFunc
 
+	// initialized on first enabled Sanitize call, to ensure only tenant with
+	// sanitization enabled register these metrics.
 	metricTotalSpansSanitized prometheus.Counter
 	demandGauge               prometheus.Gauge
 
@@ -49,14 +51,12 @@ type DrainSanitizer struct {
 
 func NewDrainSanitizer(tenant string, sanitizeModeF sanitizeModeFunc, staleDuration time.Duration) *DrainSanitizer {
 	return &DrainSanitizer{
-		drain:                     drain.New(tenant, drain.DefaultConfig()),
-		tenant:                    tenant,
-		sanitizeModeF:             sanitizeModeF,
-		metricTotalSpansSanitized: metricTotalSpansSanitized.WithLabelValues(tenant),
-		demand:                    NewCardinality(staleDuration, removeStaleSeriesInterval),
-		demandGauge:               metricPostSanitizationDemand.WithLabelValues(tenant),
-		demandUpdateChan:          time.Tick(15 * time.Second),
-		pruneChan:                 time.Tick(5 * time.Minute),
+		drain:            drain.New(tenant, drain.DefaultConfig()),
+		tenant:           tenant,
+		sanitizeModeF:    sanitizeModeF,
+		demand:           NewCardinality(staleDuration, removeStaleSeriesInterval),
+		demandUpdateChan: time.Tick(15 * time.Second),
+		pruneChan:        time.Tick(5 * time.Minute),
 	}
 }
 
@@ -70,6 +70,12 @@ func (s *DrainSanitizer) Sanitize(lbls labels.Labels) labels.Labels {
 
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
+
+	// only register metrics when feature is NOT disabled.
+	if s.demandGauge == nil {
+		s.metricTotalSpansSanitized = metricTotalSpansSanitized.WithLabelValues(s.tenant)
+		s.demandGauge = metricPostSanitizationDemand.WithLabelValues(s.tenant)
+	}
 
 	s.doPeriodicMaintenanceLocked()
 

--- a/modules/generator/registry/drain_sanitizer_test.go
+++ b/modules/generator/registry/drain_sanitizer_test.go
@@ -1,11 +1,14 @@
 package registry
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	io_prometheus_client "github.com/prometheus/client_model/go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 )
@@ -102,6 +105,29 @@ func TestDrainSanitizer_DisabledMode(t *testing.T) {
 	result := sanitizer.Sanitize(lbls2)
 	require.Equal(t, "GET /api/users/456", result.Get("span_name"))
 	require.Equal(t, lbls2, result)
+}
+
+func TestDrainSanitizer_DisabledTenantNeverRegistersMetrics(t *testing.T) {
+	const tenant = "test-drain-sanitizer-disabled-tenant"
+	s := NewDrainSanitizer(tenant, func(string) string { return SpanNameSanitizationDisabled }, 15*time.Minute)
+
+	for i := range 10 {
+		s.Sanitize(labels.FromStrings("span_name", fmt.Sprintf("GET /api/x/%d", i)))
+	}
+
+	// check the metric and assert
+	for _, vec := range []prometheus.Collector{metricPostSanitizationDemand, metricTotalSpansSanitized} {
+		ch := make(chan prometheus.Metric, 100)
+		vec.Collect(ch)
+		close(ch)
+		for m := range ch {
+			var g io_prometheus_client.Metric
+			require.NoError(t, m.Write(&g))
+			for _, lbl := range g.GetLabel() {
+				require.NotEqual(t, tenant, lbl.GetValue(), "disabled tenant should never register a sanitizer metric")
+			}
+		}
+	}
 }
 
 func TestDrainSanitizer_NilClusterHandling(t *testing.T) {

--- a/modules/generator/registry/drain_sanitizer_test.go
+++ b/modules/generator/registry/drain_sanitizer_test.go
@@ -117,9 +117,11 @@ func TestDrainSanitizer_DisabledTenantNeverRegistersMetrics(t *testing.T) {
 
 	// check the metric and assert
 	for _, vec := range []prometheus.Collector{metricPostSanitizationDemand, metricTotalSpansSanitized} {
-		ch := make(chan prometheus.Metric, 100)
-		vec.Collect(ch)
-		close(ch)
+		ch := make(chan prometheus.Metric)
+		go func() {
+			vec.Collect(ch)
+			close(ch)
+		}()
 		for m := range ch {
 			var g io_prometheus_client.Metric
 			require.NoError(t, m.Write(&g))


### PR DESCRIPTION
**What this PR does**:

before this change both metrics were registered unconditionally in DrainSanitizer's constructor, so every tenant published these metrics and tenants that had the feature disabled were publishing 0 value . 

After this PR, metrics are registerd lazily on first use so these metrics are only published when the DrainSanitizer is enabled for a tenant. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)