### PR TITLE
fix(live-store): cap live trace slice capacity in FindByTraceID

### DIFF
--- a/.chloggen/fix-livestore-find-trace-by-id-slice-race.yaml
+++ b/.chloggen/fix-livestore-find-trace-by-id-slice-race.yaml
@@ -1,0 +1,10 @@
+change_type: bug_fix
+component: live-store
+note: Fix a panic in live-store `FindTraceByID` when more spans for the trace arrive while it is being combined with block data and marshalled.
+issues: []
+subtext: |
+  The live trace's `Batches` slice was handed to the trace combiner with spare capacity, so the
+  combiner's append and the push path's append wrote different batches into the same slot of the
+  live trace's backing array. `Size()` and `Marshal()` then saw different objects and marshalling
+  panicked with `slice bounds out of range`.
+user: KR-Ravindra

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -678,7 +678,9 @@ func (i *instance) FindByTraceID(ctx context.Context, traceID []byte, allowParti
 	i.liveTracesMtx.Lock()
 	if liveTrace, ok := i.liveTraces.Traces[util.HashForTraceID(traceID)]; ok {
 		tempTrace := &tempopb.Trace{}
-		tempTrace.ResourceSpans = liveTrace.Batches
+		// Cap the capacity so the combiner's appends reallocate instead of writing
+		// into the live trace's backing array, which the push path keeps appending to.
+		tempTrace.ResourceSpans = liveTrace.Batches[:len(liveTrace.Batches):len(liveTrace.Batches)]
 		// Previously there was some logic here to add inspected bytes in the ingester. But its hard to do with the different
 		// live traces format and feels inaccurate.
 		_, err := combiner.Consume(tempTrace)

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1202,6 +1203,55 @@ func TestInstanceFindByTraceID(t *testing.T) {
 
 	err = services.StopAndAwaitTerminated(t.Context(), ls)
 	require.NoError(t, err)
+}
+
+func TestInstanceFindByTraceIDDoesNotShareLiveTraceBackingArray(t *testing.T) {
+	i, ls := defaultInstanceAndTmpDir(t)
+	defer func() {
+		err := services.StopAndAwaitTerminated(t.Context(), ls)
+		require.NoError(t, err)
+	}()
+
+	id := test.ValidTraceID(nil)
+	now := time.Now()
+	push := func(batches int) {
+		traceBytes, err := test.MakeTrace(batches, id).Marshal()
+		require.NoError(t, err)
+		i.pushBytes(t.Context(), now, &tempopb.PushBytesRequest{
+			Traces: []tempopb.PreallocBytes{{Slice: traceBytes}},
+			Ids:    [][]byte{id},
+		})
+	}
+
+	// Part of the trace is already in the head block ...
+	push(1)
+	drained, err := i.cutIdleTraces(t.Context(), true)
+	require.NoError(t, err)
+	require.True(t, drained)
+
+	// ... and the rest is still live, with spare capacity in Batches.
+	push(3)
+	i.liveTracesMtx.Lock()
+	liveTrace := i.liveTraces.Traces[util.HashForTraceID(id)]
+	i.liveTracesMtx.Unlock()
+	require.NotNil(t, liveTrace)
+	require.Len(t, liveTrace.Batches, 3)
+	require.Greater(t, cap(liveTrace.Batches), len(liveTrace.Batches))
+
+	resp, err := i.FindByTraceID(t.Context(), id, true)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Trace)
+	require.Len(t, resp.Trace.ResourceSpans, 4)
+	batches := slices.Clone(resp.Trace.ResourceSpans)
+	size := resp.Trace.Size()
+
+	// More spans for the same trace arrive after the lookup. The response must not
+	// change, otherwise Size() and Marshal() disagree and marshalling panics.
+	push(1)
+	for n, batch := range batches {
+		require.Same(t, batch, resp.Trace.ResourceSpans[n])
+	}
+	require.Equal(t, size, resp.Trace.Size())
 }
 
 func TestInstanceFindByTraceIDWithSizeLimits(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

The live-store can panic while marshalling a `TraceByIDResponse`:

```
panic: runtime error: slice bounds out of range [-639:]
github.com/grafana/tempo/pkg/tempopb/common/v1.(*AnyValue).MarshalToSizedBuffer
...
github.com/grafana/tempo/pkg/tempopb.(*TraceByIDResponse).MarshalToSizedBuffer
github.com/gogo/protobuf/proto.Marshal
```

gogo's `Marshal` calls `Size()` and then `MarshalToSizedBuffer()` on the same object, so the panic means the response changed between the two calls: it still aliased memory that another goroutine was writing to.

Mechanism (as described in #6958): `FindByTraceID` ([`modules/livestore/instance_search.go#L681`](https://github.com/grafana/tempo/blob/bf9dbd054/modules/livestore/instance_search.go#L681)) hands the live trace to the combiner as `tempTrace.ResourceSpans = liveTrace.Batches`, a slice header that normally has spare capacity because the push path grows it with `append` ([`pkg/livetraces/livetraces.go#L116`](https://github.com/grafana/tempo/blob/bf9dbd054/pkg/livetraces/livetraces.go#L116)). The combiner keeps that trace as its result ([`pkg/model/trace/combine.go#L66`](https://github.com/grafana/tempo/blob/bf9dbd054/pkg/model/trace/combine.go#L66)) and, when the same trace is also found in the head/WAL/complete blocks, appends the block's batches to it ([`combine.go#L124`](https://github.com/grafana/tempo/blob/bf9dbd054/pkg/model/trace/combine.go#L124)). That append lands in the live trace's spare capacity, while the push path, under `liveTracesMtx`, appends the next incoming batch into the same slot. `Size()` and `MarshalToSizedBuffer()` can then see different `*ResourceSpans` in that slot and the buffer arithmetic goes negative.

Fix: hand the combiner `liveTrace.Batches[:len:len]` so its first append reallocates and the response never aliases the live trace's spare capacity. The batch objects themselves are shared as before; only the slice header changes, and there is no copy on the query path.

`writeHeadBlock` ([`modules/livestore/instance.go#L436`](https://github.com/grafana/tempo/blob/bf9dbd054/modules/livestore/instance.go#L436)) also wraps `liveTrace.Batches` in a `tempopb.Trace`. It is left unchanged because `CutIdle` has already removed the trace from `liveTraces.Traces` under the mutex by then, so no push can append to it, and `AppendTrace` only reads it. The issue text and the earlier attempts capped that slice too; I can add the one line for symmetry if you prefer.

Test: `TestInstanceFindByTraceIDDoesNotShareLiveTraceBackingArray` in `modules/livestore/instance_search_test.go`. One batch of a trace is cut to the head block, three more are pushed and stay live (`len 3, cap 4`), `FindByTraceID` combines both sources, then one more batch is pushed for the same trace. The test asserts the returned trace's batch pointers and `Size()` are unchanged by the later push. Without the fix it fails deterministically (the pushed batch overwrites the block's batch in the response, `require.Same` fails); with the fix it passes, also under `-race`. Locally `go test -count=1 ./modules/livestore/` passes, and `gofumpt`, `goimports`, `go vet`, `golangci-lint run --new-from-rev=upstream/main ./modules/livestore/...` and `make chlog-validate` report nothing. CI has not run on this PR yet.

Earlier PRs for this issue, #6964 and #6968, were closed without merging; #7116 (query-frontend guards) was also closed unmerged.

AI disclosure: Claude Code, operated by KR-Ravindra, was used to draft the fix, the regression test, the changelog entry and this description. KR-Ravindra reviewed the change and the test results.

**Which issue(s) this PR fixes**:
Fixes #6958

**Checklist**
- [x] Tests updated
- [ ] Documentation added (not needed: bug fix, no user-facing change)
- [x] Changelog entry added under `.chloggen/` (`fix-livestore-find-trace-by-id-slice-race.yaml`, `bug_fix` / `live-store`)
