### PR TITLE
feat(query-frontend): add op label to queue duration metric

### DIFF
--- a/.chloggen/queue-duration-op-label.yaml
+++ b/.chloggen/queue-duration-op-label.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+
+component: query-frontend
+
+note: Add an `op` label to `tempo_query_frontend_queue_duration_seconds` so queue time can be broken down by query type
+
+issues: []
+
+subtext:
+
+user: zhxiaogg

--- a/modules/frontend/v1/frontend.go
+++ b/modules/frontend/v1/frontend.go
@@ -63,7 +63,7 @@ type Frontend struct {
 	queueLength       *prometheus.GaugeVec
 	discardedRequests *prometheus.CounterVec
 	numClients        prometheus.GaugeFunc
-	queueDuration     prometheus.Histogram
+	queueDuration     *prometheus.HistogramVec
 	actualBatchSize   prometheus.Histogram
 	batchWeight       *prometheus.HistogramVec
 }
@@ -83,6 +83,16 @@ func (r *request) Weight() int {
 
 func (r *request) OriginalContext() context.Context {
 	return r.request.Context()
+}
+
+// queryOp returns the query type used to label queue metrics. Every pipeline
+// stamps a shape via the weight middleware before sharding, so this is only
+// empty for requests built outside a pipeline.
+func queryOp(req pipeline.Request) string {
+	if t := req.QueryShape().Type; t != "" {
+		return t
+	}
+	return "unknown"
 }
 
 // New creates a new frontend. Frontend implements service, and must be started and stopped.
@@ -112,14 +122,14 @@ func New(cfg Config, log log.Logger, registerer prometheus.Registerer) (*Fronten
 			Name: "tempo_query_frontend_discarded_requests_total",
 			Help: "Total number of query requests discarded.",
 		}, []string{"user"}),
-		queueDuration: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
+		queueDuration: promauto.With(registerer).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "tempo_query_frontend_queue_duration_seconds",
 			Help:                            "Time spend by requests queued.",
 			Buckets:                         prometheus.DefBuckets,
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 1 * time.Hour,
-		}),
+		}, []string{"op"}),
 		actualBatchSize: promauto.With(registerer).NewHistogram(prometheus.HistogramOpts{
 			Name:                            "tempo_query_frontend_actual_batch_size",
 			Help:                            "Batch size.",
@@ -241,7 +251,7 @@ func (f *Frontend) Process(server frontendv1pb.Frontend_ProcessServer) error {
 		for _, reqWrapper := range reqSlice {
 			req := reqWrapper.(*request)
 
-			f.queueDuration.Observe(time.Since(req.enqueueTime).Seconds())
+			f.queueDuration.WithLabelValues(queryOp(req.request)).Observe(time.Since(req.enqueueTime).Seconds())
 			req.queueSpan.End()
 
 			// only add if not expired

--- a/modules/frontend/v1/frontend_test.go
+++ b/modules/frontend/v1/frontend_test.go
@@ -122,3 +122,35 @@ func TestProcessRequestBatchReuseRace(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.GreaterOrEqual(t, srv.served, totalRequests)
 }
+
+func TestQueryOp(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		shape    pipeline.QueryShape
+		expected string
+	}{
+		{"traces", pipeline.QueryShape{Type: pipeline.QueryTypeTraces}, "traces"},
+		{"search", pipeline.QueryShape{Type: pipeline.QueryTypeSearch}, "search"},
+		{"metrics", pipeline.QueryShape{Type: pipeline.QueryTypeMetrics}, "metrics"},
+		{"metadata", pipeline.QueryShape{Type: pipeline.QueryTypeMetadata}, "metadata"},
+		{"unstamped", pipeline.QueryShape{}, "unknown"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := pipeline.NewHTTPRequest(httptest.NewRequest("GET", "/", nil))
+			req.SetQueryShape(tc.shape)
+
+			require.Equal(t, tc.expected, queryOp(req))
+		})
+	}
+}
+
+// TestQueryOpSurvivesSharding asserts the shape stamped on the parent request is
+// carried onto the sharded subrequests that are actually enqueued.
+func TestQueryOpSurvivesSharding(t *testing.T) {
+	parent := pipeline.NewHTTPRequest(httptest.NewRequest("GET", "/", nil))
+	parent.SetQueryShape(pipeline.QueryShape{Type: pipeline.QueryTypeSearch})
+
+	sub := parent.CloneFromHTTPRequest(httptest.NewRequest("GET", "/shard", nil))
+
+	require.Equal(t, "search", queryOp(sub))
+}


### PR DESCRIPTION
**What this PR does**:

Adds an `op` label to `tempo_query_frontend_queue_duration_seconds` so queue time can be broken down by query type. Values match the existing `op` label on `tempo_query_frontend_queries_total`: `traces`, `search`, `metrics`, `metadata`.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)
