### PR TITLE
doc: Update vP3 note for Block format in 3.0 docs

### DIFF
--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -24,7 +24,7 @@ As soon as a block format version is enabled, Tempo starts writing data in that 
 {{< admonition type="warning" >}}
 The v2 block format has been removed in Tempo 3.0.
 vParquet3 is deprecated.
-Tempo 3.x still reads existing vParquet3 blocks. Write new blocks in vParquet5 (default) or vParquet4.
+Tempo 3.x still reads existing vParquet3 blocks. Write new blocks in vParquet5 or vParquet4.
 {{< /admonition >}}
 
 Only Parquet-based formats are supported.

--- a/docs/sources/tempo/configuration/parquet.md
+++ b/docs/sources/tempo/configuration/parquet.md
@@ -22,13 +22,14 @@ As soon as a block format version is enabled, Tempo starts writing data in that 
 ## Block format versions
 
 {{< admonition type="warning" >}}
-The `v2` and `vParquet3` block formats have been removed in Tempo 3.0.
-Use `vParquet4` (default) or `vParquet5`. 
+The v2 block format has been removed in Tempo 3.0.
+vParquet3 is deprecated.
+Tempo 3.x still reads existing vParquet3 blocks. Write new blocks in vParquet5 (default) or vParquet4.
 {{< /admonition >}}
 
-Only Parquet-based formats are supported. 
+Only Parquet-based formats are supported.
 
-### vParquet4 
+### vParquet4
 
 The default block format is `vParquet4`.
 


### PR DESCRIPTION
**What this PR does**:

Correct the block format versions admonition to note that vParquet3 is deprecated and not removed. This was missed in the doc updates from 3.0 doc updates. 

This change is already made in main. This PR corrects the statement in the 3.0 branch.

Thanks to @tiffanyfay for finding this issue. 

**Checklist**
- [ ] Tests updated
- [X] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)