### PR TITLE
Fix autocomplete metadata intrinsic filtering

### DIFF
--- a/.chloggen/fix-7706-autocomplete-metadata-filters.yaml
+++ b/.chloggen/fix-7706-autocomplete-metadata-filters.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: traceql
+note: Fix tag value autocomplete so metadata intrinsic conditions are applied as filters instead of being silently dropped.
+issues: [7706]
+subtext:
+user: yigitcan-ozturk

--- a/tempodb/encoding/vparquet3/block_autocomplete.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete.go
@@ -335,10 +335,20 @@ func createDistinctSpanIterator(
 		// Intrinsic?
 		switch cond.Attribute.Intrinsic {
 
-		case traceql.IntrinsicSpanID,
-			traceql.IntrinsicSpanStartTime:
-			// Metadata conditions not necessary, we don't need to fetch them
-			// TODO: Add support if they're added to TraceQL
+		case traceql.IntrinsicSpanID:
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			if err != nil {
+				return nil, err
+			}
+			addPredicate(columnPathSpanID, pred)
+			continue
+
+		case traceql.IntrinsicSpanStartTime:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
+			}
+			addPredicate(columnPathSpanStartTime, pred)
 			continue
 
 		case traceql.IntrinsicName:
@@ -834,8 +844,19 @@ func createDistinctTraceIterator(
 	// otherwise we just pass the info up to the engine to make a choice
 	for _, cond := range conds {
 		switch cond.Attribute.Intrinsic {
-		case traceql.IntrinsicTraceID, traceql.IntrinsicTraceStartTime:
-			// metadata conditions not necessary, we don't need to fetch them
+		case traceql.IntrinsicTraceID:
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			if err != nil {
+				return nil, err
+			}
+			traceIters = append(traceIters, makeIter(columnPathTraceID, pred, ""))
+
+		case traceql.IntrinsicTraceStartTime:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
+			}
+			traceIters = append(traceIters, makeIter(columnPathStartTimeUnixNano, pred, ""))
 
 		case traceql.IntrinsicTraceDuration:
 			var pred parquetquery.Predicate

--- a/tempodb/encoding/vparquet3/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet3/block_autocomplete_test.go
@@ -815,6 +815,47 @@ func TestFetchTagNamesWithOrConditions(t *testing.T) {
 	}
 }
 
+func TestFetchTagValuesFiltersTraceID(t *testing.T) {
+	tr1 := fullyPopulatedTestTrace(common.ID{0x01})
+	tr2 := fullyPopulatedTestTrace(common.ID{0x02})
+	tr2.ResourceSpans[0].ScopeSpans[0].Spans[0].Name = "only-in-trace-two"
+
+	block := makeBackendBlockWithTraces(t, []*Trace{tr1, tr2})
+	conditions, err := traceql.ExtractConditionGroups(
+		`{ trace:id = "01000000000000000000000000000000" }`,
+		traceql.DefaultMaxConditionGroupsPerTagQuery,
+	)
+	require.NoError(t, err)
+
+	tag, err := traceql.ParseIdentifier("name")
+	require.NoError(t, err)
+	for i := range conditions {
+		conditions[i] = append(conditions[i], traceql.Condition{
+			Attribute: tag,
+			Op:        traceql.OpNone,
+		})
+	}
+
+	distinctValues := collector.NewDistinctValue[tempopb.TagValue](
+		1_000_000,
+		0,
+		0,
+		func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) },
+	)
+	err = block.FetchTagValues(
+		context.Background(),
+		traceql.FetchTagValuesRequest{ConditionGroups: conditions, TagName: tag},
+		traceql.MakeCollectTagValueFunc(distinctValues.Collect),
+		func(uint64) {},
+		common.DefaultSearchOptions(),
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []tempopb.TagValue{
+		stringTagValue("hello"),
+		stringTagValue("world"),
+	}, distinctValues.Values())
+}
+
 func TestFetchTagValuesWithOrConditions(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/tempodb/encoding/vparquet4/block_autocomplete.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete.go
@@ -512,10 +512,20 @@ func createDistinctSpanIterator(
 		// Intrinsic?
 		switch cond.Attribute.Intrinsic {
 
-		case traceql.IntrinsicSpanID,
-			traceql.IntrinsicSpanStartTime:
-			// Metadata conditions not necessary, we don't need to fetch them
-			// TODO: Add support if they're added to TraceQL
+		case traceql.IntrinsicSpanID:
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			if err != nil {
+				return nil, err
+			}
+			addPredicate(columnPathSpanID, pred)
+			continue
+
+		case traceql.IntrinsicSpanStartTime:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
+			}
+			addPredicate(columnPathSpanStartTime, pred)
 			continue
 
 		case traceql.IntrinsicName:
@@ -1090,8 +1100,19 @@ func createDistinctTraceIterator(
 	// otherwise we just pass the info up to the engine to make a choice
 	for _, cond := range conds {
 		switch cond.Attribute.Intrinsic {
-		case traceql.IntrinsicTraceID, traceql.IntrinsicTraceStartTime:
-			// metadata conditions not necessary, we don't need to fetch them
+		case traceql.IntrinsicTraceID:
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			if err != nil {
+				return nil, err
+			}
+			traceIters = append(traceIters, makeIter(columnPathTraceID, pred, ""))
+
+		case traceql.IntrinsicTraceStartTime:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
+			}
+			traceIters = append(traceIters, makeIter(columnPathStartTimeUnixNano, pred, ""))
 
 		case traceql.IntrinsicTraceDuration:
 			var pred parquetquery.Predicate

--- a/tempodb/encoding/vparquet4/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet4/block_autocomplete_test.go
@@ -1074,6 +1074,47 @@ func TestFetchTagNamesWithOrConditions(t *testing.T) {
 	}
 }
 
+func TestFetchTagValuesFiltersTraceID(t *testing.T) {
+	tr1 := fullyPopulatedTestTrace(common.ID{0x01})
+	tr2 := fullyPopulatedTestTrace(common.ID{0x02})
+	tr2.ResourceSpans[0].ScopeSpans[0].Spans[0].Name = "only-in-trace-two"
+
+	block := makeBackendBlockWithTraces(t, []*Trace{tr1, tr2})
+	conditions, err := traceql.ExtractConditionGroups(
+		`{ trace:id = "01000000000000000000000000000000" }`,
+		traceql.DefaultMaxConditionGroupsPerTagQuery,
+	)
+	require.NoError(t, err)
+
+	tag, err := traceql.ParseIdentifier("name")
+	require.NoError(t, err)
+	for i := range conditions {
+		conditions[i] = append(conditions[i], traceql.Condition{
+			Attribute: tag,
+			Op:        traceql.OpNone,
+		})
+	}
+
+	distinctValues := collector.NewDistinctValue[tempopb.TagValue](
+		1_000_000,
+		0,
+		0,
+		func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) },
+	)
+	err = block.FetchTagValues(
+		context.Background(),
+		traceql.FetchTagValuesRequest{ConditionGroups: conditions, TagName: tag},
+		traceql.MakeCollectTagValueFunc(distinctValues.Collect),
+		func(uint64) {},
+		common.DefaultSearchOptions(),
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []tempopb.TagValue{
+		stringTagValue("hello"),
+		stringTagValue("world"),
+	}, distinctValues.Values())
+}
+
 func TestFetchTagValuesWithOrConditions(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/tempodb/encoding/vparquet5/block_autocomplete.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete.go
@@ -576,10 +576,20 @@ func createDistinctSpanIterator(
 		// Intrinsic?
 		switch cond.Attribute.Intrinsic {
 
-		case traceql.IntrinsicSpanID,
-			traceql.IntrinsicSpanStartTime:
-			// Metadata conditions not necessary, we don't need to fetch them
-			// TODO: Add support if they're added to TraceQL
+		case traceql.IntrinsicSpanID:
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, true)
+			if err != nil {
+				return nil, err
+			}
+			addPredicate(columnPathSpanID, pred)
+			continue
+
+		case traceql.IntrinsicSpanStartTime:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
+			}
+			addPredicate(columnPathSpanStartTime, pred)
 			continue
 
 		case traceql.IntrinsicName:
@@ -1135,8 +1145,19 @@ func createDistinctTraceIterator(
 	// otherwise we just pass the info up to the engine to make a choice
 	for _, cond := range conds {
 		switch cond.Attribute.Intrinsic {
-		case traceql.IntrinsicTraceID, traceql.IntrinsicTraceStartTime:
-			// metadata conditions not necessary, we don't need to fetch them
+		case traceql.IntrinsicTraceID:
+			pred, err := createBytesPredicate(cond.Op, cond.Operands, false)
+			if err != nil {
+				return nil, err
+			}
+			traceIters = append(traceIters, makeIter(columnPathTraceID, pred, ""))
+
+		case traceql.IntrinsicTraceStartTime:
+			pred, err := createIntPredicate(cond.Op, cond.Operands)
+			if err != nil {
+				return nil, err
+			}
+			traceIters = append(traceIters, makeIter(columnPathStartTimeUnixNano, pred, ""))
 
 		case traceql.IntrinsicTraceDuration:
 			var pred parquetquery.Predicate

--- a/tempodb/encoding/vparquet5/block_autocomplete_test.go
+++ b/tempodb/encoding/vparquet5/block_autocomplete_test.go
@@ -1079,6 +1079,47 @@ func TestFetchTagNamesWithOrConditions(t *testing.T) {
 	}
 }
 
+func TestFetchTagValuesFiltersTraceID(t *testing.T) {
+	tr1 := fullyPopulatedTestTrace(common.ID{0x01})
+	tr2 := fullyPopulatedTestTrace(common.ID{0x02})
+	tr2.ResourceSpans[0].ScopeSpans[0].Spans[0].Name = "only-in-trace-two"
+
+	block := makeBackendBlockWithTraces(t, []*Trace{tr1, tr2})
+	conditions, err := traceql.ExtractConditionGroups(
+		`{ trace:id = "01000000000000000000000000000000" }`,
+		traceql.DefaultMaxConditionGroupsPerTagQuery,
+	)
+	require.NoError(t, err)
+
+	tag, err := traceql.ParseIdentifier("name")
+	require.NoError(t, err)
+	for i := range conditions {
+		conditions[i] = append(conditions[i], traceql.Condition{
+			Attribute: tag,
+			Op:        traceql.OpNone,
+		})
+	}
+
+	distinctValues := collector.NewDistinctValue[tempopb.TagValue](
+		1_000_000,
+		0,
+		0,
+		func(v tempopb.TagValue) int { return len(v.Type) + len(v.Value) },
+	)
+	err = block.FetchTagValues(
+		context.Background(),
+		traceql.FetchTagValuesRequest{ConditionGroups: conditions, TagName: tag},
+		traceql.MakeCollectTagValueFunc(distinctValues.Collect),
+		func(uint64) {},
+		common.DefaultSearchOptions(),
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []tempopb.TagValue{
+		stringTagValue("hello"),
+		stringTagValue("world"),
+	}, distinctValues.Values())
+}
+
 func TestFetchTagValuesWithOrConditions(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
**What this PR does**:

Fixes tag-value autocomplete so metadata intrinsic conditions are applied as filters instead of being silently dropped.

This draft is intentionally scoped to the metadata intrinsics discussed in #7706:

- `trace:id`
- `trace:start`
- `span:id`
- span start time

Structural operators remain out of scope for this PR.

Across vParquet3, vParquet4, and vParquet5 autocomplete paths, this change:

- builds filtering predicates for trace/span IDs and start times;
- keeps these metadata-only filters out of the selected autocomplete values;
- preserves the existing autocomplete result shape while restoring filtering semantics.

Regression coverage has been added to verify that a `trace:id` filter restricts returned span-name values to the selected trace.

**Which issue(s) this PR fixes**:

Fixes #7706

**Checklist**

- [x] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/`