### PR TITLE
[Enhancement] Remove mutexes from L1 traceql metrics

### DIFF
--- a/.chloggen/live-store-per-block-metrics-eval.yaml
+++ b/.chloggen/live-store-per-block-metrics-eval.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: live-store
+note: Improve TraceQL metrics query performance by removing lock contention between concurrently evaluated WAL blocks
+issues: [7867]
+subtext: |
+  Each block is now evaluated with its own metrics evaluator and the per-block results are
+  summed, instead of all WAL blocks sharing one evaluator guarded by a mutex.
+user: ruslan-mikhailov

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -733,8 +733,6 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	e := traceql.NewEngine()
-
 	// Parse without optimizations to read hints; optimizations are applied by CompileMetricsQueryRange.
 	expr, err := traceql.ParseNoOptimizations(req.Query)
 	if err != nil {
@@ -766,19 +764,6 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 		compileOpts = append(compileOpts, traceql.WithEngineBytesTracking(*p))
 	}
 
-	// Compile the raw version of the query for head and wal blocks
-	// These aren't cached and we put them all into the same evaluator
-	// for efficiency. iterateBlocks below evaluates wal blocks concurrently against this
-	// one evaluator, so it needs a lock; queryRangeCompleteBlock below compiles its own
-	// private evaluator per complete block and doesn't share one, so compileOpts (used there)
-	// intentionally omits the lock.
-	var rawEvalMtx sync.Mutex
-	rawCompileOpts := append([]traceql.CompileOption{traceql.WithLock(&rawEvalMtx)}, compileOpts...)
-	rawEval, err := e.CompileMetricsQueryRange(req, rawCompileOpts...)
-	if err != nil {
-		return nil, err
-	}
-
 	// This is a summation version of the query for complete blocks
 	// which can be cached. They are timeseries, so they need the job-level evaluator.
 	jobEval, err := traceql.NewEngine().CompileMetricsQueryRangeNonRaw(req, traceql.AggregateModeSum, compileOpts...)
@@ -807,35 +792,32 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 	}
 
 	search := func(ctx context.Context, _ *backend.BlockMeta, b block) error {
-		if walBlock, ok := b.(common.WALBlock); ok {
-			err := i.queryRangeWALBlock(ctx, walBlock, rawEval, maxSeries)
-			if err != nil {
-				return err
-			}
-			if maxSeries > 0 && rawEval.Length() > maxSeries {
-				maxSeriesReached.Store(true)
-				return errComplete
-			}
-			return nil
+		var (
+			resp *tempopb.QueryRangeResponse
+			err  error
+		)
+
+		switch blk := b.(type) {
+		case common.WALBlock:
+			resp, err = i.queryRangeWALBlock(ctx, blk, *req, compileOpts)
+		case *LocalBlock:
+			resp, err = i.queryRangeCompleteBlock(ctx, blk, *req, compileOpts)
+		default:
+			return fmt.Errorf("unexpected block type: %T", b)
+		}
+		if err != nil {
+			return err
 		}
 
-		if localBlock, ok := b.(*LocalBlock); ok {
-			resp, err := i.queryRangeCompleteBlock(ctx, localBlock, *req, compileOpts)
-			if err != nil {
-				return err
-			}
-			if resp != nil {
-				mergeMetrics(resp.Metrics)
-				jobEval.ObserveSeries(resp.Series)
-			}
-			if maxSeries > 0 && jobEval.Length() > maxSeries {
-				maxSeriesReached.Store(true)
-				return errComplete
-			}
-			return nil
+		if resp != nil {
+			mergeMetrics(resp.Metrics)
+			jobEval.ObserveSeries(resp.Series)
 		}
-
-		return fmt.Errorf("unexpected block type: %T", b)
+		if maxSeries > 0 && jobEval.Length() > maxSeries {
+			maxSeriesReached.Store(true)
+			return errComplete
+		}
+		return nil
 	}
 
 	err = i.iterateBlocks(ctx, time.Unix(0, int64(req.Start)), time.Unix(0, int64(req.End)), search)
@@ -844,20 +826,9 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 		return nil, err
 	}
 
-	// Combine the raw results into the job results
-	walResults := rawEval.Results().ToProto(req)
-	jobEval.ObserveSeries(walResults)
-
 	r := jobEval.Results()
 	rr := r.ToProto(req)
 
-	rawEm := rawEval.Metrics()
-	mergeMetrics(&tempopb.SearchMetrics{
-		InspectedBytes:    rawEm.Bytes,
-		BackendReads:      rawEm.BackendReads,
-		BackendBytes:      rawEm.BackendBytes,
-		AdditionalMetrics: rawEm.AdditionalMetrics,
-	})
 	metricQueryInspectedBytesTotal.WithLabelValues(i.tenantID, queryOpQueryRange).Add(float64(metrics.InspectedBytes))
 
 	if maxSeriesReached.Load() {
@@ -874,13 +845,18 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 	}, nil
 }
 
-func (i *instance) queryRangeWALBlock(ctx context.Context, b common.WALBlock, eval traceql.MetricsEvaluator, maxSeries int) error {
+func (i *instance) queryRangeWALBlock(ctx context.Context, b common.WALBlock, req tempopb.QueryRangeRequest, compileOpts []traceql.CompileOption) (*tempopb.QueryRangeResponse, error) {
 	m := b.BlockMeta()
 	ctx, span := tracer.Start(ctx, "instance.QueryRange.WALBlock", oteltrace.WithAttributes(
 		attribute.String("block", m.BlockID.String()),
 		attribute.Int64("blockSize", int64(m.Size_)),
 	))
 	defer span.End()
+
+	eval, err := traceql.NewEngine().CompileMetricsQueryRange(&req, compileOpts...)
+	if err != nil {
+		return nil, err
+	}
 
 	fetcher := traceql.NewSpansetFetcherWrapperBoth(
 		func(ctx context.Context, req traceql.FetchSpansRequest) (traceql.FetchSpansResponse, error) {
@@ -890,7 +866,21 @@ func (i *instance) queryRangeWALBlock(ctx context.Context, b common.WALBlock, ev
 			return b.FetchSpans(ctx, req, common.DefaultSearchOptions())
 		},
 	)
-	return eval.Do(ctx, fetcher, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()), maxSeries)
+	err = eval.Do(ctx, fetcher, uint64(m.StartTime.UnixNano()), uint64(m.EndTime.UnixNano()), int(req.MaxSeries))
+	if err != nil {
+		return nil, err
+	}
+
+	em := eval.Metrics()
+	return &tempopb.QueryRangeResponse{
+		Series: eval.Results().ToProto(&req),
+		Metrics: &tempopb.SearchMetrics{
+			InspectedBytes:    em.Bytes,
+			BackendReads:      em.BackendReads,
+			BackendBytes:      em.BackendBytes,
+			AdditionalMetrics: em.AdditionalMetrics,
+		},
+	}, nil
 }
 
 // queryRangeCompleteBlock returns the per-block QueryRangeResponse. A cache hit

--- a/modules/livestore/instance_search.go
+++ b/modules/livestore/instance_search.go
@@ -826,6 +826,15 @@ func (i *instance) QueryRange(ctx context.Context, req *tempopb.QueryRangeReques
 		return nil, err
 	}
 
+	// edge case when no blocks were processed, init with a baseline
+	if jobEval.Length() == 0 {
+		baseline, err := traceql.NewEngine().CompileMetricsQueryRange(req, compileOpts...)
+		if err != nil {
+			return nil, err
+		}
+		jobEval.ObserveSeries(baseline.Results().ToProto(req))
+	}
+
 	r := jobEval.Results()
 	rr := r.ToProto(req)
 

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -1855,3 +1855,27 @@ func TestQueryRangeConcurrentWALBlocks(t *testing.T) {
 		require.Len(t, resp.Series, 2)
 	})
 }
+
+func TestQueryRangeNoDataReturnsZeroedSeries(t *testing.T) {
+	i, _ := defaultInstance(t)
+	ctx := user.InjectOrgID(context.Background(), testTenantID)
+
+	end := time.Now().Truncate(time.Minute)
+	req := &tempopb.QueryRangeRequest{
+		Query:     "{} | count_over_time()",
+		Start:     uint64(end.Add(-2 * time.Minute).UnixNano()),
+		End:       uint64(end.UnixNano()),
+		Step:      uint64(time.Minute),
+		MaxSeries: 10,
+	}
+
+	resp, err := i.QueryRange(ctx, req)
+	require.NoError(t, err)
+
+	require.Len(t, resp.Series, 1, "an ungrouped query must still report a series when nothing matches")
+	require.NotEmpty(t, resp.Series[0].Samples, "empty samples")
+	for _, sample := range resp.Series[0].Samples {
+		require.Zero(t, sample.Value, "no data in range, so every step must be zero")
+	}
+	require.Equal(t, tempopb.PartialStatus_COMPLETE, resp.Status)
+}

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -1762,3 +1762,96 @@ func findCacheFile(t *testing.T, blockDir string) string {
 	t.Fatalf("no cache_query_range_*.buf file found in %s", blockDir)
 	return ""
 }
+
+// TestQueryRangeConcurrentWALBlocks covers the multi-WAL-block path with QueryBlockConcurrency > 1.
+// The test asserts that no spans are lost or double counted when several blocks are evaluated at once
+func TestQueryRangeConcurrentWALBlocks(t *testing.T) {
+	const (
+		walBlocks      = 4
+		tracesPerBlock = 5
+	)
+
+	i, _ := defaultInstance(t)
+	i.Cfg.QueryBlockConcurrency = walBlocks
+
+	ctx := user.InjectOrgID(context.Background(), testTenantID)
+	now := time.Now()
+
+	// Each block gets its own value for span.blk, so the query below yields exactly one series
+	// per block and the expected span count is known.
+	totalSpans := 0
+	for blk := range walBlocks {
+		for range tracesPerBlock {
+			id := make([]byte, 16)
+			_, err := crand.Read(id)
+			require.NoError(t, err)
+
+			tt := test.MakeTrace(1, id)
+			kv := &v1.KeyValue{Key: "blk", Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: "b" + strconv.Itoa(blk)}}}
+			for _, batch := range tt.ResourceSpans {
+				for _, ils := range batch.ScopeSpans {
+					for _, span := range ils.Spans {
+						span.StartTimeUnixNano = uint64(now.UnixNano())
+						span.EndTimeUnixNano = uint64(now.UnixNano())
+						span.Attributes = append(span.Attributes, kv)
+						totalSpans++
+					}
+				}
+			}
+			trace.SortTrace(tt)
+			traceBytes, err := tt.Marshal()
+			require.NoError(t, err)
+
+			i.pushBytes(ctx, now, &tempopb.PushBytesRequest{
+				Traces: []tempopb.PreallocBytes{{Slice: traceBytes}},
+				Ids:    [][]byte{id},
+			})
+		}
+
+		_, err := i.cutIdleTraces(ctx, true)
+		require.NoError(t, err)
+		_, err = i.cutBlocks(ctx, true)
+		require.NoError(t, err)
+	}
+
+	// check wal blocks count to validate test setup
+	require.Len(t, i.blocks.Load().walBlocks, walBlocks)
+
+	newReq := func(maxSeries uint32) *tempopb.QueryRangeRequest {
+		return &tempopb.QueryRangeRequest{
+			Query:     "{} | count_over_time() by (span.blk)",
+			Start:     uint64(now.Add(-time.Minute).UnixNano()),
+			End:       uint64(now.Add(time.Minute).UnixNano()),
+			Step:      uint64(15 * time.Second),
+			MaxSeries: maxSeries,
+		}
+	}
+
+	countSpans := func(resp *tempopb.QueryRangeResponse) float64 {
+		var total float64
+		for _, s := range resp.Series {
+			for _, sample := range s.Samples {
+				total += sample.Value
+			}
+		}
+		return total
+	}
+
+	t.Run("all blocks contribute exactly once", func(t *testing.T) {
+		// Repeated to catch a result that depends on the order blocks happen to finish in.
+		for range 3 {
+			resp, err := i.QueryRange(ctx, newReq(100))
+			require.NoError(t, err)
+			require.Len(t, resp.Series, walBlocks, "expected one series per WAL block")
+			require.Equal(t, float64(totalSpans), countSpans(resp), "spans lost or double counted")
+			require.Equal(t, tempopb.PartialStatus_COMPLETE, resp.Status)
+		}
+	})
+
+	t.Run("MaxSeries reports partial", func(t *testing.T) {
+		resp, err := i.QueryRange(ctx, newReq(2))
+		require.NoError(t, err)
+		require.Equal(t, tempopb.PartialStatus_PARTIAL, resp.Status)
+		require.Len(t, resp.Series, 2)
+	})
+}

--- a/pkg/traceql/engine_metrics.go
+++ b/pkg/traceql/engine_metrics.go
@@ -1104,7 +1104,6 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 
 	// Watchers are scoped to this Compile call. EngineBytesWatcher is installed fresh when enabled via
 	// WithEngineBytesTracking; additional watchers come from WithWatchers (e.g. per-tenant overrides).
-	// Access to watchers is synchronized by each metricsEvaluator's own (optional) lock; see WithLock.
 	watchers := &spanWatchers{}
 	if cfg.engineBytesTracking {
 		watchers.Add(NewEngineBytesWatcher())
@@ -1157,7 +1156,6 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 			maxExemplars:      exemplars,
 			exemplarMap:       make(map[string]struct{}, exemplars), // TODO: Lazy, use bloom filter, CM sketch or something
 			needsFullTrace:    NeedsFullTrace(pipeline),
-			mtx:               cfg.lock,
 		}
 
 		// Determine usage of new fetch layer.
@@ -1230,13 +1228,6 @@ func (e *Engine) CompileMetricsQueryRange(req *tempopb.QueryRangeRequest, opts .
 		storageReq.SecondPass = func(s *Spanset) ([]*Spanset, error) {
 			if s == nil || len(s.Spans) == 0 {
 				return nil, nil
-			}
-			// The traceql engine isn't thread-safe.
-			// But parallelization is required for good metrics performance.
-			// So we do external locking here, when needed (see WithLock).
-			if me.mtx != nil {
-				me.mtx.Lock()
-				defer me.mtx.Unlock()
 			}
 			return pipeline.evaluate([]*Spanset{s})
 		}
@@ -1462,6 +1453,7 @@ func (e *batchMetricsEvaluator) Results() SeriesSet {
 	return merged
 }
 
+// metricsEvaluator does no locking and must be driven by a single goroutine
 type metricsEvaluator struct {
 	start, end                      uint64
 	checkTime                       bool
@@ -1479,7 +1471,6 @@ type metricsEvaluator struct {
 	backendBytes      uint64
 	additionalMetrics map[string]int64
 	watchers          *spanWatchers
-	mtx               *sync.Mutex
 }
 
 // EvaluatorMetrics is the snapshot returned by MetricsEvaluator.Metrics().
@@ -1561,13 +1552,7 @@ func (e *metricsEvaluator) Do(ctx context.Context, f SpansetFetcher, fetcherStar
 	defer fetch.Results.Close()
 
 	seriesCount := 0
-	if e.mtx != nil {
-		e.mtx.Lock()
-	}
 	watch := e.watchers.Active()
-	if e.mtx != nil {
-		e.mtx.Unlock()
-	}
 
 	for {
 		ss, err := fetch.Results.Next(ctx)
@@ -1576,10 +1561,6 @@ func (e *metricsEvaluator) Do(ctx context.Context, f SpansetFetcher, fetcherStar
 		}
 		if ss == nil {
 			break
-		}
-
-		if e.mtx != nil {
-			e.mtx.Lock()
 		}
 
 		if e.storageReq.TraceSampler != nil {
@@ -1628,9 +1609,6 @@ func (e *metricsEvaluator) Do(ctx context.Context, f SpansetFetcher, fetcherStar
 
 		seriesCount = e.metricsPipeline.length()
 
-		if e.mtx != nil {
-			e.mtx.Unlock()
-		}
 		ss.Release()
 
 		if maxSeries > 0 && seriesCount >= maxSeries {
@@ -1638,10 +1616,6 @@ func (e *metricsEvaluator) Do(ctx context.Context, f SpansetFetcher, fetcherStar
 		}
 	}
 
-	if e.mtx != nil {
-		e.mtx.Lock()
-		defer e.mtx.Unlock()
-	}
 	if fetch.Stats != nil {
 		e.accumulateFetchStats(fetch.Stats())
 	}
@@ -1684,13 +1658,7 @@ func (e *metricsEvaluator) DoSpansOnly(ctx context.Context, f SpansetFetcher, fe
 
 	defer fetch.Results.Close()
 
-	if e.mtx != nil {
-		e.mtx.Lock()
-	}
 	watch := e.watchers.Active()
-	if e.mtx != nil {
-		e.mtx.Unlock()
-	}
 
 	for {
 		done, err := func() (done bool, err error) {
@@ -1700,13 +1668,6 @@ func (e *metricsEvaluator) DoSpansOnly(ctx context.Context, f SpansetFetcher, fe
 			}
 			if s == nil {
 				return true, nil
-			}
-
-			// Acquire lock while doing engine work, if required. It is
-			// not required above while doing storage work.
-			if e.mtx != nil {
-				e.mtx.Lock()
-				defer e.mtx.Unlock()
 			}
 
 			if e.checkTime {
@@ -1748,10 +1709,6 @@ func (e *metricsEvaluator) DoSpansOnly(ctx context.Context, f SpansetFetcher, fe
 		}
 	}
 
-	if e.mtx != nil {
-		e.mtx.Lock()
-		defer e.mtx.Unlock()
-	}
 	if fetch.Stats != nil {
 		e.accumulateFetchStats(fetch.Stats())
 	}
@@ -1760,21 +1717,12 @@ func (e *metricsEvaluator) DoSpansOnly(ctx context.Context, f SpansetFetcher, fe
 }
 
 func (e *metricsEvaluator) Length() int {
-	if e.mtx != nil {
-		e.mtx.Lock()
-		defer e.mtx.Unlock()
-	}
 	return e.metricsPipeline.length()
 }
 
 // Metrics returns a snapshot of the accumulated read-side stats from every
-// fetch this evaluator has consumed. Callers MUST hold no locks on e.mtx.
+// fetch this evaluator has consumed.
 func (e *metricsEvaluator) Metrics() EvaluatorMetrics {
-	if e.mtx != nil {
-		e.mtx.Lock()
-		defer e.mtx.Unlock()
-	}
-
 	var additional map[string]int64
 	if len(e.additionalMetrics) > 0 {
 		additional = make(map[string]int64, len(e.additionalMetrics))
@@ -1792,8 +1740,7 @@ func (e *metricsEvaluator) Metrics() EvaluatorMetrics {
 	}
 }
 
-// accumulateFetchStats merges one fetch's stats into the evaluator. Caller
-// must hold e.mtx.
+// accumulateFetchStats merges one fetch's stats into the evaluator.
 func (e *metricsEvaluator) accumulateFetchStats(s FetchSpansStats) {
 	e.bytes += s.Bytes
 	for _, v := range s.BackendReadsByRole {
@@ -1833,11 +1780,6 @@ func (e *metricsEvaluator) accumulateFetchStats(s FetchSpansStats) {
 }
 
 func (e *metricsEvaluator) Results() SeriesSet {
-	if e.mtx != nil {
-		e.mtx.Lock()
-		defer e.mtx.Unlock()
-	}
-
 	spanMultiplier := 1.0
 	if e.storageReq.SpanSampler != nil {
 		spanMultiplier = e.storageReq.SpanSampler.FinalScalingFactor()

--- a/pkg/traceql/options.go
+++ b/pkg/traceql/options.go
@@ -1,7 +1,5 @@
 package traceql
 
-import "sync"
-
 // CompileOption is a functional option for Parse, Compile, Engine.CompileMetricsQueryRange, and Engine.CompileMetricsQueryRangeNonRaw.
 // Parse and Compile silently ignore options specific to metrics queries like WithSpanOnlyFetch and WithTimeOverlapCutoff.
 type CompileOption func(*compileOptions)
@@ -17,7 +15,6 @@ type compileOptions struct {
 
 	engineBytesTracking bool
 	watchers            []SpanWatcher
-	lock                *sync.Mutex
 }
 
 func applyCompileOptions(opts ...CompileOption) compileOptions {
@@ -75,21 +72,6 @@ func WithEngineBytesTracking(v bool) CompileOption {
 func WithWatchers(watchers ...SpanWatcher) CompileOption {
 	return func(o *compileOptions) {
 		o.watchers = append(o.watchers, watchers...)
-	}
-}
-
-// WithLock supplies the lock a metrics evaluator (Engine.CompileMetricsQueryRange) uses to guard
-// its Do/DoSpansOnly work, including any watchers installed via WithWatchers and
-// WithEngineBytesTracking. Metrics query only.
-//
-// Pass this when the compiled evaluator will be driven by multiple goroutines, e.g. livestore's
-// QueryRange evaluates WAL blocks concurrently against one shared evaluator. When nil (the
-// default), the evaluator performs no locking at all; only omit this when the compiled evaluator
-// is guaranteed to be used by a single goroutine, e.g. one evaluator per block as with the
-// querier's per-block QueryRange.
-func WithLock(mtx *sync.Mutex) CompileOption {
-	return func(o *compileOptions) {
-		o.lock = mtx
 	}
 }
 

--- a/pkg/traceql/watch.go
+++ b/pkg/traceql/watch.go
@@ -72,8 +72,7 @@ func (a *attrPresenceWatcher) Stats() map[string]int64 {
 // Inactive watchers are never dropped, only moved past the boundary, so WatchSpans only walks the active prefix.
 //
 // spanWatchers does no locking of its own. Callers that share one spanWatchers across multiple
-// goroutines (e.g. a metricsEvaluator with WithLock set, used across concurrently-evaluated
-// blocks) are responsible for synchronizing every call, including Active().
+// goroutines are responsible for synchronizing every call, including Active().
 type spanWatchers struct {
 	obs    []SpanWatcher
 	active int


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does: 
Instead of creating one L1 metrics `eval` and observing results from each WAL block to it, create one `eval` per each block and feed to L2. With this change eval won't have concurrent usage and we can remove mutex from L1 eval.

## How was this PR benchmarked: 
I compared 3 version: the fix, main branch and optimisation proposal from https://github.com/grafana/tempo/pull/7711.

### Go benchmarks

First, I used benchmark from https://github.com/grafana/tempo/pull/7711, results:
```
goos: linux
goarch: arm64
pkg: github.com/grafana/tempo/modules/livestore
                                            │     main     │            perfloop             │              myfix              │
                                            │    sec/op    │    sec/op     vs base           │    sec/op     vs base           │
LiveStoreQueryRangeSpanOnlyWALContention-11   6.088m ± ∞ ¹   5.431m ± ∞ ¹  ~ (p=1.000 n=1) ²   3.904m ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                            │     main      │             perfloop             │              myfix               │
                                            │     B/op      │     B/op       vs base           │     B/op       vs base           │
LiveStoreQueryRangeSpanOnlyWALContention-11   3.196Mi ± ∞ ¹   3.236Mi ± ∞ ¹  ~ (p=1.000 n=1) ²   3.480Mi ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                            │     main     │            perfloop             │              myfix              │
                                            │  allocs/op   │  allocs/op    vs base           │  allocs/op    vs base           │
LiveStoreQueryRangeSpanOnlyWALContention-11   38.50k ± ∞ ¹   38.59k ± ∞ ¹  ~ (p=1.000 n=1) ²   40.60k ± ∞ ¹  ~ (p=1.000 n=1) ²
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```

### End-to-end benchmarks

I checked end to end latency. I used 4 queries for last 10 minutes, run 10 requests at time, 2000 total requests. rate of spans is ~150k.

| Name | Query |
| :--- | :--- |
| `avg_over_time` | `{}` \| `avg_over_time(span:duration)` |
| `sum_over_time` | `{}` \| `sum_over_time(span:duration)` |
| `count_over_time` | `{}` \| `count_over_time()` |
| `ORs` | `{(resource.service.name!="gamma-operator" \|\| resource.service.name!="modelapi") && status=error}` \| `count_over_time()` |

#### main vs the fix

<img width="1189" height="909" alt="image" src="https://github.com/user-attachments/assets/dc5bb447-5a31-4612-8e42-9d44b0b48e71" />
<img width="1189" height="440" alt="image" src="https://github.com/user-attachments/assets/705949d1-23f7-4f9f-a8b1-f3f9cc6d909d" />

We can conclude that within confidence interval latency did not become worse

#### the fix vs perfloop's proposal

<img width="1189" height="909" alt="image" src="https://github.com/user-attachments/assets/38ed8fec-eec7-4d77-91b4-bfb8325c27b5" />

<img width="1189" height="440" alt="image" src="https://github.com/user-attachments/assets/a825bf39-1dd2-4381-8be0-56daff0b87c8" />

Unfortunately, perfloop's proposal increases latency

## Which issue(s) this PR fixes:
Fixes #<issue number>

## Checklist
- [ ] Tests updated
- [ ] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)