### PR TITLE
feat: acccept a list of Kafka bootstrap brokers in ingest.kafka.address

### DIFF
--- a/.chloggen/kafka-broker-list.yaml
+++ b/.chloggen/kafka-broker-list.yaml
@@ -1,0 +1,23 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: tempo
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Accept a list of Kafka bootstrap brokers in `ingest.kafka.address`.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext: |
+  A single `host:port`, a comma-separated string, and a YAML list of brokers
+  are all accepted. Existing single-address configs continue to work.
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: david-vavra

--- a/docs/sources/tempo/configuration/_index.md
+++ b/docs/sources/tempo/configuration/_index.md
@@ -448,7 +448,8 @@ For architectural details, refer to the [Kafka architecture](/docs/tempo/<TEMPO_
 ingest:
 
     kafka:
-        # The Kafka backend address.
+        # The Kafka bootstrap addresses (host:port). A single address, a
+        # comma-separated list, or a YAML list of brokers.
         [address: <string> | default = "localhost:9092"]
 
         # The Kafka topic name.

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/configure-kafka.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/configure-kafka.md
@@ -147,17 +147,21 @@ Pre-create the topic and set `auto_create_topic_enabled: false` in production.
 
 ## Configure Tempo
 
-Set the bootstrap address and topic in the shared Tempo configuration:
+Set the bootstrap addresses and topic in the shared Tempo configuration:
 
 ```yaml
 ingest:
   kafka:
-    address: <KAFKA_BOOTSTRAP_ADDRESS>
+    address:
+      - <KAFKA_BOOTSTRAP_ADDRESS>
+      - <KAFKA_BOOTSTRAP_ADDRESS>
     topic: tempo-traces
     auto_create_topic_enabled: false
 ```
 
-`address` accepts one bootstrap address, after which Tempo discovers the topic's brokers from Kafka metadata.
+`address` accepts one or more bootstrap brokers as a single host:port,
+a comma-separated list, or a YAML list.
+After connecting, Tempo discovers the topic's remaining brokers from Kafka metadata.
 
 ### Configure authentication and TLS
 

--- a/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
+++ b/docs/sources/tempo/set-up-for-tracing/setup-tempo/migrate-to-3.md
@@ -343,7 +343,7 @@ Tempo logs errors such as `"the Kafka address has not been configured"`, `"ping 
 
 To resolve this issue:
 
-- Verify that `ingest.kafka.address` in your configuration points to the correct broker address.
+- Verify that `ingest.kafka.address` in your configuration points to the correct bootstrap broker addresses.
 - Confirm the broker is reachable from the Tempo deployment. Check network connectivity and firewall rules.
 - If you use SASL authentication, verify that both `sasl_username` and `sasl_password` are set. Setting only one produces the error `"the SASL username and password must be both configured to enable SASL authentication"`.
 

--- a/modules/blockbuilder/blockbuilder_test.go
+++ b/modules/blockbuilder/blockbuilder_test.go
@@ -925,7 +925,7 @@ func blockbuilderConfig(t testing.TB, address string, assignedPartitions []int32
 	cfg.BlockConfig.Version = encoding.DefaultEncoding().Version()
 
 	flagext.DefaultValues(&cfg.IngestStorageConfig.Kafka)
-	cfg.IngestStorageConfig.Kafka.Address = address
+	cfg.IngestStorageConfig.Kafka.Address = ingest.KafkaAddresses{address}
 	cfg.IngestStorageConfig.Kafka.Topic = testTopic
 	cfg.IngestStorageConfig.Kafka.ConsumerGroup = testConsumerGroup
 	cfg.AssignedPartitionsMap = map[string][]int32{cfg.InstanceID: assignedPartitions}

--- a/modules/distributor/distributor_test.go
+++ b/modules/distributor/distributor_test.go
@@ -1556,7 +1556,7 @@ func TestPushTracesSkipMetricsGenerationIngestStorage(t *testing.T) {
 	distributorCfg.PushSpansToKafka = true
 	distributorCfg.KafkaConfig = ingest.KafkaConfig{}
 	distributorCfg.KafkaConfig.RegisterFlags(&flag.FlagSet{})
-	distributorCfg.KafkaConfig.Address = kafka.ListenAddrs()[0]
+	distributorCfg.KafkaConfig.Address = ingest.KafkaAddresses{kafka.ListenAddrs()[0]}
 	distributorCfg.KafkaConfig.Topic = topic
 
 	d, err := New(
@@ -1648,7 +1648,7 @@ func TestPushTracesKafkaWriteErrorReturnsRetryableStatus(t *testing.T) {
 	distributorCfg.PushSpansToKafka = true
 	distributorCfg.KafkaConfig = ingest.KafkaConfig{}
 	distributorCfg.KafkaConfig.RegisterFlags(&flag.FlagSet{})
-	distributorCfg.KafkaConfig.Address = kafka.ListenAddrs()[0]
+	distributorCfg.KafkaConfig.Address = ingest.KafkaAddresses{kafka.ListenAddrs()[0]}
 	distributorCfg.KafkaConfig.Topic = topic
 	distributorCfg.KafkaConfig.WriteTimeout = time.Second
 

--- a/modules/livestore/instance_search_test.go
+++ b/modules/livestore/instance_search_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/grafana/tempo/modules/overrides"
 	"github.com/grafana/tempo/pkg/collector"
+	"github.com/grafana/tempo/pkg/ingest"
 	"github.com/grafana/tempo/pkg/ingest/testkafka"
 	"github.com/grafana/tempo/pkg/model/trace"
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -838,7 +839,7 @@ func defaultConfig(t testing.TB, tmpDir string) Config {
 	const testTopic = "traces"
 	_, kafkaAddr := testkafka.CreateCluster(t, 1, testTopic)
 
-	cfg.IngestConfig.Kafka.Address = kafkaAddr
+	cfg.IngestConfig.Kafka.Address = ingest.KafkaAddresses{kafkaAddr}
 	cfg.IngestConfig.Kafka.Topic = testTopic
 	cfg.IngestConfig.Kafka.ConsumerGroup = "test-consumer-group"
 

--- a/modules/livestore/live_store_test.go
+++ b/modules/livestore/live_store_test.go
@@ -727,7 +727,7 @@ func TestLiveStoreQueryMethodsBeforeStarted(t *testing.T) {
 	const testTopic = "traces"
 	_, kafkaAddr := testkafka.CreateCluster(t, 1, testTopic)
 
-	cfg.IngestConfig.Kafka.Address = kafkaAddr
+	cfg.IngestConfig.Kafka.Address = ingest.KafkaAddresses{kafkaAddr}
 	cfg.IngestConfig.Kafka.Topic = testTopic
 	cfg.IngestConfig.Kafka.ConsumerGroup = "test-consumer-group"
 

--- a/modules/livestore/partition_reader_test.go
+++ b/modules/livestore/partition_reader_test.go
@@ -36,7 +36,7 @@ func TestPartitionReaderCommits(t *testing.T) {
 			return nil, nil, false
 		})
 
-		client := testkafka.NewKafkaClient(t, address, testTopic)
+		client := testkafka.NewKafkaClient(t, []string{address}, testTopic)
 		testkafka.SendReq(t.Context(), t, client, ingest.Encode, testTenantID)
 
 		consumeFn := func(_ context.Context, rs recordIter, _ time.Time) (*kadm.Offset, error) {
@@ -68,7 +68,7 @@ func TestPartitionReaderCommits(t *testing.T) {
 			return nil, nil, false
 		})
 
-		client := testkafka.NewKafkaClient(t, address, testTopic)
+		client := testkafka.NewKafkaClient(t, []string{address}, testTopic)
 		testkafka.SendReq(t.Context(), t, client, ingest.Encode, testTenantID)
 
 		consumed := make(chan struct{})
@@ -118,7 +118,7 @@ func TestPartitionReaderLag(t *testing.T) {
 	// commitInterval=0 commits synchronously
 	r := defaultPartitionReaderWithCommitInterval(t, address, 0, consumeFn)
 
-	client := testkafka.NewKafkaClient(t, address, testTopic)
+	client := testkafka.NewKafkaClient(t, []string{address}, testTopic)
 	records := 10
 	for range records {
 		testkafka.SendReq(t.Context(), t, client, ingest.Encode, testTenantID)
@@ -136,7 +136,7 @@ func TestFetchLastCommittedOffsetForceFromLookback(t *testing.T) {
 
 	t.Run("committed offset exists, forceFromLookback=false uses committed offset", func(t *testing.T) {
 		_, address := testkafka.CreateCluster(t, 1, testTopic)
-		client := testkafka.NewKafkaClient(t, address, testTopic)
+		client := testkafka.NewKafkaClient(t, []string{address}, testTopic)
 
 		// Produce a record and commit an offset
 		testkafka.SendReq(t.Context(), t, client, ingest.Encode, testTenantID)
@@ -154,7 +154,7 @@ func TestFetchLastCommittedOffsetForceFromLookback(t *testing.T) {
 		l := test.NewTestingLogger(t)
 		cfg := ingest.KafkaConfig{}
 		flagext.DefaultValues(&cfg)
-		cfg.Address = address
+		cfg.Address = ingest.KafkaAddresses{address}
 		cfg.Topic = testTopic
 		cfg.ConsumerGroup = testConsumerGroup
 
@@ -174,7 +174,7 @@ func TestFetchLastCommittedOffsetForceFromLookback(t *testing.T) {
 
 	t.Run("committed offset exists, forceFromLookback=true ignores committed offset", func(t *testing.T) {
 		_, address := testkafka.CreateCluster(t, 1, testTopic)
-		client := testkafka.NewKafkaClient(t, address, testTopic)
+		client := testkafka.NewKafkaClient(t, []string{address}, testTopic)
 
 		// Produce a record and commit an offset
 		testkafka.SendReq(t.Context(), t, client, ingest.Encode, testTenantID)
@@ -192,7 +192,7 @@ func TestFetchLastCommittedOffsetForceFromLookback(t *testing.T) {
 		l := test.NewTestingLogger(t)
 		cfg := ingest.KafkaConfig{}
 		flagext.DefaultValues(&cfg)
-		cfg.Address = address
+		cfg.Address = ingest.KafkaAddresses{address}
 		cfg.Topic = testTopic
 		cfg.ConsumerGroup = testConsumerGroup
 
@@ -218,7 +218,7 @@ func TestFetchLastCommittedOffsetForceFromLookback(t *testing.T) {
 		l := test.NewTestingLogger(t)
 		cfg := ingest.KafkaConfig{}
 		flagext.DefaultValues(&cfg)
-		cfg.Address = address
+		cfg.Address = ingest.KafkaAddresses{address}
 		cfg.Topic = testTopic
 		cfg.ConsumerGroup = testConsumerGroup
 
@@ -244,7 +244,7 @@ func defaultPartitionReaderWithCommitInterval(t *testing.T, address string, comm
 
 	cfg := ingest.KafkaConfig{}
 	flagext.DefaultValues(&cfg)
-	cfg.Address = address
+	cfg.Address = ingest.KafkaAddresses{address}
 	cfg.Topic = testTopic
 	cfg.ConsumerGroup = testConsumerGroup
 

--- a/pkg/ingest/balancer_rebalance_test.go
+++ b/pkg/ingest/balancer_rebalance_test.go
@@ -92,7 +92,7 @@ func TestCooperativeActiveStickyBalancer_InactivePartitionsStayOnOwnerAcrossReba
 	tracker := newOwnershipTracker()
 
 	cfg := ingest.KafkaConfig{
-		Address:                        addr,
+		Address:                        ingest.KafkaAddresses{addr},
 		Topic:                          rebalanceTopic,
 		ConsumerGroup:                  rebalanceGroup,
 		DisableKafkaTelemetry:          true,

--- a/pkg/ingest/config.go
+++ b/pkg/ingest/config.go
@@ -102,14 +102,69 @@ func (cfg *Config) Validate() error {
 	return cfg.Kafka.Validate()
 }
 
+// KafkaAddresses is a list of Kafka bootstrap broker host:port pairs.
+// YAML accepts a single address, a comma-separated string, or a list of addresses.
+// Flags accept a comma-separated string.
+type KafkaAddresses []string
+
+// String implements flag.Value.
+func (v KafkaAddresses) String() string {
+	return strings.Join(v, ",")
+}
+
+// Set implements flag.Value. The flag value replaces any previous addresses
+// so RegisterFlags can set a default without appending when the flag is provided.
+func (v *KafkaAddresses) Set(s string) error {
+	*v = parseKafkaAddresses(s)
+	return nil
+}
+
+// FlagType implements flagext.Value so the generated docs describe the flag as a string.
+func (KafkaAddresses) FlagType() string {
+	return "string"
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler.
+func (v *KafkaAddresses) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err == nil {
+		return v.Set(s)
+	}
+
+	var slice []string
+	if err := unmarshal(&slice); err != nil {
+		return err
+	}
+	*v = parseKafkaAddresses(slice...)
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (v KafkaAddresses) MarshalYAML() (interface{}, error) {
+	return v.String(), nil
+}
+
+func parseKafkaAddresses(values ...string) KafkaAddresses {
+	out := make(KafkaAddresses, 0, len(values))
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+	return out
+}
+
 // KafkaConfig holds the generic config for the Kafka backend.
 type KafkaConfig struct {
-	Address      string        `yaml:"address"`
-	Topic        string        `yaml:"topic"`
-	ClientID     string        `yaml:"client_id"`
-	ClientRack   string        `yaml:"client_rack"`
-	DialTimeout  time.Duration `yaml:"dial_timeout"`
-	WriteTimeout time.Duration `yaml:"write_timeout"`
+	Address      KafkaAddresses `yaml:"address"`
+	Topic        string         `yaml:"topic"`
+	ClientID     string         `yaml:"client_id"`
+	ClientRack   string         `yaml:"client_rack"`
+	DialTimeout  time.Duration  `yaml:"dial_timeout"`
+	WriteTimeout time.Duration  `yaml:"write_timeout"`
 
 	SASL       KafkaAuthConfig `yaml:",inline"`
 	TLSEnabled bool            `yaml:"tls_enabled"`
@@ -145,7 +200,8 @@ func (cfg *KafkaConfig) RegisterFlags(f *flag.FlagSet) {
 }
 
 func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
-	f.StringVar(&cfg.Address, prefix+".address", "localhost:9092", "The Kafka backend address.")
+	cfg.Address = KafkaAddresses{"localhost:9092"}
+	f.Var(&cfg.Address, prefix+".address", "The Kafka backend addresses. Accepts a comma-separated list of host:port pairs used as bootstrap brokers.")
 	f.StringVar(&cfg.Topic, prefix+".topic", "", "The Kafka topic name.")
 	f.StringVar(&cfg.ClientID, prefix+".client-id", "", "The Kafka client ID.")
 	f.StringVar(&cfg.ClientRack, prefix+".client-rack", "", "The rack identifier for this Kafka client. Corresponds to the Kafka client.rack setting and enables fetching from the closest replica (KIP-392). Set this to the instance's availability zone to reduce cross-zone Kafka traffic.")
@@ -178,7 +234,7 @@ func (cfg *KafkaConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) 
 }
 
 func (cfg *KafkaConfig) Validate() error {
-	if cfg.Address == "" {
+	if len(cfg.Address) == 0 {
 		return ErrMissingKafkaAddress
 	}
 	if cfg.Topic == "" {

--- a/pkg/ingest/config_sasl_test.go
+++ b/pkg/ingest/config_sasl_test.go
@@ -28,7 +28,7 @@ import (
 func validSASLBaseConfig() KafkaConfig {
 	cfg := KafkaConfig{}
 	flagext.DefaultValues(&cfg)
-	cfg.Address = "localhost:9092"
+	cfg.Address = KafkaAddresses{"localhost:9092"}
 	cfg.Topic = "tempo"
 	return cfg
 }

--- a/pkg/ingest/config_test.go
+++ b/pkg/ingest/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
+	yamlv2 "go.yaml.in/yaml/v2"
 )
 
 func TestKafkaConfig_ClientRackFlag(t *testing.T) {
@@ -47,7 +48,7 @@ func TestSetDefaultNumberOfPartitionsForAutocreatedTopics(t *testing.T) {
 	}
 
 	cfg := KafkaConfig{
-		Address:                          cluster.ListenAddrs()[0],
+		Address:                          KafkaAddresses{cluster.ListenAddrs()[0]},
 		AutoCreateTopicDefaultPartitions: 100,
 	}
 
@@ -114,7 +115,7 @@ func TestParseProducerCompression_UnsetVsExplicitNone(t *testing.T) {
 
 func TestKafkaConfig_Validate_ProducerCompression(t *testing.T) {
 	cfg := KafkaConfig{
-		Address:                    "localhost:9092",
+		Address:                    KafkaAddresses{"localhost:9092"},
 		Topic:                      "test",
 		ProducerMaxRecordSizeBytes: minProducerRecordDataBytesLimit,
 	}
@@ -130,4 +131,86 @@ func TestKafkaConfig_Validate_ProducerCompression(t *testing.T) {
 	// validate that an invalid value raises an error.
 	cfg.ProducerCompression = "unsupported"
 	require.ErrorIs(t, cfg.Validate(), ErrInvalidProducerCompression)
+}
+
+func TestKafkaAddresses(t *testing.T) {
+	t.Run("flag default is a single localhost broker", func(t *testing.T) {
+		var cfg KafkaConfig
+		f := flag.NewFlagSet("test", flag.PanicOnError)
+		cfg.RegisterFlags(f)
+
+		require.Equal(t, KafkaAddresses{"localhost:9092"}, cfg.Address)
+		require.NoError(t, f.Parse(nil))
+		require.Equal(t, KafkaAddresses{"localhost:9092"}, cfg.Address)
+	})
+
+	t.Run("flag replaces the default with a comma-separated list", func(t *testing.T) {
+		var cfg KafkaConfig
+		f := flag.NewFlagSet("test", flag.PanicOnError)
+		cfg.RegisterFlags(f)
+
+		require.NoError(t, f.Parse([]string{"-kafka.address=kafka-1:9092, kafka-2:9092"}))
+		require.Equal(t, KafkaAddresses{"kafka-1:9092", "kafka-2:9092"}, cfg.Address)
+	})
+
+	tests := []struct {
+		name string
+		yaml string
+		want KafkaAddresses
+	}{
+		{
+			name: "single string",
+			yaml: "address: kafka-1:9092\n",
+			want: KafkaAddresses{"kafka-1:9092"},
+		},
+		{
+			name: "comma-separated string",
+			yaml: "address: kafka-1:9092, kafka-2:9092\n",
+			want: KafkaAddresses{"kafka-1:9092", "kafka-2:9092"},
+		},
+		{
+			name: "yaml list",
+			yaml: "address:\n  - kafka-1:9092\n  - kafka-2:9092\n",
+			want: KafkaAddresses{"kafka-1:9092", "kafka-2:9092"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run("yaml "+tc.name, func(t *testing.T) {
+			var cfg KafkaConfig
+			require.NoError(t, yamlv2.Unmarshal([]byte(tc.yaml), &cfg))
+			require.Equal(t, tc.want, cfg.Address)
+		})
+	}
+}
+
+func TestKafkaConfig_Validate_Address(t *testing.T) {
+	cfg := KafkaConfig{
+		Address:                    KafkaAddresses{"localhost:9092"},
+		Topic:                      "test",
+		ProducerMaxRecordSizeBytes: minProducerRecordDataBytesLimit,
+	}
+	require.NoError(t, cfg.Validate())
+
+	cfg.Address = nil
+	require.ErrorIs(t, cfg.Validate(), ErrMissingKafkaAddress)
+
+	cfg.Address = KafkaAddresses{}
+	require.ErrorIs(t, cfg.Validate(), ErrMissingKafkaAddress)
+}
+
+func TestCommonKafkaClientOptions_MultipleSeedBrokers(t *testing.T) {
+	cluster, err := kfake.NewCluster(kfake.NumBrokers(2))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	cfg := KafkaConfig{
+		Address: KafkaAddresses(cluster.ListenAddrs()),
+		Topic:   "test",
+	}
+	opts, err := commonKafkaClientOptions(cfg, nil, log.NewNopLogger())
+	require.NoError(t, err)
+
+	client, err := kgo.NewClient(opts...)
+	require.NoError(t, err)
+	t.Cleanup(client.Close)
 }

--- a/pkg/ingest/kafka_tls_sasl_test.go
+++ b/pkg/ingest/kafka_tls_sasl_test.go
@@ -169,7 +169,7 @@ func mtlsScramKafkaConfig(t *testing.T, address, topic string, certs testCerts, 
 
 	cfg := ingest.KafkaConfig{}
 	flagext.DefaultValues(&cfg)
-	cfg.Address = address
+	cfg.Address = ingest.KafkaAddresses{address}
 	cfg.Topic = topic
 	cfg.WriteTimeout = 10 * time.Second
 

--- a/pkg/ingest/partition_offset_client_test.go
+++ b/pkg/ingest/partition_offset_client_test.go
@@ -191,7 +191,7 @@ func createTestKafkaConfig(clusterAddr string) KafkaConfig {
 		MaxRetries: 0,
 	}
 
-	cfg.Address = clusterAddr
+	cfg.Address = KafkaAddresses{clusterAddr}
 	cfg.Topic = topicName
 	cfg.WriteTimeout = 5 * time.Second
 	cfg.concurrentFetchersFetchBackoffConfig = fastFetchBackoffConfig

--- a/pkg/ingest/testkafka/client.go
+++ b/pkg/ingest/testkafka/client.go
@@ -13,9 +13,9 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
-func NewKafkaClient(t testing.TB, address, topic string) *kgo.Client {
+func NewKafkaClient(t testing.TB, addresses []string, topic string) *kgo.Client {
 	writeClient, err := kgo.NewClient(
-		kgo.SeedBrokers(address),
+		kgo.SeedBrokers(addresses...),
 		kgo.AllowAutoTopicCreation(),
 		kgo.DefaultProduceTopic(topic),
 		// We will choose the Partition of each record.

--- a/pkg/ingest/writer_client.go
+++ b/pkg/ingest/writer_client.go
@@ -118,7 +118,7 @@ func (o onlySampledTraces) Inject(ctx context.Context, carrier propagation.TextM
 func commonKafkaClientOptions(cfg KafkaConfig, metrics *kprom.Metrics, logger log.Logger) ([]kgo.Opt, error) {
 	opts := []kgo.Opt{
 		kgo.ClientID(cfg.ClientID),
-		kgo.SeedBrokers(cfg.Address),
+		kgo.SeedBrokers(cfg.Address...),
 		kgo.DialTimeout(cfg.DialTimeout),
 
 		// A cluster metadata update is a request sent to a broker and getting back the map of partitions and

--- a/pkg/ingest/writer_client_test.go
+++ b/pkg/ingest/writer_client_test.go
@@ -50,7 +50,7 @@ func TestCommonKafkaClientOptions_ClientRack(t *testing.T) {
 	// Instead we verify that setting ClientRack still produces a valid client
 	// that kgo.NewClient accepts.
 	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
-	cfg := KafkaConfig{Address: "localhost:9092", Topic: "test", ClientRack: "us-east-1a"}
+	cfg := KafkaConfig{Address: KafkaAddresses{"localhost:9092"}, Topic: "test", ClientRack: "us-east-1a"}
 
 	opts, err := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestCommonKafkaClientOptions_EmptyClientRack(t *testing.T) {
 	// An empty ClientRack must not add the Rack option, so rack-aware fetching
 	// stays disabled by default.
 	metrics := kprom.NewMetrics("", kprom.Registerer(prometheus.NewPedanticRegistry()))
-	cfg := KafkaConfig{Address: "localhost:9092", Topic: "test"}
+	cfg := KafkaConfig{Address: KafkaAddresses{"localhost:9092"}, Topic: "test"}
 
 	opts, err := commonKafkaClientOptions(cfg, metrics, test.NewTestingLogger(t))
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does**:
Support for kafka broker address to be passed as a list.

**Which issue(s) this PR fixes**:
https://github.com/grafana/tempo/issues/7880

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [x] Changelog entry added under `.chloggen/` (run `make chlog-new`, or `make chlog-new FILENAME=<name>` to override the default branch-name file; see `.chloggen/README.md`)