### PR TITLE
docs: reference Adaptive Traces in tail sampling doc

### DIFF
--- a/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
+++ b/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
@@ -31,9 +31,10 @@ Tail sampling is more complex to configure, implement, and maintain but is the r
 
 You can use sampling with Tempo using Grafana or Grafana Cloud.
 
-{{< admonition type="tip" >}}
-If you send traces to Grafana Cloud Traces, you can use [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) instead of building and operating your own tail sampling pipeline. Adaptive Traces is a managed tail sampling capability that analyzes your trace data, recommends sampling policies (for example, keep traces with errors or high latency), and applies them for you.
-{{< /admonition >}}
+
+If you send traces to Grafana Cloud Traces, you can use [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) instead of building and operating your own tail sampling pipeline. 
+Adaptive Traces is a managed tail sampling capability that analyzes your trace data, recommends sampling policies (for example, keep traces with errors or high latency), and applies them for you.
+Adaptive Traces can also generate metrics from all received traces.
 
 ![Tail sampling overview and components with Tempo, Alloy, and Grafana](/media/docs/tempo/sampling/tempo-tail-based-sampling.svg)
 

--- a/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
+++ b/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
@@ -167,9 +167,9 @@ This can have an effect on observation of data inside Grafana.
 
 The following is a suggested pipeline that can be applied to both [Grafana Alloy](https://grafana.com/docs/alloy/latest/) and the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), to carry out tail sampling, but also ensure that other telemetry signals are still captured for observation from within Grafana and Grafana Cloud.
 
-{{< admonition type="note" >}}
-This section describes how to build and operate this pipeline yourself. If you send traces to Grafana Cloud Traces, [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) provides equivalent tail sampling as a managed feature, without requiring you to deploy and maintain a two-layer collector pipeline.
-{{< /admonition >}}
+This section describes how to build and operate this pipeline yourself. 
+If you send traces to Grafana Cloud Traces, [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) provides equivalent tail sampling as a managed feature, without requiring you to deploy and maintain a two-layer collector pipeline.
+Adaptive Traces can also generate metrics from all received traces.
 
 This pipeline exists in the second layer of collectors, sent data by the load balancing layer, and is commonly deployed as a Kubernetes `StatefulSet` to ensure that each instance has a consistent identity. A realistic example pipeline could be made of up the following components:
 

--- a/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
+++ b/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
@@ -32,9 +32,11 @@ Tail sampling is more complex to configure, implement, and maintain but is the r
 You can use sampling with Tempo using Grafana or Grafana Cloud.
 
 
-If you send traces to Grafana Cloud Traces, you can use [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) instead of building and operating your own tail sampling pipeline. 
+{{< admonition type="tip" >}}
+If you send traces to Grafana Cloud Traces, you can use [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) instead of building and operating your own tail sampling pipeline.
 Adaptive Traces is a managed tail sampling capability that analyzes your trace data, recommends sampling policies (for example, keep traces with errors or high latency), and applies them for you.
 Adaptive Traces can also generate metrics from all received traces.
+{{< /admonition >}}
 
 ![Tail sampling overview and components with Tempo, Alloy, and Grafana](/media/docs/tempo/sampling/tempo-tail-based-sampling.svg)
 

--- a/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
+++ b/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
@@ -31,6 +31,10 @@ Tail sampling is more complex to configure, implement, and maintain but is the r
 
 You can use sampling with Tempo using Grafana or Grafana Cloud.
 
+{{< admonition type="tip" >}}
+If you send traces to Grafana Cloud Traces, you can use [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) instead of building and operating your own tail sampling pipeline. Adaptive Traces is a managed tail sampling capability that analyzes your trace data, recommends sampling policies (for example, keep traces with errors or high latency), and applies them for you.
+{{< /admonition >}}
+
 ![Tail sampling overview and components with Tempo, Alloy, and Grafana](/media/docs/tempo/sampling/tempo-tail-based-sampling.svg)
 
 ### Resources
@@ -39,6 +43,7 @@ You can use sampling with Tempo using Grafana or Grafana Cloud.
 - Sampling in Grafana Cloud Traces with a collector: [Head sampling](https://grafana.com/docs/opentelemetry/collector/sampling/head/) and [Tail sampling](https://grafana.com/docs/opentelemetry/collector/sampling/tail/)
 - [Enable tail sampling in Tempo](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/grafana-alloy/tail-sampling/enable-tail-sampling/)
 - [Sampling policies and strategies](https://grafana.com/docs/tempo/<TEMPO_VERSION>/configuration/grafana-alloy/tail-sampling/policies-strategies/)
+- [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/): managed tail sampling for Grafana Cloud Traces
 
 ## Sampling and telemetry correlation
 
@@ -160,6 +165,10 @@ The act of sampling reduces the amount of tracing telemetry data that's sent to 
 This can have an effect on observation of data inside Grafana.
 
 The following is a suggested pipeline that can be applied to both [Grafana Alloy](https://grafana.com/docs/alloy/latest/) and the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/), to carry out tail sampling, but also ensure that other telemetry signals are still captured for observation from within Grafana and Grafana Cloud.
+
+{{< admonition type="note" >}}
+This section describes how to build and operate this pipeline yourself. If you send traces to Grafana Cloud Traces, [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) provides equivalent tail sampling as a managed feature, without requiring you to deploy and maintain a two-layer collector pipeline.
+{{< /admonition >}}
 
 This pipeline exists in the second layer of collectors, sent data by the load balancing layer, and is commonly deployed as a Kubernetes `StatefulSet` to ensure that each instance has a consistent identity. A realistic example pipeline could be made of up the following components:
 

--- a/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
+++ b/docs/sources/tempo/set-up-for-tracing/instrument-send/set-up-collector/tail-sampling/_index.md
@@ -34,7 +34,7 @@ You can use sampling with Tempo using Grafana or Grafana Cloud.
 
 {{< admonition type="tip" >}}
 If you send traces to Grafana Cloud Traces, you can use [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) instead of building and operating your own tail sampling pipeline.
-Adaptive Traces is a managed tail sampling capability that analyzes your trace data, recommends sampling policies (for example, keep traces with errors or high latency), and applies them for you.
+Adaptive Traces is a managed tail sampling capability that analyzes your trace data, recommends sampling policies, for example, keeping traces with errors or high latency, and applies them for you.
 Adaptive Traces can also generate metrics from all received traces.
 {{< /admonition >}}
 


### PR DESCRIPTION
Point Grafana Cloud Traces users to [Adaptive Traces](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/adaptive-telemetry/adaptive-traces/) as a managed alternative to the self-managed tail sampling pipeline described in this doc.

Adds a tip admonition near the head/tail sampling explanation, a Resources link, and a note at the top of the "Pipeline workflows" section clarifying that section describes the self-managed approach.

Made with the help of Cursor and Opus 4.6.