### PR TITLE
chore(operations): suppress trufflehog false positive on live-store alert config field

### DIFF
--- a/.chloggen/fix-trufflehog-false-positive-live-store-alert.yaml
+++ b/.chloggen/fix-trufflehog-false-positive-live-store-alert.yaml
@@ -1,0 +1,25 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: change
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: operations
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Suppress a secret-scanner false positive on a config field name in the alerting mixin.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  The `live_store_partition_lag_warning_seconds` config field name in
+  operations/tempo-mixin/alerts.libsonnet was being flagged by automated secret
+  scanning as a possible Lob API key, since it happens to start with "live_".
+  No credential is present; this adds an inline ignore annotation.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: yvrhdn

--- a/operations/tempo-mixin/alerts.libsonnet
+++ b/operations/tempo-mixin/alerts.libsonnet
@@ -222,7 +222,7 @@
             alert: 'TempoLiveStorePartitionLagWarning',
             expr: |||
               max by (%s, partition, group) (avg_over_time(tempo_ingest_group_partition_lag_seconds{namespace=~"%s", container="%s"}[6m])) > %d
-            ||| % [$._config.group_by_cluster, $._config.namespace, $._config.jobs.live_store, $._config.alerts.live_store_partition_lag_warning_seconds],
+            ||| % [$._config.group_by_cluster, $._config.namespace, $._config.jobs.live_store, $._config.alerts.live_store_partition_lag_warning_seconds],  // trufflehog:ignore - config field name, not a credential
             'for': '5m',
             labels: {
               severity: 'warning',


### PR DESCRIPTION
**What this PR does**:
`operations/tempo-mixin/alerts.libsonnet`'s `live_store_partition_lag_warning_seconds` config field name was being flagged by TruffleHog secret scanning as a possible Lob API key, since Lob's live-mode key prefix is also `live_`. It's an ordinary Jsonnet config field name (used consistently alongside sibling fields like `live_store_partition_lag_critical_seconds`), not a credential.

Adds an inline `trufflehog:ignore` annotation on the flagged line (TruffleHog's ignore mechanism matches the literal substring regardless of the host language's comment syntax; `jsonnetfmt` normalized it to Jsonnet's canonical `//` comment style). Verified the compiled `alerts.yaml` output is byte-identical before and after this change.

**Which issue(s) this PR fixes**:
N/A — not tied to an open issue.

**Checklist**
- [ ] Tests updated (not applicable — no behavior change; verified compiled output is unchanged)
- [ ] Documentation added (not applicable)
- [x] Changelog entry added under `.chloggen/`

---
Conversation: https://app.warp.dev/conversation/ca04389f-29f8-4560-b4d6-931913b184f6
