### PR TITLE
docs: Updates for vP5 default in 3.1

### DIFF
--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -28,7 +28,7 @@ As soon as a block format version is enabled, Tempo starts writing data in that 
 {{< admonition type="warning" >}}
 The `v2` block format has been removed in Tempo 3.0.
 `vParquet3` is deprecated.
-Tempo still reads existing `vParquet3` blocks.
+Tempo 3.x still reads existing `vParquet3` blocks.
 Write new blocks in `vParquet5` (default) or `vParquet4`.
 {{< /admonition >}}
 

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -11,9 +11,13 @@ Tempo has a default columnar block format based on Apache Parquet.
 This format is required for tags-based search as well as [TraceQL](../../traceql/), the query language for traces.
 The columnar block format improves search performance and enables an ecosystem of tools, including [Tempo CLI](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/tempo_cli/#analyse-blocks), to access the underlying trace data.
 
+Starting in Tempo 3.1, Tempo writes new blocks in `vParquet5` by default.
+Existing `vParquet4` blocks remain readable.
+No data migration is required.
+
 ## Considerations
 
-The Parquet block format has been the default since Tempo 2.0 and is the only supported block format in Tempo 3.0.
+The Parquet block format has been the default since Tempo 2.0 and is the only supported block format in Tempo 3.x.
 
 If you install using the [Tempo Helm charts](https://grafana.com/docs/tempo/<TEMPO_VERSION>/setup/helm-chart/), then Parquet is enabled by default.
 No data conversion or upgrade process is necessary.
@@ -26,18 +30,11 @@ The `v2` and `vParquet3` block formats have been removed in Tempo 3.0.
 Use `vParquet5` (default) or `vParquet4`. 
 {{< /admonition >}}
 
-Only Parquet-based formats are supported. 
-
-### vParquet4 
-
-`vParquet4` is available as an opt-in alternative to the default `vParquet5` format.
-
-`vParquet4` introduces columns that enable querying for data in array attributes as well as events and links.
-For more information, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
+Only Parquet-based formats are supported.
 
 ### vParquet5
 
-`vParquet5` is the default block format.
+`vParquet5` is the default block format as of Tempo 3.1.
 It builds on vParquet4 with the following improvements:
 
 - Expanded dedicated columns: Up to 20 dedicated string columns and 5 dedicated integer columns per scope (span, resource, and event), compared with 10 string columns per scope in vParquet4.
@@ -46,6 +43,13 @@ It builds on vParquet4 with the following improvements:
 - Array-valued dedicated columns: Dedicated columns can store multiple values per attribute using the `options: ["array"]` configuration.
 
 For details on configuring dedicated attribute columns with vParquet5 features, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
+
+### vParquet4
+
+`vParquet4` is available as an opt-in alternative to the default `vParquet5` format.
+
+`vParquet4` introduces columns that enable querying for data in array attributes as well as events and links.
+For more information, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
 
 ## Change the block format version
 
@@ -58,6 +62,7 @@ storage:
       version: <version>
 ```
 
+If you omit `version`, Tempo writes `vParquet5`.
 Replace `<version>` with `vParquet4` or `vParquet5`.
 
 To keep writing the previous `vParquet4` format, set the `version` option to `vParquet4`.

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -41,7 +41,7 @@ It builds on vParquet4 with the following improvements:
 - Event-scoped dedicated columns: Dedicated attribute columns can target event-scoped attributes such as `exception.message`.
 - Blob column support: High-cardinality or high-length string attributes (for example, stack traces or UUIDs) can use `zstd` compression instead of dictionary encoding for better efficiency.
 - Array-valued dedicated columns: Dedicated columns can store multiple values per attribute using the `options: ["array"]` configuration.
-
+- Materialized timestamp columns for faster metrics queries using common step intervals of 15s, 60s, 300s, and 1h, and any even multiples of those.  The best value is chosen by automatically based on the query time range when the step interval is left as `auto`.
 For details on configuring dedicated attribute columns with vParquet5 features, refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/dedicated_columns/).
 
 ### vParquet4

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -12,7 +12,7 @@ This format is required for tags-based search as well as [TraceQL](../../traceql
 The columnar block format improves search performance and enables an ecosystem of tools, including [Tempo CLI](https://grafana.com/docs/tempo/<TEMPO_VERSION>/operations/tempo_cli/#analyse-blocks), to access the underlying trace data.
 
 Starting in Tempo 3.1, Tempo writes new blocks in `vParquet5` by default.
-Existing `vParquet4` blocks remain readable.
+Existing `vParquet4` and `vParquet3` blocks remain readable.
 No data migration is required.
 
 ## Considerations
@@ -26,8 +26,10 @@ As soon as a block format version is enabled, Tempo starts writing data in that 
 ## Block format versions
 
 {{< admonition type="warning" >}}
-The `v2` and `vParquet3` block formats have been removed in Tempo 3.0.
-Use `vParquet5` (default) or `vParquet4`. 
+The `v2` block format has been removed in Tempo 3.0.
+`vParquet3` is deprecated.
+Tempo still reads existing `vParquet3` blocks.
+Write new blocks in `vParquet5` (default) or `vParquet4`.
 {{< /admonition >}}
 
 Only Parquet-based formats are supported.

--- a/docs/sources/tempo/operations/dedicated_columns.md
+++ b/docs/sources/tempo/operations/dedicated_columns.md
@@ -12,6 +12,7 @@ rather than in the generic attribute key-value list.
 Dedicated attribute columns are available when using `vParquet4` or later block formats.
 
 `vParquet5` expands on the feature with doubled string column limits, integer dedicated columns, event-scoped attributes, array-valued attributes, and blob attributes using the `options` field.
+As of Tempo 3.1, Tempo writes `vParquet5` by default, so these expanded limits apply without setting `storage.trace.block.version`.
 
 ## Configuration
 

--- a/docs/sources/tempo/operations/schema.md
+++ b/docs/sources/tempo/operations/schema.md
@@ -21,8 +21,8 @@ This document describes the schema used with the Parquet block format.
 
 ## Version applicability
 
-Tempo 3.1 and later write new blocks using the vParquet5 schema by default.
-vParquet4 remains available as an opt-in write format and differs in some schema details.
+Tempo defaults to the vParquet5 schema. vParquet4 remains available and differs in some schema details.
+Unless otherwise noted, the sections below describe vParquet4.
 
 The column tables and collapsed schema example below describe vParquet4.
 A [summary of vParquet5 differences](#summary-of-vparquet5-differences) lists what changed.

--- a/docs/sources/tempo/operations/schema.md
+++ b/docs/sources/tempo/operations/schema.md
@@ -14,15 +14,18 @@ aliases:
 <!-- vale Grafana.GooglePassive = NO -->
 <!-- vale Grafana.GoogleWill = NO -->
 
-Apache Parquet is the only supported block format in Tempo 3.0.
+Apache Parquet is the only supported block format in Tempo 3.x.
 Refer to the [Parquet configuration options](../../configuration/parquet/) for more information.
 
 This document describes the schema used with the Parquet block format.
 
 ## Version applicability
 
-Tempo defaults to the vParquet5 schema. vParquet4 remains available and differs in some schema details.
-Unless otherwise noted, the sections below describe vParquet4.
+Tempo 3.1 and later write new blocks using the vParquet5 schema by default.
+vParquet4 remains available as an opt-in write format and differs in some schema details.
+
+The column tables and collapsed schema example below describe vParquet4.
+A [summary of vParquet5 differences](#summary-of-vparquet5-differences) lists what changed.
 
 The following sections apply to both vParquet4 and vParquet5:
 

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -532,7 +532,9 @@ of dedicated columns.
 ### Convert vParquet3 to vParquet4
 
 {{< admonition type="warning" >}}
-`vParquet3` is deprecated. Convert any remaining vParquet3 blocks to vParquet4 or later before upgrading to Tempo 3.0.
+`vParquet3` is deprecated.
+Tempo 3.x still reads existing vParquet3 blocks, so converting them isn't required to upgrade.
+Convert remaining vParquet3 blocks to vParquet4 or later if you want to stop relying on the deprecated format.
 {{< /admonition >}}
 
 ```bash

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -531,10 +531,10 @@ of dedicated columns.
 
 ### Convert vParquet3 to vParquet4
 
-{{< admonition type="warning" >}}
+{{< admonition type="note" >}}
 `vParquet3` is deprecated.
-Tempo 3.x still reads existing vParquet3 blocks, so converting them isn't required to upgrade.
-Convert remaining vParquet3 blocks to vParquet4 or later if you want to stop relying on the deprecated format.
+Tempo 3.x still reads existing vParquet3 blocks, so you don't need to convert them before you upgrade.
+Use this command to convert remaining vParquet3 blocks to vParquet4 or later.
 {{< /admonition >}}
 
 ```bash

--- a/docs/sources/tempo/reference-tempo-architecture/block-format.md
+++ b/docs/sources/tempo/reference-tempo-architecture/block-format.md
@@ -85,11 +85,11 @@ Refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VER
 Tempo uses versioned block formats.
 As of Tempo 3.1, new blocks are written in vParquet5 by default.
 
-| Version   | Status                                      |
-| --------- | ------------------------------------------- |
-| vParquet3 | Deprecated in 2.10; still readable in 3.x   |
-| vParquet4 | Production-ready, opt-in                    |
-| vParquet5 | Default and latest                          |
+| Version   | Status                                    |
+| --------- | ----------------------------------------- |
+| vParquet3 | Deprecated in 2.10; still readable in 3.x |
+| vParquet4 | Production-ready, opt-in                  |
+| vParquet5 | Default and latest                        |
 
 If you omit `version`, Tempo writes vParquet5.
 To keep writing vParquet4, set the version explicitly:

--- a/docs/sources/tempo/reference-tempo-architecture/block-format.md
+++ b/docs/sources/tempo/reference-tempo-architecture/block-format.md
@@ -85,11 +85,11 @@ Refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VER
 Tempo uses versioned block formats.
 As of Tempo 3.1, new blocks are written in vParquet5 by default.
 
-| Version   | Status                             |
-| --------- | ---------------------------------- |
-| vParquet3 | Deprecated in 2.10, removed in 3.0 |
-| vParquet4 | Production-ready, opt-in           |
-| vParquet5 | Default and latest                 |
+| Version   | Status                                      |
+| --------- | ------------------------------------------- |
+| vParquet3 | Deprecated in 2.10; still readable in 3.x   |
+| vParquet4 | Production-ready, opt-in                    |
+| vParquet5 | Default and latest                          |
 
 If you omit `version`, Tempo writes vParquet5.
 To keep writing vParquet4, set the version explicitly:

--- a/docs/sources/tempo/reference-tempo-architecture/block-format.md
+++ b/docs/sources/tempo/reference-tempo-architecture/block-format.md
@@ -4,7 +4,7 @@ menuTitle: Block format
 description: How Tempo stores trace data in Apache Parquet blocks.
 weight: 500
 topicType: concept
-versionDate: 2026-03-20
+versionDate: 2026-08-25
 ---
 
 # Block format
@@ -83,14 +83,16 @@ Refer to [Dedicated attribute columns](https://grafana.com/docs/tempo/<TEMPO_VER
 ## Block format versions
 
 Tempo uses versioned block formats.
+As of Tempo 3.1, new blocks are written in vParquet5 by default.
 
 | Version   | Status                             |
 | --------- | ---------------------------------- |
 | vParquet3 | Deprecated in 2.10, removed in 3.0 |
-| vParquet4 | Production-ready, opt-in            |
+| vParquet4 | Production-ready, opt-in           |
 | vParquet5 | Default and latest                 |
 
-The block format is configured in:
+If you omit `version`, Tempo writes vParquet5.
+To keep writing vParquet4, set the version explicitly:
 
 ```yaml
 storage:
@@ -99,7 +101,9 @@ storage:
       version: vParquet4
 ```
 
-Existing blocks in older formats remain readable. New blocks are always written in the configured version.
+Existing blocks in older formats remain readable.
+New blocks are always written in the configured version.
+No data migration is required when the default changes.
 
 ## Related resources
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -6,7 +6,7 @@ weight: 520
 aliases:
   - ../migrate-to-3/
 topicType: task
-versionDate: 2026-02-25
+versionDate: 2026-08-25
 ---
 
 # Migrate from Tempo 2.x to 3.0
@@ -32,12 +32,12 @@ Running two Tempo deployments in parallel increases infrastructure costs for the
 
 Confirm the following before you start:
 
-- Your Tempo 2.x deployment uses **vParquet4 or later** as the block format.
-  Tempo 3.0 doesn't support vParquet3 or earlier.
-  If you're using an older format, upgrade your block format before migrating.
+- Your Tempo 2.x deployment writes **vParquet4 or later**.
+  `vParquet3` is deprecated.
+  Tempo 3.x still reads existing vParquet3 blocks, so you don't need to convert them before migrating.
+  If your configuration still specifies `vParquet3`, upgrade the write format before migrating.
   Refer to [Change the block format version](/docs/tempo/<TEMPO_VERSION>/configuration/parquet/#change-the-block-format-version).
   Tempo 3.1 writes new blocks as vParquet5 by default.
-  Existing vParquet4 blocks remain readable; you don't need to convert them.
 - **Microservices mode only**: You have a running **Kafka-compatible system** (for example, Apache Kafka or Redpanda). Monolithic mode does not require Kafka.
 - You have access to the **same object storage** bucket or container used by your 2.x deployment.
 - If you're running **scalable monolithic mode** (SSB), plan to switch to either monolithic or microservices mode. SSB has been removed in Tempo 3.0.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -32,10 +32,9 @@ Running two Tempo deployments in parallel increases infrastructure costs for the
 
 Confirm the following before you start:
 
-- Your Tempo 2.x deployment writes **vParquet4 or later**.
-  `vParquet3` is deprecated.
+- `vParquet3` is deprecated.
   Tempo 3.x still reads existing vParquet3 blocks, so you don't need to convert them before migrating.
-  If your configuration still specifies `vParquet3`, upgrade the write format before migrating.
+  If your configuration still specifies `vParquet3`, change the write format to **vParquet4 or later**.
   Refer to [Change the block format version](/docs/tempo/<TEMPO_VERSION>/configuration/parquet/#change-the-block-format-version).
   Tempo 3.1 writes new blocks as vParquet5 by default.
 - **Microservices mode only**: You have a running **Kafka-compatible system** (for example, Apache Kafka or Redpanda). Monolithic mode does not require Kafka.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -32,7 +32,12 @@ Running two Tempo deployments in parallel increases infrastructure costs for the
 
 Confirm the following before you start:
 
-- Your Tempo 2.x deployment uses **vParquet4 or later** as the block format. Tempo 3.0 doesn't support vParquet3 or earlier. If you're using an older format, upgrade your block format before migrating. Refer to [Change the block format version](/docs/tempo/<TEMPO_VERSION>/configuration/parquet/#change-the-block-format-version).
+- Your Tempo 2.x deployment uses **vParquet4 or later** as the block format.
+  Tempo 3.0 doesn't support vParquet3 or earlier.
+  If you're using an older format, upgrade your block format before migrating.
+  Refer to [Change the block format version](/docs/tempo/<TEMPO_VERSION>/configuration/parquet/#change-the-block-format-version).
+  Tempo 3.1 writes new blocks as vParquet5 by default.
+  Existing vParquet4 blocks remain readable; you don't need to convert them.
 - **Microservices mode only**: You have a running **Kafka-compatible system** (for example, Apache Kafka or Redpanda). Monolithic mode does not require Kafka.
 - You have access to the **same object storage** bucket or container used by your 2.x deployment.
 - If you're running **scalable monolithic mode** (SSB), plan to switch to either monolithic or microservices mode. SSB has been removed in Tempo 3.0.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
@@ -166,10 +166,10 @@ query_frontend:
 Tempo 3.0 is a major release that replaces the ingester-based architecture with a new design that separates the read and write paths.
 Block-builders, live-stores, and a backend scheduler replace ingesters and the compactor. For a detailed description of the new architecture, refer to the [Tempo architecture reference](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/).
 
-{{< admonition type="warning" >}}
-Tempo 3.x writes vParquet4 or later.
-`vParquet3` is deprecated; Tempo still reads existing vParquet3 blocks.
-If your storage configuration specifies `vParquet3`, upgrade the write format before migrating.
+{{< admonition type="caution" >}}
+`vParquet3` is deprecated.
+Tempo 3.x still reads existing vParquet3 blocks, so you don't need to convert them.
+If your storage configuration specifies `vParquet3`, change the write format to `vParquet4` or later.
 Refer to [Change the block format version](/docs/tempo/<TEMPO_VERSION>/configuration/parquet/#change-the-block-format-version).
 {{< /admonition >}}
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/upgrade.md
@@ -167,7 +167,10 @@ Tempo 3.0 is a major release that replaces the ingester-based architecture with 
 Block-builders, live-stores, and a backend scheduler replace ingesters and the compactor. For a detailed description of the new architecture, refer to the [Tempo architecture reference](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/).
 
 {{< admonition type="warning" >}}
-Tempo 3.0 requires vParquet4 or later as the block format. If your storage configuration specifies vParquet3 or earlier, upgrade the block format before migrating. Refer to [Change the block format version](/docs/tempo/<TEMPO_VERSION>/configuration/parquet/#change-the-block-format-version).
+Tempo 3.x writes vParquet4 or later.
+`vParquet3` is deprecated; Tempo still reads existing vParquet3 blocks.
+If your storage configuration specifies `vParquet3`, upgrade the write format before migrating.
+Refer to [Change the block format version](/docs/tempo/<TEMPO_VERSION>/configuration/parquet/#change-the-block-format-version).
 {{< /admonition >}}
 
 The migration path depends on your deployment mode:


### PR DESCRIPTION
**What this PR does**:

Minor updates to several doc pages for vParquet5 as default. These are minor additions to help with https://github.com/grafana/tempo/pull/7775. 

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)