### PR TITLE
fix: preserve Kafka broker configs when setting default partitions

### DIFF
--- a/.chloggen/fix-kafka-incremental-broker-config.yaml
+++ b/.chloggen/fix-kafka-incremental-broker-config.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: bug_fix
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: tempo
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Preserve unrelated Kafka broker configuration, including consumer group offsets retention, when setting the default partition count for auto-created topics.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: [7869]
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: carles-grafana

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -275,7 +275,7 @@ func (cfg KafkaConfig) SetDefaultNumberOfPartitionsForAutocreatedTopics(logger l
 	defer adm.Close()
 
 	defaultNumberOfPartitions := fmt.Sprintf("%d", cfg.AutoCreateTopicDefaultPartitions)
-	_, err = adm.AlterBrokerConfigsState(context.Background(), []kadm.AlterConfig{
+	_, err = adm.AlterBrokerConfigs(context.Background(), []kadm.AlterConfig{
 		{
 			Op:    kadm.SetConfig,
 			Name:  "num.partitions",

--- a/pkg/ingest/config_test.go
+++ b/pkg/ingest/config_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
-	"github.com/twmb/franz-go/pkg/kmsg"
 )
 
 func TestKafkaConfig_ClientRackFlag(t *testing.T) {
@@ -32,30 +32,40 @@ func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(cluster.Close)
 
-	addrs := cluster.ListenAddrs()
-	require.Len(t, addrs, 1)
+	client, err := kgo.NewClient(kgo.SeedBrokers(cluster.ListenAddrs()...))
+	require.NoError(t, err)
+	adm := kadm.NewClient(client)
+	t.Cleanup(adm.Close)
+
+	retention := "5256000"
+	responses, err := adm.AlterBrokerConfigs(t.Context(), []kadm.AlterConfig{
+		{Op: kadm.SetConfig, Name: "offsets.retention.minutes", Value: &retention},
+	})
+	require.NoError(t, err)
+	for _, response := range responses {
+		require.NoError(t, response.Err)
+	}
 
 	cfg := KafkaConfig{
-		Address:                          addrs[0],
+		Address:                          cluster.ListenAddrs()[0],
 		AutoCreateTopicDefaultPartitions: 100,
 	}
 
-	cluster.ControlKey(kmsg.AlterConfigs.Int16(), func(request kmsg.Request) (kmsg.Response, error, bool) {
-		r := request.(*kmsg.AlterConfigsRequest)
-
-		require.Len(t, r.Resources, 1)
-		res := r.Resources[0]
-		require.Equal(t, kmsg.ConfigResourceTypeBroker, res.ResourceType)
-		require.Len(t, res.Configs, 1)
-		cfg := res.Configs[0]
-		require.Equal(t, "num.partitions", cfg.Name)
-		require.NotNil(t, *cfg.Value)
-		require.Equal(t, "100", *cfg.Value)
-
-		return &kmsg.AlterConfigsResponse{}, nil, true
-	})
-
 	cfg.SetDefaultNumberOfPartitionsForAutocreatedTopics(log.NewNopLogger())
+
+	configs, err := adm.DescribeBrokerConfigs(t.Context())
+	require.NoError(t, err)
+	brokerConfig, err := configs.On("", nil)
+	require.NoError(t, err)
+	require.NoError(t, brokerConfig.Err)
+
+	values := make(map[string]string, len(brokerConfig.Configs))
+	for _, config := range brokerConfig.Configs {
+		values[config.Key] = config.MaybeValue()
+	}
+	require.Equal(t, "100", values["num.partitions"])
+	require.Equal(t, retention, values["offsets.retention.minutes"],
+		"setting default partitions must preserve unrelated broker configuration")
 }
 
 func TestParseProducerCompression(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

When topic auto-creation is enabled and the default partition count is positive, Tempo's Kafka reader and writer initialization sets the cluster-wide num.partitions configuration. This happens on client initialization even when the topic already exists.

AlterBrokerConfigsState replaces the full dynamic broker configuration with the supplied values. Since Tempo supplies only num.partitions, unrelated overrides such as offsets.retention.minutes are cleared. Component restarts can therefore reset consumer group offsets retention to the broker default.

Use AlterBrokerConfigs to update num.partitions incrementally while preserving unrelated settings. The existing franz-go dependency supports this API; no dependency or configuration change is required.

Replace the mocked request assertion with a broker-state regression test that verifies both the requested partition count and preservation of an existing retention override. The test fails before the fix (5256000 minutes becomes 10080) and passes afterward. Verified with go test ./pkg/ingest -count=1.

This prevents future resets but does not restore overrides already cleared. IncrementalAlterConfigs support must be available on the Kafka-compatible backend.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)