### PR TITLE
Enforce vParquet3 deprecation for writes and compaction

### DIFF
--- a/.chloggen/deprecate-vparquet3-writes.yaml
+++ b/.chloggen/deprecate-vparquet3-writes.yaml
@@ -1,0 +1,20 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: breaking
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: storage
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Enforce the vParquet3 deprecation. Tempo now refuses to start with `storage.trace.block.version` set to `vParquet3`, and the compactor no longer compacts existing vParquet3 blocks together.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  Existing vParquet3 blocks remain readable and are left as-is. Set the block version to
+  vParquet4 or later.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: mdisibio

--- a/tempodb/blockselector/compaction_block_selector_test.go
+++ b/tempodb/blockselector/compaction_block_selector_test.go
@@ -652,7 +652,7 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				{
 					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
-					Version: "vParquet3",
+					Version: "vParquet4",
 				},
 				{
 					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000003"),
@@ -662,19 +662,19 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 				{
 					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000004"),
 					EndTime: now,
-					Version: "vParquet3",
+					Version: "vParquet4",
 				},
 			},
 			expected: []*backend.BlockMeta{
 				{
 					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
-					Version: "vParquet3",
+					Version: "vParquet4",
 				},
 				{
 					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000004"),
 					EndTime: now,
-					Version: "vParquet3",
+					Version: "vParquet4",
 				},
 			},
 			expectedHash: fmt.Sprintf("%v-%v-%v-%v", tenantID, 0, now.Unix(), 0),
@@ -822,6 +822,25 @@ func TestTimeWindowBlockSelectorBlocksToCompact(t *testing.T) {
 					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000002"),
 					EndTime: now,
 					Version: "preview1",
+				},
+			},
+			expected:       nil,
+			expectedHash:   "",
+			expectedSecond: nil,
+			expectedHash2:  "",
+		},
+		{
+			name: "deprecated vParquet3 blocks are ignored for compaction",
+			blocklist: []*backend.BlockMeta{
+				{
+					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000001"),
+					EndTime: now,
+					Version: "vParquet3",
+				},
+				{
+					BlockID: backend.MustParse("00000000-0000-0000-0000-000000000002"),
+					EndTime: now,
+					Version: "vParquet3",
 				},
 			},
 			expected:       nil,

--- a/tempodb/config_test.go
+++ b/tempodb/config_test.go
@@ -160,6 +160,17 @@ func TestDeprecatedVersions(t *testing.T) {
 			},
 			err: "vParquet5-preview1 is not a valid block version for creating blocks",
 		},
+		{
+			cfg: &Config{
+				WAL: &wal.Config{},
+				Block: &common.BlockConfig{
+					BloomFP:             0.01,
+					BloomShardSizeBytes: 1,
+					Version:             "vParquet3",
+				},
+			},
+			err: "vParquet3 is not a valid block version for creating blocks",
+		},
 	}
 
 	for _, test := range tests {

--- a/tempodb/encoding/vparquet3/encoding.go
+++ b/tempodb/encoding/vparquet3/encoding.go
@@ -21,12 +21,16 @@ func (v Encoding) NewCompactor(opts common.CompactionOptions) common.Compactor {
 	return NewCompactor(opts)
 }
 
+// CompactionSupported returns false because vParquet3 is deprecated. Existing
+// vParquet3 blocks are left as-is and are not compacted with each other.
 func (v Encoding) CompactionSupported() bool {
-	return true
+	return false
 }
 
+// WritesSupported returns false because vParquet3 is deprecated and read-only.
+// Existing vParquet3 blocks remain readable.
 func (v Encoding) WritesSupported() bool {
-	return true
+	return false
 }
 
 func (v Encoding) OpenBlock(meta *backend.BlockMeta, r backend.Reader) (common.BackendBlock, error) {


### PR DESCRIPTION
**What this PR does**:
vParquet3 has been documented as deprecated since Tempo 2.10/3.0, but nothing in code enforced it. This flips `WritesSupported()`/`CompactionSupported()` to `false` for vParquet3, so:
- Tempo refuses to start if configured to write vParquet3 blocks.
- The compactor no longer compacts existing vParquet3 blocks together.
- Reads of existing vParquet3 blocks are unaffected.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [x] Changelog entry added under `.chloggen/`