### PR TITLE
feat: add mTLS authentication to tempo-cli API queries

### DIFF
--- a/.chloggen/tempo-cli-mtls.yaml
+++ b/.chloggen/tempo-cli-mtls.yaml
@@ -1,0 +1,21 @@
+# Changelog entry. Generate a copy with `make chlog-new`, then fill in the fields.
+
+# One of: breaking | change | feature | enhancement | bug_fix | security
+change_type: enhancement
+
+# Component or area of the change. Must be one of the components in .chloggen/config.yaml,
+# e.g. distributor, querier, query-frontend, storage, operations.
+component: tempo-cli
+
+# A brief description of the change. Surround with quotes ("") if it must start with a backtick (`).
+note: Authenticate tempo-cli API queries over HTTPS and gRPC with mTLS client certificates, with optional custom CA bundles and TLS server names.
+
+# (Optional) PR number(s), e.g. [7339]. Leave blank to auto-fill at release. See
+# .chloggen/README.md.
+issues: []
+
+# (Optional) Additional lines rendered under the note. Use a pipe (|) for multiline text.
+subtext:
+
+# The GitHub handle (without the leading @) of the change's author. Rendered as "(@handle)".
+user: dobesv

--- a/cmd/tempo-cli/cmd-query-metrics-query-range.go
+++ b/cmd/tempo-cli/cmd-query-metrics-query-range.go
@@ -18,6 +18,8 @@ import (
 )
 
 type metricsQueryCmd struct {
+	tlsOptions
+
 	HostPort string `arg:"" help:"tempo host and port. scheme and path will be provided based on query type. e.g. localhost:3200"`
 	TraceQL  string `arg:"" optional:"" help:"TraceQL query string"`
 	Start    string `arg:"" optional:"" help:"start time in RFC3339 (e.g. 2006-01-02T15:04:05Z07:00) or relative (e.g. now-1h) format"`
@@ -79,7 +81,7 @@ func (cmd *metricsQueryCmd) queryRangeGRPC(req *tempopb.QueryRangeRequest) error
 	}
 	ctx = applyHeadersGRPC(ctx, cmd.Headers)
 
-	creds, err := grpcTransportCredentials(cmd.Secure)
+	creds, err := cmd.grpcTransportCredentials(cmd.Secure)
 	if err != nil {
 		return err
 	}
@@ -88,6 +90,7 @@ func (cmd *metricsQueryCmd) queryRangeGRPC(req *tempopb.QueryRangeRequest) error
 	if err != nil {
 		return err
 	}
+	defer clientConn.Close()
 
 	client := tempopb.NewStreamingQuerierClient(clientConn)
 
@@ -115,6 +118,13 @@ func (cmd *metricsQueryCmd) queryRangeGRPC(req *tempopb.QueryRangeRequest) error
 
 // nolint: goconst // goconst wants us to make http:// a const
 func (cmd *metricsQueryCmd) queryRangeHTTP(req *tempopb.QueryRangeRequest) error {
+	transport, err := cmd.httpTransport(cmd.Secure)
+	if err != nil {
+		return err
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport}
+
 	httpReq, err := http.NewRequest("GET", httpScheme(cmd.Secure)+"://"+path.Join(cmd.HostPort, cmd.PathPrefix, api.PathMetricsQueryRange), nil)
 	if err != nil {
 		return err
@@ -128,7 +138,7 @@ func (cmd *metricsQueryCmd) queryRangeHTTP(req *tempopb.QueryRangeRequest) error
 	}
 	applyHeadersHTTP(httpReq, cmd.Headers)
 
-	httpResp, err := http.DefaultClient.Do(httpReq)
+	httpResp, err := client.Do(httpReq)
 	if err != nil {
 		return err
 	}
@@ -164,7 +174,7 @@ func (cmd *metricsQueryCmd) queryInstantGRPC(req *tempopb.QueryInstantRequest) e
 	}
 	ctx = applyHeadersGRPC(ctx, cmd.Headers)
 
-	creds, err := grpcTransportCredentials(cmd.Secure)
+	creds, err := cmd.grpcTransportCredentials(cmd.Secure)
 	if err != nil {
 		return err
 	}
@@ -173,6 +183,7 @@ func (cmd *metricsQueryCmd) queryInstantGRPC(req *tempopb.QueryInstantRequest) e
 	if err != nil {
 		return err
 	}
+	defer clientConn.Close()
 
 	client := tempopb.NewStreamingQuerierClient(clientConn)
 
@@ -200,6 +211,13 @@ func (cmd *metricsQueryCmd) queryInstantGRPC(req *tempopb.QueryInstantRequest) e
 
 // nolint: goconst // goconst wants us to make http:// a const
 func (cmd *metricsQueryCmd) queryInstantHTTP(req *tempopb.QueryInstantRequest) error {
+	transport, err := cmd.httpTransport(cmd.Secure)
+	if err != nil {
+		return err
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport}
+
 	httpReq, err := http.NewRequest("GET", httpScheme(cmd.Secure)+"://"+path.Join(cmd.HostPort, cmd.PathPrefix, api.PathMetricsQueryInstant), nil)
 	if err != nil {
 		return err
@@ -213,7 +231,7 @@ func (cmd *metricsQueryCmd) queryInstantHTTP(req *tempopb.QueryInstantRequest) e
 	}
 	applyHeadersHTTP(httpReq, cmd.Headers)
 
-	httpResp, err := http.DefaultClient.Do(httpReq)
+	httpResp, err := client.Do(httpReq)
 	if err != nil {
 		return err
 	}

--- a/cmd/tempo-cli/cmd-query-search-tag-values.go
+++ b/cmd/tempo-cli/cmd-query-search-tag-values.go
@@ -14,6 +14,8 @@ import (
 )
 
 type querySearchTagValuesCmd struct {
+	tlsOptions
+
 	HostPort string `arg:"" help:"tempo host and port. scheme and path will be provided based on query type. e.g. localhost:3200"`
 	Tag      string `arg:"" help:"tag name"`
 	Start    string `arg:"" optional:"" help:"start time in RFC3339 (e.g. 2006-01-02T15:04:05Z07:00) or relative (e.g. now-1h) format"`
@@ -54,14 +56,20 @@ func (cmd *querySearchTagValuesCmd) Run(_ *globalOptions) error {
 
 // nolint: goconst // goconst wants us to make http:// a const
 func (cmd *querySearchTagValuesCmd) searchHTTP(start, end int64) error {
+	transport, err := cmd.httpTransport(cmd.Secure)
+	if err != nil {
+		return err
+	}
+	defer transport.CloseIdleConnections()
+
 	if cmd.PathPrefix != "" {
 		cmd.HostPort = path.Join(cmd.HostPort, cmd.PathPrefix)
 	}
 	client := httpclient.New(httpScheme(cmd.Secure)+"://"+cmd.HostPort, cmd.OrgID)
+	client.WithTransport(transport)
 	applyHeaders(client, cmd.Headers)
 
 	var tags *tempopb.SearchTagValuesV2Response
-	var err error
 	if start != 0 || end != 0 {
 		tags, err = client.SearchTagValuesV2WithRange(cmd.Tag, cmd.Query, start, end)
 	} else {
@@ -83,7 +91,7 @@ func (cmd *querySearchTagValuesCmd) searchGRPC(start, end int64) error {
 	}
 	ctx = applyHeadersGRPC(ctx, cmd.Headers)
 
-	creds, err := grpcTransportCredentials(cmd.Secure)
+	creds, err := cmd.grpcTransportCredentials(cmd.Secure)
 	if err != nil {
 		return err
 	}
@@ -92,6 +100,7 @@ func (cmd *querySearchTagValuesCmd) searchGRPC(start, end int64) error {
 	if err != nil {
 		return err
 	}
+	defer clientConn.Close()
 
 	client := tempopb.NewStreamingQuerierClient(clientConn)
 

--- a/cmd/tempo-cli/cmd-query-search-tags.go
+++ b/cmd/tempo-cli/cmd-query-search-tags.go
@@ -14,6 +14,8 @@ import (
 )
 
 type querySearchTagsCmd struct {
+	tlsOptions
+
 	HostPort string `arg:"" help:"tempo host and port. scheme and path will be provided based on query type. e.g. localhost:3200"`
 	Start    string `arg:"" optional:"" help:"start time in RFC3339 (e.g. 2006-01-02T15:04:05Z07:00) or relative (e.g. now-1h) format"`
 	End      string `arg:"" optional:"" help:"end time in RFC3339 (e.g. 2006-01-02T15:04:05Z07:00) or relative (e.g. now) format"`
@@ -52,14 +54,20 @@ func (cmd *querySearchTagsCmd) Run(_ *globalOptions) error {
 
 // nolint: goconst // goconst wants us to make http:// a const
 func (cmd *querySearchTagsCmd) searchHTTP(start, end int64) error {
+	transport, err := cmd.httpTransport(cmd.Secure)
+	if err != nil {
+		return err
+	}
+	defer transport.CloseIdleConnections()
+
 	if cmd.PathPrefix != "" {
 		cmd.HostPort = path.Join(cmd.HostPort, cmd.PathPrefix)
 	}
 	client := httpclient.New(httpScheme(cmd.Secure)+"://"+cmd.HostPort, cmd.OrgID)
+	client.WithTransport(transport)
 	applyHeaders(client, cmd.Headers)
 
 	var tags *tempopb.SearchTagsV2Response
-	var err error
 	if start != 0 || end != 0 {
 		tags, err = client.SearchTagsV2WithRange("", "", start, end)
 	} else {
@@ -81,7 +89,7 @@ func (cmd *querySearchTagsCmd) searchGRPC(start, end int64) error {
 	}
 	ctx = applyHeadersGRPC(ctx, cmd.Headers)
 
-	creds, err := grpcTransportCredentials(cmd.Secure)
+	creds, err := cmd.grpcTransportCredentials(cmd.Secure)
 	if err != nil {
 		return err
 	}
@@ -90,6 +98,7 @@ func (cmd *querySearchTagsCmd) searchGRPC(start, end int64) error {
 	if err != nil {
 		return err
 	}
+	defer clientConn.Close()
 
 	client := tempopb.NewStreamingQuerierClient(clientConn)
 

--- a/cmd/tempo-cli/cmd-query-search.go
+++ b/cmd/tempo-cli/cmd-query-search.go
@@ -18,6 +18,8 @@ import (
 )
 
 type querySearchCmd struct {
+	tlsOptions
+
 	HostPort string `arg:"" help:"tempo host and port. scheme and path will be provided based on query type. e.g. localhost:3200"`
 	TraceQL  string `arg:"" optional:"" help:"traceql query"`
 	Start    string `arg:"" optional:"" help:"start time in RFC3339 (e.g. 2006-01-02T15:04:05Z07:00) or relative (e.g. now-1h) format"`
@@ -68,7 +70,7 @@ func (cmd *querySearchCmd) searchGRPC(req *tempopb.SearchRequest) error {
 	}
 	ctx = applyHeadersGRPC(ctx, cmd.Headers)
 
-	creds, err := grpcTransportCredentials(cmd.Secure)
+	creds, err := cmd.grpcTransportCredentials(cmd.Secure)
 	if err != nil {
 		return err
 	}
@@ -77,6 +79,7 @@ func (cmd *querySearchCmd) searchGRPC(req *tempopb.SearchRequest) error {
 	if err != nil {
 		return err
 	}
+	defer clientConn.Close()
 
 	client := tempopb.NewStreamingQuerierClient(clientConn)
 
@@ -104,6 +107,13 @@ func (cmd *querySearchCmd) searchGRPC(req *tempopb.SearchRequest) error {
 
 // nolint: goconst // goconst wants us to make http:// a const
 func (cmd *querySearchCmd) searchHTTP(req *tempopb.SearchRequest) error {
+	transport, err := cmd.httpTransport(cmd.Secure)
+	if err != nil {
+		return err
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport}
+
 	httpReq, err := http.NewRequest("GET", httpScheme(cmd.Secure)+"://"+path.Join(cmd.HostPort, cmd.PathPrefix, api.PathSearch), nil)
 	if err != nil {
 		return err
@@ -121,7 +131,7 @@ func (cmd *querySearchCmd) searchHTTP(req *tempopb.SearchRequest) error {
 	}
 	applyHeadersHTTP(httpReq, cmd.Headers)
 
-	httpResp, err := http.DefaultClient.Do(httpReq)
+	httpResp, err := client.Do(httpReq)
 	if err != nil {
 		return err
 	}

--- a/cmd/tempo-cli/cmd-query-trace-id.go
+++ b/cmd/tempo-cli/cmd-query-trace-id.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 
@@ -11,6 +12,8 @@ import (
 )
 
 type queryTraceIDCmd struct {
+	tlsOptions
+
 	APIEndpoint string `arg:"" help:"tempo api endpoint"`
 	TraceID     string `arg:"" help:"trace ID to retrieve"`
 
@@ -26,7 +29,18 @@ type queryTraceIDCmd struct {
 }
 
 func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
+	endpoint, err := url.Parse(cmd.APIEndpoint)
+	if err != nil {
+		return fmt.Errorf("parsing API endpoint: %w", err)
+	}
+	transport, err := cmd.httpTransport(endpoint.Scheme == "https")
+	if err != nil {
+		return err
+	}
+	defer transport.CloseIdleConnections()
+
 	client := httpclient.New(cmd.APIEndpoint, cmd.OrgID)
+	client.WithTransport(transport)
 	applyHeaders(client, cmd.Headers)
 	// util.QueryTrace will only add orgID header if len(orgID) > 0
 
@@ -50,7 +64,6 @@ func (cmd *queryTraceIDCmd) Run(_ *globalOptions) error {
 	}
 
 	var traceResp *tempopb.TraceByIDResponse
-	var err error
 	if cmd.Q != "" {
 		params := map[string]string{
 			"q":              cmd.Q,

--- a/cmd/tempo-cli/cmd-query-trace-id_test.go
+++ b/cmd/tempo-cli/cmd-query-trace-id_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestQueryTraceIDCmdRejectsMalformedURL(t *testing.T) {
+	cmd := &queryTraceIDCmd{APIEndpoint: "http://%", TraceID: "1234"}
+	require.ErrorContains(t, cmd.Run(nil), "parsing API endpoint")
+}
+
 func TestQueryTraceIDCmdRejectsQWithV1(t *testing.T) {
 	// --q is v2-only, so combining it with --v1 must fail fast before any request is made.
 	cmd := &queryTraceIDCmd{

--- a/cmd/tempo-cli/shared.go
+++ b/cmd/tempo-cli/shared.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,9 +14,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/prometheus/common/model"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/grafana/tempo/pkg/boundedwaitgroup"
@@ -189,21 +185,6 @@ func httpScheme(secure bool) string {
 		return "https"
 	}
 	return "http"
-}
-
-func grpcTransportCredentials(secure bool) (opt grpc.DialOption, err error) {
-	var creds credentials.TransportCredentials
-	if secure {
-		certPool, err := x509.SystemCertPool()
-		if err != nil {
-			return nil, err
-		}
-		creds = credentials.NewClientTLSFromCert(certPool, "")
-	} else {
-		creds = insecure.NewCredentials()
-	}
-
-	return grpc.WithTransportCredentials(creds), nil
 }
 
 // parseTime parses a time string that can be:

--- a/cmd/tempo-cli/tls.go
+++ b/cmd/tempo-cli/tls.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type tlsOptions struct {
+	TLSCert       string `name:"tls-cert" type:"path" help:"PEM client certificate file for mTLS; requires --tls-key and TLS"`
+	TLSKey        string `name:"tls-key" type:"path" help:"PEM private key file for mTLS; requires --tls-cert and TLS"`
+	TLSCA         string `name:"tls-ca" type:"path" help:"PEM CA certificate bundle to add to system trust roots; requires TLS"`
+	TLSServerName string `name:"tls-server-name" help:"override the TLS server name for certificate verification and SNI; requires TLS"`
+}
+
+func (o *tlsOptions) tlsConfig(secure bool) (*tls.Config, error) {
+	if !secure {
+		if o.TLSCert != "" || o.TLSKey != "" || o.TLSCA != "" || o.TLSServerName != "" {
+			return nil, fmt.Errorf("TLS options require TLS: use an https:// URL for trace-id, or --secure for other query api commands")
+		}
+		return nil, nil
+	}
+	if (o.TLSCert == "") != (o.TLSKey == "") {
+		return nil, fmt.Errorf("--tls-cert and --tls-key must be provided together")
+	}
+
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ServerName: o.TLSServerName,
+	}
+	if o.TLSCA != "" {
+		pool, err := x509.SystemCertPool()
+		if err != nil {
+			return nil, fmt.Errorf("loading system certificate pool: %w", err)
+		}
+		if pool == nil {
+			pool = x509.NewCertPool()
+		}
+		pem, err := os.ReadFile(o.TLSCA)
+		if err != nil {
+			return nil, fmt.Errorf("reading CA certificate %q: %w", o.TLSCA, err)
+		}
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("no valid certificates found in CA bundle %q", o.TLSCA)
+		}
+		cfg.RootCAs = pool
+	}
+	if o.TLSCert != "" {
+		cert, err := tls.LoadX509KeyPair(o.TLSCert, o.TLSKey)
+		if err != nil {
+			return nil, fmt.Errorf("loading client certificate and key %q, %q: %w", o.TLSCert, o.TLSKey, err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	return cfg, nil
+}
+
+func (o *tlsOptions) httpTransport(secure bool) (*http.Transport, error) {
+	cfg, err := o.tlsConfig(secure)
+	if err != nil {
+		return nil, err
+	}
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("unexpected default HTTP transport type %T", http.DefaultTransport)
+	}
+	transport := base.Clone()
+	transport.TLSClientConfig = cfg
+	return transport, nil
+}
+
+func (o *tlsOptions) grpcTransportCredentials(secure bool) (grpc.DialOption, error) {
+	cfg, err := o.tlsConfig(secure)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
+	}
+	return grpc.WithTransportCredentials(credentials.NewTLS(cfg)), nil
+}

--- a/cmd/tempo-cli/tls_test.go
+++ b/cmd/tempo-cli/tls_test.go
@@ -1,0 +1,452 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/gogo/protobuf/proto"
+	"github.com/grafana/tempo/pkg/tempopb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func TestTLSOptionsValidation(t *testing.T) {
+	invalid := filepath.Join(t.TempDir(), "invalid.pem")
+	require.NoError(t, os.WriteFile(invalid, []byte("not a certificate"), 0o600))
+	missing := filepath.Join(t.TempDir(), "missing.pem")
+
+	tests := []struct {
+		name    string
+		options tlsOptions
+		secure  bool
+		wantErr string
+	}{
+		{name: "plaintext defaults"},
+		{name: "TLS defaults", secure: true},
+		{name: "certificate without key", secure: true, options: tlsOptions{TLSCert: invalid}, wantErr: "--tls-cert and --tls-key must be provided together"},
+		{name: "key without certificate", secure: true, options: tlsOptions{TLSKey: invalid}, wantErr: "--tls-cert and --tls-key must be provided together"},
+		{name: "certificate on plaintext", options: tlsOptions{TLSCert: invalid, TLSKey: invalid}, wantErr: "require TLS"},
+		{name: "CA on plaintext", options: tlsOptions{TLSCA: invalid}, wantErr: "require TLS"},
+		{name: "server name on plaintext", options: tlsOptions{TLSServerName: "tempo.example.com"}, wantErr: "require TLS"},
+		{name: "missing CA", secure: true, options: tlsOptions{TLSCA: missing}, wantErr: "reading CA certificate"},
+		{name: "invalid CA", secure: true, options: tlsOptions{TLSCA: invalid}, wantErr: "no valid certificates"},
+		{name: "missing certificate", secure: true, options: tlsOptions{TLSCert: missing, TLSKey: invalid}, wantErr: "loading client certificate and key"},
+		{name: "invalid certificate", secure: true, options: tlsOptions{TLSCert: invalid, TLSKey: invalid}, wantErr: "loading client certificate and key"},
+		{name: "server name only", secure: true, options: tlsOptions{TLSServerName: "tempo.example.com"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := tt.options.tlsConfig(tt.secure)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if !tt.secure {
+				require.Nil(t, cfg)
+				return
+			}
+			require.NotNil(t, cfg)
+			require.False(t, cfg.InsecureSkipVerify)
+			require.Equal(t, tt.options.TLSServerName, cfg.ServerName)
+		})
+	}
+}
+
+type tlsTestPKI struct {
+	options tlsOptions
+	server  *tls.Config
+}
+
+// Generate short-lived certificates at test time so fixtures never expire in the repository.
+func newTLSTestPKI(t *testing.T) tlsTestPKI {
+	t.Helper()
+	dir := t.TempDir()
+	issue := func(name string, template, parent *x509.Certificate, signer *ecdsa.PrivateKey) tls.Certificate {
+		t.Helper()
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		if parent == nil {
+			parent, signer = template, key
+		}
+		template.NotBefore = time.Now().Add(-time.Hour)
+		template.NotAfter = time.Now().Add(time.Hour)
+		der, err := x509.CreateCertificate(rand.Reader, template, parent, &key.PublicKey, signer)
+		require.NoError(t, err)
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		require.NoError(t, err)
+		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name+".crt"), certPEM, 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name+".key"), keyPEM, 0o600))
+		cert, err := tls.X509KeyPair(certPEM, keyPEM)
+		require.NoError(t, err)
+		cert.Leaf, err = x509.ParseCertificate(der)
+		require.NoError(t, err)
+		return cert
+	}
+	ca := issue("ca", &x509.Certificate{
+		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "tempo-cli test CA"},
+		IsCA: true, BasicConstraintsValid: true, KeyUsage: x509.KeyUsageCertSign,
+	}, nil, nil)
+	caKey := ca.PrivateKey.(*ecdsa.PrivateKey)
+	server := issue("server", &x509.Certificate{
+		SerialNumber: big.NewInt(2), DNSNames: []string{"tempo.test"}, IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}, ca.Leaf, caKey)
+	issue("client", &x509.Certificate{
+		SerialNumber: big.NewInt(3), Subject: pkix.Name{CommonName: "tempo-cli test client"},
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}, ca.Leaf, caKey)
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Leaf)
+	return tlsTestPKI{
+		options: tlsOptions{TLSCert: filepath.Join(dir, "client.crt"), TLSKey: filepath.Join(dir, "client.key"), TLSCA: filepath.Join(dir, "ca.crt")},
+		server: &tls.Config{
+			MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{server},
+			ClientCAs: pool, ClientAuth: tls.RequireAndVerifyClientCert,
+		},
+	}
+}
+
+func runTLSQuery(t *testing.T, args ...string) error {
+	t.Helper()
+	commands := cli
+	parser, err := kong.New(&commands, kong.Writers(io.Discard, io.Discard))
+	require.NoError(t, err)
+	ctx, err := parser.Parse(append([]string{"query", "api"}, args...))
+	if err != nil {
+		return err
+	}
+	return ctx.Run(&commands.globalOptions)
+}
+
+func TestQueryAPIMTLSHTTP(t *testing.T) {
+	pki := newTLSTestPKI(t)
+	for _, secure := range []bool{false, true} {
+		for _, tc := range []struct {
+			name  string
+			args  []string
+			path  string
+			query string
+		}{
+			{name: "trace-v1", args: []string{"trace-id", "--v1"}, path: "/api/traces/1234"},
+			{name: "trace-v2", args: []string{"trace-id", "--q={}"}, path: "/api/v2/traces/1234", query: "{}"},
+			{name: "search", args: []string{"search"}, path: "/api/search", query: "{}"},
+			{name: "tags", args: []string{"search-tags"}, path: "/api/v2/search/tags"},
+			{name: "tag-values", args: []string{"search-tag-values", "--query={}"}, path: "/api/v2/search/tag/resource.service.name/values", query: "{}"},
+			{name: "metrics-range", args: []string{"metrics"}, path: "/api/metrics/query_range", query: "{} | rate()"},
+			{name: "metrics-instant", args: []string{"metrics", "--instant"}, path: "/api/metrics/query", query: "{} | rate()"},
+		} {
+			t.Run(httpScheme(secure)+"/"+tc.name, func(t *testing.T) {
+				called := make(chan struct{}, 1)
+				srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					called <- struct{}{}
+					assert.Equal(t, "/tempo"+tc.path, r.URL.Path)
+					assert.Equal(t, tc.query, r.URL.Query().Get("q"))
+					assert.Equal(t, "test-tenant", r.Header.Get("X-Scope-OrgID"))
+					assert.Equal(t, "Bearer token=abc", r.Header.Get("Authorization"))
+					if secure {
+						assert.Equal(t, "tempo.test", r.TLS.ServerName)
+						if assert.NotEmpty(t, r.TLS.VerifiedChains) {
+							assert.Equal(t, "tempo-cli test client", r.TLS.PeerCertificates[0].Subject.CommonName)
+						}
+					}
+					if tc.name == "trace-v1" || tc.name == "trace-v2" {
+						assert.Equal(t, "application/protobuf", r.Header.Get("Accept"))
+						var response proto.Message = &tempopb.Trace{}
+						if tc.name == "trace-v2" {
+							response = &tempopb.TraceByIDResponse{Trace: &tempopb.Trace{}}
+						}
+						body, err := proto.Marshal(response)
+						assert.NoError(t, err)
+						_, err = w.Write(body)
+						assert.NoError(t, err)
+						return
+					}
+					_, err := io.WriteString(w, "{}")
+					assert.NoError(t, err)
+				}))
+				if secure {
+					srv.TLS = pki.server.Clone()
+					srv.StartTLS()
+				} else {
+					srv.Start()
+				}
+				defer srv.Close()
+				args := append([]string{}, tc.args...)
+				if tc.args[0] == "trace-id" {
+					args = append(args, srv.URL+"/tempo", "1234")
+				} else {
+					args = append(args, "--path-prefix=/tempo", srv.Listener.Addr().String())
+					switch tc.args[0] {
+					case "search", "metrics":
+						args = append(args, tc.query)
+					case "search-tag-values":
+						args = append(args, "resource.service.name")
+					}
+					args = append(args, "now-1h", "now")
+					if secure {
+						args = append(args, "--secure")
+					}
+				}
+				args = append(args, "--org-id=test-tenant", "--header=Authorization=Bearer token=abc")
+				if secure {
+					args = append(args, "--tls-cert="+pki.options.TLSCert, "--tls-key="+pki.options.TLSKey, "--tls-ca="+pki.options.TLSCA, "--tls-server-name=tempo.test")
+				}
+				require.NoError(t, runTLSQuery(t, args...))
+				require.Len(t, called, 1)
+			})
+		}
+	}
+}
+
+func TestTLSHandshake(t *testing.T) {
+	pki := newTLSTestPKI(t)
+	untrusted := newTLSTestPKI(t)
+	for _, transport := range []string{"http", "grpc"} {
+		for _, tc := range []struct {
+			name        string
+			options     tlsOptions
+			wantErr     bool
+			errContains string
+		}{
+			{name: "valid mTLS", options: pki.options},
+			// TLS 1.3 server rejection can reach the client as EOF or a broken pipe instead of a certificate alert.
+			{name: "missing client certificate", options: tlsOptions{TLSCA: pki.options.TLSCA}, wantErr: true},
+			{name: "untrusted client certificate", options: tlsOptions{TLSCA: pki.options.TLSCA, TLSCert: untrusted.options.TLSCert, TLSKey: untrusted.options.TLSKey}, wantErr: true},
+			{name: "untrusted server", options: tlsOptions{TLSCert: pki.options.TLSCert, TLSKey: pki.options.TLSKey}, wantErr: true, errContains: "unknown authority"},
+			{name: "wrong CA", options: tlsOptions{TLSCA: untrusted.options.TLSCA, TLSCert: pki.options.TLSCert, TLSKey: pki.options.TLSKey}, wantErr: true, errContains: "unknown authority"},
+			{name: "wrong server name", options: tlsOptions{TLSCA: pki.options.TLSCA, TLSCert: pki.options.TLSCert, TLSKey: pki.options.TLSKey, TLSServerName: "wrong.test"}, wantErr: true, errContains: "wrong.test"},
+		} {
+			t.Run(transport+"/"+tc.name, func(t *testing.T) {
+				var endpoint string
+				if transport == "http" {
+					srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						_, err := io.WriteString(w, "{}")
+						assert.NoError(t, err)
+					}))
+					srv.TLS = pki.server.Clone()
+					srv.StartTLS()
+					defer srv.Close()
+					endpoint = srv.Listener.Addr().String()
+				} else {
+					endpoint = startTLSQueryGRPCServer(t, pki.server, false)
+				}
+				cmd := querySearchTagsCmd{tlsOptions: tc.options, HostPort: endpoint, Secure: true, UseGRPC: transport == "grpc", OrgID: "test-tenant"}
+				err := cmd.Run(nil)
+				if tc.wantErr {
+					require.Error(t, err)
+					if tc.errContains != "" {
+						require.ErrorContains(t, err, tc.errContains)
+					}
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
+	}
+}
+
+func TestTLSKeyValidation(t *testing.T) {
+	pki := newTLSTestPKI(t)
+	other := newTLSTestPKI(t)
+	for _, key := range []string{other.options.TLSKey, filepath.Join(t.TempDir(), "missing.key"), pki.options.TLSCert} {
+		options := pki.options
+		options.TLSKey = key
+		_, err := options.tlsConfig(true)
+		require.ErrorContains(t, err, "loading client certificate and key")
+	}
+}
+
+func TestTLSWithoutClientCertificate(t *testing.T) {
+	pki := newTLSTestPKI(t)
+	pki.server.ClientAuth = tls.NoClientCert
+	for _, transport := range []string{"http", "grpc"} {
+		t.Run(transport, func(t *testing.T) {
+			var endpoint string
+			if transport == "http" {
+				srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					_, err := io.WriteString(w, "{}")
+					assert.NoError(t, err)
+				}))
+				srv.TLS = pki.server.Clone()
+				srv.StartTLS()
+				defer srv.Close()
+				endpoint = srv.Listener.Addr().String()
+			} else {
+				endpoint = startTLSQueryGRPCServer(t, pki.server, false)
+			}
+			cmd := querySearchTagsCmd{
+				tlsOptions: tlsOptions{TLSCA: pki.options.TLSCA, TLSServerName: "tempo.test"},
+				HostPort:   endpoint, Secure: true, UseGRPC: transport == "grpc", OrgID: "test-tenant",
+			}
+			require.NoError(t, cmd.Run(nil))
+		})
+	}
+}
+
+func TestQueryAPITLSRequiresSecure(t *testing.T) {
+	for _, transport := range []string{"http", "grpc"} {
+		for _, args := range [][]string{
+			{"trace-id", "http://localhost:0", "1234"},
+			{"search", "localhost:0", "{}", "now-1h", "now"},
+			{"search-tags", "localhost:0"},
+			{"search-tag-values", "localhost:0", "resource.service.name"},
+			{"metrics", "localhost:0", "{} | rate()", "now-1h", "now"},
+			{"metrics", "--instant", "localhost:0", "{} | rate()", "now-1h", "now"},
+		} {
+			if transport == "grpc" && args[0] == "trace-id" {
+				continue
+			}
+			t.Run(transport+"/"+strings.Join(args[:2], " "), func(t *testing.T) {
+				args = append(args, "--tls-ca=unused.pem", "--org-id=test-tenant")
+				if transport == "grpc" {
+					args = append(args, "--use-grpc")
+				}
+				require.ErrorContains(t, runTLSQuery(t, args...), "require TLS")
+			})
+		}
+	}
+}
+
+func TestHTTPTransportIsolation(t *testing.T) {
+	pki := newTLSTestPKI(t)
+	base := http.DefaultTransport.(*http.Transport)
+	before := base.Clone()
+	transport, err := pki.options.httpTransport(true)
+	require.NoError(t, err)
+	defer transport.CloseIdleConnections()
+	require.NotSame(t, base, transport)
+	require.Equal(t, before.TLSClientConfig, base.TLSClientConfig)
+	require.Equal(t, base.ForceAttemptHTTP2, transport.ForceAttemptHTTP2)
+	require.NotNil(t, transport.Proxy)
+	require.Equal(t, base.TLSHandshakeTimeout, transport.TLSHandshakeTimeout)
+
+	defaults := tlsOptions{}
+	other, err := defaults.httpTransport(true)
+	require.NoError(t, err)
+	defer other.CloseIdleConnections()
+	require.Empty(t, other.TLSClientConfig.Certificates)
+	require.Nil(t, other.TLSClientConfig.RootCAs)
+	require.Empty(t, other.TLSClientConfig.ServerName)
+}
+
+type tlsQueryTestServer struct {
+	tempopb.UnimplementedStreamingQuerierServer
+}
+
+func (*tlsQueryTestServer) Search(_ *tempopb.SearchRequest, stream tempopb.StreamingQuerier_SearchServer) error {
+	return stream.Send(&tempopb.SearchResponse{})
+}
+
+func (*tlsQueryTestServer) SearchTagsV2(_ *tempopb.SearchTagsRequest, stream tempopb.StreamingQuerier_SearchTagsV2Server) error {
+	return stream.Send(&tempopb.SearchTagsV2Response{})
+}
+
+func (*tlsQueryTestServer) SearchTagValuesV2(_ *tempopb.SearchTagValuesRequest, stream tempopb.StreamingQuerier_SearchTagValuesV2Server) error {
+	return stream.Send(&tempopb.SearchTagValuesV2Response{})
+}
+
+func (*tlsQueryTestServer) MetricsQueryRange(_ *tempopb.QueryRangeRequest, stream tempopb.StreamingQuerier_MetricsQueryRangeServer) error {
+	return stream.Send(&tempopb.QueryRangeResponse{})
+}
+
+func (*tlsQueryTestServer) MetricsQueryInstant(_ *tempopb.QueryInstantRequest, stream tempopb.StreamingQuerier_MetricsQueryInstantServer) error {
+	return stream.Send(&tempopb.QueryInstantResponse{})
+}
+
+func startTLSQueryGRPCServer(t *testing.T, cfg *tls.Config, checkHeaders bool) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	opts := []grpc.ServerOption{grpc.StreamInterceptor(func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		md, _ := metadata.FromIncomingContext(stream.Context())
+		assert.Equal(t, []string{"test-tenant"}, md.Get("x-scope-orgid"))
+		if checkHeaders {
+			assert.Equal(t, []string{"Bearer token=abc"}, md.Get("authorization"))
+		}
+		if cfg != nil {
+			p, ok := peer.FromContext(stream.Context())
+			if assert.True(t, ok) {
+				info, ok := p.AuthInfo.(credentials.TLSInfo)
+				if assert.True(t, ok) {
+					if cfg.ClientAuth == tls.RequireAndVerifyClientCert {
+						assert.NotEmpty(t, info.State.VerifiedChains)
+					}
+					if checkHeaders {
+						assert.Equal(t, "tempo.test", info.State.ServerName)
+					}
+				}
+			}
+		}
+		return handler(srv, stream)
+	})}
+	if cfg != nil {
+		opts = append(opts, grpc.Creds(credentials.NewTLS(cfg.Clone())))
+	}
+	srv := grpc.NewServer(opts...)
+	tempopb.RegisterStreamingQuerierServer(srv, &tlsQueryTestServer{})
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(listener) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		require.NoError(t, <-done)
+	})
+	return listener.Addr().String()
+}
+
+func TestQueryAPIMTLSGRPC(t *testing.T) {
+	pki := newTLSTestPKI(t)
+	for _, secure := range []bool{false, true} {
+		mode := "plaintext"
+		if secure {
+			mode = "tls"
+		}
+		for _, args := range [][]string{
+			{"search"}, {"search-tags"}, {"search-tag-values"}, {"metrics"}, {"metrics", "--instant"},
+		} {
+			t.Run(mode+"/"+strings.Join(args, " "), func(t *testing.T) {
+				var cfg *tls.Config
+				if secure {
+					cfg = pki.server
+				}
+				endpoint := startTLSQueryGRPCServer(t, cfg, true)
+				args = append(args, endpoint)
+				switch args[0] {
+				case "search":
+					args = append(args, "{}")
+				case "metrics":
+					args = append(args, "{} | rate()")
+				case "search-tag-values":
+					args = append(args, "resource.service.name")
+				}
+				args = append(args, "now-1h", "now", "--use-grpc", "--org-id=test-tenant", "--header=Authorization=Bearer token=abc")
+				if secure {
+					args = append(args, "--secure", "--tls-cert="+pki.options.TLSCert, "--tls-key="+pki.options.TLSKey, "--tls-ca="+pki.options.TLSCA, "--tls-server-name=tempo.test")
+				}
+				require.NoError(t, runTLSQuery(t, args...))
+			})
+		}
+	}
+}

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -76,57 +76,19 @@ You can configure the backend using the following options:
 
 Each option applies only to the command in which it's used. For example, `--backend <value>` doesn't permanently change where Tempo stores data. It only changes it for command in which you apply the option.
 
+## TLS options
+
+All `query api` commands support these options for HTTPS and gRPC TLS connections.
+Use an `https://` URL for `trace-id`, or `--secure` for the other commands.
+
+- `--tls-cert <path>`, `--tls-key <path>` PEM client certificate and matching unencrypted private key for mutual TLS (mTLS).
+  Both must be provided together.
+- `--tls-ca <path>` PEM CA bundle added to the system trust roots for server certificate verification.
+- `--tls-server-name <name>` Override the server name used for certificate verification and SNI.
+
+The CA and server-name options can also be used without a client certificate.
+
 ## Query API command
-
-### TLS and client certificates
-
-All `query api` commands support mutual TLS (mTLS) authentication with a client certificate and private key.
-These options work with HTTPS and with the existing `--use-grpc` mode,
-including instant and range metrics queries.
-
-Enable TLS explicitly:
-use an `https://` URL for `trace-id`,
-or add `--secure` for `search`, `search-tags`, `search-tag-values`, and `metrics`.
-Supplying TLS options for a plaintext connection returns an error.
-
-| Option | Description |
-| ------ | ----------- |
-| `--tls-cert <path>` | PEM client certificate file, optionally including its intermediate certificate chain. Requires `--tls-key`. |
-| `--tls-key <path>` | Unencrypted PEM private key matching the client certificate. Requires `--tls-cert`. |
-| `--tls-ca <path>` | Optional PEM CA certificate bundle added to the system trust roots to verify the server certificate. |
-| `--tls-server-name <name>` | Optional override for the server name used for certificate verification and SNI. |
-
-You can use `--tls-ca` and `--tls-server-name` without a client certificate for ordinary TLS connections.
-Server certificate verification remains enabled.
-
-For example, connect through a local port forward
-while verifying the server's certificate against its original name:
-
-```bash
-tempo-cli query api search-tags localhost:8443 \
-  --secure --tls-ca ca.crt --tls-server-name tempo.example.com
-```
-
-Retrieve a trace over HTTPS with mTLS:
-
-```bash
-tempo-cli query api trace-id https://tempo.example.com f1cfe82a8eef933b \
-  --tls-cert client.crt --tls-key client.key --tls-ca ca.crt
-```
-
-Search over HTTPS with mTLS:
-
-```bash
-tempo-cli query api search tempo.example.com:443 '{status = error}' now-1h now \
-  --secure --tls-cert client.crt --tls-key client.key --tls-ca ca.crt
-```
-
-For gRPC, add `--use-grpc` and specify the server's gRPC endpoint:
-
-```bash
-tempo-cli query api search tempo.example.com:9095 '{status = error}' now-1h now \
-  --use-grpc --secure --tls-cert client.crt --tls-key client.key --tls-ca ca.crt
-```
 
 ### Trace ID
 
@@ -143,6 +105,7 @@ Arguments:
 
 Options:
 
+- [TLS options](#tls-options)
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
 - `--header <key=value>` Extra HTTP header to send with the request. Can be specified multiple times.
 - `--v1` use v1 API (use /api/traces endpoint to fetch traces, default: /api/v2/traces).
@@ -178,6 +141,7 @@ Arguments:
 
 Options:
 
+- [TLS options](#tls-options)
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
 - `--header <key=value>` Extra header to send with the request (as gRPC metadata when using `--use-grpc`). Can be specified multiple times.
 - `--use-grpc` Use GRPC streaming
@@ -230,6 +194,7 @@ Arguments:
 
 Options:
 
+- [TLS options](#tls-options)
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
 - `--header <key=value>` Extra header to send with the request (as gRPC metadata when using `--use-grpc`). Can be specified multiple times.
 - `--use-grpc` Use GRPC streaming
@@ -275,6 +240,7 @@ Arguments:
 
 Options:
 
+- [TLS options](#tls-options)
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
 - `--header <key=value>` Extra header to send with the request (as gRPC metadata when using `--use-grpc`). Can be specified multiple times.
 - `--query <value>` TraceQL query to filter attribute results by.
@@ -315,6 +281,7 @@ Arguments:
 
 Options:
 
+- [TLS options](#tls-options)
 - `--org-id <value>` Organization ID (for use in multi-tenant setup).
 - `--header <key=value>` Extra header to send with the request (as gRPC metadata when using `--use-grpc`). Can be specified multiple times.
 - `--use-grpc` Use GRPC streaming

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -78,6 +78,56 @@ Each option applies only to the command in which it's used. For example, `--back
 
 ## Query API command
 
+### TLS and client certificates
+
+All `query api` commands support mutual TLS (mTLS) authentication with a client certificate and private key.
+These options work with HTTPS and with the existing `--use-grpc` mode,
+including instant and range metrics queries.
+
+Enable TLS explicitly:
+use an `https://` URL for `trace-id`,
+or add `--secure` for `search`, `search-tags`, `search-tag-values`, and `metrics`.
+Supplying TLS options for a plaintext connection returns an error.
+
+| Option | Description |
+| ------ | ----------- |
+| `--tls-cert <path>` | PEM client certificate file, optionally including its intermediate certificate chain. Requires `--tls-key`. |
+| `--tls-key <path>` | Unencrypted PEM private key matching the client certificate. Requires `--tls-cert`. |
+| `--tls-ca <path>` | Optional PEM CA certificate bundle added to the system trust roots to verify the server certificate. |
+| `--tls-server-name <name>` | Optional override for the server name used for certificate verification and SNI. |
+
+You can use `--tls-ca` and `--tls-server-name` without a client certificate for ordinary TLS connections.
+Server certificate verification remains enabled.
+
+For example, connect through a local port forward
+while verifying the server's certificate against its original name:
+
+```bash
+tempo-cli query api search-tags localhost:8443 \
+  --secure --tls-ca ca.crt --tls-server-name tempo.example.com
+```
+
+Retrieve a trace over HTTPS with mTLS:
+
+```bash
+tempo-cli query api trace-id https://tempo.example.com f1cfe82a8eef933b \
+  --tls-cert client.crt --tls-key client.key --tls-ca ca.crt
+```
+
+Search over HTTPS with mTLS:
+
+```bash
+tempo-cli query api search tempo.example.com:443 '{status = error}' now-1h now \
+  --secure --tls-cert client.crt --tls-key client.key --tls-ca ca.crt
+```
+
+For gRPC, add `--use-grpc` and specify the server's gRPC endpoint:
+
+```bash
+tempo-cli query api search tempo.example.com:9095 '{status = error}' now-1h now \
+  --use-grpc --secure --tls-cert client.crt --tls-key client.key --tls-ca ca.crt
+```
+
 ### Trace ID
 
 Call the Tempo API and retrieve a trace by ID.


### PR DESCRIPTION
**What this PR does**:
Allow tempo-cli to query servers that require a TLS client certificate. Add --tls-cert, --tls-key, --tls-ca, and --tls-server-name to all query API commands over HTTPS and their existing gRPC modes, including instant and range metrics queries.

Require a certificate/key pair and explicit TLS activation through an HTTPS trace-id URL or --secure on host/port commands. Add custom CAs to system trust roots and keep server certificate verification enabled. Use per-command transports and close idle HTTP and gRPC connections.

**Which issue(s) this PR fixes**:
Fixes #7877

**Checklist**
- [x] Tests updated with real HTTP/gRPC mTLS handshakes and invalid configurations
- [x] Documentation added with mTLS and custom CA/server-name examples
- [x] Changelog entry added under .chloggen/

**Validation**:
CLI and HTTP-client race tests, formatting, diff-scoped lint, changelog validation, and tempo-cli build pass. 

AI assistance: Codex implemented the code, tests, and documentation.