### PR TITLE
fix(traceql): bound Labels.MapKey writes into SeriesMapKey

### DIFF
--- a/.chloggen/traceql-series-map-key-bounds.yaml
+++ b/.chloggen/traceql-series-map-key-bounds.yaml
@@ -1,0 +1,10 @@
+change_type: enhancement
+component: traceql
+note: Hardens TraceQL metrics queries so a series carrying more labels than the series key can hold degrades instead of crashing the querier.
+issues: []
+subtext: |
+  `Labels.MapKey` wrote into a fixed-size array without a bounds check, so any series
+  exceeding the key capacity panicked the querier mid-query. Query validation already
+  caps `by()` clauses so this is unreachable, but the invariant is enforced in several
+  places and a single gap crashed queriers in the past (#7831).
+user: stephaniehingtgen

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -326,6 +326,13 @@ func (ls Labels) MapKey() SeriesMapKey {
 		if l.Name == model.MetricNameLabel {
 			continue
 		}
+		if i == len(key) {
+			// Unreachable: MetricsAggregate.validate caps by() clauses so the group-by
+			// labels plus the reserved internal label always fit. Guarded anyway because
+			// a querier must not crash on a series that slips past validation; dropping
+			// the overflow can only merge series in a query that was already invalid.
+			break
+		}
 		key[i] = SeriesMapLabel{Name: l.Name, Value: l.Value.MapKey()}
 		i++
 	}

--- a/pkg/traceql/engine_metrics_test.go
+++ b/pkg/traceql/engine_metrics_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	commonv1proto "github.com/grafana/tempo/pkg/tempopb/common/v1"
 	"github.com/grafana/tempo/pkg/util"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1770,6 +1771,82 @@ func TestMetricsMathGroupByBoundary(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestLabelsMapKeyBounds checks MapKey never writes past the end of SeriesMapKey.
+// Query validation caps by() clauses so the overflow cases here are unreachable in
+// practice, but MapKey runs on every series in a querier and must not panic.
+func TestLabelsMapKeyBounds(t *testing.T) {
+	// labels builds n distinct labels, prefixed by the given names.
+	labels := func(n int, prefix ...string) Labels {
+		out := make(Labels, 0, n+len(prefix))
+		for _, p := range prefix {
+			out = append(out, Label{Name: p, Value: NewStaticString(p)})
+		}
+		for i := range n {
+			name := fmt.Sprintf("span.attr%d", i)
+			out = append(out, Label{Name: name, Value: NewStaticString(name)})
+		}
+		return out
+	}
+
+	tcs := []struct {
+		name string
+		in   Labels
+		want int // number of labels expected to occupy a slot in the key
+	}{
+		{"empty", nil, 0},
+		{"under the max", labels(maxSeriesMapKeyLabels - 1), maxSeriesMapKeyLabels - 1},
+		{"at the max", labels(maxSeriesMapKeyLabels), maxSeriesMapKeyLabels},
+		{"one over the max", labels(maxSeriesMapKeyLabels + 1), maxSeriesMapKeyLabels},
+		{"far over the max", labels(maxSeriesMapKeyLabels * 3), maxSeriesMapKeyLabels},
+		// __name__ is skipped, so it must not consume a slot.
+		{"at the max plus __name__", labels(maxSeriesMapKeyLabels, model.MetricNameLabel), maxSeriesMapKeyLabels},
+		{"over the max plus __name__", labels(maxSeriesMapKeyLabels+1, model.MetricNameLabel), maxSeriesMapKeyLabels},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var key SeriesMapKey
+			require.NotPanics(t, func() {
+				key = tc.in.MapKey()
+			}, "MapKey must not panic on %d labels", len(tc.in))
+
+			var got int
+			for _, l := range key {
+				if l.Name != "" {
+					got++
+				}
+			}
+			require.Equal(t, tc.want, got, "occupied slots in the key")
+
+			// Labels that do fit are recorded in order, and __name__ is never recorded.
+			for i := 0; i < tc.want; i++ {
+				require.NotEqual(t, model.MetricNameLabel, key[i].Name)
+				require.Equal(t, fmt.Sprintf("span.attr%d", i), key[i].Name)
+			}
+		})
+	}
+}
+
+// TestLabelsMapKeyDistinguishesSeries checks that series differing only within the
+// key's capacity still map to distinct keys.
+func TestLabelsMapKeyDistinguishesSeries(t *testing.T) {
+	base := make(Labels, 0, maxSeriesMapKeyLabels)
+	for i := range maxSeriesMapKeyLabels {
+		base = append(base, Label{Name: fmt.Sprintf("span.attr%d", i), Value: NewStaticString("a")})
+	}
+
+	seen := map[SeriesMapKey]struct{}{}
+	for i := range maxSeriesMapKeyLabels {
+		other := make(Labels, len(base))
+		copy(other, base)
+		other[i] = Label{Name: other[i].Name, Value: NewStaticString("b")}
+		seen[other.MapKey()] = struct{}{}
+	}
+	seen[base.MapKey()] = struct{}{}
+
+	require.Len(t, seen, maxSeriesMapKeyLabels+1, "each distinct series must get its own key")
 }
 
 func TestCountOverTimeInstantNs(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What this PR does**:

Adds a bounds guard to `Labels.MapKey` so it can no longer write past the end of the fixed-size `SeriesMapKey` array.

This came out of investigating a production panic reported against the `weekly-r266` build:

```
panic: runtime error: index out of range [5] with length 5
  pkg/traceql/engine_metrics.go:329   (Labels.MapKey)
  pkg/traceql/engine_metrics.go:1447  (batchMetricsEvaluator.Results)
  modules/querier/querier_query_range.go:136
```

### Root cause of the reported panic (already fixed on main)

`SeriesMapKey` was `[maxGroupBys]SeriesMapLabel`, i.e. exactly 5 slots. `batchMetricsEvaluator.Results` appends a `__query_fragment` label to each sub-query's series when a query is one arm of a math expression. A sub-query using all 5 permitted group-by attributes therefore produced 6 labels, and `MapKey` wrote index 5 into a 5-element array.

That defect was **already fixed on `main`** by c64f0ee52 (#7831), which sized the array as `maxGroupBys + 1` to reserve a slot for the internal label. The latent bug was introduced by b48101988 (#6866, "Support Math in TraceQL Metrics"), which added `__query_fragment` without widening the key. The `r266` release branch contains #6866 but not the fix, which is why the `weekly-r266` build still panics — **it needs a backport of #7831**, which is outside the scope of this PR.

### What this PR adds on top of that

The capacity invariant is real but implicit, and it is enforced in several places away from the array it protects — `MetricsAggregate.validate` reserves a slot for `__bucket`, `avgOverTimeSeriesAggregator` reserves one for `__meta_type`, and `batchMetricsEvaluator.Results` relies on the `+ 1`. A single gap in that chain already crashed queriers once. Since `MapKey` runs on every series in a querier, a gap costs the whole process rather than one query, which conflicts with the repo's "do not panic in production server or library code" standard.

The guard makes an unexpected label count degrade to merged series instead of a crash. Reachable behavior is unchanged, and I verified the guard alone is sufficient to stop the reported panic: with the array temporarily reverted to the r266 size of `maxGroupBys`, `TestMetricsMathGroupByBoundary` passes rather than panicking.

**Which issue(s) this PR fixes**:

N/A — follow-up hardening for the code path in #7831.

**Checklist**
- [x] Tests updated — `TestLabelsMapKeyBounds` covers empty, at-max, over-max and `__name__`-skipping inputs and fails with the exact `index out of range` panic at `engine_metrics.go:329` without the guard; `TestLabelsMapKeyDistinguishesSeries` pins that series differing within the key's capacity still get distinct keys, so the guard cannot silently collapse valid series.
- [ ] Documentation added — n/a, no user-facing behavior change.
- [x] Changelog entry added under `.chloggen/` — `traceql-series-map-key-bounds.yaml` (`enhancement`, since no reachable bug on `main` changes behavior).

### Verification

- `go test ./pkg/traceql/... -race` passes.
- `golangci-lint run --new-from-rev=origin/main` reports 0 issues.
- `gofumpt`/`gofmt` clean; `make chlog-validate` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c29178be-c79f-4a9e-8559-a09151e44b48?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c29178be-c79f-4a9e-8559-a09151e44b48&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

