### PR TITLE
feat: metrics-generator identifier in metrics defaults to ring identity

### DIFF
--- a/.chloggen/dv-metrics-generator-id.yaml
+++ b/.chloggen/dv-metrics-generator-id.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+component: metrics-generator
+note: Use the configured ring identity for the `__metrics_gen_instance` label to prevent time-series collisions when metrics-generator is deployed within Tempo cluster as multiple Statefulsets.
+issues: []
+subtext: |
+  During rollout, series using the old hostname identity and the new ring identity can coexist until the registry staleness interval expires, potentially causing temporary double-counting.
+user: david-vavra

--- a/docs/sources/tempo/reference-tempo-architecture/components/metrics-generator.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/metrics-generator.md
@@ -98,6 +98,12 @@ prometheus_remote_storage_samples_failed_total
 prometheus_remote_storage_samples_dropped_total
 ```
 
+Every generated series includes the `__metrics_gen_instance` label. Its value is the
+metrics-generator ring identity configured by `metrics_generator.ring.instance_id`,
+which defaults to the hostname. Configure a globally unique ring identity for every
+metrics-generator that writes to the same remote-write endpoint. Reusing an identity
+causes independent generators to write different samples to the same series.
+
 ## Related resources
 
 Refer to the [metrics-generator documentation](https://grafana.com/docs/tempo/<TEMPO_VERSION>/metrics-from-traces/metrics-generator/) for configuration and usage details.

--- a/modules/generator/instance.go
+++ b/modules/generator/instance.go
@@ -95,6 +95,9 @@ type instance struct {
 func newInstance(cfg *Config, instanceID string, overrides metricsGeneratorOverrides, wal storage.Storage, logger log.Logger) (*instance, error) {
 	logger = log.With(logger, "tenant", instanceID)
 
+	registryConfig := cfg.Registry
+	registryConfig.GeneratorInstanceID = cfg.Ring.InstanceID
+
 	limitLogger := tempo_log.NewRateLimitedLogger(1, level.Warn(logger))
 	var limiter registry.Limiter
 	switch cfg.LimiterType {
@@ -111,7 +114,7 @@ func newInstance(cfg *Config, instanceID string, overrides metricsGeneratorOverr
 		instanceID: instanceID,
 		overrides:  overrides,
 
-		registry: registry.New(&cfg.Registry, overrides, instanceID, wal, logger, limiter),
+		registry: registry.New(&registryConfig, overrides, instanceID, wal, logger, limiter),
 		wal:      wal,
 
 		processors: make(map[string]processor.Processor),

--- a/modules/generator/registry/config.go
+++ b/modules/generator/registry/config.go
@@ -6,6 +6,9 @@ import (
 )
 
 type Config struct {
+	// GeneratorInstanceID is injected from the metrics-generator ring configuration.
+	GeneratorInstanceID string `yaml:"-"`
+
 	// CollectionInterval controls how often to collect metrics.
 	// Defaults to 15s.
 	CollectionInterval time.Duration `yaml:"collection_interval"`

--- a/modules/generator/registry/registry.go
+++ b/modules/generator/registry/registry.go
@@ -150,8 +150,11 @@ func New(cfg *Config, overrides Overrides, tenant string, appendable storage.App
 	for k, v := range cfg.ExternalLabels {
 		externalLabels[k] = v
 	}
-	hostname, _ := os.Hostname()
-	externalLabels["__metrics_gen_instance"] = hostname
+	generatorInstanceID := cfg.GeneratorInstanceID
+	if generatorInstanceID == "" {
+		generatorInstanceID, _ = os.Hostname()
+	}
+	externalLabels["__metrics_gen_instance"] = generatorInstanceID
 
 	if cfg.InjectTenantIDAs != "" {
 		externalLabels[cfg.InjectTenantIDAs] = tenant

--- a/modules/generator/registry/registry_test.go
+++ b/modules/generator/registry/registry_test.go
@@ -207,6 +207,7 @@ func TestManagedRegistry_externalLabels(t *testing.T) {
 	appender := &capturingAppender{}
 
 	cfg := &Config{
+		GeneratorInstanceID: "ring-instance",
 		ExternalLabels: map[string]string{
 			"__foo": "bar",
 		},
@@ -218,8 +219,8 @@ func TestManagedRegistry_externalLabels(t *testing.T) {
 	counter.Inc(labels.New(), 1.0)
 
 	expectedSamples := []sample{
-		newSample(map[string]string{"__name__": "my_counter", "__metrics_gen_instance": mustGetHostname(), "__foo": "bar"}, 0, 0),
-		newSample(map[string]string{"__name__": "my_counter", "__metrics_gen_instance": mustGetHostname(), "__foo": "bar"}, 0, 1),
+		newSample(map[string]string{"__name__": "my_counter", "__metrics_gen_instance": "ring-instance", "__foo": "bar"}, 0, 0),
+		newSample(map[string]string{"__name__": "my_counter", "__metrics_gen_instance": "ring-instance", "__foo": "bar"}, 0, 1),
 	}
 	collectRegistryMetricsAndAssert(t, registry, appender, expectedSamples)
 }


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
fix proposal for https://github.com/grafana/tempo/issues/7853

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)