### PR TITLE
fix(traceql): cache subtree analyses to avoid O(n^3) parsing

### DIFF
--- a/.chloggen/fix-traceql-long-arithmetic-chain-cubic.yaml
+++ b/.chloggen/fix-traceql-long-arithmetic-chain-cubic.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: traceql
+note: Cache subtree analyses in `newBinaryOperation` to avoid O(n^3) parsing of long arithmetic chains.
+issues: [7815]
+subtext: Long left-associative arithmetic chains (e.g. hundreds of thousands of `+` terms) previously re-walked the whole AST subtree for `referencesSpan`/`validate`/`impliedType` on every bottom-up reduction. The results are now cached per node, turning cubic parse time into quadratic.
+user: waterWang

--- a/pkg/traceql/ast.go
+++ b/pkg/traceql/ast.go
@@ -659,6 +659,17 @@ type BinaryOperation struct {
 	compiledExpressions []*regexp.Regexp
 
 	b branchOptimizer
+
+	// Cached results of the pure AST analyses below. The AST is immutable after
+	// construction (LHS/RHS are finalized in newBinaryOperation before any of
+	// these are first consulted), so each value is computed once and reused.
+	// Without caching, a long left-associative arithmetic chain re-walks the
+	// whole subtree for referencesSpan/impliedType/validate on every bottom-up
+	// reduction, yielding O(n^3) parse time (grafana/tempo#7815).
+	referencesSpanCache *bool
+	impliedTypeCache    *StaticType
+	validateCache       error
+	validateComputed    bool
 }
 
 func newBinaryOperation(op Operator, lhs, rhs FieldExpression) FieldExpression {
@@ -707,6 +718,14 @@ func normalizeTraceIDOperand(operand Static) Static {
 func (BinaryOperation) __fieldExpression() {}
 
 func (o *BinaryOperation) impliedType() StaticType {
+	if o.impliedTypeCache == nil {
+		t := o.computeImpliedType()
+		o.impliedTypeCache = &t
+	}
+	return *o.impliedTypeCache
+}
+
+func (o *BinaryOperation) computeImpliedType() StaticType {
 	if o.Op.isBoolean() {
 		return TypeBoolean
 	}
@@ -722,7 +741,11 @@ func (o *BinaryOperation) impliedType() StaticType {
 }
 
 func (o *BinaryOperation) referencesSpan() bool {
-	return o.LHS.referencesSpan() || o.RHS.referencesSpan()
+	if o.referencesSpanCache == nil {
+		v := o.LHS.referencesSpan() || o.RHS.referencesSpan()
+		o.referencesSpanCache = &v
+	}
+	return *o.referencesSpanCache
 }
 
 type UnaryOperation struct {

--- a/pkg/traceql/ast_validate.go
+++ b/pkg/traceql/ast_validate.go
@@ -197,6 +197,14 @@ func (f ScalarFilter) validate() error {
 }
 
 func (o *BinaryOperation) validate() error {
+	if !o.validateComputed {
+		o.validateComputed = true
+		o.validateCache = o.computeValidate()
+	}
+	return o.validateCache
+}
+
+func (o *BinaryOperation) computeValidate() error {
 	if err := o.LHS.validate(); err != nil {
 		return err
 	}

--- a/pkg/traceql/parse_long_chain_test.go
+++ b/pkg/traceql/parse_long_chain_test.go
@@ -1,0 +1,88 @@
+package traceql
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression test for grafana/tempo#7815.
+//
+// A long left-associative arithmetic chain used to parse in O(n^3) because
+// newBinaryOperation ran uncached whole-subtree walks (referencesSpan,
+// validate/impliedType) on every bottom-up reduction. At 4,000 terms the
+// unfixed parser took ~3.5 minutes.
+//
+// Two triggers are covered:
+//   - a chain that cannot be constant-folded because it contains a division by
+//     zero (exercises the validate + execute fold path), and
+//   - a chain whose leading operand references the span (exercises the
+//     referencesSpan-only path, since the fold is skipped for span-referencing
+//     expressions).
+//
+// The wall-clock bounds are deliberately generous to avoid CI flakiness. Under
+// the O(n^3) behavior these term counts would take many minutes to hours.
+func TestParseLongArithmeticChain(t *testing.T) {
+	cases := []struct {
+		name       string
+		query      string
+		maxSeconds float64
+	}{
+		{
+			name:       "unfoldable-constant-chain",
+			query:      "{1/0+" + strings.Repeat("1+", 7998) + "1}",
+			maxSeconds: 30,
+		},
+		{
+			name:       "span-referencing-chain",
+			query:      "{nestedSetLeft" + strings.Repeat("+1", 20000) + "}",
+			maxSeconds: 10,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			maxDuration := time.Duration(tc.maxSeconds * float64(time.Second))
+			start := time.Now()
+			expr, err := ParseNoOptimizations(tc.query)
+			elapsed := time.Since(start)
+
+			if err != nil {
+				t.Fatalf("ParseNoOptimizations returned error: %v", err)
+			}
+			if expr == nil {
+				t.Fatal("ParseNoOptimizations returned a nil expression")
+			}
+			if elapsed > maxDuration {
+				t.Fatalf("parsing %d bytes took %v (exceeds %v); O(n^3) regression",
+					len(tc.query), elapsed, maxDuration)
+			}
+			t.Logf("parsed %d bytes in %v", len(tc.query), elapsed)
+		})
+	}
+}
+
+func BenchmarkParseArithmeticChain(b *testing.B) {
+	sizes := []int{250, 500, 1000, 2000, 4000, 8000}
+	for _, n := range sizes {
+		q := "{1/0+" + strings.Repeat("1+", n-2) + "1}"
+		b.Run(itoa(n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = ParseNoOptimizations(q)
+			}
+		})
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

`newBinaryOperation` runs two uncached whole-subtree walks (`referencesSpan` and `validate`, which in turn calls `impliedType`) on every bottom-up reduction. For a long left-associative arithmetic chain this makes parsing **O(n^3)**: a 32 KiB query (a quarter of the default query-size limit) burned ~40 minutes of CPU on one core (grafana/tempo#7815).

This PR caches those pure AST analyses on the `BinaryOperation` node. Because the AST is immutable after construction (LHS/RHS are finalized in `newBinaryOperation` before the analyses are first consulted), each result is computed once and reused.

**Measured speedup** (parse of `{1/0+1+1+...+1}`, single core):

| terms | before | after |
| ---: | ---: | ---: |
| 500 | 385 ms | 10 ms |
| 1,000 | 3.3 s | 27 ms |
| 2,000 | 26 s | 109 ms |
| 4,000 | ~3.5 min | 447 ms |

The span-referencing variant (`{nestedSetLeft+1+1+...}`) drops from quadratic to ~linear and parses 20,000 terms in ~1.5s.

**Which issue(s) this PR fixes:**

Fixes #7815

**Special notes for your reviewer:**

- The caches are lazily computed and never invalidated; the AST is immutable after construction, and `execute`'s commutative LHS/RHS swap (ast_execute.go) does not change `referencesSpan`/`impliedType`/`validate` results.
- Includes a regression test covering both the unfoldable-constant chain and the span-referencing chain.
- Changelog entry added under `.chloggen/`.

**Checklist**

- [x] Tests updated
- [x] CHANGELOG entry added
- [x] `CHANGELOG.md` not touched directly
- [x] Documentation not needed