### PR TITLE
fix(metrics-generator): seed _sum with a zero baseline on new histogram series

### DIFF
--- a/.chloggen/fix-spanmetrics-sum-zero-seed.yaml
+++ b/.chloggen/fix-spanmetrics-sum-zero-seed.yaml
@@ -1,0 +1,27 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: metrics-generator
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Fix classic histogram `_sum` series (e.g. `traces_spanmetrics_latency_sum`) under-reporting via `increase()`/`rate()` for series that are frequently created and evicted.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  `_count` and `_bucket` series were already seeded with a zero sample when a series is
+  first created (or recreated after being evicted as stale), so `increase()`/`rate()`
+  can correctly attribute their first real value. `_sum` was missing this seed, so
+  `increase()`/`rate()` could under-count or drop the contribution of series with high
+  churn. Applies to both the classic-only histogram path and classic histograms emitted
+  in "both" (native + classic) mode.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: yvrhdn

--- a/modules/generator/processor/servicegraphs/servicegraphs_test.go
+++ b/modules/generator/processor/servicegraphs/servicegraphs_test.go
@@ -575,7 +575,7 @@ func TestServiceGraphs_histogramModesEmitValuesAndExemplars(t *testing.T) {
 
 			wantSamples := 2 // request counter initialization and current value
 			if tt.wantClassic {
-				wantSamples = 23
+				wantSamples = 26
 			}
 			wantHistograms := 0
 			if tt.wantNative {

--- a/modules/generator/registry/histogram.go
+++ b/modules/generator/registry/histogram.go
@@ -231,7 +231,11 @@ func (h *histogram) collectMetrics(appender storage.Appender, timeMs int64) erro
 			// We set the timestamp of the init serie at the end of the previous minute, that way we ensure it ends in a
 			// different aggregation interval to avoid be downsampled.
 			endOfLastMinuteMs := getEndOfLastMinuteMs(timeMs)
-			_, err := appender.Append(0, s.countLabels, endOfLastMinuteMs, 0)
+			_, err := appender.Append(0, s.sumLabels, endOfLastMinuteMs, 0)
+			if err != nil && !isOutOfOrderError(err) {
+				return err
+			}
+			_, err = appender.Append(0, s.countLabels, endOfLastMinuteMs, 0)
 			if err != nil && !isOutOfOrderError(err) {
 				return err
 			}

--- a/modules/generator/registry/histogram_test.go
+++ b/modules/generator/registry/histogram_test.go
@@ -36,6 +36,7 @@ func Test_histogram(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // Zero entry for value-1 series
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0), // Zero entry for value-1 series
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0), // Zero entry for bucket
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -45,6 +46,7 @@ func Test_histogram(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // Zero entry for value-2 series
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, endOfLastMinuteMs, 0), // Zero entry for value-2 series
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -87,6 +89,7 @@ func Test_histogram(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-3"}, endOfLastMinuteMs, 0), // Zero entry for value-3 series
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-3"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-3"}, endOfLastMinuteMs, 0), // Zero entry for value-3 series
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-3"}, collectionTimeMs, 3),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-3", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-3", "le": "1"}, collectionTimeMs, 0),
@@ -180,6 +183,7 @@ func Test_histogram_cantAdd(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -189,6 +193,7 @@ func Test_histogram_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -219,6 +224,7 @@ func Test_histogram_cantAdd(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
 		newSample(map[string]string{"__name__": "my_histogram_count", "metric_overflow": "true"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "metric_overflow": "true"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "metric_overflow": "true"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "metric_overflow": "true"}, collectionTimeMs, 3),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "metric_overflow": "true", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "metric_overflow": "true", "le": "1"}, collectionTimeMs, 0),
@@ -254,6 +260,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -263,6 +270,7 @@ func Test_histogram_removeStaleSeries(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -307,6 +315,7 @@ func Test_histogram_externalLabels(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1", "external_label": "external_value"}, collectionTimeMs, 1),
@@ -316,6 +325,7 @@ func Test_histogram_externalLabels(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "+Inf", "external_label": "external_value"}, collectionTimeMs, 1),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-2", "external_label": "external_value"}, collectionTimeMs, 1.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1", "external_label": "external_value"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-2", "le": "1", "external_label": "external_value"}, collectionTimeMs, 0),
@@ -407,6 +417,7 @@ func Test_histogram_concurrencyCorrectness(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, float64(totalCount.Load())),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 2*float64(totalCount.Load())),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 0),
@@ -428,6 +439,7 @@ func Test_histogram_span_multiplier(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1"}, collectionTimeMs, 6.5),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1"}, collectionTimeMs, 11.5),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1.5),

--- a/modules/generator/registry/native_histogram.go
+++ b/modules/generator/registry/native_histogram.go
@@ -464,7 +464,11 @@ func (h *nativeHistogram) nativeHistograms(appender storage.Appender, lbls label
 func (h *nativeHistogram) classicHistograms(appender storage.Appender, timeMs int64, s *nativeHistogramSeries) error {
 	if s.isNew() {
 		endOfLastMinuteMs := getEndOfLastMinuteMs(timeMs)
-		_, err := appender.Append(0, s.countLabels, endOfLastMinuteMs, 0)
+		_, err := appender.Append(0, s.sumLabels, endOfLastMinuteMs, 0)
+		if err != nil {
+			return err
+		}
+		_, err = appender.Append(0, s.countLabels, endOfLastMinuteMs, 0)
 		if err != nil {
 			return err
 		}

--- a/modules/generator/registry/native_histogram_test.go
+++ b/modules/generator/registry/native_histogram_test.go
@@ -80,6 +80,7 @@ func Test_Histograms(t *testing.T) {
 					expectedSamples: []sample{
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -120,6 +121,7 @@ func Test_Histograms(t *testing.T) {
 					expectedSamples: []sample{
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -129,6 +131,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -174,6 +177,7 @@ func Test_Histograms(t *testing.T) {
 					expectedSamples: []sample{
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -183,6 +187,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -232,6 +237,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-3"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-3"}, collectionTimeMs, 3),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-3", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-3", "le": "1"}, collectionTimeMs, 0),
@@ -277,6 +283,7 @@ func Test_Histograms(t *testing.T) {
 					expectedSamples: []sample{
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 20),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 20*1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 0),
@@ -286,6 +293,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 20),
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 13),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 13*3),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -332,6 +340,7 @@ func Test_Histograms(t *testing.T) {
 					expectedSamples: []sample{
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-1"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-1"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "1"}, collectionTimeMs, 1),
@@ -341,6 +350,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-1", "le": "+Inf"}, collectionTimeMs, 1),
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-2"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-2"}, collectionTimeMs, 1.5),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "1"}, collectionTimeMs, 0),
@@ -390,6 +400,7 @@ func Test_Histograms(t *testing.T) {
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-2", "le": "+Inf"}, collectionTimeMs, 2),
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, endOfLastMinuteMs, 0), // zero count at the beginning
 						newSample(map[string]string{"__name__": "test_histogram_count", "label": "value-3"}, collectionTimeMs, 1),
+						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-3"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_sum", "label": "value-3"}, collectionTimeMs, 3),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-3", "le": "1"}, endOfLastMinuteMs, 0),
 						newSample(map[string]string{"__name__": "test_histogram_bucket", "label": "value-3", "le": "1"}, collectionTimeMs, 0),

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -152,6 +152,7 @@ func TestManagedRegistry_histogram(t *testing.T) {
 	expectedSamples := []sample{
 		newSample(map[string]string{"__name__": "histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
 		newSample(map[string]string{"__name__": "histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 1, 1.0),
+		newSample(map[string]string{"__name__": "histogram_sum", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
 		newSample(map[string]string{"__name__": "histogram_sum", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 1, 1.0),
 		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 0),
 		newSample(map[string]string{"__name__": "histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 1, 1.0),
@@ -371,6 +372,7 @@ func TestManagedRegistry_maxLabelNameLength(t *testing.T) {
 		newSample(map[string]string{"__name__": "counter", "very_len": "very_", "__metrics_gen_instance": mustGetHostname()}, 1, 1.0),
 		newSample(map[string]string{"__name__": "histogram_count", "another_": "anoth", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
 		newSample(map[string]string{"__name__": "histogram_count", "another_": "anoth", "__metrics_gen_instance": mustGetHostname()}, 1, 1.0),
+		newSample(map[string]string{"__name__": "histogram_sum", "another_": "anoth", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
 		newSample(map[string]string{"__name__": "histogram_sum", "another_": "anoth", "__metrics_gen_instance": mustGetHostname()}, 1, 1.0),
 		newSample(map[string]string{"__name__": "histogram_bucket", "another_": "anoth", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 0),
 		newSample(map[string]string{"__name__": "histogram_bucket", "another_": "anoth", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 1, 1.0),
@@ -1090,6 +1092,7 @@ func TestManagedRegistry_borrowedLabelsSurviveScratchReuse(t *testing.T) {
 		newSample(map[string]string{"__name__": "my_counter", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
 		newSample(map[string]string{"__name__": "my_histogram_count", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
+		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 0),
 		newSample(map[string]string{"__name__": "my_histogram_sum", "label": "value-1", "__metrics_gen_instance": mustGetHostname()}, 0, 1),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 0),
 		newSample(map[string]string{"__name__": "my_histogram_bucket", "label": "value-1", "__metrics_gen_instance": mustGetHostname(), "le": "1"}, 0, 1),


### PR DESCRIPTION
**What this PR does**:
Classic histogram `_count` and `_bucket` series are seeded with a zero sample when a series is first created (or recreated after being evicted as stale), so `increase()`/`rate()` queries can correctly attribute the series' first real value across that boundary. `_sum` was missing this same zero-seed: `increase()`/`rate()` over a range that captures a series' birth has no earlier sample to diff against, and under-counts (or entirely drops) that series' contribution.

This affects any classic histogram (e.g. `traces_spanmetrics_latency_sum`, `traces_service_graph_request_*_seconds_sum`) for tenants where individual series churn frequently — for example, high-cardinality dimension configs where many label combinations are created and evicted (15m default stale duration) within a typical query window.

This adds the same zero-seed for `_sum` that `_count`/`_bucket` already get, in both:
- `modules/generator/registry/histogram.go` (classic-only histogram mode)
- `modules/generator/registry/native_histogram.go`'s `classicHistograms()` (classic emission in "both" native+classic mode)

Test expectations updated accordingly across `histogram_test.go`, `native_histogram_test.go`, `registry_test.go`, and `servicegraphs_test.go`.

**Note**: while reviewing the surrounding code, I noticed `native_histogram.go`'s `classicHistograms()` bucket-loop zero-seed check tests a stale `err` variable from an earlier append rather than the `appendErr` returned by that call, so it can never actually catch a failed bucket zero-seed append. Left out of scope here since it's pre-existing and unrelated to this fix — happy to file/fix separately.

**Which issue(s) this PR fixes**:
N/A — not tied to an open issue.

**Checklist**
- [x] Tests updated
- [ ] Documentation added (not applicable — internal correctness fix, no user-facing config/API change)
- [x] Changelog entry added under `.chloggen/`

