### PR TITLE
Reject an out-of-range ingester sequence number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- next version -->
-* [BUGFIX] Reject an ingester sequence number that does not fit a partition ID instead of wrapping it [#7852](https://github.com/grafana/tempo/pull/7852) (@arpitjain099)
+* [BUGFIX] Reject an ingester sequence number that does not fit a partition ID instead of wrapping it [#7851](https://github.com/grafana/tempo/pull/7851) (@arpitjain099)
 
 # v3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- next version -->
+* [BUGFIX] Reject an ingester sequence number that does not fit a partition ID instead of wrapping it [#7852](https://github.com/grafana/tempo/pull/7852) (@arpitjain099)
 
 # v3.0.2
 

--- a/pkg/ingest/util.go
+++ b/pkg/ingest/util.go
@@ -31,8 +31,10 @@ func IngesterPartitionID(ingesterID string) (int32, error) {
 		return 0, fmt.Errorf("ingester ID %s doesn't match regular expression %q", ingesterID, ingesterIDRegexp.String())
 	}
 
-	// Parse the ingester sequence number.
-	ingesterSeq, err := strconv.Atoi(match[1])
+	// Parse the ingester sequence number. Parsing straight into 32 bits keeps a
+	// sequence number that cannot be a partition ID an error, rather than
+	// wrapping it into some other partition on the conversion below.
+	ingesterSeq, err := strconv.ParseInt(match[1], 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("no ingester sequence number in ingester ID %s", ingesterID)
 	}

--- a/pkg/ingest/util_test.go
+++ b/pkg/ingest/util_test.go
@@ -37,3 +37,34 @@ func TestHandleKafkaError(t *testing.T) {
 		require.Equal(t, test.expectedRefresh, refreshCalled, "HandleKafkaError(%v) refresh function call mismatch", test.err)
 	}
 }
+
+func TestIngesterPartitionID(t *testing.T) {
+	tests := []struct {
+		ingesterID  string
+		expected    int32
+		expectedErr bool
+	}{
+		{ingesterID: "ingester-0", expected: 0},
+		{ingesterID: "ingester-1", expected: 1},
+		{ingesterID: "ingester-zone-a-2", expected: 2},
+		{ingesterID: "ingester-2147483647", expected: 2147483647},
+		// Past what a partition ID can hold: this used to wrap round to
+		// -2147483648 and address a different partition.
+		{ingesterID: "ingester-2147483648", expectedErr: true},
+		{ingesterID: "ingester-9223372036854775808", expectedErr: true},
+		{ingesterID: "ingester", expectedErr: true},
+		{ingesterID: "ingester-abc", expectedErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.ingesterID, func(t *testing.T) {
+			actual, err := IngesterPartitionID(test.ingesterID)
+			if test.expectedErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does:**

Fixes #7850.

`IngesterPartitionID` parses the sequence number with `strconv.Atoi` and then converts to `int32`. On a 64-bit build `Atoi` returns a 64-bit `int`, so a sequence number above `math.MaxInt32` converts silently: `ingester-2147483648` comes back as partition `-2147483648` rather than an error, and both callers (`modules/livestore` and `modules/blockbuilder`) take that as the partition they own.

Parsing with `strconv.ParseInt(match[1], 10, 32)` keeps the same error path and makes the out-of-range case an error instead of a wrap. Nothing else changes: the regexp, the error text and the return type are as they were.

`TestIngesterPartitionID` covers the ordinary IDs, a zone-suffixed one, `MaxInt32` exactly, and the two out-of-range shapes. The `ingester-2147483648` case fails on main with "An error is expected but got nil".

`go test ./pkg/ingest/` passes and `go vet` is clean.

**Which issue(s) this PR fixes:**

Fixes #7850

**Checklist**
- [x] Tests updated
- [x] `CHANGELOG.md` updated - the section is `main / unreleased`
