### PR TITLE
Add per-tenant distributor push shape metrics

### DIFF
--- a/.chloggen/distributor-push-shape-metrics.yaml
+++ b/.chloggen/distributor-push-shape-metrics.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: distributor
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: "Add per-tenant push shape metrics: tenant label on `tempo_distributor_push_duration_seconds`, plus new `tempo_distributor_push_bytes` and `tempo_distributor_received_traces_total`"
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: zalegrala

--- a/modules/distributor/distributor.go
+++ b/modules/distributor/distributor.go
@@ -106,6 +106,20 @@ var (
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
 	})
+	metricPushBytes = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       "tempo",
+		Name:                            "distributor_push_bytes",
+		Help:                            "The decoded size of each push, per tenant",
+		Buckets:                         prometheus.ExponentialBuckets(1024, 2, 16), // 1KiB to 32MiB
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	}, []string{"tenant"})
+	metricReceivedTraces = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "tempo",
+		Name:      "distributor_received_traces_total",
+		Help:      "The total number of traces received per tenant",
+	}, []string{"tenant"})
 	metricAttributesTruncated = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "tempo",
 		Name:      "distributor_attributes_truncated_total",
@@ -464,6 +478,7 @@ func (d *Distributor) PushTraces(ctx context.Context, traces ptrace.Traces) (*te
 	span.SetAttributes(attribute.String("orgID", userID))
 	defer d.padWithArtificialDelay(reqStart, userID)
 	metricIngressBytes.WithLabelValues(userID).Add(float64(size))
+	metricPushBytes.WithLabelValues(userID).Observe(float64(size))
 
 	if spanCount == 0 {
 		return &tempopb.PushResponse{}, nil
@@ -827,6 +842,7 @@ func requestsByTraceID(batches []*v1.ResourceSpans, userID string, spanCount, ma
 	}
 
 	metricTracesPerBatch.Observe(float64(len(tracesByID)))
+	metricReceivedTraces.WithLabelValues(userID).Add(float64(len(tracesByID)))
 
 	ringTokens := make([]uint32, 0, len(tracesByID))
 	traces := make([]*rebatchedTrace, 0, len(tracesByID))

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/dskit/services"
 	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
@@ -1282,6 +1283,37 @@ func TestDistributor(t *testing.T) {
 			assert.Equal(t, tc.expectedError, err)
 		})
 	}
+}
+
+func TestPushTraces_RecordsPerTenantShapeMetrics(t *testing.T) {
+	// Other tests in this package push traces for the same "test" tenant via
+	// the shared package-level ctx, so these package-level metrics need a
+	// reset immediately before use, not just in cleanup.
+	metricPushBytes.Reset()
+	metricReceivedTraces.Reset()
+	t.Cleanup(func() {
+		metricPushBytes.Reset()
+		metricReceivedTraces.Reset()
+	})
+
+	limits := overrides.Config{}
+	limits.RegisterFlagsAndApplyDefaults(&flag.FlagSet{})
+	d := prepare(t, limits, nil)
+
+	b := test.MakeBatch(10, []byte{})
+	traces := batchesToTraces(t, []*v1.ResourceSpans{b})
+
+	_, err := d.PushTraces(ctx, traces)
+	require.NoError(t, err)
+
+	bytesMetric := &dto.Metric{}
+	require.NoError(t, metricPushBytes.WithLabelValues("test").(prometheus.Histogram).Write(bytesMetric))
+	assert.Equal(t, uint64(1), bytesMetric.Histogram.GetSampleCount())
+	assert.Greater(t, bytesMetric.Histogram.GetSampleSum(), 0.0)
+
+	tracesMetric := &dto.Metric{}
+	require.NoError(t, metricReceivedTraces.WithLabelValues("test").Write(tracesMetric))
+	assert.Equal(t, float64(1), tracesMetric.Counter.GetValue())
 }
 
 func TestLogReceivedSpans(t *testing.T) {

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -41,6 +41,7 @@ import (
 	"github.com/grafana/tempo/pkg/tempopb"
 	"github.com/grafana/tempo/pkg/usagestats"
 	"github.com/grafana/tempo/pkg/util/log"
+	"github.com/grafana/tempo/pkg/validation"
 )
 
 const (
@@ -355,8 +356,11 @@ func (r *receiversShim) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 
 	start := time.Now()
 	_, err = r.pusher.PushTraces(ctx, td)
-	if tenantErr == nil {
-		metricPushDuration.WithLabelValues(tenant).Observe(time.Since(start).Seconds())
+	// user.ExtractOrgID above returns the org ID header verbatim, unvalidated,
+	// so it's not safe to use as a metric label: a malformed value would create
+	// a permanent, unbounded-cardinality series. Use the validated tenant ID instead.
+	if validTenant, vErr := validation.ExtractValidTenantID(ctx); vErr == nil {
+		metricPushDuration.WithLabelValues(validTenant).Observe(time.Since(start).Seconds())
 	}
 	if err != nil {
 		if tenantErr == nil {

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -48,7 +48,7 @@ const (
 )
 
 var (
-	metricPushDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+	metricPushDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:                       "tempo",
 		Name:                            "distributor_push_duration_seconds",
 		Help:                            "Records the amount of time to process and route a batch through the distributor.",
@@ -56,7 +56,7 @@ var (
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: 1 * time.Hour,
-	})
+	}, []string{"tenant"})
 
 	statReceiverOtlp   = usagestats.NewInt("receiver_enabled_otlp")
 	statReceiverJaeger = usagestats.NewInt("receiver_enabled_jaeger")
@@ -355,7 +355,9 @@ func (r *receiversShim) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 
 	start := time.Now()
 	_, err = r.pusher.PushTraces(ctx, td)
-	metricPushDuration.Observe(time.Since(start).Seconds())
+	if tenantErr == nil {
+		metricPushDuration.WithLabelValues(tenant).Observe(time.Since(start).Seconds())
+	}
 	if err != nil {
 		if tenantErr == nil {
 			r.logger.Log("msg", "pusher failed to consume trace data", "tenant", tenant, "err", err)

--- a/modules/distributor/receiver/shim.go
+++ b/modules/distributor/receiver/shim.go
@@ -356,11 +356,12 @@ func (r *receiversShim) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 
 	start := time.Now()
 	_, err = r.pusher.PushTraces(ctx, td)
+	pushDuration := time.Since(start)
 	// user.ExtractOrgID above returns the org ID header verbatim, unvalidated,
 	// so it's not safe to use as a metric label: a malformed value would create
 	// a permanent, unbounded-cardinality series. Use the validated tenant ID instead.
 	if validTenant, vErr := validation.ExtractValidTenantID(ctx); vErr == nil {
-		metricPushDuration.WithLabelValues(validTenant).Observe(time.Since(start).Seconds())
+		metricPushDuration.WithLabelValues(validTenant).Observe(pushDuration.Seconds())
 	}
 	if err != nil {
 		if tenantErr == nil {

--- a/modules/distributor/receiver/shim_test.go
+++ b/modules/distributor/receiver/shim_test.go
@@ -265,6 +265,24 @@ func TestConsumeTraces_RecordsPerTenantPushDuration(t *testing.T) {
 	assert.Equal(t, uint64(1), m.Histogram.GetSampleCount())
 }
 
+func TestConsumeTraces_SkipsPushDurationForInvalidTenant(t *testing.T) {
+	metricPushDuration.Reset()
+	t.Cleanup(func() {
+		metricPushDuration.Reset()
+	})
+
+	// MultiTenancyMiddleware injects the org ID header value into the context
+	// unvalidated. A malformed value here must not create a new label series.
+	invalidTenant := "not a/valid tenant"
+	ctx := user.InjectOrgID(context.Background(), invalidTenant)
+
+	shim := &receiversShim{pusher: &erroringPusher{}}
+
+	require.NoError(t, shim.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+
+	assert.Equal(t, 0, testutil.CollectAndCount(metricPushDuration))
+}
+
 func TestKafkaWriteTimeoutHTTPStatus(t *testing.T) {
 	receiverCfg := map[string]interface{}{
 		"otlp": map[string]interface{}{

--- a/modules/distributor/receiver/shim_test.go
+++ b/modules/distributor/receiver/shim_test.go
@@ -11,8 +11,10 @@ import (
 
 	dslog "github.com/grafana/dskit/log"
 	"github.com/grafana/dskit/services"
+	"github.com/grafana/dskit/user"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -244,6 +246,23 @@ func (p *erroringPusher) PushTraces(context.Context, ptrace.Traces) (*tempopb.Pu
 
 func (p *erroringPusher) RetryInfoEnabled(context.Context) (bool, error) {
 	return false, nil
+}
+
+func TestConsumeTraces_RecordsPerTenantPushDuration(t *testing.T) {
+	t.Cleanup(func() {
+		metricPushDuration.Reset()
+	})
+
+	tenant := "test"
+	ctx := user.InjectOrgID(context.Background(), tenant)
+
+	shim := &receiversShim{pusher: &erroringPusher{}}
+
+	require.NoError(t, shim.ConsumeTraces(ctx, testdata.GenerateTraces(1)))
+
+	m := &dto.Metric{}
+	require.NoError(t, metricPushDuration.WithLabelValues(tenant).(prometheus.Histogram).Write(m))
+	assert.Equal(t, uint64(1), m.Histogram.GetSampleCount())
 }
 
 func TestKafkaWriteTimeoutHTTPStatus(t *testing.T) {


### PR DESCRIPTION
**What this PR does**:

Adds per-tenant observability for distributor push shape, so a single misbehaving push (slow trickle, ballooning size, abnormal shape) can be attributed to a tenant without cross-referencing other systems. This came up during a recent page where existing distributor metrics could show ingest volume but not push shape.

Three additive, per-tenant signals, each reusing scalars the push path already computes (no new pass over spans):
- Added a `tenant` label to `tempo_distributor_push_duration_seconds`. Per-tenant request duration minus this isolates network/decode time from our processing time.
- Added `tempo_distributor_push_bytes{tenant}`, a native histogram of **decoded** push size. Catches a single giant push that byte-rate counters smooth away.
- Added `tempo_distributor_received_traces_total{tenant}`, incremented by the per-push rebatched trace count. Combined with per-tenant spans, gives per-tenant spans-per-trace.

Purely additive: existing dashboards/alerts querying these metrics without a tenant filter are unaffected (verified the writes-mixin latency panel aggregates with `by (le,)`, no tenant filter).

Out of scope: `push_bytes` measures decoded size only, not wire bytes, so it does not capture compression ratio or detect disabled compression. Decoding happens in the vendored OTel receiver before our code sees the payload, so wire-byte capture needs its own spike (HTTP `Content-Length`, gRPC compressed size, or a per-tenant `tempo_request_message_bytes` variant) and stays an open question in the design doc. Also out of scope: threshold-triggered structured logs for the specific offending push, and deferred aggregate/attribute analytics.

**Which issue(s) this PR fixes**:

N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/`

